### PR TITLE
Certify the makespan bound a Cumulative's energy carries

### DIFF
--- a/dev_docs/README.md
+++ b/dev_docs/README.md
@@ -171,6 +171,13 @@ library. For an introduction to *using* the solver, start with the top-level
   certificate takes and why non-unit coefficients need the third, how a cut is
   restricted to the tasks present at one time point when its heights cannot move,
   and the differential fixture that separates this from the capacity-one stage.
+- [Certified makespan lower bounds from a `Cumulative`'s energy](certified-makespan-bounds.md) —
+  turning the `L` those two presolvers report into a number the proof contains.
+  Covers the window-energy argument under the objective's order literal, the two
+  places the derived bound is *not* `L`, why the deadline step has to be a `pol`
+  and cannot be a RUP (and so why a makespan is a variable with rows around it
+  rather than a kind of variable), the three mutations VeriPB refuses and the
+  fourth that cannot be caught, and the RCPSP bounds artefact.
 - [Restarts, nogoods, and dom/wdeg weighting](restarts-nogoods-weighting.md) —
   the search-side machinery from issue #315: the restart loop and its
   `SearchResult` unwind signal, `RestartSchedule`, the `ConflictObserver`

--- a/dev_docs/certified-makespan-bounds.md
+++ b/dev_docs/certified-makespan-bounds.md
@@ -1,0 +1,193 @@
+# Certified makespan lower bounds from a `Cumulative`'s energy
+
+A `Cumulative` of capacity `C` over tasks with lengths `d_i` and heights `h_i`
+says the schedule cannot be short. The tasks need `Σ_i d_i h_i` units of a
+resource supplying `C` per time step, so no schedule can finish before their
+ratio. That is Sidorov's `L`, the number
+[`InferredCumulative`](inferred-cumulative.md) and
+[`InferredDisjunctive`](inferred-disjunctive.md) report as
+`largest_capacity_bound`, and for a lifted cut it can beat anything the donor's
+own row gives.
+
+Reporting it and proving it are different things. What a proof contained before
+this was the derived constraint's per-time rows and whatever its propagator
+happened to say at the nodes the search reached; the ratio argument appeared
+nowhere. `gcs/constraints/innards/makespan_energy.hh` makes it, and the
+constraint infers the bound at the root, so a `.pbp` now contains the number as
+well as the run that used it.
+
+## The argument
+
+Let `M` be the makespan and suppose `M ≤ μ`. Then:
+
+- every task is confined to `[lo, μ)`, where `lo` is the earliest time any of
+  them can be running;
+- [the window-energy lemma](cumulative-proof-logging.md) gives each task
+  `Σ_{t ∈ [lo, μ)} active_{i,t} ≥ d_i`;
+- summing those weighted by `h_i`, against the constraint's capacity rows summed
+  over the same window, cancels every activity term and leaves a line with
+  nothing but negative coefficients against a positive right-hand side — a
+  contradiction exactly when `Σ_i d_i h_i > C · |rows in the window|`;
+- the wrapping RUP concludes `M ≥ μ + 1`.
+
+`makespan_energy_bound` walks the candidate `μ` and returns the largest one
+refuted; `derive_makespan_bound` emits the argument for it, as one `pol` over
+the rows and the per-task lemmas. The constraint then infers `M ≥ μ + 1` with
+that as its `JustifyExplicitly`, from an initialiser, so it fires once at the
+root.
+
+### Two places the bound is not `L`
+
+**It can be larger.** `L` divides by `μ`, assuming the tasks may start at time
+zero. The derivation divides by the number of time points it has a capacity row
+for, which starts at the earliest time any task can be running — so a set of
+tasks that precedences keep away from the origin gets a better bound, and every
+time point before that window is a unit of supply the resource never had to
+provide.
+
+**It can be smaller,** or absent. The lemma speaks only about tasks with a
+constant length and height and a start that is a plain variable (see
+`prepare_cumulative_overload_check`); a task it cannot speak about carries none
+of the energy `L` counted. And a window narrow enough to exclude a task's whole
+duration gets only the part that fits — which is why the search starts from what
+the model already implies rather than from the makespan variable's declared
+lower bound. That distinction is not cosmetic: initialisers run before anything
+has propagated, so the makespan's own lower bound is still zero at that point,
+and without it the search settles for a window too narrow to hold every task.
+Sound, and a weaker number than the constraint deserves.
+
+## The deadline is a `pol`, not a RUP
+
+The step that makes this an argument about the makespan rather than about the
+tasks' own domains is `start_i ≤ μ - d_i`. It follows from the model's
+`makespan - start_i ≥ d_i` and the negated conclusion `M ≤ μ`, and it is **not**
+reverse unit propagation: a checker will not carry a bound from one variable's
+bits to another's across a linear row, whatever the two order literals say. That
+is the same wall [`VeriPB` RUP limits](../dev_docs/README.md) put in front of
+every cross-variable linear inference, and the answer is the same — a cutting
+planes step.
+
+Adding the model's row to the two order literals' own definitions cancels both
+variables' bits exactly:
+
+```
+    bits(s) + K₁·¬[s ≥ v]                      ≥ v        (definition of [s ≥ v])
+    bits(M) - bits(s)                          ≥ b        (the model's row)
+   -bits(M) + K₂·[M ≥ μ+1]                     ≥ -μ       (definition of [M ≥ μ+1])
+   -------------------------------------------------------
+             K₁·¬[s ≥ v] + K₂·[M ≥ μ+1]        ≥ v + b - μ
+```
+
+and with `v = μ - b + 1` the right-hand side is exactly one, so saturating lands
+on the clause `¬[s ≥ v] ∨ [M ≥ μ+1]`. The lemma's own RUPs then resolve against
+it one order literal at a time, which they can, because that reasoning stays
+inside a single variable's bits.
+
+So a makespan is not a kind of variable — it is a variable a model has put rows
+around. `find_makespan_links`
+([`gcs/presolvers/innards/makespan_links.hh`](../gcs/presolvers/innards/makespan_links.hh))
+goes looking for them rather than taking them on trust, so naming a variable
+that is not a makespan gives a weaker bound instead of a rejected proof. It
+matches the linear family's two-term unconditional rows over plain variables,
+which is what a scheduling model's makespan rows are and what MiniZinc's
+`int_lin_le` flattens them to. A comparison spelling (`start + length ≤
+makespan`) says the same thing over an offset view, whose bits would not cancel
+against the plain variable's, so it is not matched.
+
+## Testing it
+
+`derived_cumulative_test.cc` has the mechanism: three tasks of length two on a
+unary resource, which must run one after another, so no schedule finishes before
+six — and the model's rows say only that the makespan is at least two. Over
+`[0, 5)` the tasks need six units and the resource supplies five, a margin of
+exactly one, which is what makes the mutations below bite.
+
+Three of them, all refused by VeriPB:
+
+- **`ClaimHigherBound`**, the signature test: claim one more than the energy
+  supports. A derivation with slack in it verifies whatever it concludes, and
+  only a refused `+1` says the honest number is the one the arithmetic reaches.
+
+  Two shapes, because neither works everywhere. Where a wider window would have
+  another capacity row in it, the argument moves to that window and comes up
+  exactly one unit of supply short. Where it would not — the honest window
+  already reaching the last row — widening changes nothing, so instead the
+  honest window keeps its honest contradiction and only the *conclusion* moves:
+  the `pol` then contradicts under `[M ≤ bound-1]` while the wrapping RUP
+  asserts under `[M ≤ bound]`, which is one order literal short of firing.
+- **`OmitCapacityRow`**: count the window one row short. The omitted row's
+  activity terms then have nothing to cancel against and survive with a
+  *positive* sign, so the line reached is `Σ_i h_i a_{i,t} ≥ k` rather than a
+  contradiction.
+- **`ForgetTheDeadline`**: derive the tasks' window energy without the negated
+  conclusion in its context, so the end-of-window literals are claimed without
+  the deadline that gives them.
+
+A fourth was tried and dropped, and the reason is worth keeping: **deriving a
+task's energy over a window *narrower* than the rows cover is not catchable.**
+Its leftovers survive negatively, so the line stays contradictory and VeriPB
+rightly accepts a derivation that is merely longer than it needed to be. Only
+corruptions that make the sum come up *short* can be refused.
+
+### When the `+1` is a test at all
+
+Two conditions, and both bite on real instances.
+
+**The horizon has to be at least the bound.** Below it the honest derivation is
+a refutation rather than an inference, and every claim follows from a
+contradiction.
+
+**The instance has to be feasible at the bound** — which is to say the bound has
+to be the optimum. Anywhere else, "the makespan is at least one more" is *true*,
+and a checker that finds a way to agree has found nothing wrong: the run is
+refuting an infeasible instance either way, and the derivation's sound half
+(the `pol` still says the tasks cannot be active outside their windows) is
+enough to let unit propagation get there. That is not a defect in the mutation,
+it is what a mutation means — a corruption you cannot distinguish from the truth
+is not a corruption.
+
+So the discipline lives in two places. The margin-of-one fixture above is where
+it is *made* to bite, and the artefact below runs it per instance and requires a
+refusal only on the instances the bound closes.
+
+## The RCPSP artefact
+
+`examples/rcpsp --dzn` reads the MiniZinc `.dzn` flavour the Pack and Pack_d
+collections use; `--infer-disjunctive` and `--infer-cumulative` run the two
+stages, and `--infer-makespan-bound` (on by default) has them derive their
+bounds rather than only report them. `--mutate-makespan-bound` claims one more,
+for the discipline above.
+
+The certificate for a bound `B` is the decision variant at `B - 1`: the
+derivation refutes it at the root, so the proof is the bound's certificate and
+nothing else. Before that, the same question with the bound switched off, which
+must *not* close at the root — or something else in the model is doing the work
+and the instance says nothing about the bound.
+
+A bound at or below the critical path is reported and skipped: `--deadline`
+never takes the horizon below the critical path, so the question those runs
+would ask is not the one they look like.
+
+See `~/claude/tmp/rcpsp-bounds-672/` for the sweep, which runs every instance in
+both collections through all three stages, verifies each honest proof, records
+each `+1`, and checks every bound against a makespan somebody has actually
+achieved.
+
+Over the Pack collection in all three stages and Pack_d in the capacity-one
+stage — 227 runs, no failures — 92 of the 110 instances get a certified bound,
+every one of them beating the critical path, and **29 are closed**: the bound
+equals the best makespan anybody found, so no search is needed at all. The
+paper's §5.1 claims "no less than twelve". The largest is 3050; the median
+`.pbp` is 28 MB and the largest 504 MB, and `veripb` takes 45 s on that one.
+
+Twenty-three instances fall short of Sidorov's `L`, and on every one of them it
+is this presolver's *own* `L` that falls short while the derivation reaches it
+exactly. That is an inference gap and not a certification one — his lifting
+subproblem spans every resource and
+[`InferredCumulative`](inferred-cumulative.md)'s is single-resource — which
+makes it a measurement of what #673 costs.
+
+Note the makespan rows have to be there to be cited: `--variant=global` puts the
+whole temporal network into one `DifferenceConstraints` propagator, so there is
+no per-task row to sum and the bound falls back to whatever the tasks' own
+domains give.

--- a/dev_docs/inferred-cumulative.md
+++ b/dev_docs/inferred-cumulative.md
@@ -33,6 +33,11 @@ length five, that is `21 / 2 = 10.5` against the donor row's own `45 / 5 = 9`. A
 horizon of ten satisfies the resource and not the cut, which is exactly the
 fixture the test refutes at the root.
 
+Give the presolver the makespan variable, with `with_makespan`, and it derives
+that ratio rather than only reporting it: see
+[certified makespan bounds](certified-makespan-bounds.md), which is where the
+argument, its mutations and the RCPSP artefact live.
+
 The ratio is also the *only* thing a cut can buy, which is why it is what covers
 and constraints are both ranked by. Note that it is not used as a filter: the
 published procedure discards a constraint only when a model row dominates it
@@ -262,12 +267,6 @@ not — which veripb refuses inside the replay rather than at the pin.
   stops. Sidorov solves those subproblems and so could we — the precedent for a
   nested solve is `gcs/presolvers/auto_table/auto_table.cc` — but the result
   would have to be posted uncertified, which is not a trade this plan makes.
-- **Certified makespan bounds**
-  ([#672](https://github.com/ciaranm/glasgow-constraint-solver/issues/672)).
-  `largest_capacity_bound` is a number the presolver computed, not a bound the
-  proof establishes. Turning it into a refutation of `[M ≤ μ]` for each candidate
-  `μ`, and shipping a table of RCPSP bounds each with its verified `.pbp`, is the
-  headline deliverable of issue #549.
 - Optional tasks, variable durations or demands, and lifting during search
   (a constraint lifted from a conflict does not propagate after backtracking, so
   this is root-level only).

--- a/dev_docs/inferred-disjunctive.md
+++ b/dev_docs/inferred-disjunctive.md
@@ -151,7 +151,10 @@ presolver reports **exactly the bound the paper does**, under his own budgets
 | Pack-d | 8, 9, 12, 15, 16, 17, 18, 20, 24, 43 | 10 / 10 |
 
 Eleven of the twenty have `L` equal to the best known makespan, so the bound
-closes the instance with no search at all.
+closes the instance with no search at all. Give the presolver the makespan
+variable, with `with_makespan`, and that bound is *derived* rather than
+reported: see [certified makespan bounds](certified-makespan-bounds.md), which
+carries the argument and the sweep over both collections.
 
 Two things about the comparison are worth writing down, because both are easy to
 get wrong and neither is visible from the paper:

--- a/examples/rcpsp/rcpsp.cc
+++ b/examples/rcpsp/rcpsp.cc
@@ -33,6 +33,27 @@
 // see rcpsp_instance.hh. Scale up with --size (more tasks), --max-duration
 // (longer time horizon, so larger start-time domains) and --resources.
 //
+// Inferred resources, and the makespan bound they carry
+// -----------------------------------------------------
+//
+// --infer-disjunctive and --infer-cumulative run the two presolvers that read
+// implied resources off the posted ones: cliques of tasks no single resource
+// can hold pairwise, and cover inequalities lifted to non-unit heights. Each
+// posts a derived Cumulative, adding nothing to the model.
+//
+// What such a constraint is worth is energy, and energy is a bound on the
+// makespan: its tasks need a fixed number of resource-units out of something
+// that supplies so many per time step. --infer-makespan-bound, on by default,
+// has that bound *derived* rather than only reported, by naming the makespan
+// variable to the presolvers. It is only a bound if the model says every task
+// finishes by it, so the derivation sums the model's own
+// `start + duration <= makespan` rows --- which exist under --variant=decomposed
+// and --variant=presolved and not under --variant=global, where the whole
+// temporal network is one propagator instead.
+//
+// --mutate-makespan-bound claims one more than the energy supports, which VeriPB
+// must refuse. See dev_docs/certified-makespan-bounds.md.
+//
 // RCPSP/max
 // ---------
 //
@@ -79,6 +100,7 @@
 #include <gcs/constraints/disjunctive.hh>
 #include <gcs/constraints/linear.hh>
 #include <gcs/presolvers/difference_logic.hh>
+#include <gcs/presolvers/inferred_cumulative/inferred_cumulative.hh>
 #include <gcs/presolvers/inferred_disjunctive/inferred_disjunctive.hh>
 #include <gcs/problem.hh>
 #include <gcs/search_heuristics.hh>
@@ -300,6 +322,29 @@ auto main(int argc, char * argv[]) -> int
             ("infer-disjunctive-posted",                                                                 //
                 "Cap how many cliques are posted (Sidorov's N_out)",                                     //
                 cxxopts::value<std::size_t>()->default_value("5"))                                       //
+            ("infer-cumulative",                                                                         //
+                "Run the InferredCumulative presolver, which lifts cover inequalities over a "           //
+                "resource's capacity rows into implied Cumulatives with non-unit heights",               //
+                cxxopts::value<bool>()->default_value("false"))                                          //
+            ("infer-cumulative-covers",                                                                  //
+                "Cap how many covers are grown and lifted (Sidorov's N_cover)",                          //
+                cxxopts::value<std::size_t>()->default_value("100"))                                     //
+            ("infer-cumulative-posted",                                                                  //
+                "Cap how many lifted cuts are posted (Sidorov's N_out)",                                 //
+                cxxopts::value<std::size_t>()->default_value("5"))                                       //
+            ("infer-cumulative-lifting-calls",                                                           //
+                "Cap how many lifting subproblems are solved (Sidorov's N_calls)",                       //
+                cxxopts::value<std::size_t>()->default_value("20000"))                                   //
+            ("mutate-makespan-bound",                                                                    //
+                "Claim a makespan one larger than the inferred constraints' energy supports. For "       //
+                "validating the bound only: VeriPB must reject the resulting proof, and a run that "     //
+                "verifies is a finding about the honest derivation",                                     //
+                cxxopts::value<bool>()->default_value("false"))                                          //
+            ("infer-makespan-bound",                                                                     //
+                "Have the inferring presolvers derive a lower bound on the makespan from each "          //
+                "constraint they post, rather than only reporting one. Needs the model's "               //
+                "`start + duration <= makespan` rows, so --variant=global does not have them",           //
+                cxxopts::value<bool>()->default_value("true"))                                           //
             ("file",                                                                                     //
                 "Read a single-mode RCPSP/max instance from PATH, in ProGen/max .sch format (the "       //
                 "UBO, CD and SM sets), instead of generating one",                                       //
@@ -662,11 +707,43 @@ auto main(int argc, char * argv[]) -> int
     // Added after every Cumulative above, because what it has to work with is
     // the set of posted resources: it looks for pairs of tasks that some
     // resource cannot hold together, and grows those into cliques.
+    //
+    // Naming the makespan is what turns each posted constraint's capacity bound
+    // from a number the presolver reports into one the proof contains: the
+    // model's `start + duration <= makespan` rows confine the tasks to a
+    // window, and the constraint's energy then says how wide that window has to
+    // be. Those rows exist under --variant=decomposed and --variant=presolved;
+    // --variant=global puts the whole temporal network into one propagator
+    // instead, so there is no per-task row to sum and the bound falls back to
+    // whatever the tasks' own domains give.
+    auto infer_makespan_bound = options_vars["infer-makespan-bound"].as<bool>();
+    auto mutate_makespan_bound = options_vars["mutate-makespan-bound"].as<bool>();
+
     auto disjunctive_stats = std::make_shared<InferredDisjunctiveStats>();
     auto infer_disjunctive = options_vars["infer-disjunctive"].as<bool>();
-    if (infer_disjunctive)
-        problem.add_presolver(InferredDisjunctive{disjunctive_stats}.with_budgets(
-            options_vars["infer-disjunctive-candidates"].as<std::size_t>(), options_vars["infer-disjunctive-posted"].as<std::size_t>()));
+    if (infer_disjunctive) {
+        auto presolver = InferredDisjunctive{disjunctive_stats}.with_budgets(
+            options_vars["infer-disjunctive-candidates"].as<std::size_t>(), options_vars["infer-disjunctive-posted"].as<std::size_t>());
+        if (infer_makespan_bound)
+            presolver.with_makespan(makespan);
+        if (mutate_makespan_bound)
+            presolver.with_proof_mutation(inferred_disjunctive_mutation::ClaimHigherMakespanBound{});
+        problem.add_presolver(presolver);
+    }
+
+    auto cumulative_stats = std::make_shared<InferredCumulativeStats>();
+    auto infer_cumulative = options_vars["infer-cumulative"].as<bool>();
+    if (infer_cumulative) {
+        auto presolver =
+            InferredCumulative{cumulative_stats}
+                .with_budgets(options_vars["infer-cumulative-covers"].as<std::size_t>(), options_vars["infer-cumulative-posted"].as<std::size_t>())
+                .with_lifting_call_budget(options_vars["infer-cumulative-lifting-calls"].as<std::size_t>());
+        if (infer_makespan_bound)
+            presolver.with_makespan(makespan);
+        if (mutate_makespan_bound)
+            presolver.with_proof_mutation(inferred_cumulative_mutation::ClaimHigherMakespanBound{});
+        problem.add_presolver(presolver);
+    }
 
     auto all = options_vars.contains("all");
 
@@ -756,6 +833,19 @@ auto main(int argc, char * argv[]) -> int
         println("inferred_disjunctive_clique_members_posted: {}", disjunctive_stats->clique_members_posted);
         // Sidorov's L: a makespan lower bound that needs no search to believe.
         println("inferred_disjunctive_capacity_bound: {}", disjunctive_stats->largest_capacity_bound.raw_value);
+        // What of that L the proof actually contains.
+        println("inferred_disjunctive_certified_bound: {}", disjunctive_stats->certified_makespan_bound.raw_value);
+    }
+    if (infer_cumulative) {
+        println("inferred_cumulative_tasks: {}", cumulative_stats->tasks);
+        println("inferred_cumulative_covers_considered: {}", cumulative_stats->covers_considered);
+        println("inferred_cumulative_lifting_subproblems: {}", cumulative_stats->lifting_subproblems);
+        println("inferred_cumulative_cuts_found: {}", cumulative_stats->cuts_found);
+        println("inferred_cumulative_cuts_uncertifiable: {}", cumulative_stats->cuts_uncertifiable);
+        println("inferred_cumulative_cuts_posted: {}", cumulative_stats->cuts_posted);
+        println("inferred_cumulative_non_unit_cuts_posted: {}", cumulative_stats->non_unit_cuts_posted);
+        println("inferred_cumulative_capacity_bound: {}", cumulative_stats->largest_capacity_bound.raw_value);
+        println("inferred_cumulative_certified_bound: {}", cumulative_stats->certified_makespan_bound.raw_value);
     }
     if (*variant != Variant::Decomposed) {
         println("simplify: {}", simplify_name);

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -52,6 +52,7 @@ add_library(glasgow_constraint_solver
         constraints/increasing/increasing.cc
         constraints/innards/cake_truthiness.cc
         constraints/innards/linear_stages.cc
+        constraints/innards/makespan_energy.cc
         constraints/innards/product_encoding.cc
         constraints/innards/product_justify.cc
         constraints/innards/justify_not_in_range.cc
@@ -125,6 +126,7 @@ add_library(glasgow_constraint_solver
         presolvers/difference_logic/difference_logic.cc
         presolvers/inferred_cumulative/inferred_cumulative.cc
         presolvers/inferred_disjunctive/inferred_disjunctive.cc
+        presolvers/innards/makespan_links.cc
 )
 
 # The repo root contains both gcs/ and util/, so it must be on the include path.

--- a/gcs/constraints/cumulative/derived_cumulative.cc
+++ b/gcs/constraints/cumulative/derived_cumulative.cc
@@ -1,6 +1,9 @@
 #include <gcs/constraints/cumulative/derived_cumulative.hh>
+#include <gcs/constraints/cumulative/hints.hh>
 #include <gcs/constraints/cumulative/propagate.hh>
+#include <gcs/constraints/innards/makespan_energy.hh>
 #include <gcs/exception.hh>
+#include <gcs/innards/inference_tracker.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/propagators.hh>
@@ -11,6 +14,7 @@
 #include <optional>
 #include <string>
 #include <utility>
+#include <variant>
 #include <vector>
 
 using namespace gcs;
@@ -172,6 +176,92 @@ auto gcs::innards::install_derived_cumulative(
                 return false;
             inputs->capacity_lines.emplace(t, *derived);
         }
+    }
+
+    // The makespan bound, which is a statement about a variable this constraint
+    // does not otherwise mention. It fires once, so it goes in an initialiser
+    // rather than in the propagator: nothing it reads changes below the root
+    // that would let it say more.
+    if (spec.makespan) {
+        // Which tasks can carry energy is the window-energy lemma's question,
+        // and prepare_cumulative_overload_check is where it is answered. A
+        // constraint posted for its energy alone runs with the overload rule
+        // off, so ask anyway rather than going without a bound.
+        if (! spec.rules.overload) {
+            auto overload_data = prepare_cumulative_overload_check(
+                inputs->starts, inputs->lengths, inputs->heights, inputs->active_tasks, inputs->per_task_t_lo, per_task_t_hi, initial_state);
+            inputs->overload_tasks = move(overload_data.overload_tasks);
+            inputs->time_slot_prefix = move(overload_data.time_slot_prefix);
+            inputs->time_slot_lo = overload_data.time_slot_lo;
+        }
+
+        // Everything but the start bounds is settled now: the flag vectors live
+        // in `inputs`, which the initialiser holds a share of, and the windows
+        // are the ones its rows were derived over.
+        vector<makespan_energy::EnergyTask> energy_tasks;
+        vector<IntegerVariableID> scope;
+        for (auto i : inputs->overload_tasks) {
+            energy_tasks.push_back(makespan_energy::EnergyTask{.start = std::get<SimpleIntegerVariableID>(spec.tasks[i].start),
+                .length = spec.tasks[i].length,
+                .height = spec.tasks[i].height,
+                .t_lo = inputs->per_task_t_lo[i],
+                .t_hi = per_task_t_hi[i],
+                .start_lb = 0_i,
+                .start_ub = 0_i,
+                .link = i < spec.makespan_links.size() ? spec.makespan_links[i] : std::nullopt,
+                .before = logger ? &inputs->before_flags[i] : nullptr,
+                .after = logger ? &inputs->after_flags[i] : nullptr,
+                .active = logger ? &inputs->active_flags[i] : nullptr});
+            scope.push_back(spec.tasks[i].start);
+        }
+
+        propagators.install_initialiser(
+            [inputs, energy_tasks, scope, makespan = *spec.makespan, capacity = spec.capacity, mutation = spec.makespan_mutation,
+                reached = spec.makespan_bound_reached](const State & state, auto & inference, ProofLogger * const logger) mutable -> void {
+                for (auto & task : energy_tasks) {
+                    auto [s_lo, s_hi] = state.bounds(task.start);
+                    task.start_lb = s_lo;
+                    task.start_ub = s_hi;
+                }
+
+                // What the model already says the makespan is, which an energy
+                // argument has to beat to be worth making. The link rows give
+                // it directly, and asking them is not the same as asking
+                // `state`: initialisers run before anything has propagated, so
+                // the makespan's own lower bound is still whatever it was
+                // declared with. Without this the search below settles for a
+                // window too narrow to hold every task --- which is sound, and
+                // is a weaker number than the constraint deserves.
+                auto [makespan_lo, makespan_hi] = state.bounds(makespan);
+                auto known = makespan_lo;
+                for (const auto & task : energy_tasks)
+                    if (task.link)
+                        known = std::max(known, task.start_lb + task.link->bound);
+
+                auto bound = makespan_energy::makespan_energy_bound(
+                    energy_tasks, capacity, inputs->time_slot_prefix, inputs->time_slot_lo, known, makespan_hi);
+                if (! bound)
+                    return;
+
+                if (reached)
+                    reached(bound->bound);
+
+                // Tests only: claiming one more than the argument reaches must
+                // be refused, since a derivation with slack in it verifies
+                // whatever it concludes.
+                auto claimed =
+                    std::holds_alternative<makespan_energy::makespan_energy_mutation::ClaimHigherBound>(mutation) ? bound->bound + 1_i : bound->bound;
+
+                auto justify = [&](const ReasonLiterals & reason) -> void {
+                    if (logger)
+                        makespan_energy::derive_makespan_bound(
+                            *logger, reason, makespan, energy_tasks, inputs->capacity_lines, *bound, mutation, ProofLevel::Temporary);
+                };
+
+                inference.infer_greater_than_or_equal(logger, makespan, claimed,
+                    JustifyExplicitly{justify, ThenRUP::Yes, hints::CumulativeMakespan{inputs->owner}}, bounds_reason(scope));
+            },
+            InitialiserPriority::Expensive);
     }
 
     Triggers triggers;

--- a/gcs/constraints/cumulative/derived_cumulative.hh
+++ b/gcs/constraints/cumulative/derived_cumulative.hh
@@ -3,6 +3,7 @@
 
 #include <gcs/constraint_id.hh>
 #include <gcs/constraints/cumulative/cumulative.hh>
+#include <gcs/constraints/innards/makespan_energy.hh>
 #include <gcs/innards/proofs/proof_line.hh>
 #include <gcs/innards/proofs/proof_logger-fwd.hh>
 #include <gcs/innards/propagators-fwd.hh>
@@ -118,6 +119,39 @@ namespace gcs::innards
          * ProofModel, so it cannot write to the OPB even by mistake.
          */
         std::function<auto(ProofLogger &, const DerivedCumulativeRows &, Integer t)->std::optional<ProofLine>> recipe;
+
+        /**
+         * \brief A variable every task must finish by, if there is one: the
+         * makespan this constraint's energy bounds from below.
+         *
+         * Set it, along with \ref makespan_links, and the constraint pushes that
+         * variable's lower bound once, at the root, with a certificate. What
+         * makes the variable a makespan is those links: the rows saying each
+         * task finishes by it are what confine the tasks to the window the
+         * argument counts supply over, and they are summed into the derivation
+         * rather than taken on trust. Name a variable that is not a makespan
+         * and the bound is simply weaker, not wrong.
+         *
+         * The bound is found from the task geometry and the links' bounds
+         * alone, so it is the same with proofs off; only the certificate needs
+         * a logger.
+         */
+        std::optional<IntegerVariableID> makespan = std::nullopt;
+
+        /// Per task, the model row saying that task must finish by the
+        /// makespan. A task with none keeps only what its own domain gives,
+        /// which is a weaker bound rather than a wrong one; see
+        /// find_makespan_links, which is what a presolver builds this with.
+        std::vector<std::optional<makespan_energy::MakespanLink>> makespan_links = {};
+
+        /// Called with the bound, if one is reached. For a presolver to record
+        /// what its inference came to, which is the number a bounds artefact
+        /// reports.
+        std::function<auto(Integer)->void> makespan_bound_reached = {};
+
+        /// Corrupt the makespan bound's certificate. For tests only, which
+        /// assert that VeriPB rejects the result; see MakespanEnergyMutation.
+        makespan_energy::MakespanEnergyMutation makespan_mutation = makespan_energy::makespan_energy_mutation::None{};
 
         /// Which propagation rules the derived constraint runs. The default is
         /// all of them: it gets the same time-tabling and overload checking a

--- a/gcs/constraints/cumulative/derived_cumulative_test.cc
+++ b/gcs/constraints/cumulative/derived_cumulative_test.cc
@@ -1,11 +1,13 @@
 #include <gcs/constraints/cumulative.hh>
 #include <gcs/constraints/cumulative/derived_cumulative.hh>
 #include <gcs/constraints/innards/constraints_test_utils.hh>
+#include <gcs/constraints/linear.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
 #include <gcs/innards/proofs/pol_builder.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/proofs/subset_sum_strengthening.hh>
 #include <gcs/presolver.hh>
+#include <gcs/presolvers/innards/makespan_links.hh>
 #include <gcs/problem.hh>
 #include <gcs/solve.hh>
 
@@ -94,16 +96,32 @@ namespace
         /// A derived constraint whose tasks run longer than the donor's, so it
         /// asks about (task, time) pairs the donor never encoded. The install
         /// must decline.
-        BeyondDonorWindow
+        BeyondDonorWindow,
+        /// C'_t := C_t, plus a certified lower bound on the makespan from the
+        /// tasks' energy.
+        Makespan,
+        /// The same, claiming a makespan one larger than the energy supports.
+        /// VeriPB must reject.
+        MakespanClaimHigher,
+        /// The same, counting the window one capacity row short. VeriPB must
+        /// reject.
+        MakespanOmitRow,
+        /// The same, deriving the tasks' window energy without the deadline
+        /// that confines them to the window. VeriPB must reject.
+        MakespanForgetDeadline
     };
 
     struct DerivedDemoPresolver : Presolver
     {
         Demo demo;
+        // The model's makespan variable, for the demos that bound it.
+        optional<IntegerVariableID> makespan;
         // Set by run(), read by the test: whether anything was installed.
         std::shared_ptr<bool> installed = std::make_shared<bool>(false);
+        // Set by the derived constraint's initialiser: the bound it reached.
+        std::shared_ptr<optional<Integer>> bound_reached = std::make_shared<optional<Integer>>();
 
-        explicit DerivedDemoPresolver(Demo d) : demo(d)
+        explicit DerivedDemoPresolver(Demo d, optional<IntegerVariableID> m = nullopt) : demo(d), makespan(m)
         {
         }
 
@@ -191,6 +209,36 @@ namespace
                     };
                 } break;
 
+                case Demo::Makespan:
+                case Demo::MakespanClaimHigher:
+                case Demo::MakespanOmitRow:
+                case Demo::MakespanForgetDeadline:
+                    if (! makespan)
+                        fail("a makespan demo was run on a model with no makespan variable");
+                    spec.makespan = makespan;
+                    {
+                        // What the model says the makespan is: the rows the
+                        // derivation sums, rather than a promise it makes.
+                        auto links = find_makespan_links(problem, logger, *makespan);
+                        for (const auto & task : spec.tasks) {
+                            auto link = links.find(task.start);
+                            spec.makespan_links.push_back(link == links.end() ? nullopt : make_optional<makespan_energy::MakespanLink>(link->second));
+                        }
+                    }
+                    spec.makespan_bound_reached = [reached = bound_reached](Integer bound) { *reached = bound; };
+                    switch (demo) {
+                    case Demo::MakespanClaimHigher: spec.makespan_mutation = makespan_energy::makespan_energy_mutation::ClaimHigherBound{}; break;
+                    case Demo::MakespanOmitRow: spec.makespan_mutation = makespan_energy::makespan_energy_mutation::OmitCapacityRow{}; break;
+                    case Demo::MakespanForgetDeadline: spec.makespan_mutation = makespan_energy::makespan_energy_mutation::ForgetTheDeadline{}; break;
+                    default: break;
+                    }
+                    spec.recipe = [row_of](ProofLogger & logger, const DerivedCumulativeRows & rows, Integer) -> optional<ProofLine> {
+                        PolBuilder copy;
+                        copy.add(row_of(rows));
+                        return copy.emit(logger, ProofLevel::Top);
+                    };
+                    break;
+
                 case Demo::BeyondDonorWindow:
                     // One unit longer than the donor's tasks, so the derived
                     // constraint's last time point is one the donor never
@@ -212,8 +260,9 @@ namespace
 
         [[nodiscard]] auto clone() const -> unique_ptr<Presolver> override
         {
-            auto result = make_unique<DerivedDemoPresolver>(demo);
+            auto result = make_unique<DerivedDemoPresolver>(demo, makespan);
             result->installed = installed;
+            result->bound_reached = bound_reached;
             return result;
         }
     };
@@ -224,6 +273,11 @@ namespace
         vector<int> lengths;
         vector<int> heights;
         int capacity;
+        /// When set, the model also gets a `makespan` variable over
+        /// `[0, horizon]` with `start_i + length_i <= makespan` for every task
+        /// --- which is the entailment the makespan bound's derivation rests
+        /// on, and the only thing that makes those demos legal.
+        optional<int> makespan_horizon = nullopt;
     };
 
     auto is_satisfying(const Instance & inst, const vector<int> & starts) -> bool
