### PR TITLE
Move the proof-mutation variants into the innards namespace (#669)

### DIFF
--- a/examples/rcpsp/rcpsp.cc
+++ b/examples/rcpsp/rcpsp.cc
@@ -727,7 +727,7 @@ auto main(int argc, char * argv[]) -> int
         if (infer_makespan_bound)
             presolver.with_makespan(makespan);
         if (mutate_makespan_bound)
-            presolver.with_proof_mutation(inferred_disjunctive_mutation::ClaimHigherMakespanBound{});
+            presolver.with_proof_mutation(gcs::innards::inferred_disjunctive_mutation::ClaimHigherMakespanBound{});
         problem.add_presolver(presolver);
     }
 
@@ -741,7 +741,7 @@ auto main(int argc, char * argv[]) -> int
         if (infer_makespan_bound)
             presolver.with_makespan(makespan);
         if (mutate_makespan_bound)
-            presolver.with_proof_mutation(inferred_cumulative_mutation::ClaimHigherMakespanBound{});
+            presolver.with_proof_mutation(gcs::innards::inferred_cumulative_mutation::ClaimHigherMakespanBound{});
         problem.add_presolver(presolver);
     }
 

--- a/gcs/constraints/cumulative/cumulative.hh
+++ b/gcs/constraints/cumulative/cumulative.hh
@@ -2,6 +2,7 @@
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_CUMULATIVE_CUMULATIVE_HH
 
 #include <gcs/constraint.hh>
+#include <gcs/constraints/innards/cumulative_mutations.hh>
 #include <gcs/innards/proofs/constraint_proof_model_data.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/proofs/proof_only_variables-fwd.hh>
@@ -43,113 +44,6 @@ namespace gcs
         /// effect unless \ref overload is also set.
         bool profile_overload = true;
     };
