### PR TITLE
Lift cover inequalities over every resource (#673)

### DIFF
--- a/dev_docs/certified-makespan-bounds.md
+++ b/dev_docs/certified-makespan-bounds.md
@@ -180,12 +180,19 @@ equals the best makespan anybody found, so no search is needed at all. The
 paper's §5.1 claims "no less than twelve". The largest is 3050; the median
 `.pbp` is 28 MB and the largest 504 MB, and `veripb` takes 45 s on that one.
 
-Twenty-three instances fall short of Sidorov's `L`, and on every one of them it
-is this presolver's *own* `L` that falls short while the derivation reaches it
-exactly. That is an inference gap and not a certification one — his lifting
-subproblem spans every resource and
-[`InferredCumulative`](inferred-cumulative.md)'s is single-resource — which
-makes it a measurement of what #673 costs.
+Some instances fall short of Sidorov's `L`, and on every one of them it is this
+presolver's *own* `L` that falls short while the derivation reaches it exactly:
+an inference gap and not a certification one. Most of the apparent gap is not
+even that — five of the largest shortfalls are Pack_d instances whose lifted
+stages were never run, and are compute rather than code. What is left, once the
+lifting stage has actually run, is a handful of instances short by two to four,
+and it was the measurement that motivated lifting over every resource rather
+than one, which the presolver now does; four of those instances have an `L` equal
+to their best known makespan, so closing the gap closes them.
+
+**These numbers predate that change and have not been rerun.** They are the
+single-resource lifting's, and the artefact's `run.bash` is what regenerates
+them.
 
 Note the makespan rows have to be there to be cited: `--variant=global` puts the
 whole temporal network into one `DifferenceConstraints` propagator, so there is

--- a/dev_docs/cumulative-proof-logging.md
+++ b/dev_docs/cumulative-proof-logging.md
@@ -602,8 +602,19 @@ window-energy bridges get away with `name_of` only because `Cumulative`'s flags
 are values-named. And a negated flag has no halves of its own, so bridging one
 is refused rather than silently naming the positive flag's rows.
 
-Proof size is the thing to watch: the bridges are O(tasks × times) Top lines per
-extra donor, and at `Top` none of them ever dies.
+`recover_bridged_row` composes the bridges with the row itself, which is what
+[#549's lifted cover cuts](inferred-cumulative.md) need: weaken a donor's row
+down to the members of a cut, add each member's bridge as many times as its
+coefficient, and the same inequality comes back over another donor's flags. The
+result is pinned, since a bridge pointing the wrong way is otherwise a mistake
+that only shows up thousands of lines later.
+
+Proof size is the thing to watch: the bridges are O(tasks × times) lines per
+extra donor. #548's are emitted at `Top`, where none of them ever dies, which is
+[#666](https://github.com/ciaranm/glasgow-constraint-solver/issues/666). A recipe
+that raises the level around its own working before bridging does not have that
+problem --- `InferredCumulative`'s does, and only the row it hands back
+survives.
 ## Optional tasks (issue #543)
 
 The optional-task constructor gives each task a `{0, 1}` presence

--- a/dev_docs/inferred-cumulative.md
+++ b/dev_docs/inferred-cumulative.md
@@ -49,8 +49,9 @@ set of constraints from the paper's.
 As with [capacity strengthening](cumulative-strengthening.md) and the
 [capacity-one stage](inferred-disjunctive.md), the inference cannot change a
 time-table verdict — and here the argument is a one-liner. A cut is *valid*:
-every 0/1 point the donor's row allows satisfies it. So no set of tasks that
-fits under the donor at one time point fails under the cut at that time point,
+every 0/1 point the rows it is lifted from allow satisfies it. So no set of tasks
+that fits under those resources at one time point fails under the cut at that
+time point,
 and time-tabling, which only ever reasons about one time point, can reach nothing
 new. It therefore ships with **time-tabling off**, and the test asserts
 node-for-node equality with it turned back on.
@@ -87,14 +88,27 @@ Budgets are the paper's: `N_cover`, `N_out`, and `N_calls` against the lifting
 subproblems, which are the bottleneck. The defaults here are what its
 experiments used — 100, 5 and 2·10⁴, with the capacity cap effectively off.
 
-### Where this deliberately differs
+### Every resource at once
 
-**The lifting subproblem is one resource, not all of them.** The paper's
-Equation 4 constrains over every resource at once, which is what makes its
-lifting cross-resource. Ours is a single donor row, because that is what the
-certificate can reach. This is a restriction on *what is inferred*, not only on
-what is proved, and it is
-[#673](https://github.com/ciaranm/glasgow-constraint-solver/issues/673).
+**The lifting subproblem is Equation 4's**, constrained by every posted
+resource's row rather than by the donor's alone. That is what makes the lifting
+cross-resource, and it matters because more constraints on the subproblem mean a
+*smaller* answer, and so a *larger* coefficient: the task being lifted excludes
+more, and the inequality says more.
+
+A cover still belongs to one resource --- Algorithm 1 enumerates them per row,
+and a set that fits under every resource is nobody's cover --- but the cut lifted
+from it need not be a consequence of that row, or of any single row. The
+[two-resource fixture](../gcs/presolvers/inferred_cumulative/inferred_cumulative_test.cc)
+is the smallest case: the cover belongs to the second resource, the coefficient
+comes from the first, and neither row on its own implies the result.
+
+So the presolver runs **once over the whole problem** rather than once per
+posted constraint, which is what the reference implementation's single demand
+matrix does, and the budgets follow: the cover budget applies to each resource's
+short families and then again across all of them, and the subproblem budget, the
+visited-cover rule and the output limit are one each rather than one per
+resource.
 
 **Two places where the paper and its implementation disagree**, both resolved in
 favour of the code, which produced the published results:
@@ -129,25 +143,40 @@ emptied the tail.
 ## The certificate
 
 A lifted cover cut is true because a knapsack optimum says so:
-`Σ πᵢ aᵢ ≤ π₀` holds at every 0/1 point the row allows exactly when
-`max { Σ πᵢ xᵢ : Σ cᵢ xᵢ ≤ C }` is at most `π₀`. So rather than deriving that
-conclusion, the proof derives the *computation*, in the states-and-transitions
-shape of Demirović et al. (CP 2024) — and in its **one-sided** form, the one
-their standalone knapsack solver uses, where a state says "at least this much
-weight, at most this much profit" rather than "exactly this much of each".
+`Σ πᵢ aᵢ ≤ π₀` holds at every 0/1 point the rows *jointly* allow exactly when
+`max { Σ πᵢ xᵢ : Σ c_{r,i} xᵢ ≤ C_r for every r }` is at most `π₀`. So rather
+than deriving that conclusion, the proof derives the *computation*, in the
+states-and-transitions shape of Demirović et al. (CP 2024) — and in its
+**one-sided** form, the one their standalone knapsack solver uses, where a state
+says "at least this much weight, at most this much profit" rather than "exactly
+this much of each".
+
+The same programme answers the lifting subproblem, which is not an economy but
+the point: the inference and the certificate ask the same question of the same
+rows, so a cut the procedure produces cannot be one the proof fails to reach.
 
 `validate_lifted_cover_cut` builds the programme and answers the only question
 worth asking of a candidate cut; `derive_lifted_cover_cut` emits it. Layer `i`
-holds the (weight, profit) pairs the first `i` members can reach. A successor
-either leaves the next member out, or takes it and pays its demand — and **a
-successor that would overrun the capacity is not created at all**. That is the
-only use the donor's row gets, and it is exactly what makes the cut a
-consequence of it.
+holds the (weights, profit) tuples the first `i` members can reach, with one
+weight per resource. A successor either leaves the next member out, or takes it
+and pays its demand on every resource — and **a successor that would overrun some
+capacity is not created at all**. That is the only use a row gets, and it is
+exactly what makes the cut a consequence of the rows.
 
-Each state carries three extension variables — `Σ_{j≤i} c_j a_j ≥ w`,
-`Σ_{j≤i} π_j a_j ≤ p`, and their conjunction — and each transition an
-implication, emitted as a `pol` that leaves its clause one unit propagation away
-and then the clause. Each layer then gets an at-least-one saying its states are
+Nothing here scales one row against another or adds them together, which is what
+the sketch in [#673](https://github.com/ciaranm/glasgow-constraint-solver/issues/673)
+assumed a multi-resource certificate would need. Each row is used exactly where
+the single row was used: to say that one transition cannot happen.
+
+Rows that cannot rule anything out — whose members' demands sum to no more than
+the capacity — are dropped before the programme is built, since a weight bound
+against one would be a flag per state saying nothing. Such a row admits every
+subset of the members, so no derivation could have used it.
+
+Each state carries an extension variable per resource for
+`Σ_{j≤i} c_{r,j} a_j ≥ w_r`, one for `Σ_{j≤i} π_j a_j ≤ p`, and one for their
+conjunction — and each transition an implication per half, emitted as a `pol`
+that leaves its clause one unit propagation away and then the clause. Each layer then gets an at-least-one saying its states are
 between them complete, by resolution over the layer before. At the end one more
 flag reifies the cut itself; every final state contradicts it, since a state with
 a profit above `π₀` is precisely what `validate_lifted_cover_cut` refuses; and
@@ -158,29 +187,67 @@ whole of the previous scheme: the `Normalised` model of VeriPB's arithmetic, the
 divisor and copy-count search, the cover enumeration inside the planner, and the
 backward planner the window edges needed.
 
+### Carrying a row onto other flags
+
+Each resource is a separately posted `Cumulative` with its own activity flags, so
+its row speaks a different language from the members' own. `recover_bridged_row`
+([`flag_bridge.hh`](../gcs/innards/proofs/flag_bridge.hh)) translates it: weaken
+the row down to the members, then add `c_j` copies of each member's bridge, which
+puts every flag in with both signs so all of them cancel and the constants leave
+the right-hand side where it was. The bridges are
+`recover_conjunction_flag_bridge`'s, three `pol` per member per row, since
+`active ⇔ before ∧ after` needs its conjuncts crossed first.
+
+The direction is the thing to get right and the types will not tell you: to turn
+`Σ c_j b_j ≤ C` into `Σ c_j a_j ≤ C` the sum has to be able to grow, so each
+`a_j` must imply its `b_j`. Backwards, nothing cancels. The result is pinned, so
+that a bridge pointing the wrong way is refused there rather than several
+thousand lines later, and the `BridgeWrongTask` mutation is the test.
+
+Whichever resource the members' flags already come from needs no crossing at all,
+so a single-resource cut emits none of this and pays nothing for the machinery.
+The crossing is emitted a proof level deeper than the caller's and forgotten on
+the way out, along with the rest of the working: at `Top` there would be three
+`pol` per member per resource per time point and none of them would ever be
+deleted, which is [#666](https://github.com/ciaranm/glasgow-constraint-solver/issues/666)
+all over again.
+
 ### Dominated states, which is what keeps this small
 
-A state taking no more of the resource while allowing no less on the cut says
-everything another one does, so the other can go. What survives runs strictly
-upwards in both coordinates, which means **a layer holds at most one state per
-achievable profit** — and since a state whose profit exceeds `π₀` would be a
-point breaking the cut, no layer can be wider than `π₀ + 1`.
+A state taking no more of *any* resource while allowing no less on the cut says
+everything another one does, so the other can go. What survives is an antichain.
 
-That is the whole reason this is affordable, and it is why the size below does
-not depend on the capacity at all. `π₀` is a cover's size minus one, so it is
-two or three on the constraints the procedure actually infers, where a
-capacity-indexed programme would have been as wide as the resource.
+Over one resource that antichain is a staircase running strictly upwards in both
+coordinates, so **a layer holds at most one state per achievable profit** — and
+since a state whose profit exceeds `π₀` would be a point breaking the cut, no
+layer can be wider than `π₀ + 1`. That is the whole reason this is affordable,
+and it is why the size below does not depend on the capacity at all. `π₀` is a
+cover's size minus one, so it is two or three on the constraints the procedure
+actually infers, where a capacity-indexed programme would have been as wide as
+the resource.
+
+Over several resources the frontier is a Pareto set and there is no such bound to
+lean on: a layer can hold many states of the same profit, differing in which
+resource they have spent. Measured on all 83 lifted constraints Sidorov publishes
+for Pack and Pack-d, switching every resource on takes the widest layer from 4 to
+14 and the largest programme from 111 states to 222 — the same order, not a
+different regime, because lifting drives the coefficients up and so keeps `π₀`
+small whatever the capacities are. But "measured" is not "bounded", so
+`with_programme_state_budget` exists and a cut over it is dropped and counted
+separately from one that does not hold. It is never reached in the test suite,
+and the sweep asserts that.
 
 The dropped states are never named in the proof. A transition landing on one is
 emitted straight into the state that covers it, which is valid for the same
-reason the drop was.
+reason the drop was. With more than one resource a single state can cover *both*
+branches of a transition, which cannot happen over one.
 
 ### Restricting to a time point
 
 A derived `Cumulative` has one height per task and one capacity, so every time
 point's row has to carry the *same* coefficients. At the edges of the window only
-some of the cut's tasks have flags — and only those have terms in the donor's row
-there — so the cut is simply restricted to them, which stays valid because
+some of the cut's tasks have flags — and only those have terms in the rows there —
+so the cut is simply restricted to them, which stays valid because
 setting an absent task's flag to zero is a point the cut already covered.
 
 The programme has to be built again over the members that are present, which is
@@ -206,8 +273,8 @@ asserts a non-zero restriction count so it cannot quietly stop covering them.
 ## Proof size, which is what decided the design
 
 Measured, since the estimate that nearly sank this was out by two orders of
-magnitude. One derived row costs about **fifteen lines per state**, and the
-states are `members × (π₀ + 1)`:
+magnitude. Over a single resource one derived row costs about **fifteen lines per
+state**, and the states are `members × (π₀ + 1)`:
 
 | members | capacity | `π₀` | states | lines | bytes |
 |--------:|---------:|-----:|-------:|------:|------:|
@@ -221,6 +288,12 @@ point — around `10⁶` lines per constraint at `|S| = 10`, `C = 20`, horizon 1
 because it assumed a programme per lifting step, indexed by residual capacity.
 Neither is needed: one programme certifies the finished cut, and the frontier is
 indexed by profit, which is bounded by the right-hand side.
+
+Each further resource adds a weight variable per state — two more lines to define
+it and two more per transition — and however many states the Pareto frontier
+turns out to need. On the published Pack constraints that is about three times a
+single-resource row for three resources, plus the crossing, which is a few lines
+per member per row per time point and is lost in the noise beside the programme.
 
 Over a horizon, a derived `Cumulative` costs one such row per time point. For
 eight members and a capacity of twenty:
@@ -244,29 +317,35 @@ problem.** On these numbers it is not.
 
 ### One step that is not what makes it sound
 
-The `pol` that rules a member out weakens the donor's other tasks out of the row
-first. That weakening is for the checker's benefit, not for soundness: every term
-left in adds its own demand to the degree, and the literals it leaves behind
-cannot between them cover a degree they raised by more than they can reach, so
-the member is forced out either way. What the sweep buys is that the step lands
-on a two-literal clause rather than on something as wide as the donor.
+The `pol` that rules a member out weakens the row's other tasks out of it first.
+That weakening is for the checker's benefit, not for soundness: every term left
+in adds its own demand to the degree, and the literals it leaves behind cannot
+between them cover a degree they raised by more than they can reach, so the
+member is forced out either way. What the sweep buys is that the step lands on a
+two-literal clause rather than on something as wide as the donor.
 
 So a mutation that skips a weakening cannot be caught, and there is no longer one
-that tries. The mutation that replaced it builds the programme against a capacity
-one below the donor's, so that its states claim the row rules out a member it does
+that tries. The mutation that replaced it builds the programme against capacities
+one below the rows', so that its states claim a row rules out a member it does
 not — which veripb refuses inside the replay rather than at the pin.
+
+**That mutation needs a fixture the tightening actually changes, and over several
+resources it is easy to build one where it does not.** Every state is a subset of
+the members that fits; if no feasible subset sits exactly at a capacity, taking
+one off every capacity leaves the whole programme identical and only changes
+which row gets the blame for a kill — and the kill is still true, so veripb
+rightly accepts. Worse, even a genuinely misattributed kill can survive, because
+the other rows are in the database and unit propagation can reach the same
+conclusion through them. This is the conflict-shaped-rule problem from #660
+again: corrupting the *route* is not a test when a second route is true. The
+two-resource fixture is chosen so that tightening forbids something, and the
+corruption that is specific to several resources — carrying a row onto the wrong
+member's flags — is `BridgeWrongTask`.
 
 ## What is not here
 
-- **Multi-resource lifting**
-  ([#673](https://github.com/ciaranm/glasgow-constraint-solver/issues/673)). A
-  cut mixing demands from two resources needs the two rows scaled against each
-  other, and neither schema here reaches that. The capacity-one stage spans
-  resources by merging *at-most-ones*, which works because an at-most-one is
-  scale-free; non-unit coefficients are not, which is exactly where that trick
-  stops. Sidorov solves those subproblems and so could we — the precedent for a
-  nested solve is `gcs/presolvers/auto_table/auto_table.cc` — but the result
-  would have to be posted uncertified, which is not a trade this plan makes.
 - Optional tasks, variable durations or demands, and lifting during search
   (a constraint lifted from a conflict does not propagate after backtracking, so
   this is root-level only).
+- Nothing else: the lifting is Equation 4's, over every resource, and every
+  constraint it produces is derived.

--- a/dev_docs/inferred-cumulative.md
+++ b/dev_docs/inferred-cumulative.md
@@ -110,14 +110,38 @@ short families and then again across all of them, and the subproblem budget, the
 visited-cover rule and the output limit are one each rather than one per
 resource.
 
-**Two places where the paper and its implementation disagree**, both resolved in
-favour of the code, which produced the published results:
+**Two places where the paper and its implementation disagree**, both since
+resolved by Konstantin Sidorov by email (2026-08-05), and both in the same
+direction: *longest first*.
 
-- Algorithm 2 step L3 says to lift `arg min dᵢ`, shortest duration first; the
-  implementation sorts by duration *descending*.
-- Algorithm 1 picks "the longest task among the ones satisfying …", but the code
-  compares a duration against an array *index* when doing so. Ours takes the
-  longest, as the paper says.
+- Algorithm 2 step L3 says to lift `arg min dᵢ`, shortest duration first, while
+  the implementation sorts by duration *descending*. **The paper has the typo**;
+  the intent is the longest unlifted task. Lifting assigns coefficients greedily,
+  so bringing in the tasks with the biggest effect on the bound first keeps them
+  out of the subproblem's objective while it is still small — a later task meets
+  a larger `v*` and so gets a smaller coefficient. That the order matters at all
+  is not an artefact of doing several resources: **lifting is sequence-dependent
+  even over a single row** (Zemel 1978). Which order is best is a heuristic
+  question, and depends on what will consume the constraint downstream.
+- Algorithm 1 picks "the longest task among the ones satisfying …", and the code
+  compares a duration against an array *index* when doing so. **The code has the
+  bug**; the intended line reads `durations[ix] > durations[inv_A_longest[a]]`,
+  which is what happens here.
+
+That second one is not a formality, and it matters for how the comparisons in
+this repository should be read. **The published results came from the shipped
+line**, and over the Pack and Pack-d instances the two readings pick a different
+representative on 306 of 314 resource rows. The ternary cover family that comes
+out differs on 164 of those rows and on 103 of the 110 instances.
+
+The difference runs one way. The shipped line's pick is **never longer** than the
+intended one — shorter on 542 of the 922 (demand, row) pairs and equal on the
+rest — so the corrected reading's best ternary cover is never worse, and is
+better on 61 rows. A per-instance comparison against the paper's numbers is
+therefore not a comparison over the same covers, and where this presolver's `L`
+beats the published one that is a likely cause. It is also the one place where
+reproducing the method as *described* means out-performing the artefact as
+*shipped*, which is the opposite of the usual risk and worth saying out loud.
 
 ## The certified fraction, which is the number this exists to produce
 

--- a/dev_docs/inferred-disjunctive.md
+++ b/dev_docs/inferred-disjunctive.md
@@ -172,9 +172,11 @@ get wrong and neither is visible from the paper:
 
 ## Not done
 
-- Multi-resource lifting. The single-resource half of the general lifted case is
-  [`InferredCumulative`](inferred-cumulative.md); a cut mixing demands from two
-  resources is still open (issue #549).
+- The general lifted case, with non-unit coefficients, is
+  [`InferredCumulative`](inferred-cumulative.md), and it spans resources too ---
+  by a weight per resource in its knapsack programme rather than by merging
+  at-most-ones, which is scale-free and so stops working as soon as a
+  coefficient is not one.
 - Budget-robustness sweeps on larger instances.
 - The proof-size work above.
 

--- a/dev_docs/subset-sum-strengthening.md
+++ b/dev_docs/subset-sum-strengthening.md
@@ -19,7 +19,7 @@ that matters as soon as the line is added to another one: `Σ c_i x_i ≤ B` plu
 `Σ c_i x_i ≥ B′ + 1` is perfectly consistent over the rationals, while the
 strengthened form contradicts it in one `pol` step. That is the shape all three
 consumers need — the knapsack-augmented overload check's availability bound
-(#550), Schulz's capacity reduction (#547), and single-resource lifting
+(#550), Schulz's capacity reduction (#547), and cover lifting
 certificates (#549).
 
 ## The two derivations

--- a/examples/rcpsp/rcpsp.cc
+++ b/examples/rcpsp/rcpsp.cc
@@ -323,8 +323,8 @@ auto main(int argc, char * argv[]) -> int
                 "Cap how many cliques are posted (Sidorov's N_out)",                                     //
                 cxxopts::value<std::size_t>()->default_value("5"))                                       //
             ("infer-cumulative",                                                                         //
-                "Run the InferredCumulative presolver, which lifts cover inequalities over a "           //
-                "resource's capacity rows into implied Cumulatives with non-unit heights",               //
+                "Run the InferredCumulative presolver, which lifts cover inequalities over the "         //
+                "resources' capacity rows into implied Cumulatives with non-unit heights",               //
                 cxxopts::value<bool>()->default_value("false"))                                          //
             ("infer-cumulative-covers",                                                                  //
                 "Cap how many covers are grown and lifted (Sidorov's N_cover)",                          //

--- a/gcs/innards/proofs/flag_bridge.cc
+++ b/gcs/innards/proofs/flag_bridge.cc
@@ -3,14 +3,17 @@
 #include <gcs/innards/proofs/pol_builder.hh>
 #include <gcs/innards/proofs/proof_error.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
+#include <gcs/innards/proofs/pseudo_boolean.hh>
 
 #include <cstddef>
 #include <string>
+#include <utility>
 #include <vector>
 
 using namespace gcs;
 using namespace gcs::innards;
 
+using std::move;
 using std::size_t;
 using std::string;
 using std::to_string;
@@ -88,4 +91,37 @@ auto gcs::innards::recover_conjunction_flag_bridge(ProofLogger & logger, const P
     combine.add(implied_by_condition(tracker, to));
     combine.saturate();
     return combine.emit(logger, level);
+}
+
+auto gcs::innards::recover_bridged_row(ProofLogger & logger, ProofLine row, const vector<BridgedRowTerm> & terms,
+    const vector<ProofFlag> & weaken_out, Integer capacity, ProofLevel level) -> ProofLine
+{
+    if (terms.empty())
+        throw ProofError{"bridged row: no terms to carry across, so there would be nothing left of the row"};
+
+    // Weaken first, so that the terms being carried are all there is left, and
+    // then add each one's bridge as many times as its coefficient. Every flag
+    // the row mentions then appears once with each sign and cancels, and the
+    // constants that leaves behind are exactly what the degree loses, so the
+    // right-hand side does not move.
+    //
+    // No saturation: the row wanted is the row the arithmetic lands on, and
+    // capping a coefficient at the degree would quietly hand back a different
+    // one --- stronger, which the pin below would accept without comment.
+    //
+    // A term nobody asked to weaken out is not a soundness problem, since the
+    // pin drops it again; it only makes this pol wider than it needed to be.
+    PolBuilder carry;
+    carry.add(row);
+    for (const auto & flag : weaken_out)
+        carry.weaken(flag, logger.names_and_ids_tracker());
+    for (const auto & term : terms)
+        if (term.implies_row_flag)
+            carry.add(*term.implies_row_flag, term.coefficient);
+    auto carried = carry.emit(logger, level);
+
+    WPBSum bridged;
+    for (const auto & term : terms)
+        bridged += term.coefficient * term.flag;
+    return logger.emit(ImpliesProofRule{carried}, move(bridged) <= capacity, level);
 }

--- a/gcs/innards/proofs/flag_bridge.hh
+++ b/gcs/innards/proofs/flag_bridge.hh
@@ -4,7 +4,9 @@
 #include <gcs/innards/proofs/proof_line.hh>
 #include <gcs/innards/proofs/proof_logger-fwd.hh>
 #include <gcs/innards/proofs/proof_only_variables.hh>
+#include <gcs/integer.hh>
 
+#include <optional>
 #include <vector>
 
 namespace gcs::innards
@@ -62,6 +64,62 @@ namespace gcs::innards
      */
     [[nodiscard]] auto recover_conjunction_flag_bridge(ProofLogger &, const ProofFlag & from, const std::vector<ProofFlag> & from_conjuncts,
         const ProofFlag & to, const std::vector<ProofFlag> & to_conjuncts, ProofLevel) -> ProofLine;
+
+    /**
+     * \brief One term of a row being carried onto other flags: its coefficient,
+     * the flag it is to end up over, and the bridge saying that flag implies the
+     * one the row actually mentions.
+     *
+     * The bridge points that way round and not the other, which is worth being
+     * clear about because both directions exist and only one is sound here. To
+     * turn `sum c_j b_j <= C` into `sum c_j a_j <= C` the sum has to be able to
+     * grow, so each `a_j` has to imply its `b_j`: a point where the new flag
+     * holds is one where the old one did, and so one the row already spoke
+     * about. Bridging the other way would say the row constrains points it never
+     * saw.
+     *
+     * There is nothing to carry when a term is already over the flag wanted,
+     * which is the usual case for whichever constraint the row belongs to, so
+     * the bridge is optional and a term without one is left where it is.
+     *
+     * \ingroup Innards
+     */
+    struct BridgedRowTerm
+    {
+        Integer coefficient;
+        ProofFlag flag;
+        std::optional<ProofLine> implies_row_flag;
+    };
+
+    /**
+     * \brief Recover a capacity row over another constraint's flags: the same
+     * inequality, said in flags that mean the same thing.
+     *
+     * A row belonging to one Cumulative mentions that constraint's own activity
+     * flags, and a derivation combining rows from several of them --- a cut
+     * lifted over more than one resource, which is what Sidorov's Equation 4
+     * produces --- needs them all over one set. This is what makes that
+     * possible, and it is one `pol`: weaken the row down to the terms wanted,
+     * then add `c_j` copies of each term's bridge, which puts each flag in with
+     * both signs so that all of them cancel and the constants leave the same
+     * right-hand side behind.
+     *
+     * `weaken_out` names the row's other terms, and is for shape rather than for
+     * soundness: a term left in survives into the `pol` with its own flag, which
+     * the pin below then drops again, so what a caller gets is the same row
+     * either way and only the working is wider. Passing a flag the row does not
+     * mention is what `w` rejects, so a wrong list is an error rather than a
+     * silent weakening.
+     *
+     * The result is pinned with an `ia` against the row asked for, so what comes
+     * back is literal-exact whatever shape the `pol` landed on --- and a bridge
+     * pointing the wrong way, or a coefficient that does not match the row's, is
+     * refused here rather than several thousand lines later.
+     *
+     * \ingroup Innards
+     */
+    [[nodiscard]] auto recover_bridged_row(ProofLogger &, ProofLine row, const std::vector<BridgedRowTerm> & terms,
+        const std::vector<ProofFlag> & weaken_out, Integer capacity, ProofLevel) -> ProofLine;
 }
 
 #endif

--- a/gcs/innards/proofs/flag_bridge_test.cc
+++ b/gcs/innards/proofs/flag_bridge_test.cc
@@ -16,6 +16,7 @@
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/proofs/proof_model.hh>
 
+#include <cstddef>
 #include <cstdlib>
 #include <iostream>
 #include <optional>
@@ -35,6 +36,7 @@
 
 using std::cerr;
 using std::move;
+using std::size_t;
 using std::string;
 using std::vector;
 
@@ -137,6 +139,70 @@ namespace
             fail("conjunction bridge (" + name + "): veripb " + (accepted ? "accepted" : "rejected") + " it, expecting the opposite");
         dispose_of_proof_files(proof_name);
     }
+
+    /* What one Cumulative's capacity row looks like once another's flags are
+     * speaking for it, which is what a cut lifted over several resources needs
+     * before any of its rows can be put in the same derivation.
+     */
+    enum class BridgedRowCorruption
+    {
+        None,
+        BridgeBackwards,   ///< carry `b -> a` rather than `a -> b`
+        CoefficientTooBig, ///< add one copy too many of a bridge, so it fails to cancel
+        ClaimTighter       ///< pin a capacity one below the row's
+    };
+
+    auto check_bridged_row(const string & name, BridgedRowCorruption corruption, bool expect_veripb_to_accept) -> void
+    {
+        auto proof_name = "flag_bridge_row_" + name;
+        ProofOptions proof_options{proof_name};
+        NamesAndIDsTracker tracker(proof_options);
+        ProofModel model(proof_options, tracker);
+
+        const vector<Integer> demands{2_i, 3_i, 1_i};
+        const auto capacity = 5_i;
+
+        vector<ProofFlag> ours, theirs;
+        WPBSum load;
+        for (size_t i = 0; i < demands.size(); ++i) {
+            SimpleIntegerVariableID start{i};
+            model.set_up_integer_variable(start, 0_i, 10_i, "start" + std::to_string(i), std::nullopt);
+            // The same condition written twice, as two posted constraints over
+            // the same tasks would write it.
+            ours.push_back(model.create_proof_flag_fully_reifying("ours" + std::to_string(i), WPBSum{} + 1_i * start <= 4_i));
+            theirs.push_back(model.create_proof_flag_fully_reifying("theirs" + std::to_string(i), WPBSum{} + 1_i * start <= 4_i));
+            load += demands[i] * theirs[i];
+        }
+
+        // A task of theirs that is no part of what we are asking about.
+        auto spare = model.create_proof_flag("spare");
+        load += 1_i * spare;
+        auto row = model.add_labelled_constraint("row", move(load) <= capacity);
+        model.finalise();
+
+        ProofLogger logger(proof_options, tracker);
+        tracker.switch_from_model_to_proof(&logger);
+        logger.start_proof(model);
+        tracker.emit_delayed_proof_steps();
+
+        vector<BridgedRowTerm> terms;
+        for (size_t i = 0; i < demands.size(); ++i) {
+            auto bridge = corruption == BridgedRowCorruption::BridgeBackwards ? recover_flag_bridge(logger, theirs[i], ours[i], ProofLevel::Top)
+                                                                              : recover_flag_bridge(logger, ours[i], theirs[i], ProofLevel::Top);
+            auto coefficient = (corruption == BridgedRowCorruption::CoefficientTooBig && i == 0) ? demands[i] + 1_i : demands[i];
+            terms.push_back(BridgedRowTerm{coefficient, ours[i], bridge});
+        }
+
+        auto claimed = corruption == BridgedRowCorruption::ClaimTighter ? capacity - 1_i : capacity;
+        [[maybe_unused]] auto bridged = recover_bridged_row(logger, row, terms, {spare}, claimed, ProofLevel::Top);
+        logger.conclude_none();
+        tracker.finalise();
+
+        auto accepted = run_veripb(proof_name + ".opb", proof_name + ".pbp");
+        if (accepted != expect_veripb_to_accept)
+            fail("bridged row (" + name + "): veripb " + (accepted ? "accepted" : "rejected") + " it, expecting the opposite");
+        dispose_of_proof_files(proof_name);
+    }
 }
 
 auto main(int argc, char * argv[]) -> int
@@ -166,6 +232,18 @@ auto main(int argc, char * argv[]) -> int
     // `after` is then the stronger condition and the conjunct bridge fails.
     check_conjunction("shorter_target", 3_i, 2_i, false);
     println(cerr, "conjunction bridges: derived for matching conjuncts, refused for mismatched ones");
+
+    check_bridged_row("identical", BridgedRowCorruption::None, true);
+    // The direction is the thing to get wrong, and it is invisible from the
+    // types: both bridges exist and only one of them lets the row's left-hand
+    // side grow. Backwards, nothing cancels and the pin has nothing to work on.
+    check_bridged_row("backwards", BridgedRowCorruption::BridgeBackwards, false);
+    // A coefficient that is not the row's leaves that flag behind with the
+    // wrong sign, so the row that comes out is not over the flags claimed.
+    check_bridged_row("coefficient_too_big", BridgedRowCorruption::CoefficientTooBig, false);
+    // And the capacity does not move in the crossing.
+    check_bridged_row("claim_tighter", BridgedRowCorruption::ClaimTighter, false);
+    println(cerr, "a capacity row crosses onto another constraint's flags, and does not cross wrongly");
 
     return EXIT_SUCCESS;
 }

--- a/gcs/innards/proofs/lifted_cover_cut.cc
+++ b/gcs/innards/proofs/lifted_cover_cut.cc
@@ -32,7 +32,9 @@ using std::nullopt;
 using std::optional;
 using std::size_t;
 using std::vector;
+using std::ranges::any_of;
 using std::ranges::sort;
+using std::ranges::unique;
 
 namespace
 {
@@ -44,74 +46,193 @@ namespace
         ProofLine forward, reverse;
     };
 
-    /// Drop every state another one already covers. A state taking no more of
-    /// the resource while allowing no less on the cut says everything the
-    /// covered one does, so the covered one can go --- and the state carrying
-    /// the most is never covered, so the bound the last layer reports does not
-    /// move. What is left runs strictly upwards in both coordinates, which is
-    /// why a layer holds at most one state per achievable profit.
+    /// Does the first state say everything the second does? It takes no more of
+    /// any resource and allows no less on the cut, so every point in the second
+    /// is a point in the first.
+    [[nodiscard]] auto covers(const LiftedCoverCutState & state, const LiftedCoverCutState & covered) -> bool
+    {
+        if (state.profit < covered.profit)
+            return false;
+        for (size_t row = 0; row < state.weights.size(); ++row)
+            if (state.weights[row] > covered.weights[row])
+                return false;
+        return true;
+    }
+
+    /// Drop every state another one already covers, leaving an antichain. The
+    /// state carrying the most is never covered, so the bound the last layer
+    /// reports does not move --- and every state left is still a tuple some 0/1
+    /// point reaches exactly, which is what makes that bound the true optimum
+    /// rather than an over-estimate.
+    ///
+    /// Over one row this is a staircase, and what survives runs strictly upwards
+    /// in both coordinates, which is why a layer then holds at most one state
+    /// per achievable profit. Over several there is no such shape, and the
+    /// budget is what stands in for it.
     auto reduce_to_frontier(LiftedCoverCutLayer & states) -> void
     {
-        sort(states, [](const LiftedCoverCutState & a, const LiftedCoverCutState & b) {
-            if (a.weight != b.weight)
-                return a.weight < b.weight;
-            return a.profit > b.profit;
-        });
+        sort(states);
+        states.erase(unique(states).begin(), states.end());
 
         LiftedCoverCutLayer frontier;
-        auto covered_up_to = -1_i;
         for (const auto & state : states)
-            if (state.profit > covered_up_to) {
-                covered_up_to = state.profit;
+            if (! any_of(states, [&](const LiftedCoverCutState & other) { return other != state && covers(other, state); }))
                 frontier.push_back(state);
-            }
         states = move(frontier);
     }
-}
 
-auto gcs::innards::validate_lifted_cover_cut(const vector<Integer> & demands, const vector<Integer> & coefficients, Integer capacity, Integer rhs)
-    -> optional<LiftedCoverCut>
-{
-    if (demands.size() != coefficients.size())
-        throw ProofError{"a lifted cover cut needs one coefficient per demand"};
-
-    vector<LiftedCoverCutLayer> layers{LiftedCoverCutLayer{LiftedCoverCutState{0_i, 0_i}}};
-    for (size_t member = 0; member < demands.size(); ++member) {
-        LiftedCoverCutLayer next;
-        for (const auto & state : layers.back()) {
-            // Leaving the member out reaches the same pair one layer on; taking
-            // it costs its demand and pays its coefficient, and the row rules it
-            // out entirely once that overruns the capacity. That is the only use
-            // the row gets, and is what makes the cut a consequence of it.
-            next.push_back(state);
-            if (state.weight + demands[member] <= capacity)
-                next.push_back(LiftedCoverCutState{state.weight + demands[member], state.profit + coefficients[member]});
-        }
-        reduce_to_frontier(next);
-        layers.push_back(move(next));
+    /// The rows that can rule something out: everything else admits every subset
+    /// of the members, so no derivation could use it and a weight bound against
+    /// it would be a flag per state saying nothing.
+    [[nodiscard]] auto binding_rows(const vector<vector<Integer>> & demands, const vector<Integer> & capacities) -> vector<size_t>
+    {
+        vector<size_t> binding;
+        for (size_t row = 0; row < capacities.size(); ++row)
+            if (std::accumulate(demands[row].begin(), demands[row].end(), 0_i) > capacities[row])
+                binding.push_back(row);
+        return binding;
     }
 
-    // The frontier runs upwards, so the last state of the last layer is the
-    // most any 0/1 point the row allows can put on the cut's left-hand side.
-    if (layers.back().back().profit > rhs)
-        return nullopt;
+    struct Programme
+    {
+        vector<LiftedCoverCutLayer> layers;
+        bool over_budget = false;
+        /// Set when some state's profit reached the ceiling asked about, in
+        /// which case the layers are whatever had been built when it did. Since
+        /// coefficients are never negative and a state only covers one whose
+        /// profit is no larger, such a state has a descendant in every later
+        /// layer, so stopping there loses nothing.
+        bool reached_ceiling = false;
+    };
 
-    return LiftedCoverCut{demands, coefficients, capacity, rhs, move(layers)};
+    /// Run the programme forwards, layer by layer. A state after the first `i`
+    /// members is a (weights, profit) tuple reachable by taking some of them; a
+    /// successor either leaves the next member out or takes it, and one that
+    /// would overrun some capacity is not created, because that row forbids it.
+    [[nodiscard]] auto build_programme(const vector<vector<Integer>> & demands, const vector<Integer> & coefficients,
+        const vector<Integer> & capacities, Integer profit_ceiling, size_t state_budget) -> Programme
+    {
+        auto rows = capacities.size();
+        Programme programme;
+        programme.layers.push_back(LiftedCoverCutLayer{LiftedCoverCutState{vector<Integer>(rows, 0_i), 0_i}});
+        size_t states = 1;
+
+        for (size_t member = 0; member < coefficients.size(); ++member) {
+            LiftedCoverCutLayer next;
+            for (const auto & state : programme.layers.back()) {
+                next.push_back(state);
+
+                auto weights = state.weights;
+                auto fits = true;
+                for (size_t row = 0; row < rows && fits; ++row) {
+                    weights[row] += demands[row][member];
+                    fits = weights[row] <= capacities[row];
+                }
+                if (fits)
+                    next.push_back(LiftedCoverCutState{move(weights), state.profit + coefficients[member]});
+            }
+
+            reduce_to_frontier(next);
+            states += next.size();
+            if (states > state_budget) {
+                programme.over_budget = true;
+                return programme;
+            }
+
+            programme.reached_ceiling = any_of(next, [&](const LiftedCoverCutState & state) { return state.profit >= profit_ceiling; });
+            programme.layers.push_back(move(next));
+            if (programme.reached_ceiling)
+                return programme;
+        }
+
+        return programme;
+    }
+
+    /// The most any state in a layer allows on the cut.
+    [[nodiscard]] auto largest_profit(const LiftedCoverCutLayer & layer) -> Integer
+    {
+        auto best = 0_i;
+        for (const auto & state : layer)
+            best = std::max(best, state.profit);
+        return best;
+    }
+
+    auto check_shape(const vector<vector<Integer>> & demands, const vector<Integer> & coefficients, const vector<Integer> & capacities) -> void
+    {
+        if (demands.size() != capacities.size())
+            throw ProofError{"a lifted cover cut needs one capacity per row of demands"};
+        for (const auto & row : demands)
+            if (row.size() != coefficients.size())
+                throw ProofError{"a lifted cover cut needs one coefficient per demand"};
+    }
 }
 
-auto gcs::innards::derive_lifted_cover_cut(ProofLogger & logger, ProofLine capacity_row, const LiftedCoverCut & cut, const vector<ProofFlag> & flags,
-    const vector<Integer> & claimed_coefficients, const vector<ProofFlag> & weaken_out, Integer claimed_rhs, ProofLevel level) -> ProofLine
+auto gcs::innards::validate_lifted_cover_cut(const vector<vector<Integer>> & demands, const vector<Integer> & coefficients,
+    const vector<Integer> & capacities, Integer rhs, size_t state_budget) -> LiftedCoverCutValidity
+{
+    check_shape(demands, coefficients, capacities);
+
+    auto binding = binding_rows(demands, capacities);
+    vector<vector<Integer>> kept_demands;
+    vector<Integer> kept_capacities;
+    for (auto row : binding) {
+        kept_demands.push_back(demands[row]);
+        kept_capacities.push_back(capacities[row]);
+    }
+
+    // A state whose profit is above the right-hand side is a point breaking the
+    // cut, so there is nothing to gain by carrying on once one appears --- and
+    // asking about it here is what keeps a layer to one state per achievable
+    // profit below the right-hand side, times whatever the weights need.
+    auto programme = build_programme(kept_demands, coefficients, kept_capacities, rhs + 1_i, state_budget);
+    if (programme.over_budget)
+        return LiftedCoverCutValidity{nullopt, true};
+    if (programme.reached_ceiling || largest_profit(programme.layers.back()) > rhs)
+        return LiftedCoverCutValidity{nullopt, false};
+
+    return LiftedCoverCutValidity{
+        LiftedCoverCut{move(kept_demands), move(kept_capacities), move(binding), coefficients, rhs, move(programme.layers)}, false};
+}
+
+auto gcs::innards::lifted_cover_cut_optimum(const vector<vector<Integer>> & demands, const vector<Integer> & coefficients,
+    const vector<Integer> & capacities, Integer profit_ceiling, size_t state_budget) -> LiftedCoverCutOptimum
+{
+    check_shape(demands, coefficients, capacities);
+
+    auto binding = binding_rows(demands, capacities);
+    vector<vector<Integer>> kept_demands;
+    vector<Integer> kept_capacities;
+    for (auto row : binding) {
+        kept_demands.push_back(demands[row]);
+        kept_capacities.push_back(capacities[row]);
+    }
+
+    auto programme = build_programme(kept_demands, coefficients, kept_capacities, profit_ceiling, state_budget);
+    if (programme.over_budget)
+        return LiftedCoverCutOptimum{nullopt, true};
+    if (programme.reached_ceiling)
+        return LiftedCoverCutOptimum{nullopt, false};
+
+    return LiftedCoverCutOptimum{largest_profit(programme.layers.back()), false};
+}
+
+auto gcs::innards::derive_lifted_cover_cut(ProofLogger & logger, const vector<ProofLine> & capacity_rows, const LiftedCoverCut & cut,
+    const vector<ProofFlag> & flags, const vector<Integer> & claimed_coefficients, const vector<vector<ProofFlag>> & weaken_out, Integer claimed_rhs,
+    ProofLevel level) -> ProofLine
 {
     auto members = flags.size();
-    if (members != claimed_coefficients.size() || members != cut.demands.size() || cut.layers.size() != members + 1)
+    auto rows = cut.capacities.size();
+    if (members != claimed_coefficients.size() || members != cut.coefficients.size() || cut.layers.size() != members + 1)
         throw ProofError{"a lifted cover cut needs one flag and one coefficient per member"};
+    if (capacity_rows.size() != rows || weaken_out.size() != rows)
+        throw ProofError{"a lifted cover cut needs one supplied row and one weakening list per row it kept"};
 
     WPBSum claimed;
     for (size_t member = 0; member < members; ++member)
         claimed += claimed_coefficients[member] * flags[member];
 
     // Nothing to derive: the members cannot between them reach the right-hand
-    // side, so no 0/1 point can miss it and the resource does not come into it.
+    // side, so no 0/1 point can miss it and the resources do not come into it.
     // This is the usual state of affairs at the edges of a derived constraint's
     // window, where too few of its tasks have flags to add up to anything.
     auto total = std::accumulate(cut.coefficients.begin(), cut.coefficients.end(), 0_i);
@@ -129,50 +250,67 @@ auto gcs::innards::derive_lifted_cover_cut(ProofLogger & logger, ProofLine capac
 
     const auto & tracker = logger.names_and_ids_tracker();
 
-    // The two running sums every state speaks about: what the first so-many
-    // members take from the resource, and what they put on the cut.
-    vector<WPBSum> row_prefix(members + 1), cut_prefix(members + 1);
+    // The running sums every state speaks about: what the first so-many members
+    // take from each resource, and what they put on the cut.
+    vector<vector<WPBSum>> row_prefix(rows, vector<WPBSum>(members + 1));
+    vector<WPBSum> cut_prefix(members + 1);
     for (size_t member = 0; member < members; ++member) {
-        row_prefix[member + 1] = row_prefix[member];
-        row_prefix[member + 1] += cut.demands[member] * flags[member];
+        for (size_t row = 0; row < rows; ++row) {
+            row_prefix[row][member + 1] = row_prefix[row][member];
+            row_prefix[row][member + 1] += cut.demands[row][member] * flags[member];
+        }
         cut_prefix[member + 1] = cut_prefix[member];
         cut_prefix[member + 1] += cut.coefficients[member] * flags[member];
     }
 
     // One extension variable per half of a state and one for their conjunction.
-    // A layer's weights and profits are distinct, so a state is keyed by either.
-    vector<map<Integer, Reified>> at_least(members + 1), at_most(members + 1);
+    // States within a layer share halves wherever they agree on a coordinate,
+    // which over one row means a weight is a state's whole identity and over
+    // several means the sharing is worth having.
+    vector<vector<map<Integer, Reified>>> at_least(rows, vector<map<Integer, Reified>>(members + 1));
+    vector<map<Integer, Reified>> at_most(members + 1);
     vector<map<LiftedCoverCutState, ProofFlag>> reached(members + 1);
 
     for (size_t layer = 0; layer <= members; ++layer)
         for (const auto & state : cut.layers[layer]) {
-            auto [weight_flag, weight_forward, weight_reverse] = logger.create_proof_flag_reifying(
-                row_prefix[layer] >= state.weight, format("lccw{}_{}", layer, state.weight.raw_value), ProofLevel::Temporary);
-            at_least[layer].emplace(state.weight, Reified{weight_flag, weight_forward, weight_reverse});
+            WPBSum conjuncts;
+            for (size_t row = 0; row < rows; ++row) {
+                auto weight = state.weights[row];
+                if (! at_least[row][layer].contains(weight)) {
+                    auto [flag, forward, reverse] = logger.create_proof_flag_reifying(
+                        row_prefix[row][layer] >= weight, format("lccw{}_{}_{}", row, layer, weight.raw_value), ProofLevel::Temporary);
+                    at_least[row][layer].emplace(weight, Reified{flag, forward, reverse});
+                }
+                conjuncts += 1_i * at_least[row][layer].at(weight).flag;
+            }
 
-            auto [profit_flag, profit_forward, profit_reverse] = logger.create_proof_flag_reifying(
-                cut_prefix[layer] <= state.profit, format("lccp{}_{}", layer, state.profit.raw_value), ProofLevel::Temporary);
-            at_most[layer].emplace(state.profit, Reified{profit_flag, profit_forward, profit_reverse});
+            if (! at_most[layer].contains(state.profit)) {
+                auto [flag, forward, reverse] = logger.create_proof_flag_reifying(
+                    cut_prefix[layer] <= state.profit, format("lccp{}_{}", layer, state.profit.raw_value), ProofLevel::Temporary);
+                at_most[layer].emplace(state.profit, Reified{flag, forward, reverse});
+            }
+            conjuncts += 1_i * at_most[layer].at(state.profit).flag;
 
+            auto name = format("lccs{}_{}", layer, state.profit.raw_value);
+            for (auto weight : state.weights)
+                name += format("_{}", weight.raw_value);
             auto [state_flag, state_forward, state_reverse] =
-                logger.create_proof_flag_reifying(WPBSum{} + 1_i * weight_flag + 1_i * profit_flag >= 2_i,
-                    format("lccs{}_{}_{}", layer, state.weight.raw_value, state.profit.raw_value), ProofLevel::Temporary);
+                logger.create_proof_flag_reifying(move(conjuncts) >= Integer{static_cast<long long>(rows) + 1}, name, ProofLevel::Temporary);
             reached[layer].emplace(state, state_flag);
             (void)state_forward;
             (void)state_reverse;
         }
 
-    // The empty prefix takes nothing and carries nothing, so both halves of its
-    // one state are true of every point and the reifications force the flag.
+    // The empty prefix takes nothing and carries nothing, so every half of its
+    // one state is true of every point and the reifications force the flag.
     logger.emit_rup_proof_line(WPBSum{} + 1_i * reached[0].at(cut.layers[0].front()) >= 1_i, ProofLevel::Temporary);
 
     // The state a layer kept in place of one a transition lands on: it takes no
-    // more of the resource and allows no less, so an implication into what was
-    // landed on is an implication into this. The frontier runs upwards, so the
-    // first one that qualifies is the one with the tightest profit.
+    // more of any resource and allows no less, so an implication into what was
+    // landed on is an implication into this.
     auto covering = [&](size_t layer, const LiftedCoverCutState & landed) -> const LiftedCoverCutState & {
         for (const auto & state : cut.layers[layer])
-            if (state.weight <= landed.weight && state.profit >= landed.profit)
+            if (covers(state, landed))
                 return state;
         throw ProofError{"a lifted cover cut's dynamic programme dropped a state nothing covers"};
     };
@@ -180,19 +318,18 @@ auto gcs::innards::derive_lifted_cover_cut(ProofLogger & logger, ProofLine capac
     // One transition: whether or not the layer's member is taken, a point in
     // `from` is a point in `to`. Each half is a `pol` leaving its clause one
     // unit propagation away, exactly as knapsack_upfront's forward chains do,
-    // and the state follows from the two through the conjunction.
+    // and the state follows from the halves through the conjunction.
     auto link = [&](size_t layer, const LiftedCoverCutState & from, const LiftedCoverCutState & to, bool taking) {
         auto other_branch = taking ? ! flags[layer - 1] : flags[layer - 1];
-        const auto & from_weight = at_least[layer - 1].at(from.weight);
-        const auto & to_weight = at_least[layer].at(to.weight);
-        const auto & from_profit = at_most[layer - 1].at(from.profit);
-        const auto & to_profit = at_most[layer].at(to.profit);
 
-        PolBuilder{}.add(to_weight.reverse).add(from_weight.forward).saturate().emit(logger, ProofLevel::Temporary);
-        logger.emit_rup_proof_line(WPBSum{} + 1_i * ! from_weight.flag + 1_i * other_branch + 1_i * to_weight.flag >= 1_i, ProofLevel::Temporary);
+        auto half = [&](const Reified & from_half, const Reified & to_half) {
+            PolBuilder{}.add(to_half.reverse).add(from_half.forward).saturate().emit(logger, ProofLevel::Temporary);
+            logger.emit_rup_proof_line(WPBSum{} + 1_i * ! from_half.flag + 1_i * other_branch + 1_i * to_half.flag >= 1_i, ProofLevel::Temporary);
+        };
 
-        PolBuilder{}.add(to_profit.reverse).add(from_profit.forward).saturate().emit(logger, ProofLevel::Temporary);
-        logger.emit_rup_proof_line(WPBSum{} + 1_i * ! from_profit.flag + 1_i * other_branch + 1_i * to_profit.flag >= 1_i, ProofLevel::Temporary);
+        for (size_t row = 0; row < rows; ++row)
+            half(at_least[row][layer - 1].at(from.weights[row]), at_least[row][layer].at(to.weights[row]));
+        half(at_most[layer - 1].at(from.profit), at_most[layer].at(to.profit));
 
         logger.emit_rup_proof_line(
             WPBSum{} + 1_i * ! reached[layer - 1].at(from) + 1_i * other_branch + 1_i * reached[layer].at(to) >= 1_i, ProofLevel::Temporary);
@@ -208,15 +345,26 @@ auto gcs::innards::derive_lifted_cover_cut(ProofLogger & logger, ProofLine capac
             successors += 1_i * ! reached[layer - 1].at(from);
             successors += 1_i * reached[layer].at(left_out);
 
-            auto weight = from.weight + cut.demands[member];
-            if (weight <= cut.capacity) {
-                const auto & taken = covering(layer, LiftedCoverCutState{weight, from.profit + cut.coefficients[member]});
+            // Which resource, if any, the member overruns from here. Several
+            // may; one is a proof.
+            auto overrun = optional<size_t>{};
+            auto weights = from.weights;
+            for (size_t row = 0; row < rows && ! overrun; ++row) {
+                weights[row] += cut.demands[row][member];
+                if (weights[row] > cut.capacities[row])
+                    overrun = row;
+            }
+
+            if (! overrun) {
+                const auto & taken = covering(layer, LiftedCoverCutState{move(weights), from.profit + cut.coefficients[member]});
                 link(layer, from, taken, true);
+                // One state can cover both branches, once there is more than one
+                // resource for it to be slack in.
                 if (taken != left_out)
                     successors += 1_i * reached[layer].at(taken);
             }
             else {
-                // The row rules the member out from here. Weaken it down to
+                // That row rules the member out from here. Weaken it down to
                 // this member and the ones the state already accounts for, add
                 // what the state says about those --- which cancels them --- and
                 // what is left says this member alone would overshoot.
@@ -231,12 +379,12 @@ auto gcs::innards::derive_lifted_cover_cut(ProofLogger & logger, ProofLine capac
                 // for. Removing it therefore makes nothing fail, which is why
                 // there is no mutation for it.
                 PolBuilder pol;
-                pol.add(capacity_row).add(at_least[layer - 1].at(from.weight).forward);
+                pol.add(capacity_rows[*overrun]).add(at_least[*overrun][layer - 1].at(from.weights[*overrun]).forward);
                 for (size_t later = layer; later < members; ++later)
                     pol.weaken(flags[later], tracker);
-                for (const auto & flag : weaken_out)
+                for (const auto & flag : weaken_out[*overrun])
                     pol.weaken(flag, tracker);
-                pol.saturate().divide_by(weight - cut.capacity).emit(logger, ProofLevel::Temporary);
+                pol.saturate().divide_by(weights[*overrun] - cut.capacities[*overrun]).emit(logger, ProofLevel::Temporary);
             }
 
             logger.emit_rup_proof_line(move(successors) >= 1_i, ProofLevel::Temporary);

--- a/gcs/innards/proofs/lifted_cover_cut.hh
+++ b/gcs/innards/proofs/lifted_cover_cut.hh
@@ -7,6 +7,7 @@
 #include <gcs/integer.hh>
 
 #include <compare>
+#include <cstddef>
 #include <optional>
 #include <vector>
 
@@ -16,28 +17,41 @@ namespace gcs::innards
      * \brief One state of the knapsack dynamic programme that says a lifted
      * cover cut holds.
      *
-     * Every 0/1 point reaching this state puts **at least** `weight` on the
-     * capacity row's left-hand side and **at most** `profit` on the cut's. Both
-     * halves are one-sided on purpose: it is what lets one state stand for a
-     * whole family of points, and what lets a state that uses less of the
+     * Every 0/1 point reaching this state puts **at least** `weights[r]` on the
+     * `r`th capacity row's left-hand side and **at most** `profit` on the cut's.
+     * Both halves are one-sided on purpose: it is what lets one state stand for
+     * a whole family of points, and what lets a state that uses less of every
      * resource while allowing more on the cut absorb another outright.
+     *
+     * There is one weight per row the cut is derived from, because Sidorov's
+     * lifting subproblem (his Equation 4) constrains over every resource at
+     * once, and a cut lifted that way is a consequence of those rows together
+     * rather than of any one of them. Nothing about that needs the rows scaled
+     * against each other or added together: each is used only to say that a
+     * particular transition cannot happen, which is exactly the use the single
+     * row got.
      *
      * \ingroup Innards
      */
     struct LiftedCoverCutState
     {
-        Integer weight, profit;
+        std::vector<Integer> weights;
+        Integer profit;
 
         [[nodiscard]] auto operator<=>(const LiftedCoverCutState &) const = default;
     };
 
     /**
-     * \brief The states some prefix of a cut's members can reach, in increasing
-     * order of both weight and profit.
+     * \brief The states some prefix of a cut's members can reach, with none of
+     * them covering another.
      *
-     * That ordering is not incidental: it is what is left after states another
-     * state already covers are dropped, and the last entry is therefore the
-     * most the prefix can put on the cut's left-hand side.
+     * What is left after states another state already covers are dropped is an
+     * antichain: no member of it uses no more of every resource while allowing
+     * no less on the cut than another does. Over a single row that is a
+     * staircase, so a layer holds at most one state per achievable profit and
+     * cannot be wider than the right-hand side plus one. Over several it is a
+     * Pareto frontier and no such bound holds a priori, which is why
+     * \ref validate_lifted_cover_cut takes a budget.
      *
      * \ingroup Innards
      */
@@ -45,75 +59,154 @@ namespace gcs::innards
 
     /**
      * \brief A lifted cover inequality `sum_i coefficients[i] a_i <= rhs`, and
-     * the dynamic programme that says it follows from the capacity row
-     * `sum_i demands[i] a_i <= capacity`.
+     * the dynamic programme that says it follows from the capacity rows
+     * `sum_i demands[r][i] a_i <= capacities[r]`.
      *
      * \ingroup Innards
      */
     struct LiftedCoverCut
     {
-        std::vector<Integer> demands, coefficients;
-        Integer capacity, rhs;
+        /// One row per entry, each with one demand per member. Only the rows
+        /// that can actually rule a transition out are kept; \ref row_indices
+        /// says which of the caller's rows these are.
+        std::vector<std::vector<Integer>> demands;
+        std::vector<Integer> capacities;
+        std::vector<std::size_t> row_indices;
+
+        std::vector<Integer> coefficients;
+        Integer rhs;
 
         /// One entry per prefix of the members, from the empty one to all of
-        /// them, so `layers.size()` is `demands.size() + 1`.
+        /// them, so `layers.size()` is `coefficients.size() + 1`.
         std::vector<LiftedCoverCutLayer> layers;
     };
 
     /**
-     * \brief Decide whether a lifted cover cut follows from a capacity row, by
-     * running the knapsack dynamic programme that will later be its
+     * \brief Why there is no cut, when there is no cut: because it is false, or
+     * because its programme would have been too large to emit.
+     *
+     * Worth telling apart even though a caller does the same thing with both,
+     * because they say opposite things about the inference. A false cut is a
+     * caller that asked for something untrue; a programme over budget is a cut
+     * that may well be true and that this cannot certify, which is the number
+     * the design of this file exists to keep at zero.
+     *
+     * \ingroup Innards
+     */
+    struct LiftedCoverCutValidity
+    {
+        std::optional<LiftedCoverCut> cut;
+        bool over_state_budget = false;
+    };
+
+    /**
+     * \brief Decide whether a lifted cover cut follows from some capacity rows,
+     * by running the knapsack dynamic programme that will later be its
      * certificate.
      *
-     * Returns nothing exactly when the cut is *false* --- when some 0/1 point
-     * the row allows breaks it. There is no third answer: every valid cut gets
-     * a dynamic programme and every dynamic programme becomes a proof, which is
-     * the whole point of doing it this way. The earlier design searched for a
-     * short cutting-planes derivation and refused about one valid cut in
-     * twenty-five, and a refusal there meant a constraint the published
-     * inference procedure would have posted was dropped.
+     * Returns no cut exactly when the cut is *false* --- when some 0/1 point
+     * the rows jointly allow breaks it --- or when its programme would be larger
+     * than `state_budget` states. Barring that budget there is no third answer:
+     * every valid cut gets a dynamic programme and every dynamic programme
+     * becomes a proof, which is the whole point of doing it this way. The
+     * earlier design searched for a short cutting-planes derivation and refused
+     * about one valid cut in twenty-five, and a refusal there meant a constraint
+     * the published inference procedure would have posted was dropped.
      *
      * The programme is the textbook one. A state after the first `i` members is
-     * a (weight, profit) pair some assignment to those members reaches; a
+     * a (weights, profit) tuple some assignment to those members reaches; a
      * successor either leaves the next member out, or takes it and pays its
-     * demand. A successor that would overrun the capacity is not created at
-     * all, because the row forbids it --- which is the only place the row is
-     * used, and is why the cut is a consequence of it. States another state
-     * covers are then dropped, so a layer holds only the frontier: strictly
-     * increasing weight against strictly increasing profit, at most one state
-     * per achievable profit, and so at most `rhs + 1` of them.
+     * demand on every row. A successor that would overrun *some* capacity is not
+     * created at all, because that row forbids it --- which is the only place a
+     * row is used, and is why the cut is a consequence of the rows. States
+     * another state covers are then dropped, so a layer holds only the frontier.
      *
-     * A cover is a set of members whose demands overshoot the capacity, and
+     * Rows that cannot rule anything out --- those whose members' demands sum to
+     * no more than the capacity --- are dropped before any of that, since a
+     * weight bound against one would be a flag per state saying nothing. That is
+     * a simplification rather than a restriction: such a row admits every subset
+     * of the members, so no derivation could have used it.
+     *
+     * A cover is a set of members whose demands overshoot a capacity, and
      * lifting is what brings the others in with coefficients large enough to
      * keep the inequality valid --- which is what produces the non-unit
-     * coefficients that make such a cut say something the row does not. None of
+     * coefficients that make such a cut say something the rows do not. None of
      * that appears here: which cut to aim for is the caller's business (see
      * InferredCumulative, which reproduces a published procedure's choice), and
      * this decides only whether the answer is true and assembles the reason.
      *
      * \ingroup Innards
      */
-    [[nodiscard]] auto validate_lifted_cover_cut(const std::vector<Integer> & demands, const std::vector<Integer> & coefficients, Integer capacity,
-        Integer rhs) -> std::optional<LiftedCoverCut>;
+    [[nodiscard]] auto validate_lifted_cover_cut(const std::vector<std::vector<Integer>> & demands, const std::vector<Integer> & coefficients,
+        const std::vector<Integer> & capacities, Integer rhs, std::size_t state_budget) -> LiftedCoverCutValidity;
 
     /**
-     * \brief Derive a validated lifted cover cut from a capacity row, by
+     * \brief The answer to a lifting subproblem: what the left-hand side can
+     * reach, unless that is at least the ceiling it was asked about, or the
+     * programme was over budget.
+     *
+     * \ingroup Innards
+     */
+    struct LiftedCoverCutOptimum
+    {
+        std::optional<Integer> value;
+        bool over_state_budget = false;
+    };
+
+    /**
+     * \brief The largest the cut's left-hand side can be at any 0/1 point the
+     * rows jointly allow, or nothing if that reaches `profit_ceiling`.
+     *
+     * This is Sidorov's lifting subproblem: the answer decides the coefficient a
+     * task is lifted in with, as `rhs - v*`, and a `v*` at or above the
+     * right-hand side means there is no positive coefficient to give it. So a
+     * caller only ever needs the answer up to `rhs`, and capping it is what
+     * keeps the frontier narrow enough to index by profit --- the same reason
+     * the programme certifying the finished cut is affordable.
+     *
+     * The answer is exact, not an over-estimate, which matters because a `v*`
+     * one too large is a coefficient one too small: a weaker cut than the
+     * published procedure's, and so a different constraint. Dropping a covered
+     * state cannot inflate it, because every state kept is a tuple some 0/1
+     * point reaches exactly, and a state only ever covers one whose profit is no
+     * larger.
+     *
+     * Shares the dynamic programme with \ref validate_lifted_cover_cut, which is
+     * not an economy but the point: the inference and the certificate are then
+     * the same computation, so a cut the procedure produces cannot be one the
+     * proof fails to reach.
+     *
+     * \ingroup Innards
+     */
+    [[nodiscard]] auto lifted_cover_cut_optimum(const std::vector<std::vector<Integer>> & demands, const std::vector<Integer> & coefficients,
+        const std::vector<Integer> & capacities, Integer profit_ceiling, std::size_t state_budget) -> LiftedCoverCutOptimum;
+
+    /**
+     * \brief Derive a validated lifted cover cut from its capacity rows, by
      * replaying its dynamic programme in the proof.
      *
      * The shape is Demirović et al.'s (CP 2024), in its one-sided form: an
-     * extension variable per state, reifying "at least this much weight" and
-     * "at most this much profit" and their conjunction; an implication per
-     * transition; an at-least-one per layer, saying the frontier is complete;
-     * and, at the last layer, one flag reifying the cut itself, which every
-     * final state contradicts. Nothing here is a search, so nothing here can
-     * fail on a cut \ref validate_lifted_cover_cut accepted.
+     * extension variable per row per state reifying "at least this much weight",
+     * one reifying "at most this much profit", and one for their conjunction; an
+     * implication per transition; an at-least-one per layer, saying the frontier
+     * is complete; and, at the last layer, one flag reifying the cut itself,
+     * which every final state contradicts. Nothing here is a search, so nothing
+     * here can fail on a cut \ref validate_lifted_cover_cut accepted.
      *
-     * `flags` are the members' activity flags, parallel to the cut's `demands`
-     * and `coefficients`; `weaken_out` names every *other* task with a term in
-     * the row. Getting that list wrong costs proof size rather than soundness:
-     * the one step it feeds is the `pol` ruling a member out, and saturation
-     * forces the member out whatever else is left in the row. What the list buys
-     * is that the step lands on a two-literal clause rather than on something as
+     * `capacity_rows` and `weaken_out` are parallel to the rows the cut
+     * *retained*, so a caller with a row that could not bind reads
+     * `LiftedCoverCut::row_indices` to find out it does not need to produce a
+     * line for it at all. **Every row must be expressed in the same `flags`**,
+     * which for rows belonging to different constraints means bridging them
+     * first --- recover_bridged_row does that, and is the only thing standing
+     * between this and a cut spanning several resources.
+     *
+     * `flags` are the members' activity flags, parallel to the cut's
+     * coefficients; `weaken_out[r]` names every *other* task with a term in row
+     * `r`. Getting that list wrong costs proof size rather than soundness: the
+     * one step it feeds is the `pol` ruling a member out, and saturation forces
+     * the member out whatever else is left in the row. What the list buys is
+     * that the step lands on a two-literal clause rather than on something as
      * wide as the donor.
      *
      * The scaffolding is emitted one proof level deeper than the caller's, and
@@ -131,8 +224,9 @@ namespace gcs::innards
      *
      * \ingroup Innards
      */
-    [[nodiscard]] auto derive_lifted_cover_cut(ProofLogger &, ProofLine capacity_row, const LiftedCoverCut &, const std::vector<ProofFlag> & flags,
-        const std::vector<Integer> & claimed_coefficients, const std::vector<ProofFlag> & weaken_out, Integer claimed_rhs, ProofLevel) -> ProofLine;
+    [[nodiscard]] auto derive_lifted_cover_cut(ProofLogger &, const std::vector<ProofLine> & capacity_rows, const LiftedCoverCut &,
+        const std::vector<ProofFlag> & flags, const std::vector<Integer> & claimed_coefficients,
+        const std::vector<std::vector<ProofFlag>> & weaken_out, Integer claimed_rhs, ProofLevel) -> ProofLine;
 }
 
 #endif

--- a/gcs/innards/proofs/lifted_cover_cut_test.cc
+++ b/gcs/innards/proofs/lifted_cover_cut_test.cc
@@ -78,37 +78,76 @@ namespace
         std::exit(EXIT_FAILURE);
     }
 
-    /// Does `sum pi_i a_i <= rhs` hold at every occupancy point the row allows?
-    /// Brute force over all of them, which is the only oracle that does not beg
-    /// the question.
-    [[nodiscard]] auto valid(const vector<Integer> & demands, Integer capacity, const vector<Integer> & coefficients, Integer rhs) -> bool
+    /// Does `sum pi_i a_i <= rhs` hold at every occupancy point the rows
+    /// *jointly* allow? Brute force over all of them, which is the only oracle
+    /// that does not beg the question. Several rows allow fewer points between
+    /// them than any one of them does, which is exactly why a cut lifted over
+    /// all of them can say more than one lifted over any single one.
+    [[nodiscard]] auto valid(
+        const vector<vector<Integer>> & demands, const vector<Integer> & capacities, const vector<Integer> & coefficients, Integer rhs) -> bool
     {
-        for (unsigned long long mask = 0; mask < (1uLL << demands.size()); ++mask) {
-            Integer load = 0_i, weight = 0_i;
-            for (size_t i = 0; i < demands.size(); ++i)
+        for (unsigned long long mask = 0; mask < (1uLL << coefficients.size()); ++mask) {
+            Integer weight = 0_i;
+            vector<Integer> loads(capacities.size(), 0_i);
+            for (size_t i = 0; i < coefficients.size(); ++i)
                 if (mask & (1uLL << i)) {
-                    load += demands[i];
+                    for (size_t row = 0; row < capacities.size(); ++row)
+                        loads[row] += demands[row][i];
                     weight += coefficients[i];
                 }
-            if (load <= capacity && weight > rhs)
+            auto fits = true;
+            for (size_t row = 0; row < capacities.size(); ++row)
+                fits = fits && loads[row] <= capacities[row];
+            if (fits && weight > rhs)
                 return false;
         }
         return true;
     }
 
-    /// Validate the honest cut, emit its replay against a one-row model, pin
-    /// `claimed_coefficients <= claimed_rhs`, and say whether veripb agreed. The
-    /// model carries one task the cut says nothing about, so the weakening sweep
-    /// is exercised in every case rather than assumed.
-    auto check(const string & name, const vector<Integer> & demands, Integer capacity, const vector<Integer> & coefficients, Integer rhs,
-        const vector<Integer> & claimed_coefficients, Integer claimed_rhs, bool expect_veripb_to_accept, bool expect_valid = true) -> void
+    /// The optimum the same enumeration reports, which is what a lifting
+    /// subproblem asks for.
+    [[nodiscard]] auto best(const vector<vector<Integer>> & demands, const vector<Integer> & capacities, const vector<Integer> & coefficients)
+        -> Integer
     {
-        auto cut = validate_lifted_cover_cut(demands, coefficients, capacity, rhs);
-        if (cut.has_value() != expect_valid)
-            fail(name + ": the dynamic programme " + (cut ? "accepted" : "refused") + " the cut, expecting the opposite");
-        if (cut.has_value() != valid(demands, capacity, coefficients, rhs))
-            fail(name + ": the dynamic programme disagrees with enumerating the row's occupancy points");
-        if (! cut)
+        auto most = 0_i;
+        for (unsigned long long mask = 0; mask < (1uLL << coefficients.size()); ++mask) {
+            Integer weight = 0_i;
+            vector<Integer> loads(capacities.size(), 0_i);
+            for (size_t i = 0; i < coefficients.size(); ++i)
+                if (mask & (1uLL << i)) {
+                    for (size_t row = 0; row < capacities.size(); ++row)
+                        loads[row] += demands[row][i];
+                    weight += coefficients[i];
+                }
+            auto fits = true;
+            for (size_t row = 0; row < capacities.size(); ++row)
+                fits = fits && loads[row] <= capacities[row];
+            if (fits)
+                most = std::max(most, weight);
+        }
+        return most;
+    }
+
+    /// A budget large enough that nothing here meets it. What happens when
+    /// something does has its own case.
+    const size_t generous = 100000;
+
+    /// Validate the honest cut, emit its replay against a model with one row per
+    /// capacity, pin `claimed_coefficients <= claimed_rhs`, and say whether
+    /// veripb agreed. Each row carries one task the cut says nothing about, so
+    /// the weakening sweep is exercised in every case rather than assumed.
+    auto check(const string & name, const vector<vector<Integer>> & demands, const vector<Integer> & capacities, const vector<Integer> & coefficients,
+        Integer rhs, const vector<Integer> & claimed_coefficients, Integer claimed_rhs, bool expect_veripb_to_accept, bool expect_valid = true)
+        -> void
+    {
+        auto validity = validate_lifted_cover_cut(demands, coefficients, capacities, rhs, generous);
+        if (validity.over_state_budget)
+            fail(name + ": the programme went over a budget nothing here should reach");
+        if (validity.cut.has_value() != expect_valid)
+            fail(name + ": the dynamic programme " + (validity.cut ? "accepted" : "refused") + " the cut, expecting the opposite");
+        if (validity.cut.has_value() != valid(demands, capacities, coefficients, rhs))
+            fail(name + ": the dynamic programme disagrees with enumerating the rows' occupancy points");
+        if (! validity.cut)
             return;
 
         auto proof_name = "lifted_cover_cut_" + name;
@@ -116,26 +155,41 @@ namespace
         NamesAndIDsTracker tracker(proof_options);
         ProofModel model(proof_options, tracker);
 
-        // One extra task with a term in the row and no part in the cut, so that
-        // every case has something to weaken out.
         vector<ProofFlag> flags;
-        WPBSum load;
-        for (size_t i = 0; i < demands.size(); ++i) {
+        for (size_t i = 0; i < coefficients.size(); ++i)
             flags.push_back(model.create_proof_flag("task" + to_string(i)));
-            load += demands[i] * flags[i];
+
+        // One extra task per row, with a term in it and no part in the cut, so
+        // that every case has something to weaken out. The model gets every row,
+        // including any the programme found could not bind; what is handed over
+        // is only what it kept, which is what row_indices is for.
+        vector<ProofLine> resources;
+        vector<vector<ProofFlag>> weaken_out;
+        for (size_t row = 0; row < capacities.size(); ++row) {
+            WPBSum load;
+            for (size_t i = 0; i < coefficients.size(); ++i)
+                load += demands[row][i] * flags[i];
+            auto spare = model.create_proof_flag("spare" + to_string(row));
+            load += 1_i * spare;
+            resources.push_back(model.add_labelled_constraint("resource" + to_string(row), move(load) <= capacities[row]));
+            weaken_out.push_back({spare});
         }
-        auto spare = model.create_proof_flag("spare");
-        load += 1_i * spare;
-        auto resource = model.add_labelled_constraint("resource", move(load) <= capacity);
         model.finalise();
+
+        vector<ProofLine> kept_resources;
+        vector<vector<ProofFlag>> kept_weaken_out;
+        for (auto row : validity.cut->row_indices) {
+            kept_resources.push_back(resources[row]);
+            kept_weaken_out.push_back(weaken_out[row]);
+        }
 
         ProofLogger logger(proof_options, tracker);
         tracker.switch_from_model_to_proof(&logger);
         logger.start_proof(model);
         tracker.emit_delayed_proof_steps();
 
-        [[maybe_unused]] auto line =
-            derive_lifted_cover_cut(logger, resource, *cut, flags, claimed_coefficients, {spare}, claimed_rhs, ProofLevel::Top);
+        [[maybe_unused]] auto line = derive_lifted_cover_cut(
+            logger, kept_resources, *validity.cut, flags, claimed_coefficients, kept_weaken_out, claimed_rhs, ProofLevel::Top);
         logger.conclude_none();
         tracker.finalise();
 
@@ -145,20 +199,35 @@ namespace
         dispose_of_proof_files(proof_name);
     }
 
+    /// The single-row case, which is most of them and reads better without the
+    /// extra braces.
+    auto check(const string & name, const vector<Integer> & demands, Integer capacity, const vector<Integer> & coefficients, Integer rhs,
+        const vector<Integer> & claimed_coefficients, Integer claimed_rhs, bool expect_veripb_to_accept, bool expect_valid = true) -> void
+    {
+        check(name, vector<vector<Integer>>{demands}, vector<Integer>{capacity}, coefficients, rhs, claimed_coefficients, claimed_rhs,
+            expect_veripb_to_accept, expect_valid);
+    }
+
     /// The honest cut, and then the two "one better" claims over it. Every
     /// certified artefact gets this treatment: with small integers a slack
     /// derivation can verify by coincidence, and a +1 rejection is what says the
     /// honest one is tight to its claim rather than merely true.
-    auto check_and_claim_one_better(
-        const string & name, const vector<Integer> & demands, Integer capacity, const vector<Integer> & coefficients, Integer rhs) -> void
+    auto check_and_claim_one_better(const string & name, const vector<vector<Integer>> & demands, const vector<Integer> & capacities,
+        const vector<Integer> & coefficients, Integer rhs) -> void
     {
-        check(name, demands, capacity, coefficients, rhs, coefficients, rhs, true);
-        check(name + "_tighter_rhs", demands, capacity, coefficients, rhs, coefficients, rhs - 1_i, false);
+        check(name, demands, capacities, coefficients, rhs, coefficients, rhs, true);
+        check(name + "_tighter_rhs", demands, capacities, coefficients, rhs, coefficients, rhs - 1_i, false);
         for (size_t i = 0; i < coefficients.size(); ++i) {
             auto raised = coefficients;
             raised[i] += 1_i;
-            check(name + "_raised_" + to_string(i), demands, capacity, coefficients, rhs, raised, rhs, false);
+            check(name + "_raised_" + to_string(i), demands, capacities, coefficients, rhs, raised, rhs, false);
         }
+    }
+
+    auto check_and_claim_one_better(
+        const string & name, const vector<Integer> & demands, Integer capacity, const vector<Integer> & coefficients, Integer rhs) -> void
+    {
+        check_and_claim_one_better(name, vector<vector<Integer>>{demands}, vector<Integer>{capacity}, coefficients, rhs);
     }
 }
 
@@ -167,49 +236,109 @@ auto main(int argc, char * argv[]) -> int
     establish_and_announce_seed(argc, argv);
 
     // The property that matters, and the one that needs no proof checker: the
-    // dynamic programme is built exactly when the cut holds. Most random claims
-    // here are nonsense and have to be refused, and enough of the rest have to
-    // be real for this to be saying something.
+    // dynamic programme is built exactly when the cut holds, and the optimum it
+    // reports is the one enumeration reports. Most random claims here are
+    // nonsense and have to be refused, and enough of the rest have to be real
+    // for this to be saying something.
     {
         std::mt19937 rand(*get_seed());
-        std::uniform_int_distribution<> n_dist(2, 5), cap_dist(4, 15), coeff_dist(1, 3);
-        size_t validated = 0, refused = 0, validated_non_unit = 0, largest_layer = 0;
+        std::uniform_int_distribution<> n_dist(2, 5), rows_dist(1, 3), cap_dist(4, 15), coeff_dist(1, 3);
+        size_t validated = 0, refused = 0, validated_non_unit = 0, validated_multi_row = 0, only_together = 0, largest_layer = 0;
         for (size_t trial = 0; trial < 4000; ++trial) {
             auto n = static_cast<size_t>(n_dist(rand));
-            auto capacity = Integer{cap_dist(rand)};
-            vector<Integer> demands, coefficients;
-            std::uniform_int_distribution<> demand_dist(1, static_cast<int>(capacity.raw_value));
-            for (size_t i = 0; i < n; ++i) {
-                demands.push_back(Integer{demand_dist(rand)});
-                coefficients.push_back(Integer{coeff_dist(rand)});
+            auto rows = static_cast<size_t>(rows_dist(rand));
+            vector<Integer> capacities, coefficients;
+            vector<vector<Integer>> demands(rows);
+            for (size_t row = 0; row < rows; ++row) {
+                capacities.push_back(Integer{cap_dist(rand)});
+                std::uniform_int_distribution<> demand_dist(0, static_cast<int>(capacities[row].raw_value));
+                for (size_t i = 0; i < n; ++i)
+                    demands[row].push_back(Integer{demand_dist(rand)});
             }
+            for (size_t i = 0; i < n; ++i)
+                coefficients.push_back(Integer{coeff_dist(rand)});
             auto total = std::accumulate(coefficients.begin(), coefficients.end(), 0_i);
             std::uniform_int_distribution<> rhs_dist(0, static_cast<int>(total.raw_value));
             auto rhs = Integer{rhs_dist(rand)};
 
-            auto cut = validate_lifted_cover_cut(demands, coefficients, capacity, rhs);
-            if (cut.has_value() != valid(demands, capacity, coefficients, rhs))
-                fail("the dynamic programme disagrees with enumeration over demands " + to_string(demands.size()) + " and capacity " +
-                    to_string(capacity.raw_value));
-            if (! cut) {
+            auto validity = validate_lifted_cover_cut(demands, coefficients, capacities, rhs, generous);
+            if (validity.over_state_budget)
+                fail("the programme went over a budget these sizes cannot reach");
+            if (validity.cut.has_value() != valid(demands, capacities, coefficients, rhs))
+                fail("the dynamic programme disagrees with enumeration over " + to_string(n) + " members and " + to_string(rows) + " rows");
+
+            // The same programme answering the question its inference half asks:
+            // what is the most the left-hand side can be? Exactly, not an
+            // over-estimate --- a lifting subproblem answered one too high is a
+            // coefficient one too low, which is a different constraint from the
+            // published procedure's.
+            auto enumerated = best(demands, capacities, coefficients);
+            auto optimum = lifted_cover_cut_optimum(demands, coefficients, capacities, total + 1_i, generous);
+            if (optimum.over_state_budget || ! optimum.value)
+                fail("the lifting subproblem gave no answer below a ceiling nothing can reach");
+            if (*optimum.value != enumerated)
+                fail("the lifting subproblem says " + to_string(optimum.value->raw_value) + " where enumeration says " +
+                    to_string(enumerated.raw_value));
+
+            // And that the ceiling really does cap rather than corrupt.
+            auto capped = lifted_cover_cut_optimum(demands, coefficients, capacities, enumerated, generous);
+            if (capped.value)
+                fail("the lifting subproblem answered below a ceiling its answer reaches");
+
+            if (! validity.cut) {
                 ++refused;
                 continue;
             }
             ++validated;
             if (*std::max_element(coefficients.begin(), coefficients.end()) > 1_i && total > rhs)
                 ++validated_non_unit;
-            for (const auto & layer : cut->layers)
+            if (validity.cut->row_indices.size() > 1) {
+                ++validated_multi_row;
+                // Does it need them all? A cut no single row implies is one the
+                // single-resource certificate could not have reached at all.
+                auto alone = false;
+                for (size_t row = 0; row < rows && ! alone; ++row)
+                    alone = valid({demands[row]}, {capacities[row]}, coefficients, rhs);
+                if (! alone)
+                    ++only_together;
+            }
+            for (const auto & layer : validity.cut->layers)
                 largest_layer = std::max(largest_layer, layer.size());
         }
         println(cerr,
-            "{} random cuts validated ({} with a non-unit coefficient and something to derive), {} refused, the widest layer holding {} states",
-            validated, validated_non_unit, refused, largest_layer);
+            "{} random cuts validated ({} with a non-unit coefficient and something to derive, {} needing more than one row, {} needing all of "
+            "them), {} refused, the widest layer holding {} states",
+            validated, validated_non_unit, validated_multi_row, only_together, refused, largest_layer);
         // A programme that refused everything would agree with enumeration on
         // the refusals alone and have derived nothing at all.
         if (validated < 100 || validated_non_unit < 10)
             fail("the random corpus is not exercising the dynamic programme: " + to_string(validated) + " validated, " +
                 to_string(validated_non_unit) + " with a non-unit coefficient");
+        // And one that never needed a second row would say nothing about the
+        // thing this file was extended for.
+        if (only_together < 10)
+            fail("the random corpus found only " + to_string(only_together) + " cuts that need more than one row");
     }
+
+    // Rows that cannot rule anything out are dropped rather than carried as a
+    // flag per state saying nothing, and the caller's numbering survives it.
+    {
+        auto validity = validate_lifted_cover_cut({{1_i, 1_i}, {5_i, 5_i}}, {1_i, 1_i}, {10_i, 6_i}, 1_i, generous);
+        if (! validity.cut)
+            fail("the two-row cut with one useless row was refused");
+        if (validity.cut->row_indices != vector<size_t>{1})
+            fail("the row that cannot rule anything out was kept, or the wrong one was");
+    }
+
+    // A budget is a refusal that says so, rather than a cut quietly going
+    // missing. Nothing else in this file is anywhere near it.
+    {
+        auto validity = validate_lifted_cover_cut(
+            {{3_i, 3_i, 3_i, 3_i, 3_i, 3_i}, {1_i, 2_i, 3_i, 4_i, 5_i, 6_i}}, {1_i, 1_i, 1_i, 1_i, 1_i, 1_i}, {9_i, 12_i}, 3_i, 4);
+        if (validity.cut || ! validity.over_state_budget)
+            fail("a programme past its state budget was not refused as one");
+    }
+    println(cerr, "the programme decides validity and optima exactly, drops rows that cannot bind, and refuses to go over budget");
 
     if (! can_run_veripb()) {
         println(cerr, "veripb is not available, so the rest of this test is skipped");
@@ -266,6 +395,31 @@ auto main(int argc, char * argv[]) -> int
     // A cut that is not valid has no programme to build and no proof to emit.
     check("invalid_rhs", {6_i, 6_i, 6_i}, 10_i, {1_i, 1_i, 1_i}, 0_i, {1_i, 1_i, 1_i}, 0_i, false, false);
     println(cerr, "an invalid cut is refused rather than derived");
+
+    // Several rows, which is what Sidorov's Equation 4 lifts over and where a
+    // certificate built around a single one stops. Two resources of capacity
+    // five, each with one task that fills it and three that half do: `2a + b + c
+    // + 2d <= 2` holds at every point the two allow between them, and at neither
+    // resource's own points --- the first admits {b, d} for three, and the second
+    // {a, b} for three. So this is not the single-row cut with extra rows
+    // watching: it is a constraint no single row implies, and the only thing
+    // that changed is that the programme carries a weight per row.
+    check_and_claim_one_better("two_rows", {{5_i, 2_i, 2_i, 2_i}, {2_i, 2_i, 2_i, 5_i}}, {5_i, 5_i}, {2_i, 1_i, 1_i, 2_i}, 2_i);
+    check("two_rows_one_alone", {5_i, 2_i, 2_i, 2_i}, 5_i, {2_i, 1_i, 1_i, 2_i}, 2_i, {2_i, 1_i, 1_i, 2_i}, 2_i, false, false);
+    check("two_rows_other_alone", {2_i, 2_i, 2_i, 5_i}, 5_i, {2_i, 1_i, 1_i, 2_i}, 2_i, {2_i, 1_i, 1_i, 2_i}, 2_i, false, false);
+    println(cerr, "a cut needing two rows derives, and neither row derives it alone");
+
+    // Three of them, each ruling out one pair, which is the shape a cut lifted
+    // across a project's resources actually has: no resource is where the
+    // argument lives, and every one of them is doing some of it.
+    check_and_claim_one_better("three_rows", {{3_i, 3_i, 1_i}, {1_i, 3_i, 3_i}, {3_i, 1_i, 3_i}}, {5_i, 5_i, 5_i}, {1_i, 1_i, 1_i}, 1_i);
+    println(cerr, "a cut whose rows each rule out one pair derives");
+
+    // A row that cannot rule anything out is not in the programme, so a cut
+    // beside one derives exactly as it does without it --- and the caller's
+    // numbering of its rows is what it passes, not the programme's.
+    check_and_claim_one_better("useless_row_beside", {{1_i, 1_i, 1_i}, {6_i, 6_i, 6_i}}, {20_i, 10_i}, {1_i, 1_i, 1_i}, 1_i);
+    println(cerr, "a row that cannot bind is dropped without disturbing the rest");
 
     return EXIT_SUCCESS;
 }

--- a/gcs/innards/proofs/subset_sum_strengthening.hh
+++ b/gcs/innards/proofs/subset_sum_strengthening.hh
@@ -105,7 +105,7 @@ namespace gcs::innards
      * deriving: it is what later cutting-planes arithmetic can use. This is the
      * integrality argument behind a knapsack-augmented overload check's
      * availability bound (issue #550), Schulz's capacity reduction (#547) and
-     * single-resource lifting certificates (#549).
+     * lifted cover cut certificates (#549).
      *
      * Two derivations, chosen automatically:
      *

--- a/gcs/presolvers/inferred_cumulative/inferred_cumulative.cc
+++ b/gcs/presolvers/inferred_cumulative/inferred_cumulative.cc
@@ -146,8 +146,11 @@ namespace
     ///
     /// The reference implementation compares a duration against an *index* when
     /// picking the longest task of a given demand (`durations[ix] >
-    /// inv_A_longest[a]`), which cannot be what was meant; the paper says
-    /// longest and that is what happens here.
+    /// inv_A_longest[a]`); Sidorov confirms the intended line is
+    /// `durations[ix] > durations[inv_A_longest[a]]`, which is what happens
+    /// here. Its published results came from the shipped line, so the ternary
+    /// covers here are not the ones its numbers were produced from --- never
+    /// worse ones, which is the awkward direction. See the writeup.
     [[nodiscard]] auto collect_covers(const vector<Task> & tasks, const vector<Integer> & demands, Integer capacity, size_t max_covers,
         size_t cover_cardinality) -> vector<vector<size_t>>
     {
@@ -288,8 +291,12 @@ namespace
     /// The right-hand side never moves.
     ///
     /// Longest first follows the reference implementation, which sorts by
-    /// duration descending; the paper's Algorithm 2 says `arg min d_i`. The
-    /// published results came from the code.
+    /// duration descending; the paper's Algorithm 2 says `arg min d_i`, and
+    /// Sidorov confirms that is the typo. Bringing the tasks with the biggest
+    /// effect on the bound in first keeps them out of the subproblem's objective
+    /// while it is still small, so they meet a smaller `v*` and get a larger
+    /// coefficient. Lifting is sequence-dependent even over one row (Zemel
+    /// 1978), so the order is load-bearing rather than cosmetic.
     struct Lifted
     {
         vector<Integer> coefficients;

--- a/gcs/presolvers/inferred_cumulative/inferred_cumulative.cc
+++ b/gcs/presolvers/inferred_cumulative/inferred_cumulative.cc
@@ -1,6 +1,7 @@
 #include <gcs/constraint_id.hh>
 #include <gcs/constraints/cumulative.hh>
 #include <gcs/constraints/cumulative/derived_cumulative.hh>
+#include <gcs/innards/proofs/flag_bridge.hh>
 #include <gcs/innards/proofs/lifted_cover_cut.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
@@ -37,21 +38,49 @@ using std::size_t;
 using std::to_string;
 using std::unique_ptr;
 using std::vector;
+using std::ranges::any_of;
 
 namespace
 {
-    /// One task of a donor that could carry a cut.
-    struct Task
+    /// One posted Cumulative a cut can be lifted over.
+    struct Donor
     {
-        size_t position;
-        IntegerVariableID start;
-        Integer length, demand;
-        Integer t_lo, t_hi;
+        ConstraintID id;
+        size_t size;
+        Integer capacity;
     };
 
-    /// A lifted cover inequality over some of a donor's tasks: `sum_i
-    /// coefficients[i] a_i <= rhs`, with `support` indexing into the donor's
-    /// task list.
+    /// One task, as it appears across every donor.
+    ///
+    /// Sidorov's Equation 4 constrains over all of the resources at once, so
+    /// what the procedure works on is a matrix rather than a row: one column per
+    /// task, one row per resource. Tasks are matched across posted constraints
+    /// by their start variable and length, which is what his
+    /// `extract_cumulative_matrix` does with the interval expressions, and two
+    /// of a donor's own tasks that look the same stay separate rather than being
+    /// folded into one column.
+    struct Task
+    {
+        IntegerVariableID start;
+        Integer length;
+        Integer t_lo, t_hi;
+
+        /// Per donor: what this task takes, and where it sits in that donor's
+        /// task list. Absent where the donor has no such task, and zero where it
+        /// has one that consumes nothing --- which is not the same thing, since
+        /// only the first means there is no flag to speak with.
+        vector<Integer> demands;
+        vector<optional<size_t>> positions;
+
+        /// The donor whose flags speak for this task: the first one that gives
+        /// it a term of its own. A cut's members can perfectly well take theirs
+        /// from different donors, which is what DerivedCumulativeTask naming a
+        /// donor per task is for.
+        size_t canonical_donor;
+    };
+
+    /// A lifted cover inequality over some tasks: `sum_i coefficients[i] a_i <=
+    /// rhs`, with `support` indexing into the joint task list.
     struct Cut
     {
         vector<size_t> support;
@@ -89,6 +118,18 @@ namespace
         return tracker.find_proof_flag_values(donor, ConstraintProofModelData<Cumulative>::active_flag_key(position, t));
     }
 
+    /// The `before` and `after` flags an `active` flag is the conjunction of,
+    /// which is what a bridge between two donors' copies of it has to line up.
+    [[nodiscard]] auto active_conjuncts_for(const NamesAndIDsTracker & tracker, const ConstraintID & donor, size_t position, Integer t)
+        -> optional<vector<ProofFlag>>
+    {
+        auto before = tracker.find_proof_flag_values(donor, ConstraintProofModelData<Cumulative>::before_flag_key(position, t));
+        auto after = tracker.find_proof_flag_values(donor, ConstraintProofModelData<Cumulative>::after_flag_key(position, t));
+        if (! before || ! after)
+            return std::nullopt;
+        return vector<ProofFlag>{*before, *after};
+    }
+
     /// Algorithm 1 of Sidorov (CP 2026), for one resource. Two families.
     ///
     /// **Short covers**: every pair whose demands overshoot, and --- for each
@@ -107,13 +148,14 @@ namespace
     /// picking the longest task of a given demand (`durations[ix] >
     /// inv_A_longest[a]`), which cannot be what was meant; the paper says
     /// longest and that is what happens here.
-    [[nodiscard]] auto collect_covers(const vector<Task> & tasks, Integer capacity, size_t max_covers, size_t cover_cardinality)
-        -> vector<vector<size_t>>
+    [[nodiscard]] auto collect_covers(const vector<Task> & tasks, const vector<Integer> & demands, Integer capacity, size_t max_covers,
+        size_t cover_cardinality) -> vector<vector<size_t>>
     {
         auto n = tasks.size();
         map<Integer, vector<size_t>> by_demand;
         for (size_t i = 0; i < n; ++i)
-            by_demand[tasks[i].demand].push_back(i);
+            if (demands[i] > 0_i)
+                by_demand[demands[i]].push_back(i);
 
         map<Integer, size_t> longest_of_demand;
         for (const auto & [demand, group] : by_demand) {
@@ -134,13 +176,15 @@ namespace
 
         for (size_t x = 0; x < n; ++x)
             for (size_t y = x + 1; y < n; ++y)
-                if (tasks[x].demand + tasks[y].demand > capacity)
+                if (demands[x] + demands[y] > capacity)
                     remember({x, y});
 
         if (cover_cardinality >= 3)
             for (size_t x = 0; x < n; ++x)
                 for (size_t y = x + 1; y < n; ++y) {
-                    auto room = capacity - tasks[x].demand - tasks[y].demand;
+                    if (demands[x] <= 0_i || demands[y] <= 0_i)
+                        continue;
+                    auto room = capacity - demands[x] - demands[y];
                     if (room < 0_i)
                         continue;
                     for (const auto & [demand, z] : longest_of_demand)
@@ -203,30 +247,39 @@ namespace
 
     /// The lifting subproblem `v*` of Sidorov Equation 4: the most the current
     /// inequality's left-hand side can weigh over the variables already in it,
-    /// once `member` is forced to run and has taken its demand off the
-    /// capacity. A 0/1 knapsack, by the usual table over residual capacity.
+    /// once `member` is forced to run and has taken its demand off every
+    /// resource.
     ///
-    /// The paper solves this over *every* resource at once, which is what makes
-    /// its lifting cross-resource; this is one row, matching what the
-    /// certificate can reach. See issue #673.
-    [[nodiscard]] auto lifting_subproblem(
-        const vector<Task> & tasks, Integer capacity, const vector<Integer> & coefficients, const vector<size_t> & support, size_t member) -> Integer
+    /// This is a multi-dimensional knapsack, and it is answered by the very
+    /// programme that will certify the finished cut --- indexed by profit, and
+    /// capped at the right-hand side, because a `v*` that reaches it leaves no
+    /// positive coefficient to lift with and the exact value stops mattering.
+    /// Sharing that machinery is not an economy: it is what makes a cut the
+    /// procedure infers one the proof can reach, since both are asking the same
+    /// question of the same rows.
+    struct Subproblem
     {
-        auto residual = capacity - tasks[member].demand;
-        if (residual < 0_i)
-            return 0_i;
+        optional<Integer> optimum;
+        bool over_budget = false;
+    };
 
-        vector<Integer> best(static_cast<size_t>(residual.raw_value) + 1, 0_i);
-        for (auto i : support) {
-            if (coefficients[i] <= 0_i)
-                continue;
-            for (auto room = residual; room >= tasks[i].demand; --room) {
-                auto with = best[static_cast<size_t>((room - tasks[i].demand).raw_value)] + coefficients[i];
-                auto & here = best[static_cast<size_t>(room.raw_value)];
-                here = max(here, with);
-            }
+    [[nodiscard]] auto lifting_subproblem(const vector<vector<Integer>> & demands, const vector<Integer> & capacities,
+        const vector<Integer> & coefficients, const vector<size_t> & support, size_t member, Integer rhs, size_t state_budget) -> Subproblem
+    {
+        vector<Integer> residual, support_coefficients;
+        vector<vector<Integer>> support_demands(capacities.size());
+        for (size_t row = 0; row < capacities.size(); ++row) {
+            residual.push_back(capacities[row] - demands[row][member]);
+            if (residual.back() < 0_i)
+                return Subproblem{0_i, false};
+            for (auto i : support)
+                support_demands[row].push_back(demands[row][i]);
         }
-        return best[static_cast<size_t>(residual.raw_value)];
+        for (auto i : support)
+            support_coefficients.push_back(coefficients[i]);
+
+        auto answer = lifted_cover_cut_optimum(support_demands, support_coefficients, residual, rhs, state_budget);
+        return Subproblem{answer.value, answer.over_state_budget};
     }
 
     /// Algorithm 2's inner loop: start from the cover inequality
@@ -242,9 +295,11 @@ namespace
         vector<Integer> coefficients;
         Integer rhs;
         size_t subproblems;
+        size_t over_budget;
     };
 
-    [[nodiscard]] auto lift_cover(const vector<Task> & tasks, Integer capacity, const vector<size_t> & cover, size_t budget) -> Lifted
+    [[nodiscard]] auto lift_cover(const vector<Task> & tasks, const vector<vector<Integer>> & demands, const vector<Integer> & capacities,
+        const vector<size_t> & cover, size_t budget, size_t state_budget) -> Lifted
     {
         vector<Integer> coefficients(tasks.size(), 0_i);
         for (auto i : cover)
@@ -262,44 +317,63 @@ namespace
         });
 
         auto support = cover;
-        size_t used = 0;
+        size_t used = 0, over_budget = 0;
         for (auto member : remaining) {
             if (used >= budget)
                 break;
             ++used;
-            auto lifted = rhs - lifting_subproblem(tasks, capacity, coefficients, support, member);
-            // A negative coefficient would mean the subproblem beat the
-            // right-hand side, which cannot happen for a valid inequality; the
-            // reference implementation warns about it rather than trusting it.
+            auto subproblem = lifting_subproblem(demands, capacities, coefficients, support, member, rhs, state_budget);
+            if (subproblem.over_budget) {
+                // No answer means no coefficient: the task is left out, which
+                // weakens the cut rather than invalidating it. Counted, because
+                // a constraint that differs from the published procedure's is
+                // worth knowing about even when it is still sound.
+                ++over_budget;
+                continue;
+            }
+            // A subproblem that reaches the right-hand side leaves nothing
+            // positive to lift with, and the reference implementation warns
+            // about the negative coefficient rather than trusting it.
+            if (! subproblem.optimum)
+                continue;
+            auto lifted = rhs - *subproblem.optimum;
             if (lifted <= 0_i)
                 continue;
             coefficients[member] = lifted;
             support.push_back(member);
         }
 
-        return Lifted{move(coefficients), rhs, used};
+        return Lifted{move(coefficients), rhs, used, over_budget};
     }
+
+    /// One member of a cut, as the per-time recipe needs to see it.
+    struct RecipeMember
+    {
+        /// Where its flags come from, and where it sits there.
+        size_t canonical_donor;
+        size_t canonical_position;
+        /// Per donor, as in Task.
+        vector<Integer> demands;
+        vector<optional<size_t>> positions;
+        Integer coefficient, t_lo, t_hi;
+    };
 
     /// Everything the per-time recipe needs, copied out of the presolver so the
     /// closure owns it.
     struct Recipe
     {
-        ConstraintID donor;
-        size_t donor_size;
-        Integer capacity, rhs;
+        vector<Donor> donors;
+        vector<RecipeMember> members;
+        Integer rhs;
+        size_t state_budget;
         InferredCumulativeMutation mutation;
         shared_ptr<map<vector<size_t>, optional<LiftedCoverCut>>> programmes;
         shared_ptr<InferredCumulativeStats> stats;
-
-        /// One entry per member of the cut, in the derived constraint's own
-        /// task order, filled in by the caller after construction.
-        vector<size_t> positions;
-        vector<Integer> demands, coefficients, t_lo, t_hi;
     };
 }
 
 InferredCumulative::InferredCumulative(shared_ptr<InferredCumulativeStats> stats) :
-    _stats(move(stats)), _max_covers(100), _max_posted(5), _maximum_capacity(1000), _max_lifting_calls(20000),
+    _stats(move(stats)), _max_covers(100), _max_posted(5), _maximum_capacity(1000), _max_lifting_calls(20000), _max_programme_states(100000),
     // Energy only: a valid cut holds at every 0/1 point the donor's row allows,
     // so no time-tabling verdict about a single time point can differ.
     _rules(CumulativeRules{.time_table = false, .overload = true, .profile_overload = true}), _mutation(inferred_cumulative_mutation::None{})
@@ -322,6 +396,12 @@ auto InferredCumulative::with_maximum_capacity(size_t capacity) -> InferredCumul
 auto InferredCumulative::with_lifting_call_budget(size_t calls) -> InferredCumulative &
 {
     _max_lifting_calls = calls;
+    return *this;
+}
+
+auto InferredCumulative::with_programme_state_budget(size_t states) -> InferredCumulative &
+{
+    _max_programme_states = states;
     return *this;
 }
 
@@ -357,6 +437,15 @@ auto InferredCumulative::run(Problem & problem, Propagators & propagators, State
     if (_makespan)
         makespan_links = find_makespan_links(problem, logger, *_makespan);
 
+    // One pass over every posted Cumulative rather than one pass each, because
+    // Equation 4's lifting subproblem is over all of them at once. Everything
+    // downstream --- the cover budget, the visited rule, the subproblem budget,
+    // and how many constraints are posted --- is then global, which is what the
+    // reference implementation does with its single matrix.
+    vector<Donor> donors;
+    vector<Task> tasks;
+    map<pair<IntegerVariableID, Integer>, size_t> task_of;
+
     for (const auto & donor : problem.each_constraint_of_type<Cumulative>()) {
         bump(&InferredCumulativeStats::donors_seen);
 
@@ -376,25 +465,9 @@ auto InferredCumulative::run(Problem & problem, Propagators & propagators, State
         }
 
         const auto & starts = donor.starts();
-        vector<Task> tasks;
-        bool constant = true;
-        for (size_t i = 0; i < starts.size(); ++i) {
-            auto length = constant_value_of(donor.lengths()[i]);
-            auto demand = constant_value_of(donor.heights()[i]);
-            if (! length || ! demand) {
-                constant = false;
-                break;
-            }
-            // A task with nothing to contribute has no term in the row and no
-            // flags, and one that alone exceeds the capacity can never run at
-            // all --- the donor's own row says so, and including it would pad
-            // every cover it touched.
-            if (*length <= 0_i || *demand <= 0_i || *demand > *capacity)
-                continue;
-            auto [s_lo, s_hi] = state.bounds(starts[i]);
-            tasks.push_back(Task{i, starts[i], *length, *demand, s_lo, s_hi + *length - 1_i});
-        }
-
+        auto constant = true;
+        for (size_t i = 0; i < starts.size() && constant; ++i)
+            constant = is_constant_variable(donor.lengths()[i]) && is_constant_variable(donor.heights()[i]);
         if (! constant) {
             bump(&InferredCumulativeStats::declined_variable_arguments);
             if (logger)
@@ -402,276 +475,463 @@ auto InferredCumulative::run(Problem & problem, Propagators & propagators, State
             continue;
         }
 
-        bump(&InferredCumulativeStats::tasks, tasks.size());
-        if (tasks.size() < 2)
-            continue;
+        auto which = donors.size();
+        donors.push_back(Donor{donor.constraint_id(), starts.size(), *capacity});
 
-        vector<Integer> demands, durations;
-        for (const auto & task : tasks) {
-            demands.push_back(task.demand);
-            durations.push_back(task.length);
+        // Every task already found needs a slot for the donor just added,
+        // whether or not it turns out to appear in it --- and before the loop
+        // below, which is what fills those slots in.
+        for (auto & task : tasks) {
+            task.demands.resize(donors.size(), 0_i);
+            task.positions.resize(donors.size(), std::nullopt);
         }
 
-        vector<size_t> by_demand(tasks.size());
-        std::iota(by_demand.begin(), by_demand.end(), size_t{0});
-        std::sort(by_demand.begin(), by_demand.end(), [&](size_t a, size_t b) {
-            if (tasks[a].demand != tasks[b].demand)
-                return tasks[a].demand > tasks[b].demand;
+        for (size_t i = 0; i < starts.size(); ++i) {
+            auto length = *constant_value_of(donor.lengths()[i]);
+            auto demand = *constant_value_of(donor.heights()[i]);
+            // A task with nothing to contribute has no term in this donor's row
+            // and no flags there, and one that alone exceeds the capacity can
+            // never run at all --- the donor's own row says so, and including it
+            // would pad every cover it touched. Either way it is this *donor*
+            // that has nothing to say about it, and another may still have.
+            if (length <= 0_i || demand <= 0_i || demand > *capacity)
+                continue;
+
+            // Matched across donors by start and length, and a donor's second
+            // task with the same pair stays its own column rather than being
+            // merged into the first.
+            auto key = pair{starts[i], length};
+            auto found = task_of.find(key);
+            if (found != task_of.end() && ! tasks[found->second].positions[which]) {
+                tasks[found->second].demands[which] = demand;
+                tasks[found->second].positions[which] = i;
+                continue;
+            }
+
+            auto [s_lo, s_hi] = state.bounds(starts[i]);
+            Task task{starts[i], length, s_lo, s_hi + length - 1_i, vector<Integer>(donors.size(), 0_i),
+                vector<optional<size_t>>(donors.size(), std::nullopt), which};
+            task.demands[which] = demand;
+            task.positions[which] = i;
+            task_of.emplace(key, tasks.size());
+            tasks.push_back(move(task));
+        }
+    }
+
+    bump(&InferredCumulativeStats::tasks, tasks.size());
+    if (donors.empty() || tasks.size() < 2)
+        return true;
+
+    vector<Integer> capacities, durations;
+    for (const auto & donor : donors)
+        capacities.push_back(donor.capacity);
+    for (const auto & task : tasks)
+        durations.push_back(task.length);
+
+    vector<vector<Integer>> demands(donors.size());
+    for (size_t row = 0; row < donors.size(); ++row)
+        for (const auto & task : tasks)
+            demands[row].push_back(task.demands[row]);
+
+    // Algorithm 1, per resource, and then merged: the covers a resource can
+    // offer are its own, but which of them are worth lifting is decided across
+    // all of them, as `collect_cover_sets` does. Covers of more than three tasks
+    // survive the budget outright, since nothing else produces them.
+    vector<vector<size_t>> covers;
+    {
+        set<vector<size_t>> seen;
+        vector<vector<size_t>> pooled;
+        for (size_t row = 0; row < donors.size(); ++row)
+            for (auto & cover : collect_covers(tasks, demands[row], capacities[row], _max_covers, _maximum_capacity + 1))
+                if (seen.insert(cover).second)
+                    pooled.push_back(move(cover));
+
+        auto bound_of = [&](const vector<size_t> & cover) {
+            auto total = 0_i;
+            for (auto i : cover)
+                total += tasks[i].length;
+            return pair{total, Integer{static_cast<long long>(cover.size()) - 1}};
+        };
+        std::sort(pooled.begin(), pooled.end(), [&](const vector<size_t> & a, const vector<size_t> & b) {
+            auto [ta, ra] = bound_of(a);
+            auto [tb, rb] = bound_of(b);
+            if (ta * rb != tb * ra)
+                return ta * rb > tb * ra;
             return a < b;
         });
 
-        // Algorithm 2: lift each cover, skipping any whose support a previous
-        // lifting already established, and keeping the best `_max_posted` by
-        // capacity bound. Nothing here asks whether a constraint can be
-        // *proved* --- that comes after, so the gap between what the published
-        // method infers and what we can certify is a number rather than a
-        // design decision.
-        vector<Cut> cuts;
-        vector<pair<set<size_t>, size_t>> visited;
-        auto calls_left = _max_lifting_calls;
+        // `[c for c in covers if len(c) > 3] + covers[:pool_size]`: every cover
+        // of more than three tasks survives outright, since nothing but the
+        // equal-demand families produces one, and then the best `max_covers`
+        // overall whatever their size. So the budget bites twice --- once on
+        // each resource's short families, and again across all of them.
+        set<vector<size_t>> taken;
+        for (const auto & cover : pooled)
+            if (cover.size() > 3 && taken.insert(cover).second)
+                covers.push_back(cover);
+        for (size_t i = 0; i < pooled.size() && i < _max_covers; ++i)
+            if (taken.insert(pooled[i]).second)
+                covers.push_back(pooled[i]);
+    }
 
-        for (const auto & cover : collect_covers(tasks, *capacity, _max_covers, _maximum_capacity + 1)) {
-            bump(&InferredCumulativeStats::covers_considered);
+    // Algorithm 2: lift each cover, skipping any whose support a previous
+    // lifting already established, and keeping the best `_max_posted` by
+    // capacity bound. Nothing here asks whether a constraint can be *proved* ---
+    // that comes after, so the gap between what the published method infers and
+    // what we can certify is a number rather than a design decision.
+    vector<Cut> cuts;
+    vector<pair<set<size_t>, size_t>> visited;
+    auto calls_left = _max_lifting_calls;
 
-            // Example 12: a cover already inside the support of something
-            // lifted earlier will re-derive it, so the subproblems are wasted.
-            bool already = false;
-            for (const auto & [support, cardinality] : visited)
-                if (cardinality <= cover.size() && std::includes(support.begin(), support.end(), cover.begin(), cover.end())) {
-                    already = true;
-                    break;
-                }
-            if (already) {
-                bump(&InferredCumulativeStats::dropped_visited);
-                continue;
-            }
+    for (const auto & cover : covers) {
+        bump(&InferredCumulativeStats::covers_considered);
 
-            if (calls_left == 0)
+        // Example 12: a cover already inside the support of something lifted
+        // earlier will re-derive it, so the subproblems are wasted.
+        auto already = false;
+        for (const auto & [support, cardinality] : visited)
+            if (cardinality <= cover.size() && std::includes(support.begin(), support.end(), cover.begin(), cover.end())) {
+                already = true;
                 break;
-            auto lifted = lift_cover(tasks, *capacity, cover, calls_left);
-            calls_left -= lifted.subproblems;
-            bump(&InferredCumulativeStats::lifting_subproblems, lifted.subproblems);
-            if (lifted.rhs < 1_i)
-                continue;
-
-            vector<size_t> support;
-            for (size_t i = 0; i < tasks.size(); ++i)
-                if (lifted.coefficients[i] > 0_i)
-                    support.push_back(i);
-            if (support.size() < 2)
-                continue;
-
-            set<size_t> unit;
-            for (size_t i = 0; i < tasks.size(); ++i)
-                if (lifted.coefficients[i] == 1_i)
-                    unit.insert(i);
-            visited.emplace_back(move(unit), cover.size());
-
-            // Dominance: a constraint the donor's own row already implies term
-            // by term says nothing new.
-            bool dominated = true;
-            for (size_t i = 0; i < tasks.size() && dominated; ++i)
-                if (lifted.coefficients[i] > demands[i])
-                    dominated = false;
-            if (dominated && *capacity > lifted.rhs)
-                dominated = false;
-            if (dominated) {
-                bump(&InferredCumulativeStats::dropped_dominated);
-                continue;
             }
-
-            Integer energy = 0_i;
-            for (auto i : support)
-                energy += durations[i] * lifted.coefficients[i];
-
-            vector<Integer> cut_coefficients;
-            for (auto i : support)
-                cut_coefficients.push_back(lifted.coefficients[i]);
-            cuts.push_back(Cut{support, move(cut_coefficients), lifted.rhs, {}, energy});
-            bump(&InferredCumulativeStats::cuts_found);
+        if (already) {
+            bump(&InferredCumulativeStats::dropped_visited);
+            continue;
         }
 
-        // Step L5: the best `_max_posted` by capacity bound.
-        std::sort(cuts.begin(), cuts.end(), [&](const Cut & a, const Cut & b) {
-            if (a.energy * b.rhs != b.energy * a.rhs)
-                return a.energy * b.rhs > b.energy * a.rhs;
-            return a.support < b.support;
-        });
-        if (cuts.size() > _max_posted) {
-            bump(&InferredCumulativeStats::dropped_over_budget, cuts.size() - _max_posted);
-            cuts.erase(cuts.begin() + static_cast<long>(_max_posted), cuts.end());
+        if (calls_left == 0)
+            break;
+        auto lifted = lift_cover(tasks, demands, capacities, cover, calls_left, _max_programme_states);
+        calls_left -= lifted.subproblems;
+        bump(&InferredCumulativeStats::lifting_subproblems, lifted.subproblems);
+        bump(&InferredCumulativeStats::lifting_subproblems_over_budget, lifted.over_budget);
+        if (lifted.rhs < 1_i)
+            continue;
+
+        vector<size_t> support;
+        for (size_t i = 0; i < tasks.size(); ++i)
+            if (lifted.coefficients[i] > 0_i)
+                support.push_back(i);
+        if (support.size() < 2)
+            continue;
+
+        set<size_t> unit;
+        for (size_t i = 0; i < tasks.size(); ++i)
+            if (lifted.coefficients[i] == 1_i)
+                unit.insert(i);
+        visited.emplace_back(move(unit), cover.size());
+
+        // Dominance: a constraint some model row already implies term by term
+        // says nothing new.
+        auto dominated = false;
+        for (size_t row = 0; row < donors.size() && ! dominated; ++row) {
+            auto row_dominates = capacities[row] <= lifted.rhs;
+            for (size_t i = 0; i < tasks.size() && row_dominates; ++i)
+                row_dominates = lifted.coefficients[i] <= demands[row][i];
+            dominated = row_dominates;
+        }
+        if (dominated) {
+            bump(&InferredCumulativeStats::dropped_dominated);
+            continue;
         }
 
-        // Only now, the part the paper does not have to do: build the dynamic
-        // programme that says each cut follows from the donor's row, which is
-        // also its certificate. Algorithm 2 solves its lifting subproblems
-        // exactly, so this should accept everything it produced; a constraint it
-        // refuses is a constraint the published method inferred and that does
-        // not in fact hold, which is dropped and counted rather than asserted.
-        vector<Cut> accepted;
-        for (auto & cut : cuts) {
-            vector<Integer> support_demands;
+        Integer energy = 0_i;
+        for (auto i : support)
+            energy += durations[i] * lifted.coefficients[i];
+
+        vector<Integer> cut_coefficients;
+        for (auto i : support)
+            cut_coefficients.push_back(lifted.coefficients[i]);
+        cuts.push_back(Cut{support, move(cut_coefficients), lifted.rhs, {}, energy});
+        bump(&InferredCumulativeStats::cuts_found);
+    }
+
+    // Step L5: the best `_max_posted` by capacity bound.
+    std::sort(cuts.begin(), cuts.end(), [&](const Cut & a, const Cut & b) {
+        if (a.energy * b.rhs != b.energy * a.rhs)
+            return a.energy * b.rhs > b.energy * a.rhs;
+        return a.support < b.support;
+    });
+    if (cuts.size() > _max_posted) {
+        bump(&InferredCumulativeStats::dropped_over_budget, cuts.size() - _max_posted);
+        cuts.erase(cuts.begin() + static_cast<long>(_max_posted), cuts.end());
+    }
+
+    // Only now, the part the paper does not have to do: build the dynamic
+    // programme that says each cut follows from the rows, which is also its
+    // certificate. Algorithm 2 solves its lifting subproblems exactly, so this
+    // should accept everything it produced; a constraint it refuses is a
+    // constraint the published method inferred and that does not in fact hold,
+    // which is dropped and counted rather than asserted.
+    vector<Cut> accepted;
+    for (auto & cut : cuts) {
+        vector<vector<Integer>> support_demands(donors.size());
+        for (size_t row = 0; row < donors.size(); ++row)
             for (auto i : cut.support)
-                support_demands.push_back(demands[i]);
-            cut.validated = validate_lifted_cover_cut(support_demands, cut.coefficients, *capacity, cut.rhs);
-            if (! cut.validated) {
-                bump(&InferredCumulativeStats::cuts_uncertifiable);
-                if (logger)
-                    logger->emit_proof_comment("presolve lifted cover: dropping an inferred constraint over " + to_string(cut.support.size()) +
-                        " tasks, it does not follow from the donor's row");
-                continue;
-            }
-            accepted.push_back(move(cut));
+                support_demands[row].push_back(demands[row][i]);
+
+        auto validity = validate_lifted_cover_cut(support_demands, cut.coefficients, capacities, cut.rhs, _max_programme_states);
+        cut.validated = move(validity.cut);
+        if (! cut.validated) {
+            bump(validity.over_state_budget ? &InferredCumulativeStats::dropped_over_state_budget : &InferredCumulativeStats::cuts_uncertifiable);
+            if (logger)
+                logger->emit_proof_comment("presolve lifted cover: dropping an inferred constraint over " + to_string(cut.support.size()) +
+                    " tasks, " + (validity.over_state_budget ? "its dynamic programme is over budget" : "it does not follow from the rows"));
+            continue;
+        }
+        accepted.push_back(move(cut));
+    }
+
+    for (const auto & cut : accepted) {
+        vector<DerivedCumulativeTask> derived_tasks;
+        Recipe recipe{.donors = donors,
+            .members = {},
+            .rhs = cut.rhs,
+            .state_budget = _max_programme_states,
+            .mutation = _mutation,
+            .programmes = make_shared<map<vector<size_t>, optional<LiftedCoverCut>>>(),
+            .stats = _stats};
+        vector<optional<makespan_energy::MakespanLink>> links;
+        for (size_t k = 0; k < cut.support.size(); ++k) {
+            const auto & task = tasks[cut.support[k]];
+            auto link = makespan_links.find(task.start);
+            links.push_back(link == makespan_links.end() ? std::nullopt : optional<makespan_energy::MakespanLink>{link->second});
+            derived_tasks.push_back(DerivedCumulativeTask{
+                donors[task.canonical_donor].id, *task.positions[task.canonical_donor], task.start, task.length, cut.coefficients[k]});
+            recipe.members.push_back(RecipeMember{task.canonical_donor, *task.positions[task.canonical_donor], task.demands, task.positions,
+                cut.coefficients[k], task.t_lo, task.t_hi});
         }
 
-        for (const auto & cut : accepted) {
-            vector<DerivedCumulativeTask> derived_tasks;
-            Recipe recipe{.donor = donor.constraint_id(),
-                .donor_size = starts.size(),
-                .capacity = *capacity,
-                .rhs = cut.rhs,
-                .mutation = _mutation,
-                .programmes = make_shared<map<vector<size_t>, optional<LiftedCoverCut>>>(),
-                .stats = _stats,
-                .positions = {},
-                .demands = {},
-                .coefficients = {},
-                .t_lo = {},
-                .t_hi = {}};
-            vector<optional<makespan_energy::MakespanLink>> links;
-            for (size_t k = 0; k < cut.support.size(); ++k) {
-                const auto & task = tasks[cut.support[k]];
-                auto link = makespan_links.find(task.start);
-                links.push_back(link == makespan_links.end() ? std::nullopt : optional<makespan_energy::MakespanLink>{link->second});
-                derived_tasks.push_back(DerivedCumulativeTask{recipe.donor, task.position, task.start, task.length, cut.coefficients[k]});
-                recipe.positions.push_back(task.position);
-                recipe.demands.push_back(task.demand);
-                recipe.coefficients.push_back(cut.coefficients[k]);
-                recipe.t_lo.push_back(task.t_lo);
-                recipe.t_hi.push_back(task.t_hi);
-            }
+        // Every time point in the middle of the window has all of the cut's
+        // members present, and its programme is the one discovery already built.
+        // Seed it, so only the restrictions at the edges --- where some members
+        // have no flags and so no terms in the rows --- have a programme of
+        // their own.
+        vector<size_t> everyone(recipe.members.size());
+        std::iota(everyone.begin(), everyone.end(), size_t{0});
+        recipe.programmes->emplace(move(everyone), cut.validated);
 
-            // Every time point in the middle of the window has all of the cut's
-            // members present, and its programme is the one discovery already
-            // built. Seed it, so only the restrictions at the edges --- where
-            // some members have no flags and so no terms in the row --- have a
-            // programme of their own.
-            vector<size_t> everyone(recipe.positions.size());
-            std::iota(everyone.begin(), everyone.end(), size_t{0});
-            recipe.programmes->emplace(move(everyone), cut.validated);
+        // Only the rows the programme kept are ever cited, and a restriction to
+        // fewer members can only make fewer of them bind, so this is every donor
+        // whose row could be wanted at any time point.
+        vector<ConstraintID> row_donors;
+        for (auto row : cut.validated->row_indices)
+            row_donors.push_back(donors[row].id);
 
-            DerivedCumulativeSpec spec{.tasks = derived_tasks,
-                .capacity = cut.rhs,
-                .row_donors = vector<ConstraintID>{recipe.donor},
-                .recipe = [recipe](ProofLogger & recipe_logger, const DerivedCumulativeRows & rows, Integer t) -> optional<ProofLine> {
-                    const auto & tracker = recipe_logger.names_and_ids_tracker();
-                    auto row = rows.find(recipe.donor);
-                    if (row == rows.end())
+        DerivedCumulativeSpec spec{.tasks = derived_tasks,
+            .capacity = cut.rhs,
+            .row_donors = row_donors,
+            .recipe = [recipe](ProofLogger & recipe_logger, const DerivedCumulativeRows & rows, Integer t) -> optional<ProofLine> {
+                const auto & tracker = recipe_logger.names_and_ids_tracker();
+
+                // Only the members whose window covers `t` have flags, and they
+                // are exactly the ones with a term in the rows there. The
+                // coefficients cannot move to suit them --- a Cumulative has one
+                // height per task --- so the cut is simply restricted, and stays
+                // valid because setting an absent task's flag to zero is a point
+                // the cut already covered.
+                vector<size_t> present;
+                vector<ProofFlag> flags;
+                vector<Integer> coefficients;
+                for (size_t k = 0; k < recipe.members.size(); ++k) {
+                    const auto & member = recipe.members[k];
+                    if (t < member.t_lo || t > member.t_hi)
+                        continue;
+                    auto flag = active_flag_for(tracker, recipe.donors[member.canonical_donor].id, member.canonical_position, t);
+                    if (! flag)
                         return std::nullopt;
+                    present.push_back(k);
+                    flags.push_back(*flag);
+                    coefficients.push_back(member.coefficient);
+                }
+                if (present.empty())
+                    return std::nullopt;
 
-                    // Only the members whose window covers `t` have flags, and
-                    // they are exactly the ones with a term in the donor's row
-                    // there. The coefficients cannot move to suit them --- a
-                    // Cumulative has one height per task --- so the cut is
-                    // simply restricted, and stays valid because setting an
-                    // absent task's flag to zero is a point the cut already
-                    // covered.
-                    vector<size_t> present;
-                    vector<ProofFlag> flags;
-                    vector<Integer> demands, coefficients;
-                    for (size_t k = 0; k < recipe.positions.size(); ++k) {
-                        if (t < recipe.t_lo[k] || t > recipe.t_hi[k])
-                            continue;
-                        auto flag = active_flag_for(tracker, recipe.donor, recipe.positions[k], t);
-                        if (! flag)
-                            return std::nullopt;
-                        present.push_back(k);
-                        flags.push_back(*flag);
-                        demands.push_back(recipe.demands[k]);
-                        coefficients.push_back(recipe.coefficients[k]);
+                vector<vector<Integer>> present_demands(recipe.donors.size());
+                vector<Integer> capacities;
+                for (size_t row = 0; row < recipe.donors.size(); ++row) {
+                    capacities.push_back(recipe.donors[row].capacity);
+                    for (auto k : present)
+                        present_demands[row].push_back(recipe.members[k].demands[row]);
+                }
+
+                // A miss here is a genuine restriction: the row for a time point
+                // where every member is present is the programme discovery
+                // built, seeded before any of this ran.
+                auto cached = recipe.programmes->find(present);
+                if (cached == recipe.programmes->end()) {
+                    if (recipe.stats)
+                        ++recipe.stats->restricted_rows_rebuilt;
+                    cached = recipe.programmes
+                                 ->emplace(present,
+                                     validate_lifted_cover_cut(present_demands, coefficients, capacities, recipe.rhs, recipe.state_budget).cut)
+                                 .first;
+                }
+                if (! cached->second)
+                    return std::nullopt;
+
+                auto claimed = coefficients;
+                auto claimed_rhs = recipe.rhs;
+                auto programme = cached->second;
+                auto bridge_wrong_task = std::holds_alternative<inferred_cumulative_mutation::BridgeWrongTask>(recipe.mutation);
+                overloaded{//
+                    [&](const inferred_cumulative_mutation::None &) {},
+                    [&](const inferred_cumulative_mutation::ClaimTighterCapacity &) { claimed_rhs -= 1_i; },
+                    [&](const inferred_cumulative_mutation::ClaimTallerTask &) {
+                        if (! claimed.empty())
+                            claimed[0] += 1_i;
+                    },
+                    [&](const inferred_cumulative_mutation::ClaimTighterRow &) {
+                        auto tighter = capacities;
+                        for (auto & capacity : tighter)
+                            capacity -= 1_i;
+                        programme = validate_lifted_cover_cut(present_demands, coefficients, tighter, recipe.rhs, recipe.state_budget).cut;
+                    },
+                    // Corrupts the makespan bound rather than the rows, so the
+                    // rows are the honest ones.
+                    [&](const inferred_cumulative_mutation::ClaimHigherMakespanBound &) {},
+                    // Corrupts the crossing, which happens below.
+                    [&](const inferred_cumulative_mutation::BridgeWrongTask &) {}}
+                    .visit(recipe.mutation);
+                // A mutation that leaves nothing to derive has nothing to be
+                // rejected either, and a test asserting on it would be asserting
+                // that a constraint went missing.
+                if (! programme)
+                    return std::nullopt;
+
+                // The rows go one level deeper than the caller's, so that the
+                // bridges carrying them onto the members' own flags die with the
+                // rest of the working: there are three `pol` per member per
+                // donor per time point, and at Top none of them would ever be
+                // deleted. Only the pin the caller gets back survives.
+                auto saved_level = recipe_logger.proof_level();
+                recipe_logger.enter_proof_level(saved_level + 1);
+
+                vector<ProofLine> kept_rows;
+                vector<vector<ProofFlag>> kept_weaken_out;
+                auto give_up = false;
+                for (auto row : programme->row_indices) {
+                    const auto & donor = recipe.donors[row];
+                    auto line = rows.find(donor.id);
+                    if (line == rows.end()) {
+                        give_up = true;
+                        break;
                     }
 
-                    // Everything else of the donor's that could be running now
-                    // has to come out of the row first. Over every position,
-                    // not up to the first one without flags: a task outside its
-                    // window has neither a term nor a flag, and stopping there
-                    // would leave the later tasks' terms in.
-                    set<size_t> in_the_cut;
-                    for (auto k : present)
-                        in_the_cut.insert(recipe.positions[k]);
-
-                    vector<ProofFlag> weaken_out;
-                    for (size_t position = 0; position < recipe.donor_size; ++position) {
-                        if (in_the_cut.contains(position))
+                    // Which of the present members this row actually speaks
+                    // about, and where they sit in it.
+                    vector<BridgedRowTerm> terms;
+                    set<size_t> in_the_row;
+                    auto missing = false;
+                    for (size_t j = 0; j < present.size() && ! missing; ++j) {
+                        const auto & member = recipe.members[present[j]];
+                        if (member.demands[row] <= 0_i)
                             continue;
-                        if (auto flag = active_flag_for(tracker, recipe.donor, position, t))
+                        auto position = member.positions[row];
+                        if (! position) {
+                            missing = true;
+                            break;
+                        }
+                        in_the_row.insert(*position);
+
+                        // Nothing to carry when the row already speaks in the
+                        // member's own flags, which is the whole of the
+                        // single-resource case.
+                        optional<ProofLine> bridge;
+                        if (member.canonical_donor != row) {
+                            // Whose flag this term is carried onto. Honestly its
+                            // own; under the mutation, the member before it, so
+                            // that the row ends up saying something about a
+                            // different task from the one it is spending its
+                            // capacity on.
+                            auto onto = j;
+                            if (bridge_wrong_task && j > 0)
+                                onto = j - 1;
+                            const auto & carried = recipe.members[present[onto]];
+
+                            auto theirs = active_flag_for(tracker, donor.id, *position, t);
+                            auto their_conjuncts = active_conjuncts_for(tracker, donor.id, *position, t);
+                            auto our_conjuncts =
+                                active_conjuncts_for(tracker, recipe.donors[carried.canonical_donor].id, carried.canonical_position, t);
+                            if (! theirs || ! their_conjuncts || ! our_conjuncts) {
+                                missing = true;
+                                break;
+                            }
+                            bridge = recover_conjunction_flag_bridge(
+                                recipe_logger, flags[onto], *our_conjuncts, *theirs, *their_conjuncts, ProofLevel::Temporary);
+                            terms.push_back(BridgedRowTerm{member.demands[row], flags[onto], bridge});
+                            continue;
+                        }
+                        terms.push_back(BridgedRowTerm{member.demands[row], flags[j], bridge});
+                    }
+
+                    if (missing || terms.empty()) {
+                        give_up = true;
+                        break;
+                    }
+
+                    // Everything else of this donor's that could be running now
+                    // has to come out of the row. Over every position, not up to
+                    // the first one without flags: a task outside its window has
+                    // neither a term nor a flag, and stopping there would leave
+                    // the later tasks' terms in.
+                    vector<ProofFlag> weaken_out;
+                    for (size_t position = 0; position < donor.size; ++position) {
+                        if (in_the_row.contains(position))
+                            continue;
+                        if (auto flag = active_flag_for(tracker, donor.id, position, t))
                             weaken_out.push_back(*flag);
                     }
 
-                    // A miss here is a genuine restriction: the row for a time
-                    // point where every member is present is the programme
-                    // discovery built, seeded before any of this ran.
-                    auto cached = recipe.programmes->find(present);
-                    if (cached == recipe.programmes->end()) {
-                        if (recipe.stats)
-                            ++recipe.stats->restricted_rows_rebuilt;
-                        cached =
-                            recipe.programmes->emplace(present, validate_lifted_cover_cut(demands, coefficients, recipe.capacity, recipe.rhs)).first;
+                    auto bridged = any_of(terms, [](const BridgedRowTerm & term) { return term.implies_row_flag.has_value(); });
+                    if (! bridged) {
+                        kept_rows.push_back(line->second);
+                        kept_weaken_out.push_back(move(weaken_out));
                     }
-                    if (! cached->second)
-                        return std::nullopt;
+                    else {
+                        kept_rows.push_back(
+                            recover_bridged_row(recipe_logger, line->second, terms, weaken_out, donor.capacity, ProofLevel::Temporary));
+                        kept_weaken_out.emplace_back();
+                    }
+                }
 
-                    auto claimed = coefficients;
-                    auto claimed_rhs = recipe.rhs;
-                    auto programme = cached->second;
-                    overloaded{//
-                        [&](const inferred_cumulative_mutation::None &) {},
-                        [&](const inferred_cumulative_mutation::ClaimTighterCapacity &) { claimed_rhs -= 1_i; },
-                        [&](const inferred_cumulative_mutation::ClaimTallerTask &) {
-                            if (! claimed.empty())
-                                claimed[0] += 1_i;
-                        },
-                        [&](const inferred_cumulative_mutation::ClaimTighterRow &) {
-                            programme = validate_lifted_cover_cut(demands, coefficients, recipe.capacity - 1_i, recipe.rhs);
-                        },
-                        // Corrupts the makespan bound rather than the row, so
-                        // the row is the honest one.
-                        [&](const inferred_cumulative_mutation::ClaimHigherMakespanBound &) {}}
-                        .visit(recipe.mutation);
-                    // A mutation that leaves nothing to derive has nothing to be
-                    // rejected either, and a test asserting on it would be
-                    // asserting that a constraint went missing.
-                    if (! programme)
-                        return std::nullopt;
+                optional<ProofLine> result;
+                if (! give_up)
+                    result =
+                        derive_lifted_cover_cut(recipe_logger, kept_rows, *programme, flags, claimed, kept_weaken_out, claimed_rhs, ProofLevel::Top);
 
-                    return derive_lifted_cover_cut(recipe_logger, row->second, *programme, flags, claimed, weaken_out, claimed_rhs, ProofLevel::Top);
+                recipe_logger.enter_proof_level(saved_level);
+                recipe_logger.forget_proof_level(saved_level + 2);
+                return result;
+            },
+            .makespan = _makespan,
+            .makespan_links = links,
+            .makespan_bound_reached =
+                [stats = _stats](Integer bound) {
+                    if (stats && bound > stats->certified_makespan_bound)
+                        stats->certified_makespan_bound = bound;
                 },
-                .makespan = _makespan,
-                .makespan_links = links,
-                .makespan_bound_reached =
-                    [stats = _stats](Integer bound) {
-                        if (stats && bound > stats->certified_makespan_bound)
-                            stats->certified_makespan_bound = bound;
-                    },
-                .makespan_mutation = std::holds_alternative<inferred_cumulative_mutation::ClaimHigherMakespanBound>(_mutation)
-                    ? makespan_energy::MakespanEnergyMutation{makespan_energy::makespan_energy_mutation::ClaimHigherBound{}}
-                    : makespan_energy::MakespanEnergyMutation{makespan_energy::makespan_energy_mutation::None{}},
-                .rules = _rules};
+            .makespan_mutation = std::holds_alternative<inferred_cumulative_mutation::ClaimHigherMakespanBound>(_mutation)
+                ? makespan_energy::MakespanEnergyMutation{makespan_energy::makespan_energy_mutation::ClaimHigherBound{}}
+                : makespan_energy::MakespanEnergyMutation{makespan_energy::makespan_energy_mutation::None{}},
+            .rules = _rules};
 
-            if (! install_derived_cumulative(propagators, state, logger, move(spec))) {
-                bump(&InferredCumulativeStats::declined_by_install);
-                continue;
-            }
-
-            bump(&InferredCumulativeStats::cuts_posted);
-            if (*std::max_element(cut.coefficients.begin(), cut.coefficients.end()) > 1_i)
-                bump(&InferredCumulativeStats::non_unit_cuts_posted);
-            if (_stats && cut.bound() > _stats->largest_capacity_bound)
-                _stats->largest_capacity_bound = cut.bound();
-            if (logger)
-                logger->emit_proof_comment("presolve lifted cover: inferred a cut over " + to_string(cut.support.size()) + " tasks with capacity " +
-                    to_string(cut.rhs.raw_value) + ", makespan bound " + to_string(cut.bound().raw_value));
+        if (! install_derived_cumulative(propagators, state, logger, move(spec))) {
+            bump(&InferredCumulativeStats::declined_by_install);
+            continue;
         }
+
+        bump(&InferredCumulativeStats::cuts_posted);
+        if (*std::max_element(cut.coefficients.begin(), cut.coefficients.end()) > 1_i)
+            bump(&InferredCumulativeStats::non_unit_cuts_posted);
+        if (cut.validated->row_indices.size() > 1)
+            bump(&InferredCumulativeStats::multi_resource_cuts_posted);
+        if (_stats && cut.bound() > _stats->largest_capacity_bound)
+            _stats->largest_capacity_bound = cut.bound();
+        if (logger)
+            logger->emit_proof_comment("presolve lifted cover: inferred a cut over " + to_string(cut.support.size()) + " tasks on " +
+                to_string(cut.validated->row_indices.size()) + " resources with capacity " + to_string(cut.rhs.raw_value) + ", makespan bound " +
+                to_string(cut.bound().raw_value));
     }
 
     return true;
@@ -683,6 +943,7 @@ auto InferredCumulative::clone() const -> unique_ptr<Presolver>
     result->with_budgets(_max_covers, _max_posted);
     result->with_maximum_capacity(_maximum_capacity);
     result->with_lifting_call_budget(_max_lifting_calls);
+    result->with_programme_state_budget(_max_programme_states);
     result->with_rules(_rules);
     result->with_proof_mutation(_mutation);
     if (_makespan)

--- a/gcs/presolvers/inferred_cumulative/inferred_cumulative.hh
+++ b/gcs/presolvers/inferred_cumulative/inferred_cumulative.hh
@@ -59,11 +59,24 @@ namespace gcs
         struct ClaimHigherMakespanBound
         {
         };
+
+        /// Carry a resource's row onto the *wrong* member's flags when a cut
+        /// spans more than one of them, so that the row a state is ruled out by
+        /// is about a task other than the one it names.
+        ///
+        /// The corruption a cut over several resources adds over one over a
+        /// single resource: nothing else in this list touches the crossing, and
+        /// with one donor there is no crossing to touch --- so a fixture for
+        /// this has to be genuinely multi-resource, which is the point of
+        /// having it.
+        struct BridgeWrongTask
+        {
+        };
     }
 
     using InferredCumulativeMutation = std::variant<inferred_cumulative_mutation::None, inferred_cumulative_mutation::ClaimTighterCapacity,
         inferred_cumulative_mutation::ClaimTallerTask, inferred_cumulative_mutation::ClaimTighterRow,
-        inferred_cumulative_mutation::ClaimHigherMakespanBound>;
+        inferred_cumulative_mutation::ClaimHigherMakespanBound, inferred_cumulative_mutation::BridgeWrongTask>;
 
     /**
      * \brief What the inferred-Cumulative presolver did, filled in when it runs.
@@ -93,6 +106,12 @@ namespace gcs
         /// this, because it is the bottleneck of Algorithm 2.
         std::size_t lifting_subproblems = 0;
 
+        /// Of those, ones whose programme went over the state budget, so the
+        /// task was left out of the cut rather than lifted into it. A cut short
+        /// of a coefficient is weaker than the published procedure's, not
+        /// unsound; this is the number that says so.
+        std::size_t lifting_subproblems_over_budget = 0;
+
         /// Constraints Algorithm 2 inferred: what the published method would
         /// post, before anything is asked about proving them.
         std::size_t cuts_found = 0;
@@ -121,6 +140,19 @@ namespace gcs
         /// Of those, the ones with a coefficient above one --- the inference
         /// this stage adds over the capacity-one stage before it.
         std::size_t non_unit_cuts_posted = 0;
+
+        /**
+         * \brief Of those, the ones whose certificate needs more than one
+         * resource's capacity row.
+         *
+         * Equation 4's lifting is over every resource at once, so a cut can be a
+         * consequence of several rows together and of none of them alone. The
+         * derivation for one carries every row it needs onto the members' own
+         * flags first, which is machinery a single-resource cut never touches,
+         * so this is the number that says whether the multi-resource path ran at
+         * all --- and a corpus where it is zero has tested none of it.
+         */
+        std::size_t multi_resource_cuts_posted = 0;
 
         /**
          * \brief Time points whose row had to be derived over *fewer* than the
@@ -175,17 +207,23 @@ namespace gcs
         /// Covers already inside the support of something lifted earlier, which
         /// would re-derive it and waste the subproblems (paper, Example 12).
         std::size_t dropped_visited = 0;
-        /// Constraints a donor's own row already implies term by term.
+        /// Constraints some model row already implies term by term.
         std::size_t dropped_dominated = 0;
         std::size_t dropped_over_budget = 0;
+        /// Cuts whose dynamic programme would have been wider than the state
+        /// budget allows. Distinct from \ref cuts_uncertifiable, which counts
+        /// constraints that do not hold: these may well, and a non-zero count
+        /// here is a certificate this could not afford rather than one it could
+        /// not find.
+        std::size_t dropped_over_state_budget = 0;
         std::size_t declined_by_install = 0;
         ///@}
     };
 
     /**
      * \brief Infer `Cumulative` constraints with non-unit heights, by lifting
-     * cover inequalities over a posted Cumulative's capacity rows, and post them
-     * in derived mode.
+     * cover inequalities over the posted Cumulatives' capacity rows, and post
+     * them in derived mode.
      *
      * This is the second stage of Sidorov (CP 2026). A *cover* is a set of tasks
      * whose demands together overshoot a resource, so they cannot all run;
@@ -208,16 +246,27 @@ namespace gcs
      * InferredDisjunctive and CumulativeStrengthening do; a test asserting the
      * redundancy has to turn it back on.
      *
+     * **Every resource at once**, which is Equation 4 and is what makes the
+     * lifting cross-resource. A cover belongs to one row --- Algorithm 1
+     * enumerates them per resource --- but the subproblem deciding what
+     * coefficient to lift a task in with is constrained by all of them, so it
+     * gives a smaller answer and hence a larger coefficient than any single row
+     * would. The cut that comes out can then be a consequence of several rows
+     * together and of none of them alone, which is why one pass runs over the
+     * whole problem rather than one pass per posted constraint, and why the
+     * budgets, the visited-cover rule and the output limit are all global.
+     *
      * Restricted, as its stage in the plan is, to constant lengths, heights and
      * capacities, and to donors with no optional tasks.
      *
      * Nothing reaches the OPB. Every row of every posted constraint is
      * *derived*, by \ref validate_lifted_cover_cut and
      * \ref derive_lifted_cover_cut, which certify a cut by replaying the
-     * knapsack dynamic programme that says it holds. That is complete by
-     * construction, so the constraints coming from the published procedure
-     * rather than from what happens to be easy to prove costs nothing:
-     * \ref InferredCumulativeStats::cuts_uncertifiable is zero.
+     * knapsack dynamic programme that says it holds --- over one weight per
+     * resource, and carrying each resource's row onto the members' own flags
+     * first. That is complete by construction, so the constraints coming from
+     * the published procedure rather than from what happens to be easy to prove
+     * costs nothing: \ref InferredCumulativeStats::cuts_uncertifiable is zero.
      *
      * \ingroup Presolvers
      */
@@ -229,6 +278,7 @@ namespace gcs
         std::size_t _max_posted;
         std::size_t _maximum_capacity;
         std::size_t _max_lifting_calls;
+        std::size_t _max_programme_states;
         CumulativeRules _rules;
         InferredCumulativeMutation _mutation;
         std::optional<IntegerVariableID> _makespan;
@@ -267,6 +317,23 @@ namespace gcs
          * them rather than against wall-clock.
          */
         auto with_lifting_call_budget(std::size_t calls) -> InferredCumulative &;
+
+        /**
+         * \brief How many states a cut's dynamic programme may hold before it
+         * is dropped uncertified.
+         *
+         * Nothing the published procedure produces comes close, and on the
+         * paper's own instances no programme exceeds a few hundred states, so
+         * this exists to bound a pathology rather than to make a trade. Over a
+         * single row a layer cannot be wider than the right-hand side plus one,
+         * which is two or three; over several the frontier is a Pareto set and
+         * there is no such bound to lean on, so there is a number instead.
+         *
+         * A cut dropped this way is counted separately from one that does not
+         * hold (\ref InferredCumulativeStats::dropped_over_state_budget), since
+         * they say opposite things about the inference.
+         */
+        auto with_programme_state_budget(std::size_t states) -> InferredCumulative &;
 
         /**
          * \brief Select which propagation rules the inferred constraints run.

--- a/gcs/presolvers/inferred_cumulative/inferred_cumulative_test.cc
+++ b/gcs/presolvers/inferred_cumulative/inferred_cumulative_test.cc
@@ -29,7 +29,17 @@
  * over a fixture carrying a spare task, so that the row the certificate runs on
  * has something in it the cut is not about. A third mutation corrupts the
  * derivation rather than the claim, by building the certificate's dynamic
- * programme against a capacity one below the donor's.
+ * programme against capacities one below the rows'.
+ *
+ * Then all of that again over two resources, which is what Equation 4's lifting
+ * is actually over. That fixture's cut is a consequence of both rows and of
+ * neither alone, so nothing in the single-resource cases reaches the machinery
+ * it needs: a weight per resource in the programme, and each resource's row
+ * carried onto the members' own flags before any of them can be put in the same
+ * derivation. `BridgeWrongTask` is the mutation that only exists there --- with
+ * one resource there is no crossing to corrupt --- and the verified sweep draws
+ * one to three resources so that veripb sees the crossing across many shapes
+ * rather than only over the fixture built to need it.
  */
 
 #include <gcs/constraints/cumulative.hh>
@@ -92,7 +102,18 @@ namespace
         std::exit(EXIT_FAILURE);
     }
 
-    /// One resource: a task list and a capacity, plus the horizon they live in.
+    /// A further resource over the same tasks: what each takes of it, and how
+    /// much of it there is.
+    struct Resource
+    {
+        vector<Integer> demands;
+        Integer capacity;
+    };
+
+    /// A task list with lengths and a horizon, and one or more resources over
+    /// it. More than one is what Equation 4's lifting is for, and is posted as
+    /// one Cumulative apiece --- which is also how Sidorov's own preprocessor
+    /// builds an RCPSP.
     struct Instance
     {
         vector<Integer> demands, lengths;
@@ -104,6 +125,16 @@ namespace
         /// task the window `[0, horizon - 1]` whatever its length, so a fixture
         /// leaving this empty exercises none of the window-edge restriction.
         vector<int> latest_start = {};
+
+        /// Resources beyond the first.
+        vector<Resource> also = {};
+
+        [[nodiscard]] auto resources() const -> vector<Resource>
+        {
+            vector<Resource> all{Resource{demands, capacity}};
+            all.insert(all.end(), also.begin(), also.end());
+            return all;
+        }
 
         [[nodiscard]] auto latest(std::size_t i) const -> int
         {
@@ -136,6 +167,38 @@ namespace
     auto lifted_instance_with_spare(int horizon) -> Instance
     {
         return Instance{{5_i, 2_i, 2_i, 2_i, 1_i}, {3_i, 5_i, 5_i, 5_i, 1_i}, 5_i, horizon};
+    }
+
+    /// One whose equal-demand family is a cover of *four* tasks: four demands of
+    /// two overshoot a capacity of seven, and five of them are there for the
+    /// longest and the shortest four to be different sets. That size is what
+    /// survives the budget being applied a second time across the resources.
+    auto long_cover_instance(int horizon) -> Instance
+    {
+        return Instance{{5_i, 2_i, 2_i, 2_i, 2_i, 2_i}, {3_i, 6_i, 5_i, 5_i, 5_i, 4_i}, 7_i, horizon};
+    }
+
+    /// Two resources, and a cut that is a consequence of both of them and of
+    /// neither alone. This is what Equation 4's lifting is for, and nothing in
+    /// the single-resource fixtures above reaches it.
+    ///
+    /// The two rows do different halves of the work, which is the point. The
+    /// cover `{0, 1, 2}` belongs to the *second* resource --- two and three and
+    /// one overshoot its five --- and is no cover of the first, where the same
+    /// three tasks come to exactly its three. Lifting the fourth task then asks
+    /// what those three can still weigh once it is running, and the answer comes
+    /// from the *first* resource, which the fourth task fills on its own, so
+    /// nothing else can run beside it and the coefficient is two rather than
+    /// one.
+    ///
+    /// So `a0 + a1 + a2 + 2 a3 <= 2` needs both rows and each for a different
+    /// reason: the second is what refuses `{0, 1, 2}` and the first is what
+    /// refuses `{1, 3}`. Its energy is fifteen against a capacity of two, so no
+    /// schedule is shorter than eight --- which is the optimum, while the best
+    /// either row reaches on its own is seven.
+    auto two_resource_instance(int horizon) -> Instance
+    {
+        return Instance{{1_i, 1_i, 1_i, 3_i}, {2_i, 5_i, 4_i, 2_i}, 3_i, horizon, {}, {Resource{{2_i, 3_i, 1_i, 2_i}, 5_i}}};
     }
 
     enum struct Stage
@@ -176,7 +239,8 @@ namespace
             p.minimise(*makespan);
         }
 
-        p.post(Cumulative{starts, instance.lengths, instance.demands, instance.capacity}.with_rules(setup.rules));
+        for (const auto & resource : instance.resources())
+            p.post(Cumulative{starts, instance.lengths, resource.demands, resource.capacity}.with_rules(setup.rules));
 
         switch (setup.stage) {
             using enum Stage;
@@ -252,15 +316,17 @@ namespace
         auto n = instance.demands.size();
         set<vector<int>> expected;
         vector<int> current(n, 0);
+        auto resources = instance.resources();
         auto ok = [&]() {
-            for (int t = 0; t < instance.horizon; ++t) {
-                Integer load = 0_i;
-                for (std::size_t i = 0; i < n; ++i)
-                    if (t >= current[i] && t < current[i] + instance.lengths[i].raw_value)
-                        load += instance.demands[i];
-                if (load > instance.capacity)
-                    return false;
-            }
+            for (int t = 0; t < instance.horizon; ++t)
+                for (const auto & resource : resources) {
+                    Integer load = 0_i;
+                    for (std::size_t i = 0; i < n; ++i)
+                        if (t >= current[i] && t < current[i] + instance.lengths[i].raw_value)
+                            load += resource.demands[i];
+                    if (load > resource.capacity)
+                        return false;
+                }
             return true;
         };
         auto recurse = [&](auto && self, std::size_t at) -> void {
@@ -508,14 +574,22 @@ auto main(int argc, char * argv[]) -> int
         solve_instance(lifted_instance(13), Setup{.stats = unbounded}, nullopt);
         auto stats = make_shared<InferredCumulativeStats>();
         solve_instance(lifted_instance(13), Setup{.max_covers = 0, .stats = stats}, nullopt);
-        // The cover budget caps the *short* families only: the equal-demand
-        // long covers are added after it has been applied, exactly as in the
-        // reference implementation, so this does not go to zero.
         if (stats->covers_considered >= unbounded->covers_considered)
             fail("a zero cover budget considered " + to_string(stats->covers_considered) + " covers against " +
                 to_string(unbounded->covers_considered) + " unbounded, so the budget did not bite");
+    }
+    {
+        // The cover budget bites twice, and what survives both is a cover of
+        // *more* than three tasks: the equal-demand families are added after
+        // each resource's own budget, and the merge across resources then keeps
+        // every large cover outright and only the best `max_covers` of the rest.
+        // A long cover of exactly three does not survive a budget of zero, which
+        // is why this fixture's five demand-two tasks under a capacity of seven
+        // are five and not four.
+        auto stats = make_shared<InferredCumulativeStats>();
+        solve_instance(long_cover_instance(13), Setup{.max_covers = 0, .stats = stats}, nullopt);
         if (stats->covers_considered == 0)
-            fail("a zero cover budget dropped the long covers too, which are added after it");
+            fail("a zero cover budget dropped the long covers too, which survive it");
     }
     {
         auto stats = make_shared<InferredCumulativeStats>();
@@ -629,21 +703,24 @@ auto main(int argc, char * argv[]) -> int
     // shapes rather than only the hand-built fixture.
     {
         std::mt19937 rand(*get_seed());
-        std::uniform_int_distribution<> n_dist(3, 5), cap_dist(4, 10), len_dist(1, 3), tall_dist(0, 2), pin_dist(0, 1);
+        std::uniform_int_distribution<> n_dist(3, 5), rows_dist(1, 3), cap_dist(4, 10), len_dist(1, 3), tall_dist(0, 2), pin_dist(0, 1);
 
-        std::size_t posted = 0, restricted = 0, inferred = 0, uncertifiable = 0, over_budget = 0, declined = 0;
+        std::size_t posted = 0, restricted = 0, inferred = 0, uncertifiable = 0, over_budget = 0, declined = 0, over_state_budget = 0,
+                    subproblems_over_budget = 0, multi_resource = 0;
         for (int k = 0; k < 25; ++k) {
-            auto capacity = cap_dist(rand);
-            Instance instance{{}, {}, Integer{capacity}, 0};
-            std::uniform_int_distribution<> tall(capacity / 2 + 1, capacity), rest(1, capacity / 2);
-
+            // One to three resources over the same tasks, so that the crossing
+            // is exercised over many shapes rather than only over the fixture
+            // built to need it --- and so that a cut whose certificate cites two
+            // rows is checked by veripb rather than argued about.
+            auto rows = rows_dist(rand);
             auto n = n_dist(rand);
+
+            Instance instance{{}, {}, 0_i, 0};
             int longest = 0;
             for (int i = 0; i < n; ++i) {
                 auto length = len_dist(rand);
                 longest = std::max(longest, length);
                 instance.lengths.push_back(Integer{length});
-                instance.demands.push_back(Integer{0 == tall_dist(rand) ? tall(rand) : rest(rand)});
             }
             instance.horizon = longest + 3;
             for (int i = 0; i < n; ++i) {
@@ -651,11 +728,25 @@ auto main(int argc, char * argv[]) -> int
                 instance.latest_start.push_back(0 == pin_dist(rand) && latest > 1 ? latest - 1 : latest);
             }
 
+            for (int row = 0; row < rows; ++row) {
+                auto capacity = cap_dist(rand);
+                std::uniform_int_distribution<> tall(capacity / 2 + 1, capacity), rest(1, capacity / 2);
+                vector<Integer> demands;
+                for (int i = 0; i < n; ++i)
+                    demands.push_back(Integer{0 == tall_dist(rand) ? tall(rand) : rest(rand)});
+                if (0 == row) {
+                    instance.demands = move(demands);
+                    instance.capacity = Integer{capacity};
+                }
+                else
+                    instance.also.push_back(Resource{move(demands), Integer{capacity}});
+            }
+
             auto stats = make_shared<InferredCumulativeStats>();
             auto lifted = solve_instance(instance, Setup{.stats = stats}, make_optional("inferred_cumulative_sweep"));
             if (lifted.solutions != expected_solutions(instance)) {
-                println(cerr, "demands={} lengths={} capacity={} horizon={} latest={}", instance.demands, instance.lengths,
-                    instance.capacity.raw_value, instance.horizon, instance.latest_start);
+                println(cerr, "demands={} lengths={} capacity={} horizon={} latest={} extra rows={}", instance.demands, instance.lengths,
+                    instance.capacity.raw_value, instance.horizon, instance.latest_start, instance.also.size());
                 fail("the verified sweep lost solutions");
             }
             posted += stats->cuts_posted;
@@ -664,6 +755,9 @@ auto main(int argc, char * argv[]) -> int
             uncertifiable += stats->cuts_uncertifiable;
             over_budget += stats->dropped_over_budget;
             declined += stats->declined_by_install;
+            over_state_budget += stats->dropped_over_state_budget;
+            subproblems_over_budget += stats->lifting_subproblems_over_budget;
+            multi_resource += stats->multi_resource_cuts_posted;
         }
 
         if (posted == 0)
@@ -675,17 +769,30 @@ auto main(int argc, char * argv[]) -> int
         // of a derivation, or declined by the install. If those do not add up,
         // something else is happening to constraints and the certified fraction
         // means nothing.
-        if (posted + uncertifiable + over_budget + declined != inferred)
+        if (posted + uncertifiable + over_budget + declined + over_state_budget != inferred)
             fail("the sweep inferred " + to_string(inferred) + " constraints but accounts for " + to_string(posted) + " posted, " +
-                to_string(uncertifiable) + " uncertifiable, " + to_string(over_budget) + " over budget and " + to_string(declined) + " declined");
+                to_string(uncertifiable) + " uncertifiable, " + to_string(over_budget) + " over budget, " + to_string(over_state_budget) +
+                " over the state budget and " + to_string(declined) + " declined");
         // And the certified fraction is all of it. This is the whole point of
         // certifying by replaying the lifting procedure's own knapsack
         // programme: it is complete by construction, where the cutting-planes
         // search it replaced dropped about one constraint in twenty-five.
         if (uncertifiable != 0)
             fail("the sweep could not derive " + to_string(uncertifiable) + " constraints, which the dynamic programme should make impossible");
+        // The state budget is there for a pathology, not for these: a programme
+        // it stops is a cut this could probably have certified, and one it stops
+        // during lifting is a coefficient the published procedure would have
+        // found. Either happening at these sizes means the budget is wrong.
+        if (over_state_budget != 0 || subproblems_over_budget != 0)
+            fail("the sweep hit the state budget " + to_string(over_state_budget) + " times certifying and " + to_string(subproblems_over_budget) +
+                " times lifting, at sizes where it should never be reached");
+        // And the multi-resource path is genuinely being checked here rather
+        // than only by the fixture built for it.
+        if (multi_resource == 0)
+            fail("no cut in the verified sweep needed more than one row, so veripb checked no crossing");
         auto attempted = inferred - over_budget;
-        println(cerr, "verified sweep: {} of {} attempted constraints certified, {} rows restricted", posted, attempted, restricted);
+        println(cerr, "verified sweep: {} of {} attempted constraints certified ({} over more than one row), {} rows restricted", posted, attempted,
+            multi_resource, restricted);
     }
 
     // Nothing may have reached the OPB: the whole plan turns on an inferred
@@ -730,6 +837,74 @@ auto main(int argc, char * argv[]) -> int
             if (run_veripb(name + ".opb", name + ".pbp"))
                 fail("veripb accepted the " + what + " mutation, so the honest certificate has slack in it");
             println(cerr, "veripb rejected the {} mutation, as expected", what);
+            dispose_of_proof_files(name);
+        }
+    }
+
+    // Two resources, which is what Equation 4's lifting is actually over, and
+    // the only fixture here whose certificate carries a row onto flags that are
+    // not its own.
+    {
+        auto stats = make_shared<InferredCumulativeStats>();
+
+        auto resources_only = solve_instance(two_resource_instance(7), Setup{.stage = Stage::none}, nullopt);
+        if (resources_only.refuted_at_root)
+            fail("two resources: the rows alone refuted at the root, so the fixture proves nothing");
+
+        auto lifted =
+            solve_instance(two_resource_instance(7), Setup{.stats = stats}, proofs ? make_optional("inferred_cumulative_two_resources") : nullopt);
+
+        if (stats->donors_seen != 2)
+            fail("two resources: saw " + to_string(stats->donors_seen) + " donors, so they were not both offered");
+        if (stats->multi_resource_cuts_posted == 0)
+            fail("two resources: every posted cut came from a single row, so the crossing this fixture exists for never ran");
+        if (stats->non_unit_cuts_posted == 0)
+            fail("two resources: nothing posted with a coefficient above one, so this is the capacity-one stage's case and not this one");
+        // Fifteen units of a supply of two: eight, which is the optimum, and one
+        // more than either row reaches on its own.
+        if (stats->largest_capacity_bound != 8_i)
+            fail("two resources: reported a makespan bound of " + to_string(stats->largest_capacity_bound.raw_value) +
+                ", not the eight the cut "
+                "carries");
+        if (! lifted.refuted_at_root)
+            fail("two resources: the cut did not refute a horizon of seven at the root");
+
+        println(cerr, "two resources: {} cuts posted, {} of them over more than one row, bound {}, refuted at the root against {} nodes without",
+            stats->cuts_posted, stats->multi_resource_cuts_posted, stats->largest_capacity_bound.raw_value, resources_only.recursions);
+    }
+
+    // And the horizon it does not refute enumerates correctly, which is the
+    // half that says the cut is implied rather than merely strong.
+    {
+        auto stats = make_shared<InferredCumulativeStats>();
+        auto instance = two_resource_instance(8);
+        auto outcome = solve_instance(instance, Setup{.stats = stats}, proofs ? make_optional("inferred_cumulative_two_resources_sat") : nullopt);
+        if (stats->multi_resource_cuts_posted == 0)
+            fail("two resources, satisfiable: no cut over more than one row was posted");
+        if (outcome.solutions != expected_solutions(instance))
+            fail("two resources, satisfiable: " + to_string(outcome.solutions.size()) + " solutions against " +
+                to_string(expected_solutions(instance).size()) + " by brute force");
+        println(cerr, "two resources: {} solutions at the bound, matching brute force", outcome.solutions.size());
+    }
+
+    // Every mutation again, over the fixture that crosses --- including the one
+    // that can only exist here, where a row is carried onto the wrong member's
+    // flags. With a single donor there is no crossing for it to corrupt.
+    if (proofs) {
+        for (const auto & [what, mutation] :
+            {std::pair<string, InferredCumulativeMutation>{"one less capacity", inferred_cumulative_mutation::ClaimTighterCapacity{}},
+                std::pair<string, InferredCumulativeMutation>{"one more height", inferred_cumulative_mutation::ClaimTallerTask{}},
+                std::pair<string, InferredCumulativeMutation>{"a tighter row", inferred_cumulative_mutation::ClaimTighterRow{}},
+                std::pair<string, InferredCumulativeMutation>{"the wrong task bridged", inferred_cumulative_mutation::BridgeWrongTask{}}}) {
+            const string name = "inferred_cumulative_two_resource_mutation";
+            Problem p;
+            post(p, two_resource_instance(8), Setup{.mutation = mutation});
+            solve_with(
+                p, SolveCallbacks{.trace = [](const CurrentState &) -> bool { return true; }}, make_optional<ProofOptions>(ProofFileNames{name}));
+
+            if (run_veripb(name + ".opb", name + ".pbp"))
+                fail("veripb accepted the " + what + " mutation over two resources, so that certificate has slack in it");
+            println(cerr, "veripb rejected the {} mutation over two resources, as expected", what);
             dispose_of_proof_files(name);
         }
     }


### PR DESCRIPTION
Closes #673, the last piece of #549's inference: Sidorov's Equation 4 lifts a cover over *every* resource at once, and `InferredCumulative` was doing it over one.

## The issue's premise turned out not to hold

#673 says a cut mixing demands from two resources "needs the two rows scaled against each other, and the scaling is what has to be justified", and lists a cross-row scaling schema or a replayed nested solve as the two ways out. That was written against #671's **original** certificate — the three `pol` shapes and the `Normalised` search — which #675 deleted. The knapsack DP replay that took its place generalises without scaling anything:

- a state stops being `(weight, profit)` and becomes `(weight per row, profit)`;
- a successor is refused when it overruns *some* capacity, and that kill `pol` cites whichever row it was;
- the goal flag, the layer at-least-ones and the pin are untouched.

No row is ever added to another. Each is used exactly where the single row was used: to say one transition cannot happen. **The issue body is stale and I have not edited it.**

## What it costs, measured rather than argued

Dominance stops being a staircase and becomes a Pareto frontier, so the `π₀ + 1` bound on a layer's width is gone. Measured against all 83 lifted constraints Sidorov publishes for Pack and Pack-d: switching every resource on takes the widest layer from 4 to 14 and the largest programme from 111 states to 222. Same order, not a different regime — lifting drives the coefficients up, so `π₀` stays at two or three whatever the capacities are.

"Measured" is not "bounded", so `with_programme_state_budget` exists, a cut over it is dropped and counted separately from one that does not hold, and the sweep asserts it is never reached.

Incidentally, 80 of those 83 published cuts are certifiable from a single row. Certifying against the smallest sufficient row set would therefore have left the multi-resource path running on 3 cuts in 83 and permanently under-exercised, so the certificate mirrors Equation 4 instead and uses every row that can bind.

## Three commits

1. **`recover_bridged_row`** — each resource is a separately posted `Cumulative` with its own activity flags, so its row has to be carried onto the members' before it can join the derivation. Weaken the row down to the members, add each one's bridge `c_j` times, everything cancels and the right-hand side stays put. Pinned, since a bridge pointing the wrong way is otherwise a mistake that surfaces thousands of lines later.
2. **The certificate**, generalised as above, plus `lifted_cover_cut_optimum` so the lifting subproblem and the validity check are the same programme over the same rows — which is what keeps `cuts_uncertifiable` zero by construction.
3. **The presolver**, now one pass over the whole problem with tasks matched across constraints by start and length, matching the reference implementation's single demand matrix. The budgets follow it: the cover budget applies per resource and then again across all of them, as `collect_cover_sets` does, and the subproblem budget, visited-cover rule and output limit are one each.

That second application of the cover budget is new, and it means a long cover of exactly three no longer survives a budget of zero — so the fixture asserting long covers outlive the budget now has one of four.

## Evidence the crossing runs

A two-resource fixture built for it: the cover belongs to the second resource, the lifted coefficient comes from the first, and neither row alone implies the result. It refutes a horizon of seven at the root where the rows alone take four nodes, enumerates correctly at eight, and every mutation is run again over it — including `BridgeWrongTask`, which cannot exist with one resource.

The verified sweep now draws one to three resources, so veripb sees the crossing across many shapes rather than only over that fixture: typically half the posted cuts need more than one row, all checked, `cuts_uncertifiable` still zero.

One thing worth recording: over several resources, `ClaimTighterRow` needs a fixture the tightening actually changes. If no feasible subset sits exactly at a capacity, taking one off every capacity leaves the programme identical and only changes which row gets the blame for a kill — and the kill is still true. Even a misattributed kill can survive, because the other rows are in the database and unit propagation reaches the same conclusion through them. #660's conflict-shaped-rule problem again: corrupting the route is not a test when a second route is true. `dev_docs/inferred-cumulative.md` says so.

## Testing

632/632 ctest caps-OFF, 636/636 under clang, ASan+UBSan clean on the three affected binaries, five seeds of the presolver test and three of the certificate test. One unrelated flake on `linear_constraint_ne_iff_stateless` (a `\x00` in a proof file, the truncated-write shape); passes on rerun.

The RCPSP artefact in `~/claude/tmp/rcpsp-bounds-672/` has **not** been rerun — `dev_docs/certified-makespan-bounds.md` now says its numbers are the single-resource lifting's. Four of the instances it falls short on have an `L` equal to their best known makespan, so closing the inference gap should close them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173hT2hFo3MyGRBon8SHt2p

---

## Added after review by the author (fourth commit)

Konstantin Sidorov has settled both places where the paper and its implementation disagree, and both resolve the same way round — *longest first*:

- **Algorithm 2's `arg min dᵢ` is the paper's typo.** The intent is the longest unlifted task, because coefficients are assigned greedily: a task brought in later meets a larger `v*` and gets a smaller coefficient. Worth knowing that lifting is sequence-dependent even over a single row (Zemel 1978), so the order is load-bearing rather than cosmetic. This is what the code and this implementation already do.
- **Algorithm 1's representative is the code's bug.** The intended line is `durations[ix] > durations[inv_A_longest[a]]`, not a duration against a stored index. This is what this implementation already does — but the *published results came from the shipped line*.

That second one is not a formality. Over Pack and Pack-d the two readings pick a different representative on **306 of 314 resource rows**, giving a different ternary cover family on **164 rows and 103 of the 110 instances**. The difference runs one way: the shipped pick is **never the longer task** (shorter on 542 of 922 (demand, row) pairs, equal on the rest), so the corrected reading's best ternary cover is never worse and is better on 61 rows.

So a per-instance comparison against the paper's numbers is not a comparison over the same covers, and where this presolver's `L` beats the published one that is a likely cause. It is the one place where reproducing the method as *described* means out-performing the artefact as *shipped* — the opposite of the usual risk, and worth saying out loud given #549's rule about not out-inferring the literature.


Closes #549