@@ -247,11 +301,20 @@ namespace
         return true;
     }
 
-    auto post(Problem & p, const Instance & inst, optional<Demo> demo, CumulativeRules donor_rules = CumulativeRules{}) -> vector<IntegerVariableID>
+    struct Posted
+    {
+        vector<IntegerVariableID> starts;
+        optional<IntegerVariableID> makespan;
+        /// The demo presolver's record of what its derived constraint's
+        /// initialiser inferred, if anything.
+        std::shared_ptr<optional<Integer>> bound_reached;
+    };
+
+    auto post(Problem & p, const Instance & inst, optional<Demo> demo, CumulativeRules donor_rules = CumulativeRules{}) -> Posted
     {
         vector<IntegerVariableID> starts;
         for (auto & [lo, hi] : inst.start_ranges)
-            starts.push_back(p.create_integer_variable(Integer{lo}, Integer{hi}));
+            starts.push_back(p.create_integer_variable(Integer{lo}, Integer{hi}, "start" + std::to_string(starts.size())));
 
         vector<Integer> lengths, heights;
         for (auto l : inst.lengths)
@@ -259,10 +322,18 @@ namespace
         for (auto h : inst.heights)
             heights.push_back(Integer{h});
 
+        optional<IntegerVariableID> makespan;
+        if (inst.makespan_horizon) {
+            makespan = p.create_integer_variable(0_i, Integer{*inst.makespan_horizon}, "makespan");
+            for (size_t i = 0; i < starts.size(); ++i)
+                p.post(LinearGreaterThanEqual{WeightedSum{} + 1_i * *makespan + -1_i * starts[i], lengths[i]});
+        }
+
         p.post(Cumulative{starts, lengths, heights, Integer{inst.capacity}}.with_rules(donor_rules));
+        auto presolver = DerivedDemoPresolver{demo.value_or(Demo::Duplicate), makespan};
         if (demo)
-            p.add_presolver(DerivedDemoPresolver{*demo});
-        return starts;
+            p.add_presolver(presolver);
+        return Posted{move(starts), makespan, presolver.bound_reached};
     }
 
     struct Outcome