-
-    /**
-     * \brief Deliberate corruptions of the overload check's derivation, for
-     * testing only.
-     *
-     * A proof that verifies is necessary but not sufficient: if the honest
-     * derivation has slack in it, a wrong one verifies too, and the rule's
-     * arithmetic is then not being checked by anything. Each of these breaks
-     * one step of the emitted derivation in a way that must make VeriPB
-     * *reject* the proof; a mutation that still verifies is a finding about the
-     * honest derivation, not about the mutation.
-     *
-     * These change nothing but the proof: the same conflicts are found, the
-     * same solutions reported, and the OPB is untouched.
-     *
-     * \ingroup Constraints
-     */
-    namespace cumulative_proof_mutation
-    {
-        /// Emit the honest derivation.
-        struct None
-        {
-        };
-
-        /// Claim one more unit of activity than the window-energy lemma
-        /// derived, for the first task in the window.
-        struct OverstateWindowEnergy
-        {
-        };
-
-        /// Leave the last time point's capacity line out of the conflict's
-        /// pol, so the window appears to supply one time point less than the
-        /// energy argument was told.
-        struct OmitCapacityLine
-        {
-        };
-
-        /// Derive each task's window energy over a window one time point
-        /// short, which is honest but weaker than the conflict needs.
-        struct ShrinkLemmaWindow
-        {
-        };
-    }
-
-    using CumulativeProofMutation = std::variant<cumulative_proof_mutation::None, cumulative_proof_mutation::OverstateWindowEnergy,
-        cumulative_proof_mutation::OmitCapacityLine, cumulative_proof_mutation::ShrinkLemmaWindow>;
-
-    /**
-     * \brief Deliberate corruptions of the presence-falsification derivation,
-     * for testing only. VeriPB must reject each of them.
-     *
-     * A proof that verifies is necessary but not sufficient, so something has
-     * to check that the derivation is doing work. What that something can be is
-     * narrower here than for a bound push, and worth understanding before
-     * adding to this list: presence falsification is a *conflict-shaped* rule,
-     * whose content is "this task cannot be here at all". Once the chain has
-     * narrowed the start domain far enough, the reason context extended with
-     * "the task is present" is contradictory, and every RUP under it is
-     * vacuously valid. A mutation that merely shortens the chain therefore
-     * produces a shorter but still *sound* derivation, and VeriPB is right to
-     * accept it. Corrupting the route is not a test; corrupt the destination.
-     *
-     * So the two that bite are \ref cumulative_presence_mutation::WrongTask,
-     * which argues about a task nothing has cornered, and \ref
-     * cumulative_presence_mutation::ClaimOneTooFar, which draws the conclusion
-     * where it is false. \ref cumulative_presence_mutation::EmitNothing is the
-     * control that says the chain is required at all.
-     *
-     * All but ClaimOneTooFar change nothing except the proof: the same
-     * presences are falsified, the same solutions reported, and the OPB is
-     * untouched. ClaimOneTooFar necessarily changes the inference, since making
-     * the conclusion wrong is the whole point of it.
-     *
-     * \ingroup Constraints
-     */
-    namespace cumulative_presence_mutation
-    {
-        /// Emit the honest derivation.
-        struct None
-        {
-        };
-
-        /// Carry some other optional task's presence literal through the chain,
-        /// so the derivation argues about a task that is not the one being
-        /// falsified.
-        struct WrongTask
-        {
-        };
-
-        /// Fire on an instance where exactly one placement still fits, claiming
-        /// the task is absent when it is not. The "bound + 1 must fail" check
-        /// for this rule: it corrupts the conclusion rather than the route to
-        /// it, which is what a margin of exactly one unit is there to expose.
-        struct ClaimOneTooFar
-        {
-        };
-
-        /// Emit no chain at all, leaving the inference to the framework's
-        /// wrapping RUP. Not a corruption but a control: if VeriPB accepts
-        /// this, the chain is decoration and no mutation of it can be caught.
-        struct EmitNothing
-        {
-        };
-    }
-
-    using CumulativePresenceMutation = std::variant<cumulative_presence_mutation::None, cumulative_presence_mutation::WrongTask,
-        cumulative_presence_mutation::ClaimOneTooFar, cumulative_presence_mutation::EmitNothing>;
 
     /**
      * \brief Cumulative constraint: tasks with start times, durations, and
@@ -227,12 +121,12 @@ namespace gcs
         // conjunct, because the OPB has to stand on its own and it is the OPB,
         // not the initial State, that a checker reads.
         std::vector<std::optional<IntegerVariableID>> _presence;
-        CumulativePresenceMutation _presence_mutation = cumulative_presence_mutation::None{};
+        innards::CumulativePresenceMutation _presence_mutation = innards::cumulative_presence_mutation::None{};
         std::vector<std::size_t> _active_tasks;
         std::vector<Integer> _per_task_t_lo;
         std::vector<Integer> _per_task_t_hi;
         CumulativeRules _rules;
-        CumulativeProofMutation _proof_mutation = cumulative_proof_mutation::None{};
+        innards::CumulativeProofMutation _proof_mutation = innards::cumulative_proof_mutation::None{};
         // Overload checking, resolved in prepare(). _overload_tasks lists the
         // tasks the window-energy lemma can speak about (constant length and
         // height, and a start whose order literals the lemma can bridge to);
@@ -309,13 +203,13 @@ namespace gcs
 
         /// Corrupt one step of the overload check's derivation. For tests
         /// only, which assert that VeriPB rejects the result; see
-        /// CumulativeProofMutation.
-        auto with_proof_mutation(CumulativeProofMutation mutation) -> Cumulative &;
+        /// innards::CumulativeProofMutation.
+        auto with_proof_mutation(innards::CumulativeProofMutation mutation) -> Cumulative &;
 
         /// Corrupt one step of the presence-falsification derivation. For tests
         /// only, which assert that VeriPB rejects the result; see
-        /// CumulativePresenceMutation.
-        auto with_presence_mutation(CumulativePresenceMutation mutation) -> Cumulative &;
+        /// innards::CumulativePresenceMutation.
+        auto with_presence_mutation(innards::CumulativePresenceMutation mutation) -> Cumulative &;
 
         /**
          * \name The arguments this constraint was posted with.

--- a/gcs/constraints/cumulative/cumulative_optional_test.cc
+++ b/gcs/constraints/cumulative/cumulative_optional_test.cc
@@ -55,6 +55,7 @@ using fmt::println;
 #endif
 
 using namespace gcs;
+using namespace gcs::innards;
 using namespace gcs::test_innards;
 
 namespace

--- a/gcs/constraints/cumulative/cumulative_overload_test.cc
+++ b/gcs/constraints/cumulative/cumulative_overload_test.cc
@@ -49,6 +49,7 @@ using fmt::println;
 #endif
 
 using namespace gcs;
+using namespace gcs::innards;
 using namespace gcs::test_innards;
 
 namespace

--- a/gcs/constraints/innards/cumulative_mutations.hh
+++ b/gcs/constraints/innards/cumulative_mutations.hh
@@ -1,0 +1,137 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_INNARDS_CUMULATIVE_MUTATIONS_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_INNARDS_CUMULATIVE_MUTATIONS_HH
+
+#include <variant>
+
+/**
+ * \file
+ *
+ * Deliberate corruptions of `Cumulative`'s proof steps, which exist so that a
+ * test can show the honest derivation is tight to what it claims. They live
+ * here, in the innards, rather than beside the constraint they corrupt: a
+ * header a user of the library includes should not advertise a way to make the
+ * solver emit deliberately wrong proofs. Issue #669, and the same reason
+ * SubsetSumMutation and Am1FromPairsMutation were always here.
+ *
+ * Compiling them out of release builds was considered and rejected. The hooks
+ * are not only `if` bodies --- the flags are lambda captures in the derived
+ * constraint recipes and members that `clone()` copies --- so a build without
+ * them would ship a different closure from the one the tests exercised, and for
+ * proof logging, whose failure mode is "verifies fine but says something other
+ * than what it claimed", that is the worst place to put a configuration-
+ * dependent divergence. The mutation tests are also the only tests here that
+ * can fail for the right reason, since solutions matching brute force and
+ * veripb verifying both pass just as well when the derivation did nothing.
+ */
+
+namespace gcs::innards
+{
+    /**
+     * \brief Deliberate corruptions of the overload check's derivation, for
+     * testing only.
+     *
+     * A proof that verifies is necessary but not sufficient: if the honest
+     * derivation has slack in it, a wrong one verifies too, and the rule's
+     * arithmetic is then not being checked by anything. Each of these breaks
+     * one step of the emitted derivation in a way that must make VeriPB
+     * *reject* the proof; a mutation that still verifies is a finding about the
+     * honest derivation, not about the mutation.
+     *
+     * These change nothing but the proof: the same conflicts are found, the
+     * same solutions reported, and the OPB is untouched.
+     *
+     * \ingroup Innards
+     */
+    namespace cumulative_proof_mutation
+    {
+        /// Emit the honest derivation.
+        struct None
+        {
+        };
+
+        /// Claim one more unit of activity than the window-energy lemma
+        /// derived, for the first task in the window.
+        struct OverstateWindowEnergy
+        {
+        };
+
+        /// Leave the last time point's capacity line out of the conflict's
+        /// pol, so the window appears to supply one time point less than the
+        /// energy argument was told.
+        struct OmitCapacityLine
+        {
+        };
+
+        /// Derive each task's window energy over a window one time point
+        /// short, which is honest but weaker than the conflict needs.
+        struct ShrinkLemmaWindow
+        {
+        };
+    }
+
+    using CumulativeProofMutation = std::variant<cumulative_proof_mutation::None, cumulative_proof_mutation::OverstateWindowEnergy,
+        cumulative_proof_mutation::OmitCapacityLine, cumulative_proof_mutation::ShrinkLemmaWindow>;
+
+    /**
+     * \brief Deliberate corruptions of the presence-falsification derivation,
+     * for testing only. VeriPB must reject each of them.
+     *
+     * A proof that verifies is necessary but not sufficient, so something has
+     * to check that the derivation is doing work. What that something can be is
+     * narrower here than for a bound push, and worth understanding before
+     * adding to this list: presence falsification is a *conflict-shaped* rule,
+     * whose content is "this task cannot be here at all". Once the chain has
+     * narrowed the start domain far enough, the reason context extended with
+     * "the task is present" is contradictory, and every RUP under it is
+     * vacuously valid. A mutation that merely shortens the chain therefore
+     * produces a shorter but still *sound* derivation, and VeriPB is right to
+     * accept it. Corrupting the route is not a test; corrupt the destination.
+     *
+     * So the two that bite are \ref cumulative_presence_mutation::WrongTask,
+     * which argues about a task nothing has cornered, and \ref
+     * cumulative_presence_mutation::ClaimOneTooFar, which draws the conclusion
+     * where it is false. \ref cumulative_presence_mutation::EmitNothing is the
+     * control that says the chain is required at all.
+     *
+     * All but ClaimOneTooFar change nothing except the proof: the same
+     * presences are falsified, the same solutions reported, and the OPB is
+     * untouched. ClaimOneTooFar necessarily changes the inference, since making
+     * the conclusion wrong is the whole point of it.
+     *
+     * \ingroup Innards
+     */
+    namespace cumulative_presence_mutation
+    {
+        /// Emit the honest derivation.
+        struct None
+        {
+        };
+
+        /// Carry some other optional task's presence literal through the chain,
+        /// so the derivation argues about a task that is not the one being
+        /// falsified.
+        struct WrongTask
+        {
+        };
+
+        /// Fire on an instance where exactly one placement still fits, claiming
+        /// the task is absent when it is not. The "bound + 1 must fail" check
+        /// for this rule: it corrupts the conclusion rather than the route to
+        /// it, which is what a margin of exactly one unit is there to expose.
+        struct ClaimOneTooFar
+        {
+        };
+
+        /// Emit no chain at all, leaving the inference to the framework's
+        /// wrapping RUP. Not a corruption but a control: if VeriPB accepts
+        /// this, the chain is decoration and no mutation of it can be caught.
+        struct EmitNothing
+        {
+        };
+    }
+
+    using CumulativePresenceMutation = std::variant<cumulative_presence_mutation::None, cumulative_presence_mutation::WrongTask,
+        cumulative_presence_mutation::ClaimOneTooFar, cumulative_presence_mutation::EmitNothing>;
+}
+
+#endif

