### PR TITLE
Forget the inferring presolvers' working instead of leaving it at Top (#666)

### DIFF
--- a/dev_docs/inferred-disjunctive.md
+++ b/dev_docs/inferred-disjunctive.md
@@ -59,9 +59,9 @@ Per time point, over the clique members whose window covers it:
 
    Two members is not a special case of that routine but its smallest one, and
    where several of a clique's members share a witnessing row, recovering their
-   whole sub-clique in one step instead of pair by pair is the proof-size fix
-   [#666](https://github.com/ciaranm/glasgow-constraint-solver/issues/666) is
-   about.
+   whole sub-clique in one step instead of pair by pair would make the file
+   smaller — see Proof size, where the measurement and the reason it is not done
+   both are.
 2. **The bridge**, where the witness is not where a task's flags live — which is
    the normal case, since a clique's pairs are witnessed by different resources.
    `recover_conjunction_flag_bridge` carries it across, cached per
@@ -81,15 +81,39 @@ Measured on the three-task family over five time points: **251 lines, 11 KB, 139
 
 The shape is `O(k²)` pair derivations plus `O(k)` bridges plus `O(k)` merge steps,
 **per time point**, so the whole thing is multiplied by the horizon. At eight
-members and a horizon of a thousand that is order 10⁵ lines per clique, and every
-one of them is emitted at `ProofLevel::Top`, where it never dies and taxes every
-later unhinted RUP — the `table_layout15` pathology.
+members and a horizon of a thousand that is order 10⁵ lines per clique.
 
-Only the pinned per-time row needs to outlive the recipe. Deriving the
-intermediates at `Temporary` and forgetting them after each row, or inlining a
-whole time point into a single `pol` so they never enter the checker's database
-at all, is the fix. Neither is done yet, and it is the first thing to do before
-this is pointed at a real instance.
+**None of them stays in the database.** Only the pinned per-time row is ever cited
+again, so the bridges and the pairwise at-most-ones go one proof level deeper than
+the caller's, the merge induction one deeper again, and both are forgotten on the
+way out — the same dance `recover_am1` and `derive_lifted_cover_cut` do, and for
+the same reason. Emitting them at `Top` instead is what
+[#666](https://github.com/ciaranm/glasgow-constraint-solver/issues/666) was
+about: the `table_layout15` pathology, where a bloated live database cost twelve
+times at the root rather than at deletion time.
+
+Measured on `k`-cliques in which every pair has its own witnessing resource, so
+the bridges are at their worst:
+
+| k | time points | `pol` emitted | live before | live after |
+|--:|------------:|--------------:|------------:|-----------:|
+| 3 | 6 | 78 | 84 | 6 |
+| 4 | 8 | 256 | 264 | 8 |
+| 5 | 10 | 580 | 590 | 10 |
+| 6 | 12 | 1092 | 1104 | 12 |
+
+One line per time point survives rather than one per pair per time point, and it
+costs two `del` lines per time point — about 0.3% more proof.
+
+The **file** is another matter, and it is unchanged by this. On a real Pack
+clique (`pack008`, ten members over three resources) a time point emits 72 `pol`
+of bridges and pairwise at-most-ones and 14 of merge induction. Recovering a
+whole sub-clique in one step where members share a witnessing row would cut the
+at-most-ones by about a factor of two on the published Pack targets — 1897
+pairwise lines across the twenty of them become 881 — but it needs an induction
+over sub-clique premises rather than pairwise ones, which is a new derivation
+rather than a rearrangement of this one. Since the cost this file was paying was
+the database and not the bytes, it is not done.
 
 ## Testing it
 

--- a/gcs/innards/proofs/am1_from_pairs.cc
+++ b/gcs/innards/proofs/am1_from_pairs.cc
@@ -39,6 +39,16 @@ auto gcs::innards::recover_am1_from_pairs(ProofLogger & logger, const vector<Pro
 
     logger.emit_proof_comment("clique at-most-one over " + to_string(k) + " members");
 
+    // The induction goes one proof level deeper than the caller's own, and is
+    // forgotten on the way out. Only the pin below is ever cited again: every
+    // line between here and it exists to reach it, and at Top every one of them
+    // would stay live for the rest of the proof, taxing every later unhinted RUP
+    // (issue #666). The extra depth rather than plain Temporary is what stops
+    // the forget taking the caller's scope with it, since a caller inside a
+    // JustifyExplicitly is already using its own Temporary depth.
+    auto saved_level = logger.proof_level();
+    logger.enter_proof_level(saved_level + 1);
+
     // The base case is not a derivation: the at-most-one for the first pair
     // already is the clique inequality for those two.
     auto current = at_most_ones[1][0];
@@ -54,7 +64,7 @@ auto gcs::innards::recover_am1_from_pairs(ProofLogger & logger, const vector<Pro
                 naive.add(at_most_ones[j][i]);
         if (k > 2)
             naive.divide_by(Integer{static_cast<long long>(k) - 1});
-        current = naive.emit(logger, level);
+        current = naive.emit(logger, ProofLevel::Temporary);
     }
 
     // Then one member at a time. At the top of each pass `current` says
@@ -86,7 +96,7 @@ auto gcs::innards::recover_am1_from_pairs(ProofLogger & logger, const vector<Pro
         // and the induction would not advance.
         if (! (skip_final_division && m == k - 1))
             merge.divide_by(Integer{static_cast<long long>(m)});
-        current = merge.emit(logger, level);
+        current = merge.emit(logger, ProofLevel::Temporary);
     }
 
     // Pin what came back. Every step above is sound whatever was fed into it,
@@ -97,5 +107,10 @@ auto gcs::innards::recover_am1_from_pairs(ProofLogger & logger, const vector<Pro
     for (const auto & member : members)
         add_term_to(clique, 1_i, member);
 
-    return logger.emit(ImpliesProofRule{current}, move(clique) <= (claim_one_more ? 0_i : 1_i), level);
+    // Back at the caller's level to pin, while the induction is still alive for
+    // VeriPB to resolve the reference against, and only then drop it.
+    logger.enter_proof_level(saved_level);
+    auto result = logger.emit(ImpliesProofRule{current}, move(clique) <= (claim_one_more ? 0_i : 1_i), level);
+    logger.forget_proof_level(saved_level + 2);
+    return result;
 }

--- a/gcs/presolvers/cumulative_strengthening/cumulative_strengthening.cc
+++ b/gcs/presolvers/cumulative_strengthening/cumulative_strengthening.cc
@@ -430,10 +430,24 @@ auto CumulativeStrengthening::run(Problem & problem, Propagators & propagators, 
                 for (const auto & item : items)
                     load += item.coefficient * std::get<ProofFlag>(item.term);
 
+                // Everything between here and the pin is working: the
+                // strengthened rows, the at-most-ones and the raises all exist
+                // only to reach the line this returns, and at Top not one of
+                // them would ever be deleted (issue #666, which is the same
+                // defect one presolver over). One level deeper, and forgotten
+                // on the way out.
+                auto saved_level = recipe_logger.proof_level();
+                recipe_logger.enter_proof_level(saved_level + 1);
+                auto give_back = [&](optional<ProofLine> line) {
+                    recipe_logger.enter_proof_level(saved_level);
+                    recipe_logger.forget_proof_level(saved_level + 2);
+                    return line;
+                };
+
                 auto strengthen_to_kappa = [&](ProofLine source) -> ProofLine {
                     recipe_logger.emit_proof_comment(point->second.by_division ? "presolve cumulative gcd" : "presolve cumulative kappa");
                     auto strengthened =
-                        derive_subset_sum_strengthening(recipe_logger, items, source, capacity, ProofLevel::Top, subset_sum_corruption);
+                        derive_subset_sum_strengthening(recipe_logger, items, source, capacity, ProofLevel::Temporary, subset_sum_corruption);
                     if (stats) {
                         if (strengthened.by_division)
                             ++stats->rows_by_division;
@@ -452,8 +466,10 @@ auto CumulativeStrengthening::run(Problem & problem, Propagators & propagators, 
                 // other than where it claimed: a divisor that does not divide
                 // every height still divides *soundly*, and nothing else in the
                 // proof would object.
-                if (full_here.empty())
-                    return recipe_logger.emit(ImpliesProofRule{strengthen_to_kappa(donor_row)}, move(load) <= kappa, ProofLevel::Top);
+                if (full_here.empty()) {
+                    auto strengthened = strengthen_to_kappa(donor_row);
+                    return give_back(recipe_logger.emit(ImpliesProofRule{strengthened}, move(load) <= kappa, ProofLevel::Top));
+                }
 
                 recipe_logger.emit_proof_comment("presolve cumulative amo");
 
@@ -488,7 +504,8 @@ auto CumulativeStrengthening::run(Problem & problem, Propagators & propagators, 
                     if (unentitled_raise && heights[a] + heights[b] <= capacity)
                         demand_a = capacity - heights[b] + 1_i;
 
-                    auto recovered = recover_am1_from_row(recipe_logger, donor_row, {demand_a, heights[b]}, weaken_out, capacity, ProofLevel::Top);
+                    auto recovered =
+                        recover_am1_from_row(recipe_logger, donor_row, {demand_a, heights[b]}, weaken_out, capacity, ProofLevel::Temporary);
                     at_most_ones.emplace(key, recovered.line);
                     return recovered.line;
                 };
@@ -512,7 +529,7 @@ auto CumulativeStrengthening::run(Problem & problem, Propagators & propagators, 
                     without_full.add(donor_row);
                     for (auto i : full_here)
                         without_full.weaken(flag_for(i), tracker);
-                    row = strengthen_to_kappa(without_full.emit(recipe_logger, ProofLevel::Top));
+                    row = strengthen_to_kappa(without_full.emit(recipe_logger, ProofLevel::Temporary));
 
                     // A time point whose own largest load is below the declared
                     // capacity has to be relaxed up to it *before* anything is
@@ -524,7 +541,7 @@ auto CumulativeStrengthening::run(Problem & problem, Propagators & propagators, 
                         WPBSum rest;
                         for (const auto & item : items)
                             rest += item.coefficient * std::get<ProofFlag>(item.term);
-                        row = recipe_logger.emit(ImpliesProofRule{*row}, move(rest) <= kappa, ProofLevel::Top);
+                        row = recipe_logger.emit(ImpliesProofRule{*row}, move(rest) <= kappa, ProofLevel::Temporary);
                     }
                     return *row;
                 };
@@ -546,7 +563,7 @@ auto CumulativeStrengthening::run(Problem & problem, Propagators & propagators, 
                         // claim is only that a flag is at most one.
                         WPBSum alone;
                         alone += kappa * flag_for(task);
-                        row = recipe_logger.emit_rup_proof_line(move(alone) <= kappa, ProofLevel::Top);
+                        row = recipe_logger.emit_rup_proof_line(move(alone) <= kappa, ProofLevel::Temporary);
                         if (stats)
                             ++stats->raise_lines_emitted;
                     }
@@ -558,7 +575,7 @@ auto CumulativeStrengthening::run(Problem & problem, Propagators & propagators, 
                         PolBuilder summed;
                         for (const auto & [other, weight] : running)
                             summed.add(at_most_one_between(task, other), weight);
-                        row = summed.emit(recipe_logger, ProofLevel::Top);
+                        row = summed.emit(recipe_logger, ProofLevel::Temporary);
                         if (stats)
                             ++stats->raise_lines_emitted;
 
@@ -567,7 +584,7 @@ auto CumulativeStrengthening::run(Problem & problem, Propagators & propagators, 
                             raised += kappa * flag_for(task);
                             for (const auto & [other, weight] : running)
                                 raised += weight * flag_for(other);
-                            row = recipe_logger.emit(ImpliesProofRule{*row}, move(raised) <= kappa, ProofLevel::Top);
+                            row = recipe_logger.emit(ImpliesProofRule{*row}, move(raised) <= kappa, ProofLevel::Temporary);
                         }
                     }
                     else {
@@ -599,7 +616,7 @@ auto CumulativeStrengthening::run(Problem & problem, Propagators & propagators, 
                             for (const auto & [other, weight] : running)
                                 raise.add(at_most_one_between(task, other), e * weight);
                             raise.divide_by(lambda + e);
-                            row = raise.emit(recipe_logger, ProofLevel::Top);
+                            row = raise.emit(recipe_logger, ProofLevel::Temporary);
                             if (stats)
                                 ++stats->raise_lines_emitted;
 
@@ -613,7 +630,7 @@ auto CumulativeStrengthening::run(Problem & problem, Propagators & propagators, 
                 if (stats)
                     ++stats->rows_with_a_raise;
 
-                return recipe_logger.emit(ImpliesProofRule{*row}, move(load) <= kappa, ProofLevel::Top);
+                return give_back(recipe_logger.emit(ImpliesProofRule{*row}, move(load) <= kappa, ProofLevel::Top));
             },
             .rules = _rules};
 

--- a/gcs/presolvers/inferred_disjunctive/inferred_disjunctive.cc
+++ b/gcs/presolvers/inferred_disjunctive/inferred_disjunctive.cc
@@ -477,6 +477,21 @@ auto InferredDisjunctive::run(Problem & problem, Propagators & propagators, Stat
 
                 recipe_logger.emit_proof_comment("presolve disjunctive clique at time " + to_string(t.raw_value));
 
+                // The bridges and the pairwise at-most-ones go one proof level
+                // deeper than the caller's and are forgotten on the way out.
+                // They exist only to reach the line recover_am1_from_pairs pins,
+                // and at Top there are order k squared of them per time point,
+                // none of which is ever deleted -- 180k live constraints from
+                // one presolver on a realistic instance, taxing every later
+                // unhinted RUP (issue #666).
+                auto saved_level = recipe_logger.proof_level();
+                recipe_logger.enter_proof_level(saved_level + 1);
+                auto give_back = [&](optional<ProofLine> line) {
+                    recipe_logger.enter_proof_level(saved_level);
+                    recipe_logger.forget_proof_level(saved_level + 2);
+                    return line;
+                };
+
                 // Bridges, once per (member, witnessing resource) rather than
                 // once per pair: several pairs of a clique often share a witness.
                 map<pair<size_t, ConstraintID>, ProofLine> bridges;
@@ -497,7 +512,7 @@ auto InferredDisjunctive::run(Problem & problem, Propagators & propagators, Stat
                             " has no flags for one of the tasks it is about"};
 
                     auto line = recover_conjunction_flag_bridge(recipe_logger, std::get<2>(*from), {std::get<0>(*from), std::get<1>(*from)},
-                        std::get<2>(*to), {std::get<0>(*to), std::get<1>(*to)}, ProofLevel::Top);
+                        std::get<2>(*to), {std::get<0>(*to), std::get<1>(*to)}, ProofLevel::Temporary);
                     if (stats)
                         ++stats->bridges_derived;
                     bridges.emplace(key, line);
@@ -514,12 +529,12 @@ auto InferredDisjunctive::run(Problem & problem, Propagators & propagators, Stat
                         const auto & c = *conflicts[here[a]][here[b]];
                         auto row = rows.find(c.witness);
                         if (row == rows.end())
-                            return std::nullopt;
+                            return give_back(std::nullopt);
 
                         auto u_flags = flags_for(tracker, c.witness, c.witness_position_u, t);
                         auto v_flags = flags_for(tracker, c.witness, c.witness_position_v, t);
                         if (! u_flags || ! v_flags)
-                            return std::nullopt;
+                            return give_back(std::nullopt);
 
                         // Everything else on that resource that could be running
                         // now has to come out of the row first. Over every
@@ -565,12 +580,12 @@ auto InferredDisjunctive::run(Problem & problem, Propagators & propagators, Stat
                             pair_amo.add(*bridged_v);
                         if (bridged_u || bridged_v)
                             pair_amo.saturate();
-                        at_most_ones[b].push_back(pair_amo.emit(recipe_logger, ProofLevel::Top));
+                        at_most_ones[b].push_back(pair_amo.emit(recipe_logger, ProofLevel::Temporary));
                     }
 
-                return recover_am1_from_pairs(recipe_logger, flags, at_most_ones, ProofLevel::Top,
+                return give_back(recover_am1_from_pairs(recipe_logger, flags, at_most_ones, ProofLevel::Top,
                     claim_rhs_zero ? Am1FromPairsMutation{am1_from_pairs_mutation::ClaimOneMore{}}
-                                   : Am1FromPairsMutation{am1_from_pairs_mutation::None{}});
+                                   : Am1FromPairsMutation{am1_from_pairs_mutation::None{}}));
             },
             .makespan = _makespan,
             .makespan_links = links,

--- a/gcs/presolvers/inferred_disjunctive/inferred_disjunctive_test.cc
+++ b/gcs/presolvers/inferred_disjunctive/inferred_disjunctive_test.cc
@@ -491,6 +491,20 @@ auto main(int argc, char * argv[]) -> int
         if (0 == count_occurrences(proof, "presolve disjunctive clique at time"))
             fail("markers: no per-time clique derivation in the proof");
         println(cerr, "markers: {} per-time clique derivations", count_occurrences(proof, "presolve disjunctive clique at time"));
+
+        // And the working is deleted rather than left in the database. Every
+        // line a time point emits except its pin exists only to reach that pin,
+        // and at Top there are order k squared of them per time point that
+        // nothing ever cites again (issue #666). The presolve prefix is
+        // everything up to the last clique marker, so counting deletions there
+        // asks about this presolver rather than about the search.
+        auto prefix = proof.substr(0, proof.rfind("presolve disjunctive: inferred a clique"));
+        auto derivations = count_occurrences(prefix, "presolve disjunctive clique at time");
+        auto deletions = count_occurrences(prefix, "del ");
+        if (deletions < derivations)
+            fail("proof size: " + to_string(derivations) + " per-time derivations left " + to_string(deletions) +
+                " deletions behind, so their scaffolding is still live");
+        println(cerr, "proof size: {} deletions over {} per-time derivations, so only the pins outlive them", deletions, derivations);
         dispose_of_proof_files(name);
     }
 


### PR DESCRIPTION
Closes #666. It was straightforward, and the measurement is the headline.

## What it was

`InferredDisjunctive` proved each derived row from scratch at every time point and emitted every intermediate at `ProofLevel::Top`, where nothing is ever deleted. Only the `ia` pin per time point is ever cited again; everything else stayed in the constraint database for the rest of the proof, taxing every later unhinted RUP — the `table_layout15` shape.

The fix is the dance `recover_am1` and `derive_lifted_cover_cut` already do: the bridges and pairwise at-most-ones go one proof level deeper than the caller's, `recover_am1_from_pairs` puts its induction one deeper again, and both are forgotten on the way out. The extra depth rather than plain `Temporary` is what stops the forget taking the caller's scope with it inside a `JustifyExplicitly`.

## Measured

On `k`-cliques where every pair has its own witnessing resource, so the bridges are at their worst:

| k | time points | `pol` emitted | live before | live after |
|--:|------------:|--------------:|------------:|-----------:|
| 3 | 6 | 78 | 84 | **6** |
| 4 | 8 | 256 | 264 | **8** |
| 5 | 10 | 580 | 590 | **10** |
| 6 | 12 | 1092 | 1104 | **12** |

One line per time point survives rather than one per pair per time point, for two `del` lines per time point — about 0.3% more proof. Extrapolating the issue's own realistic case (k=8, horizon 1000, `N_out = 5`), that is ~180k live constraints from one presolver becoming ~5k.

The pin is emitted in exactly the same place, which #663's `SkipFinalDivision` mutation is what would notice otherwise. The test now also asserts a deletion per per-time derivation, since scaffolding that quietly stopped being emitted would otherwise look like a pass.

## `CumulativeStrengthening` had it too

Found while doing this rather than filed as part of it — same shape, nine emission sites, same fix.

One trap worth the comment it now has: that recipe has *two* pins, and its short path (nothing fills the resource here, so the row is the donor's strengthened) also ends in one. Moving that one to the deeper level makes the forget delete the line it just returned. VeriPB says so immediately and unambiguously — "trying to access constraint with ID 145 that has already been deleted" — which is the happy end of the range of ways to get this wrong.

## What I did *not* do, and why

#666's second candidate fix was to shrink the file as well as the database, by recovering a whole sub-clique in one step wherever members share a witnessing row. I measured what it would buy before deciding: across the twenty published Pack targets, a greedy cover takes **1897 pairwise lines to 881** — about 2.2×, with one instance at 36×.

But it needs an induction over *sub-clique* premises rather than pairwise ones, and `recover_am1_from_pairs`'s induction is specifically pairwise — it adds the `m` at-most-ones tying the new member to the ones already in, plus `m−1` copies of the clique so far. That is a new derivation to design and simulate, not a rearrangement of this one. Set against it: on a real Pack clique (`pack008`, ten members, three resources) a time point emits 72 `pol` of bridges and pairwise at-most-ones against 14 of merge, so halving the at-most-ones is maybe a quarter off the file — and the issue's own conclusion is that the file was never the cost.

So it is written up in `dev_docs/inferred-disjunctive.md` with the number, and left.

## Testing

632/632 ctest caps-OFF. Proof-size numbers regenerated from `examples/rcpsp --dzn` on generated clique fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173hT2hFo3MyGRBon8SHt2p