@@ -270,13 +341,16 @@ namespace
         set<vector<int>> solutions;
         unsigned long long recursions = 0;
         bool refuted_at_root = false;
+        /// What the makespan demos' initialiser inferred, if it ran.
+        optional<Integer> makespan_bound;
     };
 
     auto solve_it(const Instance & inst, optional<Demo> demo, const optional<string> & proof_name, CumulativeRules donor_rules = CumulativeRules{})
         -> Outcome
     {
         Problem p;
-        auto starts = post(p, inst, demo, donor_rules);
+        auto posted = post(p, inst, demo, donor_rules);
+        const auto & starts = posted.starts;
 
         Outcome outcome;
         bool reached_a_node = false, found_a_solution = false;
@@ -297,6 +371,7 @@ namespace
 
         outcome.recursions = stats.recursions;
         outcome.refuted_at_root = ! reached_a_node && ! found_a_solution;
+        outcome.makespan_bound = *posted.bound_reached;
 
         if (proof_name)
             verify_proof_and_clean_up(*proof_name);
@@ -418,9 +493,42 @@ auto main(int argc, char * argv[]) -> int
             donor_silent.recursions);
     }
 
+    // Demo three: a certified makespan bound. Three tasks of length two on a
+    // unary resource must run one after another, so no schedule finishes before
+    // time six --- and the makespan variable's own domain, and the model's
+    // `start + 2 <= makespan` rows, say only that it is at least two.
+    //
+    // The margin is exactly one: over [0, 5) the tasks need six units and the
+    // resource supplies five. That is what makes the mutations below bite; with
+    // any slack a corrupted derivation lands somewhere weaker and still
+    // contradicts.
+    const Instance makespan_instance{{{0, 5}, {0, 5}, {0, 5}}, {2, 2, 2}, {1, 1, 1}, 1, make_optional(8)};
+
+    {
+        auto with_bound = solve_it(makespan_instance, make_optional(Demo::Makespan), proofs ? make_optional("derived_cumulative_makespan") : nullopt);
+
+        if (with_bound.makespan_bound != make_optional(6_i))
+            fail("makespan demo: the derived constraint inferred " +
+                (with_bound.makespan_bound ? std::to_string(with_bound.makespan_bound->raw_value) : string{"nothing"}) +
+                ", not the six its tasks' energy supports");
+
+        set<vector<int>> expected;
+        build_expected(
+            expected, [&](const vector<int> & starts) { return is_satisfying(makespan_instance, starts); }, makespan_instance.start_ranges);
+        if (expected != with_bound.solutions)
+            fail("makespan demo: solutions do not match brute force");
+
+        // With proofs off the bound has to be the same number, or the solver is
+        // doing different arithmetic depending on whether anyone is watching.
+        auto unproved = solve_it(makespan_instance, make_optional(Demo::Makespan), nullopt);
+        if (unproved.makespan_bound != with_bound.makespan_bound)
+            fail("makespan demo: the bound differs with proofs off");
+    }
+
     // Nothing above may have reached the OPB.
     check_opb_unaffected("duplicate", duplicate_instance, Demo::Duplicate);
     check_opb_unaffected("strengthened", strengthened_instance, Demo::Strengthened);