--- a/gcs/presolvers/cumulative_strengthening/cumulative_strengthening.hh
+++ b/gcs/presolvers/cumulative_strengthening/cumulative_strengthening.hh
@@ -4,6 +4,7 @@
 #include <gcs/constraints/cumulative/cumulative.hh>
 #include <gcs/integer.hh>
 #include <gcs/presolver.hh>
+#include <gcs/presolvers/innards/cumulative_strengthening_mutations.hh>
 
 #include <cstddef>
 #include <memory>
@@ -100,59 +101,6 @@ namespace gcs
     };
 
     /**
-     * \brief Deliberate corruptions of the strengthening derivation, for
-     * testing only. VeriPB must reject each of them.
-     *
-     * \ingroup Presolvers
-     */
-    namespace cumulative_strengthening_mutation
-    {
-        /// Emit the honest derivation.
-        struct None
-        {
-        };
-
-        /// Claim a capacity one below the largest load the heights can reach.
-        /// The "bound + 1 must fail" check for this rule: it corrupts the
-        /// conclusion rather than the route to it.
-        struct ClaimOneBetter
-        {
-        };
-
-        /// Take the divisibility fast path with a divisor that does not divide
-        /// every height. Dividing is a sound proof step whatever the divisor,
-        /// so this produces a perfectly valid line that simply is not the one
-        /// the derived constraint was told it had --- which nothing catches
-        /// except the `ia` step pinning each row's content.
-        struct BogusDivisor
-        {
-        };
-
-        /// Raise the tallest task that did *not* qualify for it. The pairwise
-        /// conflict test is the only thing standing between the rule and an
-        /// unsound constraint, and this is what says so: the derivation itself
-        /// runs honestly and every step of it is sound, on a set that is wrong.
-        /// Needs a fixture with a task that fails the test, which is what an
-        /// R1 control fixture is.
-        struct RaiseUnentitled
-        {
-        };
-
-        /// Take one more than the largest step the division survives, on the
-        /// first step of each raise. The step lands on a sound but weaker line,
-        /// every later step compounds it, and the row's own `ia` pin is what
-        /// rejects. Needs a raise with a step to spare, and throws rather than
-        /// passing quietly if given one that has none.
-        struct RaiseTooFast
-        {
-        };
-    }
-
-    using CumulativeStrengtheningMutation = std::variant<cumulative_strengthening_mutation::None, cumulative_strengthening_mutation::ClaimOneBetter,
-        cumulative_strengthening_mutation::BogusDivisor, cumulative_strengthening_mutation::RaiseUnentitled,
-        cumulative_strengthening_mutation::RaiseTooFast>;
-
-    /**
      * \brief Strengthen each posted Cumulative by integrality, posting the
      * strengthened version as a *derived* constraint whose per-time capacity
      * rows are proved from the donor's.
@@ -211,7 +159,7 @@ namespace gcs
         long long _max_dynamic_programming_states;
         long long _max_raise_lines;
         CumulativeRules _rules;
-        CumulativeStrengtheningMutation _mutation;
+        innards::CumulativeStrengtheningMutation _mutation;
 
     public:
         /**
@@ -274,7 +222,7 @@ namespace gcs
 
         /// Corrupt one step of the emitted derivation. For tests only, which
         /// assert that VeriPB rejects the result.
-        auto with_proof_mutation(CumulativeStrengtheningMutation mutation) -> CumulativeStrengthening &;
+        auto with_proof_mutation(innards::CumulativeStrengtheningMutation mutation) -> CumulativeStrengthening &;
 
         [[nodiscard]] virtual auto run(Problem &, innards::Propagators &, innards::State &, innards::ProofLogger * const) -> bool override;
         [[nodiscard]] virtual auto clone() const -> std::unique_ptr<Presolver> override;

--- a/gcs/presolvers/inferred_cumulative/inferred_cumulative.hh
+++ b/gcs/presolvers/inferred_cumulative/inferred_cumulative.hh
@@ -4,6 +4,7 @@
 #include <gcs/constraints/cumulative/cumulative.hh>
 #include <gcs/integer.hh>
 #include <gcs/presolver.hh>
+#include <gcs/presolvers/innards/inferred_cumulative_mutations.hh>
 
 #include <cstddef>
 #include <memory>
@@ -12,71 +13,6 @@
 
 namespace gcs
 {
-    /**
-     * \brief Deliberate corruptions of a lifted cut's certificate, for testing
-     * only. VeriPB must reject each of them.
-     *
-     * The first two are the signature test of a lifted constraint: claim one
-     * better than was derived and require a rejection. With small,
-     * close-together integers a slack derivation can verify by coincidence ---
-     * a `pol` that lands somewhere weaker than intended still lands somewhere
-     * true --- and only a `+1` that is *refused* says the honest line is tight
-     * to what the constraint goes on to assume of it.
-     *
-     * \ingroup Presolvers
-     */
-    namespace inferred_cumulative_mutation
-    {
-        /// Emit the honest derivation.
-        struct None
-        {
-        };
-
-        /// Pin one less capacity than the derivation supports.
-        struct ClaimTighterCapacity
-        {
-        };
-
-        /// Pin one more height for the first member than the derivation
-        /// supports.
-        struct ClaimTallerTask
-        {
-        };
-
-        /// Build the dynamic programme against a capacity one smaller than the
-        /// donor's row, so that its states claim the row rules out a member it
-        /// does not. Unlike the two above, this corrupts the *derivation* rather
-        /// than what is claimed of it, and is caught inside the replay rather
-        /// than at the pin.
-        struct ClaimTighterRow
-        {
-        };
-
-        /// Claim a makespan one larger than a posted cut's energy supports.
-        /// The same discipline again, against the other thing a cut is used
-        /// for: `L` is the number this whole exercise reports, so a derivation
-        /// with slack in it would report it while proving something weaker.
-        struct ClaimHigherMakespanBound
-        {
-        };
-
-        /// Carry a resource's row onto the *wrong* member's flags when a cut
-        /// spans more than one of them, so that the row a state is ruled out by
-        /// is about a task other than the one it names.
-        ///
-        /// The corruption a cut over several resources adds over one over a
-        /// single resource: nothing else in this list touches the crossing, and
-        /// with one donor there is no crossing to touch --- so a fixture for
-        /// this has to be genuinely multi-resource, which is the point of
-        /// having it.
-        struct BridgeWrongTask
-        {
-        };
-    }
-
-    using InferredCumulativeMutation = std::variant<inferred_cumulative_mutation::None, inferred_cumulative_mutation::ClaimTighterCapacity,
-        inferred_cumulative_mutation::ClaimTallerTask, inferred_cumulative_mutation::ClaimTighterRow,
-        inferred_cumulative_mutation::ClaimHigherMakespanBound, inferred_cumulative_mutation::BridgeWrongTask>;
 
     /**
      * \brief What the inferred-Cumulative presolver did, filled in when it runs.
@@ -280,7 +216,7 @@ namespace gcs
         std::size_t _max_lifting_calls;
         std::size_t _max_programme_states;
         CumulativeRules _rules;
-        InferredCumulativeMutation _mutation;
+        innards::InferredCumulativeMutation _mutation;
         std::optional<IntegerVariableID> _makespan;
 
     public:
@@ -363,8 +299,8 @@ namespace gcs
         auto with_makespan(IntegerVariableID makespan) -> InferredCumulative &;
 
         /// Corrupt the certificate. For tests only, which assert that VeriPB
-        /// rejects the result; see InferredCumulativeMutation.
-        auto with_proof_mutation(InferredCumulativeMutation mutation) -> InferredCumulative &;
+        /// rejects the result; see innards::InferredCumulativeMutation.
+        auto with_proof_mutation(innards::InferredCumulativeMutation mutation) -> InferredCumulative &;
 
         [[nodiscard]] virtual auto run(Problem &, innards::Propagators &, innards::State &, innards::ProofLogger * const) -> bool override;
         [[nodiscard]] virtual auto clone() const -> std::unique_ptr<Presolver> override;

--- a/gcs/presolvers/inferred_disjunctive/inferred_disjunctive.hh
+++ b/gcs/presolvers/inferred_disjunctive/inferred_disjunctive.hh
@@ -4,6 +4,7 @@
 #include <gcs/constraints/cumulative/cumulative.hh>
 #include <gcs/integer.hh>
 #include <gcs/presolver.hh>
+#include <gcs/presolvers/innards/inferred_disjunctive_mutations.hh>
 
 #include <cstddef>
 #include <memory>
@@ -12,58 +13,7 @@
 
 namespace gcs
 {
-    /**
-     * \brief Deliberate corruptions of the assembled per-time certificate, for
-     * testing only. VeriPB must reject each of them.
-     *
-     * The pieces this is built from each have their own mutations, and those
-     * cover the pieces. What is left for these is the *assembly*: whether the
-     * at-most-ones being merged really are about the tasks the clique claims,
-     * whether the conclusion is the one the arithmetic supports, and whether a
-     * pair that merely looks like a conflict can be smuggled in. Each of these
-     * corrupts the conclusion rather than the route to it, since the route is
-     * where a conflict-shaped derivation forgives everything.
-     *
-     * \ingroup Presolvers
-     */
-    namespace inferred_disjunctive_mutation
-    {
-        /// Emit the honest derivation.
-        struct None
-        {
-        };
 
-        /// Claim no member may run at all, rather than at most one.
-        struct ClaimRhsZero
-        {
-        };
-
-        /// Bridge one task's flags onto the *other* task's, so the at-most-one
-        /// being merged is about a task the derivation never cornered.
-        struct BridgeWrongTask
-        {
-        };
-
-        /// Grow a clique with a task that does not conflict with its members ---
-        /// the camouflage case, where a pair's demands sum to exactly the
-        /// capacity and so are compatible by one unit. An off-by-one in the
-        /// conflict test lands exactly here.
-        struct IncludeNonConflicting
-        {
-        };
-
-        /// Claim a makespan one larger than a posted clique's energy supports.
-        /// The same discipline again, against the other thing a clique is used
-        /// for: `L` is the number this whole exercise reports, so a derivation
-        /// with slack in it would report it while proving something weaker.
-        struct ClaimHigherMakespanBound
-        {
-        };
-    }
-
-    using InferredDisjunctiveMutation =
-        std::variant<inferred_disjunctive_mutation::None, inferred_disjunctive_mutation::ClaimRhsZero, inferred_disjunctive_mutation::BridgeWrongTask,
-            inferred_disjunctive_mutation::IncludeNonConflicting, inferred_disjunctive_mutation::ClaimHigherMakespanBound>;
     /**
      * \brief What the inferred-Disjunctive presolver did, filled in when it
      * runs.
@@ -196,7 +146,7 @@ namespace gcs
         std::size_t _max_posted;
         std::size_t _min_clique_size;
         CumulativeRules _rules;
-        InferredDisjunctiveMutation _mutation;
+        innards::InferredDisjunctiveMutation _mutation;
         std::optional<IntegerVariableID> _makespan;
 
     public:
@@ -251,8 +201,8 @@ namespace gcs
 
         /// Corrupt one step of the assembled certificate. For tests only, which
         /// assert that VeriPB rejects the result; see
-        /// InferredDisjunctiveMutation.
-        auto with_proof_mutation(InferredDisjunctiveMutation mutation) -> InferredDisjunctive &;
+        /// innards::InferredDisjunctiveMutation.
+        auto with_proof_mutation(innards::InferredDisjunctiveMutation mutation) -> InferredDisjunctive &;
 
         [[nodiscard]] virtual auto run(Problem &, innards::Propagators &, innards::State &, innards::ProofLogger * const) -> bool override;
         [[nodiscard]] virtual auto clone() const -> std::unique_ptr<Presolver> override;

--- a/gcs/presolvers/innards/cumulative_strengthening_mutations.hh
+++ b/gcs/presolvers/innards/cumulative_strengthening_mutations.hh
@@ -1,0 +1,74 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_PRESOLVERS_INNARDS_CUMULATIVE_STRENGTHENING_MUTATIONS_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_PRESOLVERS_INNARDS_CUMULATIVE_STRENGTHENING_MUTATIONS_HH
+
+#include <variant>
+
+/**
+ * \file
+ *
+ * Deliberate corruptions of `CumulativeStrengthening`'s proof steps, which exist so that a test can
+ * show the honest derivation is tight to what it claims. They live here, in the
+ * innards, rather than beside the presolver they corrupt: the header a user
+ * includes to run it should not also advertise a way to make the solver emit
+ * deliberately wrong proofs. Issue #669; see
+ * gcs/constraints/innards/cumulative_mutations.hh for why compiling them out of
+ * release builds was rejected.
+ */
+
+namespace gcs::innards
+{
+    /**
+     * \brief Deliberate corruptions of the strengthening derivation, for
+     * testing only. VeriPB must reject each of them.
+     *
+     * \ingroup Innards
+     */
+    namespace cumulative_strengthening_mutation
+    {
+        /// Emit the honest derivation.
+        struct None
+        {
+        };
+
+        /// Claim a capacity one below the largest load the heights can reach.
+        /// The "bound + 1 must fail" check for this rule: it corrupts the
+        /// conclusion rather than the route to it.
+        struct ClaimOneBetter
+        {
+        };
+
+        /// Take the divisibility fast path with a divisor that does not divide
+        /// every height. Dividing is a sound proof step whatever the divisor,
+        /// so this produces a perfectly valid line that simply is not the one
+        /// the derived constraint was told it had --- which nothing catches
+        /// except the `ia` step pinning each row's content.
+        struct BogusDivisor
+        {
+        };
+
+        /// Raise the tallest task that did *not* qualify for it. The pairwise
+        /// conflict test is the only thing standing between the rule and an
+        /// unsound constraint, and this is what says so: the derivation itself
+        /// runs honestly and every step of it is sound, on a set that is wrong.
+        /// Needs a fixture with a task that fails the test, which is what an
+        /// R1 control fixture is.
+        struct RaiseUnentitled
+        {
+        };
+
+        /// Take one more than the largest step the division survives, on the
+        /// first step of each raise. The step lands on a sound but weaker line,
+        /// every later step compounds it, and the row's own `ia` pin is what
+        /// rejects. Needs a raise with a step to spare, and throws rather than
+        /// passing quietly if given one that has none.
+        struct RaiseTooFast
+        {
+        };
+    }
+
+    using CumulativeStrengtheningMutation = std::variant<cumulative_strengthening_mutation::None, cumulative_strengthening_mutation::ClaimOneBetter,
+        cumulative_strengthening_mutation::BogusDivisor, cumulative_strengthening_mutation::RaiseUnentitled,
+        cumulative_strengthening_mutation::RaiseTooFast>;
+}
+
+#endif