+    check_opb_unaffected("makespan", makespan_instance, Demo::Makespan);
 
     // A derived constraint is implied, so it must not cost solutions. Random
     // instances, against brute force, with the duplicate recipe (which keeps
@@ -465,7 +573,7 @@ auto main(int argc, char * argv[]) -> int
         auto presolver = DerivedDemoPresolver{Demo::BeyondDonorWindow};
         auto installed = presolver.installed;
         Problem p2;
-        auto starts = post(p2, duplicate_instance, nullopt);
+        post(p2, duplicate_instance, nullopt);
         p2.add_presolver(presolver);
         solve_with(p2, SolveCallbacks{.trace = [](const CurrentState &) -> bool { return false; }},
             proofs ? make_optional<ProofOptions>(ProofFileNames{"derived_cumulative_beyond_window"}) : nullopt);
@@ -492,6 +600,23 @@ auto main(int argc, char * argv[]) -> int
             fail("veripb accepted a derived capacity one lower than the derivation supports");
         println(cerr, "veripb rejected the one-lower capacity, as expected");
         dispose_of_proof_files("derived_cumulative_one_lower");
+    }
+
+    // Each way of getting the makespan bound wrong, and VeriPB refusing it.
+    // The `+1` is the one that matters: a bound whose derivation has slack
+    // verifies whatever it concludes, so only a refusal says this one is tight.
+    for (auto [demo, what] : {pair{Demo::MakespanClaimHigher, "a makespan one larger than the energy supports"},
+             pair{Demo::MakespanOmitRow, "a makespan bound counting the window one capacity row short"},
+             pair{Demo::MakespanForgetDeadline, "a makespan bound whose window energy forgets the deadline"}}) {
+        const string name = "derived_cumulative_makespan_mutation";
+        Problem p;
+        post(p, makespan_instance, make_optional(demo));
+        solve_with(p, SolveCallbacks{.trace = [](const CurrentState &) -> bool { return true; }}, make_optional<ProofOptions>(ProofFileNames{name}));
+
+        if (run_veripb(name + ".opb", name + ".pbp"))
+            fail(string{"veripb accepted "} + what);
+        println(cerr, "veripb rejected {}, as expected", what);
+        dispose_of_proof_files(name);
     }
 
     // Backtracking soak: the derived rows are emitted once, at the top of the

--- a/gcs/constraints/cumulative/hints.hh
+++ b/gcs/constraints/cumulative/hints.hh
@@ -35,6 +35,21 @@ namespace gcs::innards::hints
     {
         static constexpr std::string_view subhint_name = "overload";
     };
+
+    /**
+     * \brief Cumulative's makespan-bound hint: the owning constraint, plus the
+     * `makespan` subhint.
+     *
+     * Fires once, at the root, and pushes a variable that is not one of the
+     * constraint's own --- so it is worth being able to isolate from the two
+     * rules that reason about starts.
+     *
+     * \ingroup Innards
+     */
+    struct CumulativeMakespan : Cumulative
+    {
+        static constexpr std::string_view subhint_name = "makespan";
+    };
 }
 
 #endif

--- a/gcs/constraints/innards/makespan_energy.cc
+++ b/gcs/constraints/innards/makespan_energy.cc
@@ -1,0 +1,175 @@
+#include <gcs/constraints/innards/makespan_energy.hh>
+#include <gcs/constraints/innards/window_energy.hh>
+#include <gcs/innards/proofs/names_and_ids_tracker.hh>
+#include <gcs/innards/proofs/pol_builder.hh>
+#include <gcs/innards/proofs/proof_error.hh>
+#include <gcs/innards/proofs/proof_logger.hh>
+
+#include <algorithm>
+#include <iterator>
+#include <string>
+#include <utility>
+#include <variant>
+#include <vector>
+
+using namespace gcs;
+using namespace gcs::innards;
+using namespace gcs::innards::makespan_energy;
+
+using std::max;
+using std::min;
+using std::nullopt;
+using std::optional;
+using std::size_t;
+using std::to_string;
+using std::vector;
+
+namespace
+{
+    /// How many time points in `[from, to)` the constraint has a capacity row
+    /// for. Clamped at both ends, so a window reaching past the last row counts
+    /// what is there rather than reading off the end of the prefix sums.
+    [[nodiscard]] auto slots_within(const vector<Integer> & prefix, Integer lo, Integer from, Integer to) -> Integer
+    {
+        auto at = [&](Integer t) {
+            auto idx = (t - lo).raw_value;
+            return prefix[static_cast<size_t>(max(0LL, min(idx, static_cast<long long>(prefix.size()) - 1)))];
+        };
+        return at(to) - at(from);
+    }
+
+    /// Where a task's start can be, given a makespan of `hi`. With a link, the
+    /// model's row puts it at `hi - bound` whatever the task's own domain says,
+    /// which is where the deadline enters the arithmetic; without one, the
+    /// domain is all there is.
+    [[nodiscard]] auto start_bounds_within(const EnergyTask & task, Integer hi) -> std::pair<Integer, Integer>
+    {
+        return {task.start_lb, task.link ? min(task.start_ub, hi - task.link->bound) : task.start_ub};
+    }
+
+    /// The activity the window-energy lemma can certify for one task inside
+    /// `[lo, hi)`.
+    [[nodiscard]] auto energy_within(const EnergyTask & task, Integer lo, Integer hi) -> Integer
+    {
+        auto flags_size = static_cast<size_t>(max(0LL, (task.t_hi - task.t_lo + 1_i).raw_value));
+        return window_energy::window_energy_bound(task.length, task.t_lo, flags_size, lo, hi, start_bounds_within(task, hi));
+    }
+}
+
+auto gcs::innards::makespan_energy::makespan_energy_bound(const vector<EnergyTask> & tasks, Integer capacity,
+    const vector<Integer> & time_slot_prefix, Integer time_slot_lo, Integer known_bound, Integer search_up_to) -> optional<MakespanBound>
+{
+    if (tasks.empty() || capacity <= 0_i || time_slot_prefix.size() < 2)
+        return nullopt;
+
+    // Where the argument starts. Anything earlier has no capacity row to cite
+    // and no task that could be running, so counting it would be supply the
+    // tasks cannot draw on --- and every unit of it costs a unit of the bound.
+    auto lo = time_slot_lo;
+    auto last = lo + Integer(static_cast<long long>(time_slot_prefix.size()) - 1);
+
+    optional<MakespanBound> best;
+    for (Integer mu = lo; mu <= min(search_up_to, last); ++mu) {
+        if (mu + 1_i <= known_bound)
+            continue;
+
+        Integer energy = 0_i;
+        for (const auto & task : tasks)
+            energy += task.height * energy_within(task, lo, mu);
+
+        auto supply = capacity * slots_within(time_slot_prefix, lo, lo, mu);
+        if (energy > supply)
+            best = MakespanBound{
+                mu + 1_i, lo, mu, energy, supply, slots_within(time_slot_prefix, lo, lo, mu + 1_i) > slots_within(time_slot_prefix, lo, lo, mu)};
+    }
+
+    return best;
+}
+
+auto gcs::innards::makespan_energy::derive_makespan_bound(ProofLogger & logger, const ReasonLiterals & reason, IntegerVariableID makespan,
+    const vector<EnergyTask> & tasks, const std::map<Integer, ProofLine> & capacity_rows, const MakespanBound & bound,
+    MakespanEnergyMutation mutation, ProofLevel level) -> void
+{
+    auto claim_higher = std::holds_alternative<makespan_energy_mutation::ClaimHigherBound>(mutation);
+    auto omit_row = std::holds_alternative<makespan_energy_mutation::OmitCapacityRow>(mutation);
+    auto forget_deadline = std::holds_alternative<makespan_energy_mutation::ForgetTheDeadline>(mutation);
+
+    // Under ClaimHigherBound the caller infers one more than the argument
+    // reaches, and the window widens to match --- but only where widening
+    // brings another capacity row with it. Where it does not, the honest
+    // window and the corrupted conclusion are already a unit apart, and moving
+    // it would only be arguing about a deadline nothing else changed.
+    auto hi = claim_higher && bound.wider_supplies_more ? bound.hi + 1_i : bound.hi;
+
+    // Recomputed at the window actually argued over rather than copied from
+    // `bound`, so that a mutation's comment says what the mutation did.
+    Integer energy_here = 0_i;
+    for (const auto & task : tasks)
+        energy_here += task.height * energy_within(task, bound.lo, hi);
+    auto rows_here = std::distance(capacity_rows.begin(), capacity_rows.lower_bound(hi));
+    logger.emit_proof_comment("makespan energy: over [" + to_string(bound.lo.raw_value) + "," + to_string(hi.raw_value) + ") the tasks need " +
+        to_string(energy_here.raw_value) + " out of " + to_string(rows_here) + " time points of the resource");
+
+    // The context every step below runs under: the caller's reason, plus the
+    // negated conclusion, which is what confines each task to the window.
+    ReasonLiterals deadline{reason};
+    deadline.push_back(makespan < hi + 1_i);
+
+    PolBuilder pol;
+    for (const auto & [t, line] : capacity_rows) {
+        if (t >= hi)
+            break;
+        if (omit_row && t == hi - 1_i)
+            continue;
+        pol.add(line);
+    }
+
+    for (const auto & task : tasks) {
+        if (! task.before || ! task.after || ! task.active)
+            throw ProofError{"makespan energy bound: a task has no activity flags to argue over"};
+        // The search clipped the lemma's window using t_lo and t_hi, and the
+        // lemma will clip it using the flag range. A disagreement would make
+        // the bound the caller is about to claim one the derivation does not
+        // reach, which VeriPB would only notice as a rejected wrapping RUP.
+        if (task.active->size() != static_cast<size_t>(max(0LL, (task.t_hi - task.t_lo + 1_i).raw_value)))
+            throw ProofError{"makespan energy bound: a task's flag range is not the window the bound was searched over"};
+
+        // The deadline, made available to the lemma's own reverse unit
+        // propagation. Its end-of-window literals say `start <= hi - bound`,
+        // which follows from the model's `makespan - start >= bound` and the
+        // negated conclusion, and from nothing a checker finds on its own:
+        // reverse unit propagation will not carry a bound from one variable's
+        // bits to another's across a linear row. Adding that row to the two
+        // order literals' own definitions cancels both variables' bits exactly
+        // and leaves the clause `~[start >= v] \/ [makespan >= hi + 1]`, which
+        // the lemma's RUPs then resolve against, one order literal at a time.
+        // Only where the task's own domain does not already confine it: the
+        // lemma asks for `start < v` at `v` above what it was given as an upper
+        // bound, and where that bound is the domain's, the reason alone RUPs it.
+        if (task.link && ! forget_deadline && task.start_ub > hi - task.link->bound) {
+            if (! task.link->row)
+                throw ProofError{"makespan energy bound: a task's makespan link has no row to cite"};
+            PolBuilder confine;
+            confine.add(*task.link->row);
+            confine.add_for_literal(logger.names_and_ids_tracker(), task.start >= hi - task.link->bound + 1_i);
+            confine.add_for_literal(logger.names_and_ids_tracker(), makespan < hi + 1_i);
+            confine.saturate();
+            confine.emit(logger, level);
+        }
+
+        window_energy::ConstantLengthTask lemma_task{task.start, task.length, task.t_lo, *task.before, *task.after, *task.active};
+        auto energy = window_energy::derive_window_energy(
+            logger, forget_deadline ? reason : deadline, lemma_task, bound.lo, hi, start_bounds_within(task, hi), level);
+
+        // A task the window leaves no room for contributes nothing, which is a
+        // weaker argument rather than a wrong one: the bound search counted the
+        // same zero.
+        if (! energy)
+            continue;
+        if (energy->bound != energy_within(task, bound.lo, hi))
+            throw ProofError{"makespan energy bound: window energy derivation is weaker than the bound assumed"};
+        pol.add(energy->line, task.height);
+    }
+
+    pol.emit(logger, level);
+}