--- a/gcs/presolvers/innards/inferred_cumulative_mutations.hh
+++ b/gcs/presolvers/innards/inferred_cumulative_mutations.hh
@@ -1,0 +1,87 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_PRESOLVERS_INNARDS_INFERRED_CUMULATIVE_MUTATIONS_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_PRESOLVERS_INNARDS_INFERRED_CUMULATIVE_MUTATIONS_HH
+
+#include <variant>
+
+/**
+ * \file
+ *
+ * Deliberate corruptions of `InferredCumulative`'s proof steps, which exist so that a test can
+ * show the honest derivation is tight to what it claims. They live here, in the
+ * innards, rather than beside the presolver they corrupt: the header a user
+ * includes to run it should not also advertise a way to make the solver emit
+ * deliberately wrong proofs. Issue #669; see
+ * gcs/constraints/innards/cumulative_mutations.hh for why compiling them out of
+ * release builds was rejected.
+ */
+
+namespace gcs::innards
+{
+    /**
+     * \brief Deliberate corruptions of a lifted cut's certificate, for testing
+     * only. VeriPB must reject each of them.
+     *
+     * The first two are the signature test of a lifted constraint: claim one
+     * better than was derived and require a rejection. With small,
+     * close-together integers a slack derivation can verify by coincidence ---
+     * a `pol` that lands somewhere weaker than intended still lands somewhere
+     * true --- and only a `+1` that is *refused* says the honest line is tight
+     * to what the constraint goes on to assume of it.
+     *
+     * \ingroup Innards
+     */
+    namespace inferred_cumulative_mutation
+    {
+        /// Emit the honest derivation.
+        struct None
+        {
+        };
+
+        /// Pin one less capacity than the derivation supports.
+        struct ClaimTighterCapacity
+        {
+        };
+
+        /// Pin one more height for the first member than the derivation
+        /// supports.
+        struct ClaimTallerTask
+        {
+        };
+
+        /// Build the dynamic programme against a capacity one smaller than the
+        /// donor's row, so that its states claim the row rules out a member it
+        /// does not. Unlike the two above, this corrupts the *derivation* rather
+        /// than what is claimed of it, and is caught inside the replay rather
+        /// than at the pin.
+        struct ClaimTighterRow
+        {
+        };
+
+        /// Claim a makespan one larger than a posted cut's energy supports.
+        /// The same discipline again, against the other thing a cut is used
+        /// for: `L` is the number this whole exercise reports, so a derivation
+        /// with slack in it would report it while proving something weaker.
+        struct ClaimHigherMakespanBound
+        {
+        };
+
+        /// Carry a resource's row onto the *wrong* member's flags when a cut
+        /// spans more than one of them, so that the row a state is ruled out by
+        /// is about a task other than the one it names.
+        ///
+        /// The corruption a cut over several resources adds over one over a
+        /// single resource: nothing else in this list touches the crossing, and
+        /// with one donor there is no crossing to touch --- so a fixture for
+        /// this has to be genuinely multi-resource, which is the point of
+        /// having it.
+        struct BridgeWrongTask
+        {
+        };
+    }
+
+    using InferredCumulativeMutation = std::variant<inferred_cumulative_mutation::None, inferred_cumulative_mutation::ClaimTighterCapacity,
+        inferred_cumulative_mutation::ClaimTallerTask, inferred_cumulative_mutation::ClaimTighterRow,
+        inferred_cumulative_mutation::ClaimHigherMakespanBound, inferred_cumulative_mutation::BridgeWrongTask>;
+}
+
+#endif

--- a/gcs/presolvers/innards/inferred_disjunctive_mutations.hh
+++ b/gcs/presolvers/innards/inferred_disjunctive_mutations.hh
@@ -1,0 +1,74 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_PRESOLVERS_INNARDS_INFERRED_DISJUNCTIVE_MUTATIONS_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_PRESOLVERS_INNARDS_INFERRED_DISJUNCTIVE_MUTATIONS_HH
+
+#include <variant>
+
+/**
+ * \file
+ *
+ * Deliberate corruptions of `InferredDisjunctive`'s proof steps, which exist so that a test can
+ * show the honest derivation is tight to what it claims. They live here, in the
+ * innards, rather than beside the presolver they corrupt: the header a user
+ * includes to run it should not also advertise a way to make the solver emit
+ * deliberately wrong proofs. Issue #669; see
+ * gcs/constraints/innards/cumulative_mutations.hh for why compiling them out of
+ * release builds was rejected.
+ */
+
+namespace gcs::innards
+{
+    /**
+     * \brief Deliberate corruptions of the assembled per-time certificate, for
+     * testing only. VeriPB must reject each of them.
+     *
+     * The pieces this is built from each have their own mutations, and those
+     * cover the pieces. What is left for these is the *assembly*: whether the
+     * at-most-ones being merged really are about the tasks the clique claims,
+     * whether the conclusion is the one the arithmetic supports, and whether a
+     * pair that merely looks like a conflict can be smuggled in. Each of these
+     * corrupts the conclusion rather than the route to it, since the route is
+     * where a conflict-shaped derivation forgives everything.
+     *
+     * \ingroup Innards
+     */
+    namespace inferred_disjunctive_mutation
+    {
+        /// Emit the honest derivation.
+        struct None
+        {
+        };
+
+        /// Claim no member may run at all, rather than at most one.
+        struct ClaimRhsZero
+        {
+        };
+
+        /// Bridge one task's flags onto the *other* task's, so the at-most-one
+        /// being merged is about a task the derivation never cornered.
+        struct BridgeWrongTask
+        {
+        };
+
+        /// Grow a clique with a task that does not conflict with its members ---
+        /// the camouflage case, where a pair's demands sum to exactly the
+        /// capacity and so are compatible by one unit. An off-by-one in the
+        /// conflict test lands exactly here.
+        struct IncludeNonConflicting
+        {
+        };
+
+        /// Claim a makespan one larger than a posted clique's energy supports.
+        /// The same discipline again, against the other thing a clique is used
+        /// for: `L` is the number this whole exercise reports, so a derivation
+        /// with slack in it would report it while proving something weaker.
+        struct ClaimHigherMakespanBound
+        {
+        };
+    }
+
+    using InferredDisjunctiveMutation =
+        std::variant<inferred_disjunctive_mutation::None, inferred_disjunctive_mutation::ClaimRhsZero, inferred_disjunctive_mutation::BridgeWrongTask,
+            inferred_disjunctive_mutation::IncludeNonConflicting, inferred_disjunctive_mutation::ClaimHigherMakespanBound>;
+}
+
+#endif