--- a/gcs/constraints/innards/makespan_energy.hh
+++ b/gcs/constraints/innards/makespan_energy.hh
@@ -1,0 +1,235 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_INNARDS_MAKESPAN_ENERGY_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_INNARDS_MAKESPAN_ENERGY_HH
+
+#include <gcs/innards/proofs/proof_line.hh>
+#include <gcs/innards/proofs/proof_logger-fwd.hh>
+#include <gcs/innards/proofs/proof_only_variables.hh>
+#include <gcs/innards/reason.hh>
+#include <gcs/integer.hh>
+#include <gcs/variable_id.hh>
+
+#include <map>
+#include <optional>
+#include <variant>
+#include <vector>
+
+namespace gcs::innards::makespan_energy
+{
+    /**
+     * \brief Deliberate corruptions of a makespan bound's derivation, for
+     * testing only. VeriPB must reject each of them.
+     *
+     * A makespan bound is not conflict-shaped, which makes it easier to test
+     * than the rest of this family: the context its derivation runs under is
+     * the tasks' own bounds plus the negated conclusion, and that is
+     * satisfiable, so a corrupted route reaches a line that says less than the
+     * conclusion needs rather than one that is vacuously valid. What it does
+     * need is a fixture whose energy beats its supply by exactly one, or an
+     * understatement of a unit survives.
+     *
+     * \ingroup Innards
+     */
+    namespace makespan_energy_mutation
+    {
+        /// Emit the honest derivation.
+        struct None
+        {
+        };
+
+        /// Claim a makespan one larger than the energy supports. This is the
+        /// signature test of a bound: a derivation with slack in it verifies
+        /// whatever it concludes, and only a refused `+1` says the honest
+        /// number is the one the arithmetic reaches.
+        ///
+        /// Two shapes, because neither works everywhere. Where a wider window
+        /// would have another capacity row in it, the argument moves to that
+        /// window, and comes up exactly one unit of supply short. Where it
+        /// would not --- the honest window already reaching the last row ---
+        /// widening changes nothing at all, so instead the honest window keeps
+        /// its honest contradiction and only the *conclusion* moves: the `pol`
+        /// then contradicts under `[M <= bound - 1]` while the wrapping RUP
+        /// asserts under `[M <= bound]`, which is one order literal short of
+        /// firing.
+        ///
+        /// It says that only where the honest bound is an inference rather than
+        /// a refutation. Give the model a horizon *below* the bound and the
+        /// honest derivation reaches a contradiction, after which every claim
+        /// follows and this one verifies too --- so run it against a horizon of
+        /// at least the bound, and read a verifying run there as a finding.
+        struct ClaimHigherBound
+        {
+        };
+
+        /// Leave the window's last capacity row out of the supply, so the
+        /// resource is counted as having one time point less than the
+        /// derivation argues over.
+        ///
+        /// Not a weakening, which is why it is worth having: the omitted row's
+        /// activity terms have nothing to cancel against, so they survive with
+        /// a *positive* sign and the line reached is `sum_i h_i a_{i,t} >= k`
+        /// rather than a contradiction. The reverse mutation --- deriving a
+        /// task's energy over a narrower window than the rows cover --- is not
+        /// here for the same reason read the other way: its leftovers survive
+        /// negatively, so the line stays contradictory and VeriPB rightly
+        /// accepts a derivation that is merely longer than it needed to be.
+        struct OmitCapacityRow
+        {
+        };
+
+        /// Leave the negated conclusion out of the context the window-energy
+        /// lemma derives under, so that a task's end-of-window literals are
+        /// claimed without the deadline that gives them. That deadline is what
+        /// makes this an argument about the makespan at all, rather than one
+        /// about what the tasks' own domains already say.
+        struct ForgetTheDeadline
+        {
+        };
+    }
+
+    using MakespanEnergyMutation = std::variant<makespan_energy_mutation::None, makespan_energy_mutation::ClaimHigherBound,
+        makespan_energy_mutation::OmitCapacityRow, makespan_energy_mutation::ForgetTheDeadline>;
+
+    /**
+     * \brief The model's reason for believing a task must finish by the
+     * makespan: a posted row saying `makespan - start >= bound`.
+     *
+     * Nothing else will do. Reverse unit propagation does not cross from the
+     * makespan's bits to a start's through a linear row, whatever the bounds
+     * say --- the classic reason a cutting-planes step is needed where a RUP
+     * looks like it should work --- so the row itself has to be summed into the
+     * derivation, and a task without one keeps only whatever energy its own
+     * domain gives.
+     *
+     * `bound` is decided from the model and so is the same with proofs off,
+     * which is what keeps the inferred bound the same either way; `row` is the
+     * label naming it, and only a logger can have that.
+     *
+     * \ingroup Innards
+     */
+    struct MakespanLink
+    {
+        Integer bound;
+        std::optional<ProofLineLabel> row;
+    };
+
+    /**
+     * \brief One task of the constraint whose energy bounds a makespan.
+     *
+     * The flag vectors and the link's label are the only proof-dependent things
+     * here, and nothing the bound search reads: \ref makespan_energy_bound
+     * works entirely off the geometry, so it reaches the same answer with
+     * proofs off, and the same bound is inferred either way.
+     *
+     * \ingroup Innards
+     */
+    struct EnergyTask
+    {
+        SimpleIntegerVariableID start;
+
+        /// Constant, as the window-energy lemma requires; `height` is what this
+        /// task contributes to the constraint's capacity rows.
+        Integer length, height;
+
+        /// The window the constraint gave this task, and so the range its
+        /// activity flags cover: `[lb(start), ub(start) + length - 1]` as it
+        /// was when the constraint was installed.
+        Integer t_lo, t_hi;
+
+        /// What the start is currently known to lie within.
+        Integer start_lb, start_ub;
+
+        /// The model row confining this task to the window, if there is one:
+        /// under a makespan of `hi` the start is at most `hi - link->bound`.
+        /// Without it the task is confined only by `start_ub`, and every time
+        /// point between that and the window's end costs a unit of its energy
+        /// --- as does every unit by which the row's `bound` falls short of the
+        /// task's own length.
+        std::optional<MakespanLink> link = std::nullopt;
+
+        /// The task's per-time flags, as window_energy::ConstantLengthTask
+        /// describes them, or null with proofs off.
+        const std::vector<ProofFlag> * before = nullptr;
+        const std::vector<ProofFlag> * after = nullptr;
+        const std::vector<ProofFlag> * active = nullptr;
+    };
+
+    /**
+     * \brief A makespan lower bound the energy argument reaches, and the window
+     * it reaches it over.
+     *
+     * \ingroup Innards
+     */
+    struct MakespanBound
+    {
+        /// What to infer: the makespan is at least this.
+        Integer bound;
+
+        /// The window the derivation argues over, half-open. `hi` is
+        /// `bound - 1`: the largest makespan the argument refutes.
+        Integer lo, hi;
+
+        /// What the tasks need inside it, and what it supplies.
+        Integer energy, supply;
+
+        /// Whether a window one time point wider would have a capacity row to
+        /// go with it. False when the window already reaches the last row ---
+        /// which is only of interest to \ref makespan_energy_mutation::ClaimHigherBound,
+        /// whose whole trick is that a wider window supplies more.
+        bool wider_supplies_more;
+    };
+
+    /**
+     * \brief The strongest makespan lower bound this constraint's energy
+     * supports, or nothing when it supports none better than `known_bound`.
+     *
+     * A schedule finishing at `mu` confines every task to `[lo, mu)`, where
+     * `lo` is the earliest time any of them can be running. Between them they
+     * need `sum_i height_i * length_i` units of a resource supplying `capacity`
+     * per time point --- and only at the time points the constraint has a
+     * capacity row for, which is what `time_slot_prefix` counts and why the
+     * window's width is not what is divided by. Where the need beats the
+     * supply, `mu` is refuted, and the largest refuted `mu` gives the bound.
+     *
+     * Both sides move with `mu`, and not in lockstep: a wider window supplies
+     * more, but may also be the one that finally admits another task's whole
+     * duration. So this walks every candidate rather than assuming the first
+     * failure is the last. It stops at `search_up_to` or at the last time point
+     * with a row, whichever is smaller: past the rows nothing changes on either
+     * side, so a bound that would keep climbing there is one saying the
+     * constraint has no schedule at all, and the caller's inference is what
+     * should say so.
+     *
+     * `time_slot_prefix` and `time_slot_lo` are
+     * CumulativeOverloadData's, whose prefix sums count exactly the times some
+     * task can be running.
+     *
+     * \ingroup Innards
+     */
+    [[nodiscard]] auto makespan_energy_bound(const std::vector<EnergyTask> &, Integer capacity, const std::vector<Integer> & time_slot_prefix,
+        Integer time_slot_lo, Integer known_bound, Integer search_up_to) -> std::optional<MakespanBound>;
+
+    /**
+     * \brief Derive a makespan lower bound from a Cumulative's capacity rows
+     * and its tasks' energy.
+     *
+     * Everything is emitted under `reason` extended with the negated
+     * conclusion, so the caller must be inferring `makespan >= bound` with
+     * ThenRUP::Yes: it is that deadline which confines the tasks to the window,
+     * and without it the lemma's end-of-window literals do not hold. The model
+     * has to entail `start + length <= makespan` for every task, or those
+     * literals are not RUP and VeriPB will say so.
+     *
+     * One `pol`, over the capacity rows inside the window and each task's
+     * window energy scaled by its height. Every task's activity terms cancel
+     * against its terms in the rows, leaving a line with nothing but negative
+     * coefficients on the left and a positive right hand side --- a
+     * contradiction exactly when the bound is one \ref makespan_energy_bound
+     * accepted.
+     *
+     * \ingroup Innards
+     */
+    auto derive_makespan_bound(ProofLogger &, const ReasonLiterals & reason, IntegerVariableID makespan, const std::vector<EnergyTask> &,
+        const std::map<Integer, ProofLine> & capacity_rows, const MakespanBound &, MakespanEnergyMutation, ProofLevel) -> void;
+}
+
+#endif

--- a/gcs/presolvers/inferred_cumulative/inferred_cumulative.cc
+++ b/gcs/presolvers/inferred_cumulative/inferred_cumulative.cc
@@ -6,6 +6,7 @@
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/state.hh>
 #include <gcs/presolvers/inferred_cumulative/inferred_cumulative.hh>
+#include <gcs/presolvers/innards/makespan_links.hh>
 #include <gcs/problem.hh>
 #include <util/overloaded.hh>
 
@@ -336,12 +337,25 @@ auto InferredCumulative::with_proof_mutation(InferredCumulativeMutation mutation
     return *this;
 }
 
+auto InferredCumulative::with_makespan(IntegerVariableID makespan) -> InferredCumulative &
+{
+    _makespan = makespan;
+    return *this;
+}
+
 auto InferredCumulative::run(Problem & problem, Propagators & propagators, State & state, ProofLogger * const logger) -> bool
 {
     auto bump = [&](size_t InferredCumulativeStats::* field, size_t by = 1) {
         if (_stats)
             (*_stats).*field += by;
     };
+
+    // What the model says about the makespan, if the caller named one: the rows
+    // saying each task finishes by it, which are what a bound on it is derived
+    // from. Looked up once rather than per cut.
+    map<IntegerVariableID, makespan_energy::MakespanLink> makespan_links;
+    if (_makespan)
+        makespan_links = find_makespan_links(problem, logger, *_makespan);
 
     for (const auto & donor : problem.each_constraint_of_type<Cumulative>()) {
         bump(&InferredCumulativeStats::donors_seen);
@@ -524,8 +538,11 @@ auto InferredCumulative::run(Problem & problem, Propagators & propagators, State
                 .coefficients = {},
                 .t_lo = {},
                 .t_hi = {}};
+            vector<optional<makespan_energy::MakespanLink>> links;
             for (size_t k = 0; k < cut.support.size(); ++k) {
                 const auto & task = tasks[cut.support[k]];
+                auto link = makespan_links.find(task.start);
+                links.push_back(link == makespan_links.end() ? std::nullopt : optional<makespan_energy::MakespanLink>{link->second});
                 derived_tasks.push_back(DerivedCumulativeTask{recipe.donor, task.position, task.start, task.length, cut.coefficients[k]});
                 recipe.positions.push_back(task.position);
                 recipe.demands.push_back(task.demand);
@@ -616,7 +633,10 @@ auto InferredCumulative::run(Problem & problem, Propagators & propagators, State
                         },
                         [&](const inferred_cumulative_mutation::ClaimTighterRow &) {
                             programme = validate_lifted_cover_cut(demands, coefficients, recipe.capacity - 1_i, recipe.rhs);
-                        }}
+                        },
+                        // Corrupts the makespan bound rather than the row, so
+                        // the row is the honest one.
+                        [&](const inferred_cumulative_mutation::ClaimHigherMakespanBound &) {}}
                         .visit(recipe.mutation);
                     // A mutation that leaves nothing to derive has nothing to be
                     // rejected either, and a test asserting on it would be
@@ -626,6 +646,16 @@ auto InferredCumulative::run(Problem & problem, Propagators & propagators, State
 
                     return derive_lifted_cover_cut(recipe_logger, row->second, *programme, flags, claimed, weaken_out, claimed_rhs, ProofLevel::Top);
                 },
+                .makespan = _makespan,
+                .makespan_links = links,
+                .makespan_bound_reached =
+                    [stats = _stats](Integer bound) {
+                        if (stats && bound > stats->certified_makespan_bound)
+                            stats->certified_makespan_bound = bound;
+                    },
+                .makespan_mutation = std::holds_alternative<inferred_cumulative_mutation::ClaimHigherMakespanBound>(_mutation)
+                    ? makespan_energy::MakespanEnergyMutation{makespan_energy::makespan_energy_mutation::ClaimHigherBound{}}
+                    : makespan_energy::MakespanEnergyMutation{makespan_energy::makespan_energy_mutation::None{}},
                 .rules = _rules};
 
             if (! install_derived_cumulative(propagators, state, logger, move(spec))) {
@@ -655,5 +685,7 @@ auto InferredCumulative::clone() const -> unique_ptr<Presolver>
     result->with_lifting_call_budget(_max_lifting_calls);
     result->with_rules(_rules);
     result->with_proof_mutation(_mutation);
+    if (_makespan)
+        result->with_makespan(*_makespan);
     return result;
 }

--- a/gcs/presolvers/inferred_cumulative/inferred_cumulative.hh
+++ b/gcs/presolvers/inferred_cumulative/inferred_cumulative.hh
@@ -7,6 +7,7 @@
 
 #include <cstddef>
 #include <memory>
+#include <optional>
 #include <variant>
 
 namespace gcs
@@ -50,10 +51,19 @@ namespace gcs
         struct ClaimTighterRow
         {
         };
+
+        /// Claim a makespan one larger than a posted cut's energy supports.
+        /// The same discipline again, against the other thing a cut is used
+        /// for: `L` is the number this whole exercise reports, so a derivation
+        /// with slack in it would report it while proving something weaker.
+        struct ClaimHigherMakespanBound
+        {
+        };
     }
 
     using InferredCumulativeMutation = std::variant<inferred_cumulative_mutation::None, inferred_cumulative_mutation::ClaimTighterCapacity,
-        inferred_cumulative_mutation::ClaimTallerTask, inferred_cumulative_mutation::ClaimTighterRow>;
+        inferred_cumulative_mutation::ClaimTallerTask, inferred_cumulative_mutation::ClaimTighterRow,
+        inferred_cumulative_mutation::ClaimHigherMakespanBound>;
 
     /**
      * \brief What the inferred-Cumulative presolver did, filled in when it runs.
@@ -140,6 +150,23 @@ namespace gcs
         Integer largest_capacity_bound{0};
 
         /**
+         * \brief The largest makespan bound actually *derived*, over the posted
+         * cuts, when a makespan variable was given.
+         *
+         * The certified counterpart of \ref largest_capacity_bound, and the one
+         * that comes with a `.pbp`. It is usually the same number, and can be
+         * larger: `L` assumes the tasks may start at time zero, while the
+         * derivation argues over the window the tasks' earliest starts actually
+         * leave them, and every time point before that window is a unit the
+         * resource never had to supply. It can also be smaller, when a task the
+         * window-energy lemma cannot speak about carries some of the energy `L`
+         * counted.
+         *
+         * Zero when no makespan was given, or when nothing was posted.
+         */
+        Integer certified_makespan_bound{0};
+
+        /**
          * \name Why a candidate or a donor was passed over.
          */
         ///@{
@@ -204,6 +231,7 @@ namespace gcs
         std::size_t _max_lifting_calls;
         CumulativeRules _rules;
         InferredCumulativeMutation _mutation;
+        std::optional<IntegerVariableID> _makespan;
 
     public:
         explicit InferredCumulative(std::shared_ptr<InferredCumulativeStats> stats = nullptr);
@@ -247,6 +275,25 @@ namespace gcs
          * time-tabling verdict the donor's own row did not already reach.
          */
         auto with_rules(CumulativeRules rules) -> InferredCumulative &;
+
+        /**
+         * \brief Name the makespan, so that each posted cut also derives a
+         * lower bound on it.
+         *
+         * A cut says its tasks cannot occupy more than `pi_0` of the resource
+         * at once, and between them they need `sum_i d_i pi_i`, so no schedule
+         * can be shorter than the ratio --- Sidorov's `L`, which
+         * \ref InferredCumulativeStats::largest_capacity_bound reports and
+         * which nothing in the proof otherwise says. With a makespan given, the
+         * argument is made in the proof and the bound is inferred, so the
+         * search starts from it and a `.pbp` contains it.
+         *
+         * The model must entail `start + length <= makespan` for every task of
+         * every donor, which is what a scheduling model's makespan is for. That
+         * is a promise, not something checkable from here; break it and VeriPB
+         * refuses the derivation.
+         */
+        auto with_makespan(IntegerVariableID makespan) -> InferredCumulative &;
 
         /// Corrupt the certificate. For tests only, which assert that VeriPB
         /// rejects the result; see InferredCumulativeMutation.

--- a/gcs/presolvers/inferred_cumulative/inferred_cumulative_test.cc
+++ b/gcs/presolvers/inferred_cumulative/inferred_cumulative_test.cc
@@ -34,6 +34,7 @@
 
 #include <gcs/constraints/cumulative.hh>
 #include <gcs/constraints/innards/constraints_test_utils.hh>
+#include <gcs/constraints/linear.hh>
 #include <gcs/presolvers/inferred_cumulative.hh>
 #include <gcs/presolvers/inferred_disjunctive.hh>
 #include <gcs/problem.hh>
@@ -153,6 +154,12 @@ namespace
         InferredCumulativeMutation mutation = inferred_cumulative_mutation::None{};
         shared_ptr<InferredCumulativeStats> stats = nullptr;
         shared_ptr<InferredDisjunctiveStats> disjunctive_stats = nullptr;
+
+        /// Add a makespan variable, the `start_i + length_i <= makespan` rows
+        /// that make it one, and minimise it --- so that the cut's capacity
+        /// bound is not only reported but derived, and the search starts from
+        /// it.
+        bool minimise_makespan = false;
     };
 
     auto post(Problem & p, const Instance & instance, const Setup & setup) -> vector<IntegerVariableID>
@@ -160,6 +167,14 @@ namespace
         vector<IntegerVariableID> starts;
         for (std::size_t i = 0; i < instance.demands.size(); ++i)
             starts.push_back(p.create_integer_variable(0_i, Integer{instance.latest(i)}, "s" + to_string(i)));
+
+        optional<IntegerVariableID> makespan;
+        if (setup.minimise_makespan) {
+            makespan = p.create_integer_variable(0_i, Integer{instance.horizon}, "makespan");
+            for (std::size_t i = 0; i < starts.size(); ++i)
+                p.post(LinearGreaterThanEqual{WeightedSum{} + 1_i * *makespan + -1_i * starts[i], instance.lengths[i]});
+            p.minimise(*makespan);
+        }
 
         p.post(Cumulative{starts, instance.lengths, instance.demands, instance.capacity}.with_rules(setup.rules));
 
@@ -177,6 +192,8 @@ namespace
             presolver.with_budgets(setup.max_covers, setup.max_posted).with_proof_mutation(setup.mutation);
             if (setup.inferred_rules)
                 presolver.with_rules(*setup.inferred_rules);
+            if (makespan)
+                presolver.with_makespan(*makespan);
             p.add_presolver(presolver);
         } break;
         }
@@ -188,6 +205,8 @@ namespace
         set<vector<int>> solutions;
         unsigned long long recursions = 0;
         bool refuted_at_root = false;
+        /// The best objective reported, when the setup minimises a makespan.
+        optional<Integer> best_makespan;
     };
 
     auto solve_instance(const Instance & instance, const Setup & setup, const optional<string> & proof_name, bool verify = true) -> Outcome
@@ -204,6 +223,12 @@ namespace
                                for (const auto & v : starts)
                                    solution.push_back(s(v).raw_value);
                                outcome.solutions.insert(move(solution));