### PR DESCRIPTION
Closes #669.

Four mutation families lived in headers a user of the library includes — two of them reachable from `gcs/gcs.hh` — so the public API advertised a way to make the solver emit deliberately wrong proofs. They move to innards headers in `gcs::innards`, which is what `SubsetSumMutation` and `Am1FromPairsMutation` always did.

| variant | was | now |
|---|---|---|
| `CumulativeProofMutation` | `gcs/constraints/cumulative/cumulative.hh` | `gcs/constraints/innards/cumulative_mutations.hh` |
| `CumulativePresenceMutation` | same | same |
| `CumulativeStrengtheningMutation` | the presolver's own header | `gcs/presolvers/innards/cumulative_strengthening_mutations.hh` |
| `InferredDisjunctiveMutation` | same | `gcs/presolvers/innards/inferred_disjunctive_mutations.hh` |
| `InferredCumulativeMutation` | same (added after the issue) | `gcs/presolvers/innards/inferred_cumulative_mutations.hh` |

`gcs::CumulativeProofMutation` now fails to compile, and the compiler points at `gcs::innards::CumulativeProofMutation` — which is the whole of the intended effect.

**Namespace-as-contract rather than pimpl.** The types are still transitively reachable through the public headers, because the classes hold them by value and need the complete type. Hiding them behind a forward-declared handle would put an allocation and an indirection into every constraint object to solve a naming problem, and this tree already answered the same question the same way in #289. The signal is the namespace and the header location, as it is for every other innards type.

## Two things the issue got slightly wrong

- **`InferredCumulativeMutation` did not exist when it was filed** — the stack added it, and #678 added a sixth variant to it. Five families move, not four. Left as-is, that list would have kept growing.
- **"Nothing reaches a mutation from an example binary or a command line" is no longer true.** `examples/rcpsp` grew `--mutate-makespan-bound` in #677, and #672's RCPSP bounds artefact uses it to require a refusal on the instances the bound closes. It stays — it is load-bearing for the artefact — but it now names the innards types at the use site rather than hiding the crossing in a using-directive, so the boundary crossing is visible where it happens.

The `#ifdef`-out-of-release-builds argument stays rejected, and the reasoning is now in `gcs/constraints/innards/cumulative_mutations.hh` where someone would go looking for it rather than only in a closed issue.

## Testing

632/632 ctest caps-OFF. Coverage is unchanged by construction: in-tree tests include innards freely, and the two `Cumulative` test files take the using-directive the rest of the tree already has.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173hT2hFo3MyGRBon8SHt2p