+                               if (setup.minimise_makespan) {
+                                   Integer end = 0_i;
+                                   for (std::size_t i = 0; i < starts.size(); ++i)
+                                       end = std::max(end, s(starts[i]) + instance.lengths[i]);
+                                   outcome.best_makespan = end;
+                               }
                                return true;
                            },
                 .trace = [&](const CurrentState &) -> bool {
@@ -318,6 +343,45 @@ auto main(int argc, char * argv[]) -> int
         if (disjunctive_only.refuted_at_root)
             fail("differential pair: the capacity-one stage refuted at the root, so it did not need this one");
         println(cerr, "differential pair: capacity-one inference finds no clique and does not refute");
+    }
+
+    // The bound in the proof rather than only in the stats. With the makespan
+    // named, the presolver derives its `L` instead of reporting it, the search
+    // starts from it, and the branch-and-bound proof closes against a lower
+    // bound VeriPB has checked.
+    //
+    // Eleven against an optimum of thirteen, which is the shape of the whole
+    // exercise: `L` is a relaxation bound and is not expected to be tight. What
+    // *is* asserted is the validation the artefact runs --- a bound above a
+    // feasible makespan would be a bug, and this fixture knows its optimum. The
+    // margin-of-one fixture that says the arithmetic is tight, and the
+    // mutations that say so by being refused, are in
+    // derived_cumulative_test.cc.
+    {
+        auto stats = make_shared<InferredCumulativeStats>();
+        auto certified = solve_instance(
+            lifted_instance(13), Setup{.stats = stats, .minimise_makespan = true}, proofs ? make_optional("inferred_cumulative_makespan") : nullopt);
+
+        if (stats->largest_capacity_bound != 11_i)
+            fail("certified bound: reported an L of " + to_string(stats->largest_capacity_bound.raw_value) + ", not eleven");
+        if (stats->certified_makespan_bound != 11_i)
+            fail("certified bound: derived a makespan bound of " + to_string(stats->certified_makespan_bound.raw_value) +
+                ", not the eleven the cut's capacity bound carries");
+        if (certified.best_makespan != make_optional(13_i))
+            fail("certified bound: the optimum is " +
+                (certified.best_makespan ? to_string(certified.best_makespan->raw_value) : string{"unreachable"}) + ", not the thirteen expected");
+        if (*certified.best_makespan < stats->certified_makespan_bound)
+            fail("certified bound: derived a bound above a schedule that exists");
+
+        // The same number with proofs off, or the solver is doing different
+        // arithmetic depending on whether anyone is watching.
+        auto unproved_stats = make_shared<InferredCumulativeStats>();
+        solve_instance(lifted_instance(13), Setup{.stats = unproved_stats, .minimise_makespan = true}, nullopt);
+        if (unproved_stats->certified_makespan_bound != stats->certified_makespan_bound)
+            fail("certified bound: the bound differs with proofs off");
+
+        println(cerr, "certified makespan bound: derived {}, optimum {}, over {} nodes", stats->certified_makespan_bound.raw_value,
+            certified.best_makespan->raw_value, certified.recursions);
     }
 
     // Twelve time points, where the tasks fit: the big one alone, then two of

--- a/gcs/presolvers/inferred_disjunctive/inferred_disjunctive.cc
+++ b/gcs/presolvers/inferred_disjunctive/inferred_disjunctive.cc
@@ -12,6 +12,7 @@
 #include <gcs/innards/proofs/pseudo_boolean.hh>
 #include <gcs/innards/state.hh>
 #include <gcs/presolvers/inferred_disjunctive/inferred_disjunctive.hh>
+#include <gcs/presolvers/innards/makespan_links.hh>
 #include <gcs/problem.hh>
 
 #include <algorithm>
@@ -110,6 +111,12 @@ InferredDisjunctive::InferredDisjunctive(shared_ptr<InferredDisjunctiveStats> st
 {
 }
 
+auto InferredDisjunctive::with_makespan(IntegerVariableID makespan) -> InferredDisjunctive &
+{
+    _makespan = makespan;
+    return *this;
+}
+
 auto InferredDisjunctive::with_proof_mutation(InferredDisjunctiveMutation mutation) -> InferredDisjunctive &
 {
     _mutation = mutation;
@@ -141,6 +148,13 @@ auto InferredDisjunctive::run(Problem & problem, Propagators & propagators, Stat
         if (_stats)
             (*_stats).*field += by;
     };
+
+    // What the model says about the makespan, if the caller named one: the rows
+    // saying each task finishes by it, which are what a bound on it is derived
+    // from. Looked up once rather than per clique.
+    map<IntegerVariableID, makespan_energy::MakespanLink> makespan_links;
+    if (_makespan)
+        makespan_links = find_makespan_links(problem, logger, *_makespan);
 
     auto claim_rhs_zero = std::holds_alternative<inferred_disjunctive_mutation::ClaimRhsZero>(_mutation);
     auto bridge_wrong_task = std::holds_alternative<inferred_disjunctive_mutation::BridgeWrongTask>(_mutation);
@@ -411,9 +425,12 @@ auto InferredDisjunctive::run(Problem & problem, Propagators & propagators, Stat
         // Each member's flags come from its first appearance; the certificate
         // bridges a pair's witness across to those where they differ.
         vector<DerivedCumulativeTask> derived_tasks;
+        vector<optional<makespan_energy::MakespanLink>> links;
         set<ConstraintID> row_donors;
         for (auto i : clique) {
             const auto & home = tasks[i].appearances.front();
+            auto link = makespan_links.find(tasks[i].start);
+            links.push_back(link == makespan_links.end() ? std::nullopt : optional<makespan_energy::MakespanLink>{link->second});
             derived_tasks.push_back(DerivedCumulativeTask{home.donor, home.position, tasks[i].start, tasks[i].length, 1_i});
         }
         for (size_t a = 0; a < clique.size(); ++a)
@@ -555,6 +572,16 @@ auto InferredDisjunctive::run(Problem & problem, Propagators & propagators, Stat
                     claim_rhs_zero ? Am1FromPairsMutation{am1_from_pairs_mutation::ClaimOneMore{}}
                                    : Am1FromPairsMutation{am1_from_pairs_mutation::None{}});
             },
+            .makespan = _makespan,
+            .makespan_links = links,
+            .makespan_bound_reached =
+                [stats = _stats](Integer bound) {
+                    if (stats && bound > stats->certified_makespan_bound)
+                        stats->certified_makespan_bound = bound;
+                },
+            .makespan_mutation = std::holds_alternative<inferred_disjunctive_mutation::ClaimHigherMakespanBound>(_mutation)
+                ? makespan_energy::MakespanEnergyMutation{makespan_energy::makespan_energy_mutation::ClaimHigherBound{}}
+                : makespan_energy::MakespanEnergyMutation{makespan_energy::makespan_energy_mutation::None{}},
             .rules = _rules};
 
         if (! install_derived_cumulative(propagators, state, logger, move(spec))) {
@@ -591,5 +618,7 @@ auto InferredDisjunctive::clone() const -> unique_ptr<Presolver>
     result->with_minimum_clique_size(_min_clique_size);
     result->with_rules(_rules);
     result->with_proof_mutation(_mutation);
+    if (_makespan)
+        result->with_makespan(*_makespan);
     return result;
 }

--- a/gcs/presolvers/inferred_disjunctive/inferred_disjunctive.hh
+++ b/gcs/presolvers/inferred_disjunctive/inferred_disjunctive.hh
@@ -7,6 +7,7 @@
 
 #include <cstddef>
 #include <memory>
+#include <optional>
 #include <variant>
 
 namespace gcs
@@ -50,10 +51,19 @@ namespace gcs
         struct IncludeNonConflicting
         {
         };
+
+        /// Claim a makespan one larger than a posted clique's energy supports.
+        /// The same discipline again, against the other thing a clique is used
+        /// for: `L` is the number this whole exercise reports, so a derivation
+        /// with slack in it would report it while proving something weaker.
+        struct ClaimHigherMakespanBound
+        {
+        };
     }
 
-    using InferredDisjunctiveMutation = std::variant<inferred_disjunctive_mutation::None, inferred_disjunctive_mutation::ClaimRhsZero,
-        inferred_disjunctive_mutation::BridgeWrongTask, inferred_disjunctive_mutation::IncludeNonConflicting>;
+    using InferredDisjunctiveMutation =
+        std::variant<inferred_disjunctive_mutation::None, inferred_disjunctive_mutation::ClaimRhsZero, inferred_disjunctive_mutation::BridgeWrongTask,
+            inferred_disjunctive_mutation::IncludeNonConflicting, inferred_disjunctive_mutation::ClaimHigherMakespanBound>;
     /**
      * \brief What the inferred-Disjunctive presolver did, filled in when it
      * runs.
@@ -111,6 +121,20 @@ namespace gcs
          * Zero when nothing was posted.
          */
         Integer largest_capacity_bound{0};
+
+        /**
+         * \brief The largest makespan bound actually *derived*, over the posted
+         * cliques, when a makespan variable was given.
+         *
+         * The certified counterpart of \ref largest_capacity_bound, and the one
+         * that comes with a `.pbp`. It is usually the same number, and can be
+         * larger: `L` assumes the tasks may start at time zero, while the
+         * derivation argues over the window their earliest starts actually
+         * leave them.
+         *
+         * Zero when no makespan was given, or when nothing was posted.
+         */
+        Integer certified_makespan_bound{0};
 
         /// Flag bridges emitted, one per (task, time) that had to be carried
         /// from a witnessing resource to the one holding the task's flags.
@@ -173,6 +197,7 @@ namespace gcs
         std::size_t _min_clique_size;
         CumulativeRules _rules;
         InferredDisjunctiveMutation _mutation;
+        std::optional<IntegerVariableID> _makespan;
 
     public:
         explicit InferredDisjunctive(std::shared_ptr<InferredDisjunctiveStats> stats = nullptr);
@@ -207,6 +232,22 @@ namespace gcs
          * redundancy has to turn time-tabling back on.
          */
         auto with_rules(CumulativeRules rules) -> InferredDisjunctive &;
+
+        /**
+         * \brief Name the makespan, so that each posted clique also derives a
+         * lower bound on it.
+         *
+         * A clique's tasks run one after another, so the schedule cannot finish
+         * before their durations summed --- which is what
+         * \ref InferredDisjunctiveStats::largest_capacity_bound reports and what
+         * nothing in the proof otherwise says. With a makespan given, the
+         * argument is made in the proof and the bound is inferred.
+         *
+         * The model must entail `start + length <= makespan` for every task of
+         * every donor. That is a promise, not something checkable from here;
+         * break it and VeriPB refuses the derivation.
+         */
+        auto with_makespan(IntegerVariableID makespan) -> InferredDisjunctive &;
 
         /// Corrupt one step of the assembled certificate. For tests only, which
         /// assert that VeriPB rejects the result; see

--- a/gcs/presolvers/inferred_disjunctive/inferred_disjunctive_test.cc
+++ b/gcs/presolvers/inferred_disjunctive/inferred_disjunctive_test.cc
@@ -16,6 +16,7 @@
 
 #include <gcs/constraints/cumulative.hh>
 #include <gcs/constraints/innards/constraints_test_utils.hh>
+#include <gcs/constraints/linear.hh>
 #include <gcs/presolvers/inferred_disjunctive.hh>
 #include <gcs/problem.hh>
 #include <gcs/solve.hh>
@@ -79,6 +80,11 @@ namespace
         std::size_t max_candidates = 100, max_posted = 5;
         InferredDisjunctiveMutation mutation = inferred_disjunctive_mutation::None{};
         shared_ptr<InferredDisjunctiveStats> stats = nullptr;
+
+        /// Add a makespan variable, the `start_i + length <= makespan` rows
+        /// that make it one, and minimise it --- so that a posted clique's
+        /// total duration is not only reported but derived.
+        bool minimise_makespan = false;
     };
 
     /* k tasks of length p, and k resources of capacity one. Resource r carries
@@ -108,11 +114,21 @@ namespace
             p.post(Cumulative{starts, lengths, heights, 1_i}.with_rules(setup.rules));
         }
 
+        optional<IntegerVariableID> makespan;
+        if (setup.minimise_makespan) {
+            makespan = p.create_integer_variable(0_i, Integer{horizon}, "makespan");
+            for (const auto & start : starts)
+                p.post(LinearGreaterThanEqual{WeightedSum{} + 1_i * *makespan + -1_i * start, Integer{length}});
+            p.minimise(*makespan);
+        }
+
         if (setup.presolve) {
             auto presolver = InferredDisjunctive{setup.stats};
             presolver.with_budgets(setup.max_candidates, setup.max_posted).with_minimum_clique_size(setup.min_clique_size);
             if (setup.inferred_rules)
                 presolver.with_rules(*setup.inferred_rules);
+            if (makespan)
+                presolver.with_makespan(*makespan);
             p.add_presolver(presolver);
         }
         return starts;
@@ -242,6 +258,31 @@ auto main(int argc, char * argv[]) -> int
 
         println(cerr, "cross-resource clique: refuted at the root against {} nodes without it, {} bridges", donors_only.recursions,
             stats->bridges_derived);
+    }
+
+    // The same six, derived rather than reported. With a makespan named, the
+    // clique's total duration is pushed onto it at the root with a certificate,
+    // and it is exactly the optimum here --- three length-two tasks that must
+    // serialise finish at six and no sooner.
+    {
+        auto stats = make_shared<InferredDisjunctiveStats>();
+        auto certified = solve_family(
+            3, 2, 8, Setup{.stats = stats, .minimise_makespan = true}, proofs ? make_optional("inferred_disjunctive_makespan") : nullopt);
+
+        if (stats->largest_capacity_bound != 6_i)
+            fail("certified bound: reported an L of " + to_string(stats->largest_capacity_bound.raw_value) + ", not six");
+        if (stats->certified_makespan_bound != 6_i)
+            fail("certified bound: derived a makespan bound of " + to_string(stats->certified_makespan_bound.raw_value) +
+                ", not the six the clique carries");
+
+        // The same number with proofs off, or the solver is doing different
+        // arithmetic depending on whether anyone is watching.
+        auto unproved_stats = make_shared<InferredDisjunctiveStats>();
+        solve_family(3, 2, 8, Setup{.stats = unproved_stats, .minimise_makespan = true}, nullopt);
+        if (unproved_stats->certified_makespan_bound != stats->certified_makespan_bound)
+            fail("certified bound: the bound differs with proofs off");
+
+        println(cerr, "certified makespan bound: derived {} over {} nodes", stats->certified_makespan_bound.raw_value, certified.recursions);
     }
 
     // The sharp twin: one more unit of horizon and the three tasks fit exactly.

--- a/gcs/presolvers/innards/makespan_links.cc
+++ b/gcs/presolvers/innards/makespan_links.cc
@@ -1,0 +1,66 @@
+#include <gcs/constraints/linear.hh>
+#include <gcs/presolvers/innards/makespan_links.hh>
+#include <gcs/problem.hh>
+
+#include <optional>
+#include <variant>
+
+using namespace gcs;
+using namespace gcs::innards;
+
+using std::map;
+using std::optional;
+
+auto gcs::innards::find_makespan_links(const Problem & problem, const ProofLogger * const logger, IntegerVariableID makespan)
+    -> map<IntegerVariableID, makespan_energy::MakespanLink>
+{
+    map<IntegerVariableID, makespan_energy::MakespanLink> links;
+
+    for (const auto & [c, label] : problem.each_constraint_of_type_with_proof_data<ReifiedLinearInequality>(logger)) {
+        // A conditional row says nothing unless its condition holds, and its
+        // condition is not in the reason an energy argument gives.
+        if (! std::holds_alternative<reif::MustHold>(c.reification_condition()))
+            continue;
+
+        // The row is stored as `sum <= value`, so `makespan - start >= bound`
+        // arrives as `start - makespan <= -bound`.
+        const auto & terms = c.coefficients_and_variables().terms;
+        if (2 != terms.size())
+            continue;
+
+        optional<IntegerVariableID> start, limit;
+        for (const auto & t : terms) {
+            if (1_i == t.coefficient && ! start)
+                start = t.variable;
+            else if (-1_i == t.coefficient && ! limit)
+                limit = t.variable;
+        }
+        // Aliasing says `0 >= bound`, which is a fact about the model and not
+        // about any task.
+        if (! start || ! limit || *limit != makespan || *start == makespan)
+            continue;
+
+        // A plain variable on the task's side: the `pol` cancels this row's
+        // bits against the start's own order-literal definitions, and a view's
+        // are not those.
+        if (! std::holds_alternative<SimpleIntegerVariableID>(*start))
+            continue;
+
+        auto bound = -c.value();
+        if (bound <= 0_i)
+            continue;
+
+        // With proofs on, a row nothing can cite is a row this cannot use: the
+        // derivation would name a label the `.opb` does not contain.
+        if (logger && ! label)
+            continue;
+
+        auto existing = links.find(*start);
+        if (existing == links.end())
+            links.emplace(*start, makespan_energy::MakespanLink{bound, label});
+        else if (bound > existing->second.bound)
+            existing->second = makespan_energy::MakespanLink{bound, label};
+    }
+
+    return links;
+}

--- a/gcs/presolvers/innards/makespan_links.hh
+++ b/gcs/presolvers/innards/makespan_links.hh
@@ -1,0 +1,48 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_PRESOLVERS_INNARDS_MAKESPAN_LINKS_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_PRESOLVERS_INNARDS_MAKESPAN_LINKS_HH
+
+#include <gcs/constraints/innards/makespan_energy.hh>
+#include <gcs/innards/proofs/proof_logger-fwd.hh>
+#include <gcs/problem-fwd.hh>
+#include <gcs/variable_id.hh>
+
+#include <map>
+#include <optional>
+
+namespace gcs::innards
+{
+    /**
+     * \brief Find, for each start variable the model says must finish by
+     * `makespan`, the posted row that says so.
+     *
+     * A makespan is not a kind of variable, it is a variable a model has put
+     * rows around: `makespan - start >= length` for every task. Those rows are
+     * what confine the tasks to a window once the makespan is bounded, so an
+     * energy argument about the makespan is a `pol` over them and cannot be had
+     * without them --- reverse unit propagation will not cross from one
+     * variable's bits to another's through a linear row, whatever the bounds
+     * say.
+     *
+     * So this looks for them rather than taking them on trust: a caller naming
+     * a variable that is not a makespan gets a task with no link, which costs
+     * that task's energy, instead of a rejected proof.
+     *
+     * Only the linear family, and only its two-term unconditional rows over
+     * plain variables with coefficients `+1` and `-1` --- which is what a
+     * scheduling model's makespan rows are, and what MiniZinc's `int_lin_le`
+     * flattens them to. A comparison spelling (`start + length <= makespan`)
+     * says the same thing over an offset view, whose bits would not cancel
+     * against the plain variable's in the `pol`, so it is not matched here.
+     *
+     * The strongest row wins where a variable has several. With proofs off the
+     * links are still found --- which is the point, since the bound they let
+     * through has to be the same number either way --- and only
+     * MakespanLink::row is left empty.
+     *
+     * \ingroup Innards
+     */
+    [[nodiscard]] auto find_makespan_links(const Problem &, const ProofLogger * const, IntegerVariableID makespan)
+        -> std::map<IntegerVariableID, makespan_energy::MakespanLink>;
+}
+
+#endif


### PR DESCRIPTION
Seventh of the [#541](https://github.com/ciaranm/glasgow-constraint-solver/issues/541) stack, on top of #671. Closes #672, which is the headline deliverable of #549.

**#549 itself stays open**: its title also covers multi-resource lifting, split out as #673.

**Note the base moved.** The stack is now rebased onto `main`, because this needs #658 — the bound is inferred from an initialiser a presolver installs, and before #658 such an initialiser was silently never run. Every branch has a `<name>-pre-main-rebase` tag; `main`'s twelve commits touch `propagators`, `solve`, the difference-logic family and the git hook, none of which this stack touches, so nothing moved but the base.

## What was missing

A `Cumulative`'s tasks need `sum d_i h_i` units of a resource supplying `h_0` per time step, so no schedule can finish before their ratio. That is Sidorov's `L`, and #663 and #671 report it as `largest_capacity_bound` — but they *compute* it. What a proof contained was the constraint's per-time rows and whatever its propagator said at the nodes the search reached; the ratio argument appeared nowhere.

That is the gap between "we can report `L`" and "we can hand you a `.pbp` for it".

## The argument

Suppose the makespan is at most `mu`. Then every task is confined to one window; the window-energy lemma from #655 gives each its whole duration inside it; and summing those weighted by the heights, against the capacity rows summed over the same window, cancels every activity term and leaves nothing but negative coefficients against a positive right-hand side. One `pol`, and the wrapping RUP concludes `M >= mu + 1`.

`makespan_energy_bound` walks the candidate `mu` and returns the largest one refuted; `derive_makespan_bound` emits the argument for it. It fires once, from an initialiser, so the search starts from the bound and the proof contains it.

### It is not always `L`

**It can be larger.** `L` divides by `mu`, assuming the tasks may start at time zero. The derivation divides by the number of time points it has a capacity row for, which starts at the earliest time any task can be running — so a set of tasks the precedences keep away from the origin gets a better bound.

**It can be smaller,** or absent: the lemma speaks only about tasks with a constant length and height and a plain-variable start, and a task it cannot speak about carries none of the energy `L` counted.

## The deadline is a `pol`, not a RUP

The step that makes this an argument about the makespan rather than about the tasks' own domains is `start_i <= mu - d_i`. It follows from the model's `makespan - start_i >= d_i` and the negated conclusion, and it is **not** reverse unit propagation: a checker will not carry a bound from one variable's bits to another's across a linear row. This cost a rejected proof to rediscover, which is the third time this family has walked into it.

Adding the model's row to the two order literals' own definitions cancels both variables' bits exactly and saturates to the clause `~[s >= v] \/ [M >= mu+1]`; the lemma's own RUPs then resolve against it one order literal at a time, which works because that reasoning stays inside a single variable.

So **a makespan is not a kind of variable, it is a variable a model has put rows around**. `find_makespan_links` goes looking for them rather than taking a promise, so naming something that is not a makespan gives a weaker bound instead of a rejected proof — and `--variant=global`, whose whole temporal network is one propagator, simply has no rows to cite.

## Mutations, and the two that cannot bite

Three VeriPB refuses, over a fixture whose energy beats its supply by exactly one:

- **`ClaimHigherBound`**, the signature test. Two shapes, because neither works everywhere: where a wider window has another capacity row in it the argument moves there and comes up a unit short; where it does not, the honest window keeps its contradiction and only the conclusion moves, leaving the wrapping RUP one order literal short of firing.
- **`OmitCapacityRow`**: the omitted row's activity terms have nothing to cancel against and survive *positively*, so the line reached is not a contradiction.
- **`ForgetTheDeadline`**: derive the window energy without the negated conclusion in its context.

Two that were tried and dropped, both worth writing down:

- **Shrinking a task's window cannot be caught.** Its leftovers survive *negatively*, so the line stays contradictory and VeriPB rightly accepts a derivation that is merely longer than it needed to be. Only corruptions that make the sum come up short can be refused.
- **The `+1` is only a test where the bound is tight.** Anywhere else "the makespan is at least one more" is *true*, and a checker that finds a way to agree has found nothing wrong. That is not a defect in the mutation — a corruption you cannot distinguish from the truth is not a corruption — so the discipline lives on the margin-of-one fixture, and the artefact requires a refusal only on the instances the bound closes.

## The RCPSP artefact

`examples/rcpsp` gains `--infer-cumulative`, which is new: #671's cuts had never been run on a real instance. Plus `--infer-makespan-bound` and `--mutate-makespan-bound`.

The certificate for a bound `B` is the decision variant at `B - 1`: the bound refutes it at the root, so the proof is the bound's certificate and nothing else.

**110 instances, 227 (instance, stage) runs, no failures.** 92 instances get a certified bound, every one of them beating the critical path, and **29 are closed** — the bound equals the best makespan anybody in Sidorov's runs found, so no search is needed at all. §5.1 of the paper claims "no less than twelve".

| | |
|---|---|
| instances with a certified bound | 92 / 110 |
| of those, closed (bound == best known) | 29 |
| largest certified bound | 3050 |
| `.pbp`, median / largest | 28 MB / 504 MB |
| `veripb`, largest / total | 45 s / 16 min |
| runs whose `+1` was refused | 176 of 182 |

The six that were not refused are all far below the optimum, where "one more" is true; none is on an instance the bound closes, which is where `table.py` requires a refusal.

Coverage: the Pack collection is complete in all three stages, and Pack_d in the capacity-one stage. Pack_d's lifted stages produce 0.5–1.5 GB proofs — dominated by the derived constraints' per-time rows over four-figure horizons, which is #671's cost and #676's follow-up, not this derivation's — and are still running; the kit is resumable.

Twenty-three instances fall short of **Sidorov's** `L`. On every one of them this presolver's *own* `L` is what falls short and the derivation reaches it exactly, so that is an inference gap and not a certification one: his lifting subproblem spans every resource and #671's is single-resource. It is #673, and this is the first measurement of what it costs.

The kit is in `~/claude/tmp/rcpsp-bounds-672/`. Per instance and stage it surveys what the presolvers derive, checks the same deadline does *not* close at the root with the bound switched off, certifies the bound as a root refutation of `bound - 1`, and records what the `+1` did.
