### PR TITLE
Let a derived Cumulative reason over an optional donor

### DIFF
--- a/dev_docs/cumulative-proof-logging.md
+++ b/dev_docs/cumulative-proof-logging.md
@@ -733,12 +733,60 @@ at the point of use.
 Falsifying a presence *by* an energy argument, rather than by the
 profile, is issue 09's extension and is not here.
 
-A *derived* Cumulative (issue 04) declines the whole question: it fills
-its `presence` with nullopts, and `DerivedCumulativeSpec` says the donor
-must not be optional. Deriving over an optional donor would need the
-donor's presence literals in every reason the derived constraint gives,
-which is future work --- and the presolvers of issues 06-08 are specified
-to bail out on optional Cumulatives for v1 anyway.
+### Deriving over an optional donor
+
+A *derived* Cumulative (issue 04) works over an optional donor, and the
+striking thing is how little it takes. The rows are the argument, and an
+optional task's presence is a conjunct *inside* its activity flag rather
+than a term beside it, so `Σ h_i·active_{i,t} ≤ C` is the same row either
+way. Every recipe built on one — subset sums, at-most-ones, coefficient
+raising, cover cuts — reads it identically, and none of them changes at
+all.
+
+What does change is what the derived propagator may *say*. Pinning
+`active_{i,t} = 1` now needs `presences[i] = 1` too, so
+`DerivedCumulativeTask` carries the donor's presence argument and
+`install_derived_cumulative` resolves it through
+`cumulative_task_presence` — the same function `Cumulative::prepare`
+resolves its own with, shared precisely so that the two cannot come to
+different verdicts about which flags carry a literal. From there
+`propagate_cumulative` is the code that already knew how to do this, and
+`reason_with_presence()` supplies the literals.
+
+The window-energy lemma then comes out right without being asked. Its
+per-time step adds `active`'s `[f]` half, which for an optional task *is*
+`active ∨ ¬before ∨ ¬after ∨ ¬p`, so summing the window's worth of them
+gives
+
+```
+Σ_{t∈[a,b)} active_{i,t}  +  activity·¬p_i  ≥  activity
+```
+
+— the conditional form, for free. That leftover `activity·¬p` rides
+through the consuming `pol`, which therefore does not reach a
+contradiction on its own; the wrapping RUP disposes of it, because
+`p_i = 1` is in the reason. Which is exactly why the rule may only speak
+for tasks that are *known* present, and why both consumers filter on
+`is_present` before counting anything.
+
+At the root usually nothing is known present, so a presolver's energy
+bound counts an optional task as absent. That is weaker, not wrong. What
+it gives up is the conditional bound
+
+```
+capacity × window  ≥  Σ_i energy_i · p_i
+```
+
+which is an implied linear constraint over the presences rather than
+anything a makespan variable's lower bound can hold, and so belongs with
+the conditional-bounds follow-up below rather than here.
+
+The multi-donor case is *not* covered, and that is where the remaining
+work is: `recover_conjunction_flag_bridge` cancels two donors' conjuncts
+against each other, and a presence conjunct cancels only when both donors
+carry the same literal. Mixed arities change the degree arithmetic
+outright. The presolvers of issues 07 and 08 bridge between donors, so
+they still decline an optional one; issue 06's does not, and does not.
 
 `constraint_type()` is `cumulative_optional` for the optional form, so
 the verified-encoding chain does not silently match it against

--- a/dev_docs/cumulative-strengthening.md
+++ b/dev_docs/cumulative-strengthening.md
@@ -311,10 +311,18 @@ Each is declined rather than worked around, and counted in
 `CumulativeStrengtheningStats` so that a model drifting into one does not simply
 stop being strengthened in silence:
 
-- **Optional tasks.** A derived `Cumulative` over an optional donor would need
-  the donor's presence literals in every reason it gives; `DerivedCumulativeSpec`
-  says the donor's `presences()` must be empty. This is the v1 bail-out issues
-  #547–#549 are all specified to take.
+Optional tasks are deliberately **not** on this list. The whole strengthening is
+an argument about the donor's per-time rows, and an optional task's presence is a
+conjunct inside its activity flag rather than a term beside it, so those rows are
+the same shape either way and every subset sum, at-most-one and raise reads them
+identically. What the presence changes is the reasons the derived constraint's
+propagator gives, which `install_derived_cumulative` handles once it is told the
+donor's presence arguments — see
+[cumulative-proof-logging.md](cumulative-proof-logging.md). `InferredDisjunctive`
+and `InferredCumulative` still decline, for a reason that is theirs rather than
+this one's: they bridge flags between donors, and a presence conjunct has to
+cancel across that bridge first.
+
 - **Variable lengths, heights or capacity.** With a variable height the donor's
   row is over bit-linearised contribution flags rather than `height × active`, so
   a subset sum of the heights is not a subset sum of the row's coefficients.

--- a/gcs/constraints/cumulative/cumulative.cc
+++ b/gcs/constraints/cumulative/cumulative.cc
@@ -33,11 +33,13 @@
 using namespace gcs;
 using namespace gcs::innards;
 
+using std::make_optional;
 using std::make_shared;
 using std::make_unique;
 using std::max;
 using std::min;
 using std::move;
+using std::optional;
 using std::pair;
 using std::size_t;
 using std::string;
@@ -143,6 +145,22 @@ auto Cumulative::clone() const -> unique_ptr<Constraint>
     return result;
 }
 
+auto gcs::innards::cumulative_task_presence(const optional<IntegerVariableID> & posted) -> CumulativeTaskPresence
+{
+    if (! posted)
+        return CumulativeTaskPresence{};
+
+    if (! is_constant_variable(*posted))
+        return CumulativeTaskPresence{*posted, false};
+
+    auto value = const_value_of(*posted);
+    if (value == 1_i)
+        return CumulativeTaskPresence{};
+    if (value == 0_i)
+        return CumulativeTaskPresence{*posted, true};
+    throw InvalidProblemDefinitionException{"Cumulative: presences must be within {0, 1}"};
+}
+
 auto Cumulative::prepare(Propagators &, State & initial_state, ProofModel * const) -> bool
 {
     auto n = _starts.size();
@@ -161,25 +179,23 @@ auto Cumulative::prepare(Propagators &, State & initial_state, ProofModel * cons
         throw InvalidProblemDefinitionException{"Cumulative: capacity must be non-negative"};
 
     // Resolve each task's presence to the variable that has to appear in its
-    // active flag, or nullopt when the task is unconditionally present. Only a
-    // constant argument resolves away: a *variable* presence keeps its conjunct
-    // even if it is already fixed, because the encoding has to say what it means
-    // without appealing to a domain the OPB does not record.
+    // active flag, or nullopt when the task is unconditionally present ---
+    // by the same rule anything pinning these flags has to apply, which is why
+    // cumulative_task_presence is shared rather than open-coded here.
     _presence.assign(n, std::nullopt);
+    vector<bool> never_present(n, false);
     for (size_t i = 0; i < n; ++i) {
-        if (_presences.empty())
-            continue;
-        const auto & p = _presences[i];
-        if (is_constant_variable(p)) {
-            if (const_value_of(p) == 1_i)
-                continue;
-        }
-        else {
-            auto [lo, hi] = initial_state.bounds(p);
+        auto resolved = cumulative_task_presence(_presences.empty() ? std::nullopt : make_optional(_presences[i]));
+        _presence[i] = resolved.literal;
+        never_present[i] = resolved.never_present;
+
+        // Only now are the domains available, which is why a variable
+        // presence is range-checked here rather than in the constructor.
+        if (resolved.literal && ! is_constant_variable(*resolved.literal)) {
+            auto [lo, hi] = initial_state.bounds(*resolved.literal);
             if (lo < 0_i || hi > 1_i)
                 throw InvalidProblemDefinitionException{"Cumulative: presences must be within {0, 1}"};
         }
-        _presence[i] = p;
     }
 
     // Resolve snapshots used by define_proof_model and the propagator. For a
@@ -212,12 +228,9 @@ auto Cumulative::prepare(Propagators &, State & initial_state, ProofModel * cons
 
     // Tasks whose length can only ever be 0, or whose height can only ever be 0,
     // or which are constantly absent, never raise the load profile.
-    auto constantly_absent = [&](size_t i) {
-        return _presence[i].has_value() && is_constant_variable(*_presence[i]) && const_value_of(*_presence[i]) == 0_i;
-    };
     _active_tasks.reserve(n);
     for (size_t i = 0; i < n; ++i)
-        if (_length_ub[i] > 0_i && _height_ub[i] > 0_i && ! constantly_absent(i))
+        if (_length_ub[i] > 0_i && _height_ub[i] > 0_i && ! never_present[i])
             _active_tasks.push_back(i);
 
     if (_active_tasks.empty())

--- a/gcs/constraints/cumulative/derived_cumulative.cc
+++ b/gcs/constraints/cumulative/derived_cumulative.cc
@@ -7,6 +7,7 @@
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/propagators.hh>
+#include <gcs/innards/reason.hh>
 #include <gcs/innards/state.hh>
 
 #include <algorithm>
@@ -20,6 +21,7 @@
 using namespace gcs;
 using namespace gcs::innards;
 
+using std::make_optional;
 using std::make_shared;
 using std::move;
 using std::size_t;
@@ -28,15 +30,18 @@ using std::to_string;
 using std::vector;
 
 auto gcs::innards::derived_cumulative_tasks_from(const ConstraintID & donor, const vector<IntegerVariableID> & starts,
-    const vector<Integer> & lengths, const vector<Integer> & heights) -> vector<DerivedCumulativeTask>
+    const vector<Integer> & lengths, const vector<Integer> & heights, const vector<IntegerVariableID> & presences) -> vector<DerivedCumulativeTask>
 {
     if (starts.size() != lengths.size() || starts.size() != heights.size())
         throw InvalidProblemDefinitionException{"derived Cumulative: starts, lengths, heights must have the same size"};
+    if (! presences.empty() && starts.size() != presences.size())
+        throw InvalidProblemDefinitionException{"derived Cumulative: starts and presences must have the same size"};
 
     vector<DerivedCumulativeTask> tasks;
     tasks.reserve(starts.size());
     for (size_t i = 0; i < starts.size(); ++i)
-        tasks.push_back(DerivedCumulativeTask{donor, i, starts[i], lengths[i], heights[i]});
+        tasks.push_back(
+            DerivedCumulativeTask{donor, i, starts[i], lengths[i], heights[i], presences.empty() ? std::nullopt : make_optional(presences[i])});
     return tasks;
 }
 
@@ -56,11 +61,19 @@ auto gcs::innards::install_derived_cumulative(
     inputs->owner = CurrentlyUnnamedConstraint{};
     inputs->capacity = constant_variable(spec.capacity);
     inputs->rules = spec.rules;
-    // Every task unconditionally present: a derived Cumulative over an optional
-    // donor would have to carry that donor's presence literals into its own
-    // reasons, which is future work rather than something to get wrong quietly.
-    // See DerivedCumulativeSpec, which says no donor may be optional.
-    inputs->presence.assign(n, std::nullopt);
+
+    // Each donor's own verdict on the task's presence, reached by the rule the
+    // donor applied: the flags this constraint pins carry the literal that says
+    // yes, so a reason of ours that left it out would be claiming a load the
+    // task need not be carrying.
+    vector<bool> never_present(n, false);
+    inputs->presence.reserve(n);
+    for (size_t i = 0; i < n; ++i) {
+        auto resolved = cumulative_task_presence(spec.tasks[i].presence);
+        inputs->presence.push_back(resolved.literal);
+        never_present[i] = resolved.never_present;
+    }
+
     for (const auto & task : spec.tasks) {
         inputs->starts.push_back(task.start);
         inputs->lengths.push_back(constant_variable(task.length));
@@ -69,11 +82,12 @@ auto gcs::innards::install_derived_cumulative(
 
     // The same windowing a posted Cumulative resolves in prepare(): a task can
     // be active from its earliest start to its latest finish, and one whose
-    // length or height is zero never raises the profile at all.
+    // length or height is zero, or which can never be present at all, never
+    // raises the profile.
     inputs->per_task_t_lo.assign(n, 0_i);
     vector<Integer> per_task_t_hi(n, 0_i);
     for (size_t i = 0; i < n; ++i) {
-        if (spec.tasks[i].length <= 0_i || spec.tasks[i].height <= 0_i)
+        if (spec.tasks[i].length <= 0_i || spec.tasks[i].height <= 0_i || never_present[i])
             continue;
         inputs->active_tasks.push_back(i);
         auto [s_lo, s_hi] = initial_state.bounds(spec.tasks[i].start);
@@ -199,8 +213,9 @@ auto gcs::innards::install_derived_cumulative(
         // in `inputs`, which the initialiser holds a share of, and the windows
         // are the ones its rows were derived over.
         vector<makespan_energy::EnergyTask> energy_tasks;
-        vector<IntegerVariableID> scope;
+        vector<std::optional<IntegerVariableID>> energy_presences;
         for (auto i : inputs->overload_tasks) {
+            energy_presences.push_back(inputs->presence[i]);
             energy_tasks.push_back(makespan_energy::EnergyTask{.start = std::get<SimpleIntegerVariableID>(spec.tasks[i].start),
                 .length = spec.tasks[i].length,
                 .height = spec.tasks[i].height,
@@ -212,17 +227,36 @@ auto gcs::innards::install_derived_cumulative(
                 .before = logger ? &inputs->before_flags[i] : nullptr,
                 .after = logger ? &inputs->after_flags[i] : nullptr,
                 .active = logger ? &inputs->active_flags[i] : nullptr});
-            scope.push_back(spec.tasks[i].start);
         }
 
         propagators.install_initialiser(
-            [inputs, energy_tasks, scope, makespan = *spec.makespan, capacity = spec.capacity, mutation = spec.makespan_mutation,
-                reached = spec.makespan_bound_reached](const State & state, auto & inference, ProofLogger * const logger) mutable -> void {
-                for (auto & task : energy_tasks) {
+            [inputs, energy_tasks, energy_presences, makespan = *spec.makespan, capacity = spec.capacity, mutation = spec.makespan_mutation,
+                reached = spec.makespan_bound_reached](const State & state, auto & inference, ProofLogger * const logger) -> void {
+                // An optional task's length x height is guaranteed work only
+                // once it is known present, and at the root it usually is not.
+                // Counting one that is undecided would claim energy the
+                // schedule need not contain; leaving it out is a weaker bound
+                // rather than a wrong one. Every task that is counted puts its
+                // presence literal in the reason, which is what lets the
+                // window-energy lemma's own presence terms go away.
+                vector<makespan_energy::EnergyTask> counted;
+                vector<IntegerVariableID> scope;
+                ReasonLiterals presence_lits;
+                for (size_t i = 0; i < energy_tasks.size(); ++i) {
+                    if (energy_presences[i]) {
+                        if (state.lower_bound(*energy_presences[i]) < 1_i)
+                            continue;
+                        presence_lits.push_back(*energy_presences[i] == 1_i);
+                    }
+                    auto & task = counted.emplace_back(energy_tasks[i]);
                     auto [s_lo, s_hi] = state.bounds(task.start);
                     task.start_lb = s_lo;
                     task.start_ub = s_hi;
+                    scope.push_back(task.start);
                 }
+
+                if (counted.empty())
+                    return;
 
                 // What the model already says the makespan is, which an energy
                 // argument has to beat to be worth making. The link rows give
@@ -234,12 +268,12 @@ auto gcs::innards::install_derived_cumulative(
                 // is a weaker number than the constraint deserves.
                 auto [makespan_lo, makespan_hi] = state.bounds(makespan);
                 auto known = makespan_lo;
-                for (const auto & task : energy_tasks)
+                for (const auto & task : counted)
                     if (task.link)
                         known = std::max(known, task.start_lb + task.link->bound);
 
-                auto bound = makespan_energy::makespan_energy_bound(
-                    energy_tasks, capacity, inputs->time_slot_prefix, inputs->time_slot_lo, known, makespan_hi);
+                auto bound =
+                    makespan_energy::makespan_energy_bound(counted, capacity, inputs->time_slot_prefix, inputs->time_slot_lo, known, makespan_hi);
                 if (! bound)
                     return;
 
@@ -255,11 +289,12 @@ auto gcs::innards::install_derived_cumulative(
                 auto justify = [&](const ReasonLiterals & reason) -> void {
                     if (logger)
                         makespan_energy::derive_makespan_bound(
-                            *logger, reason, makespan, energy_tasks, inputs->capacity_lines, *bound, mutation, ProofLevel::Temporary);
+                            *logger, reason, makespan, counted, inputs->capacity_lines, *bound, mutation, ProofLevel::Temporary);
                 };
 
                 inference.infer_greater_than_or_equal(logger, makespan, claimed,
-                    JustifyExplicitly{justify, ThenRUP::Yes, hints::CumulativeMakespan{inputs->owner}}, bounds_reason(scope));
+                    JustifyExplicitly{justify, ThenRUP::Yes, hints::CumulativeMakespan{inputs->owner}},
+                    with_extra(bounds_reason(scope), presence_lits));
             },
             InitialiserPriority::Expensive);
     }

--- a/gcs/constraints/cumulative/derived_cumulative.hh
+++ b/gcs/constraints/cumulative/derived_cumulative.hh
@@ -55,6 +55,15 @@ namespace gcs::innards
         /// contribution rather than as `height x active`, and a derived row
         /// would have to speak about those bits too.
         Integer length, height;
+
+        /// The presence argument the donor was posted with at `position`, or
+        /// nullopt when the donor is not an optional-task Cumulative. As
+        /// posted, not as resolved: install_derived_cumulative puts it through
+        /// cumulative_task_presence, exactly as the donor did, so that the
+        /// reasons this constraint gives carry the presence literal its
+        /// donor's active flag was reified on --- and so that a task the donor
+        /// dropped as constantly absent is dropped here too.
+        std::optional<IntegerVariableID> presence = std::nullopt;
     };
 
     /**
@@ -85,11 +94,8 @@ namespace gcs::innards
     struct DerivedCumulativeSpec
     {
         /// The derived constraint's tasks, each pointing at the donor that
-        /// encoded it. No donor may be an optional-task Cumulative: its active
-        /// flags would carry a presence conjunct, and a derived constraint
-        /// reasoning over them would need that donor's presence literals in
-        /// every reason it gives. A caller building one of these should decline
-        /// when a donor's presences() is non-empty.
+        /// encoded it, and carrying that donor's presence argument for it if
+        /// there is one.
         std::vector<DerivedCumulativeTask> tasks;
 
         Integer capacity;
@@ -135,6 +141,13 @@ namespace gcs::innards
          * The bound is found from the task geometry and the links' bounds
          * alone, so it is the same with proofs off; only the certificate needs
          * a logger.
+         *
+         * An optional task carries no guaranteed energy until its presence is
+         * known, and at the root it usually is not, so the bound simply counts
+         * those tasks as absent. That is weaker rather than wrong: what it
+         * gives up is the conditional bound `capacity x window >= Σ energy_i
+         * x present_i`, which is an implied linear constraint over the
+         * presences rather than anything this variable's lower bound can hold.
          */
         std::optional<IntegerVariableID> makespan = std::nullopt;
 
@@ -163,10 +176,14 @@ namespace gcs::innards
      * \brief Build the task list for the common case of a derived Cumulative
      * over all of one donor's tasks, in the donor's order.
      *
+     * `presences` is the donor's own presences(), which is empty unless it was
+     * posted with the optional-task constructor.
+     *
      * \ingroup Innards
      */
     [[nodiscard]] auto derived_cumulative_tasks_from(const ConstraintID & donor, const std::vector<IntegerVariableID> & starts,
-        const std::vector<Integer> & lengths, const std::vector<Integer> & heights) -> std::vector<DerivedCumulativeTask>;
+        const std::vector<Integer> & lengths, const std::vector<Integer> & heights, const std::vector<IntegerVariableID> & presences = {})
+        -> std::vector<DerivedCumulativeTask>;
 
     /**
      * \brief Install a derived Cumulative's propagator.

--- a/gcs/constraints/cumulative/derived_cumulative_test.cc
+++ b/gcs/constraints/cumulative/derived_cumulative_test.cc
@@ -108,7 +108,14 @@ namespace
         MakespanOmitRow,
         /// The same, deriving the tasks' window energy without the deadline
         /// that confines them to the window. VeriPB must reject.
-        MakespanForgetDeadline
+        MakespanForgetDeadline,
+        /// The same over an optional donor, but with the donor's presences left
+        /// off the spec, so the derived constraint treats every task as
+        /// unconditionally present. It then counts the energy of tasks that
+        /// need not be scheduled at all, and gives reasons with nothing in them
+        /// to cancel the window-energy lemma's presence terms against. VeriPB
+        /// must reject.
+        MakespanForgetPresence
     };
 
     struct DerivedDemoPresolver : Presolver
@@ -144,7 +151,8 @@ namespace
                         divisor = Integer{std::gcd(divisor.raw_value, heights[i].raw_value)};
 
                 auto donor_id = donor.constraint_id();
-                DerivedCumulativeSpec spec{.tasks = derived_cumulative_tasks_from(donor_id, donor.starts(), lengths, heights),
+                auto presences = demo == Demo::MakespanForgetPresence ? vector<IntegerVariableID>{} : donor.presences();
+                DerivedCumulativeSpec spec{.tasks = derived_cumulative_tasks_from(donor_id, donor.starts(), lengths, heights, presences),
                     .capacity = capacity,
                     .row_donors = {donor_id},
                     .recipe = {},
@@ -213,6 +221,7 @@ namespace
                 case Demo::MakespanClaimHigher:
                 case Demo::MakespanOmitRow:
                 case Demo::MakespanForgetDeadline:
+                case Demo::MakespanForgetPresence:
                     if (! makespan)
                         fail("a makespan demo was run on a model with no makespan variable");
                     spec.makespan = makespan;
@@ -278,22 +287,31 @@ namespace
         /// --- which is the entailment the makespan bound's derivation rests
         /// on, and the only thing that makes those demos legal.
         optional<int> makespan_horizon = nullopt;
+        /// When non-empty, one per task: the domain that task's presence
+        /// variable is declared over, and the constraint is posted with the
+        /// optional-task constructor. A solution then carries every presence
+        /// after every start.
+        vector<pair<int, int>> presence_ranges = {};
     };
 
-    auto is_satisfying(const Instance & inst, const vector<int> & starts) -> bool
+    /// Over an assignment that is every start, followed by every presence if
+    /// the instance has any.
+    auto is_satisfying(const Instance & inst, const vector<int> & assignment) -> bool
     {
         auto n = inst.start_ranges.size();
+        auto present = [&](size_t i) { return inst.presence_ranges.empty() || assignment[n + i] != 0; };
+
         int t_lo = INT_MAX, t_hi = INT_MIN;
         for (size_t i = 0; i < n; ++i) {
-            if (inst.lengths[i] == 0 || inst.heights[i] == 0)
+            if (inst.lengths[i] == 0 || inst.heights[i] == 0 || ! present(i))
                 continue;
-            t_lo = min(t_lo, starts[i]);
-            t_hi = max(t_hi, starts[i] + inst.lengths[i] - 1);
+            t_lo = min(t_lo, assignment[i]);
+            t_hi = max(t_hi, assignment[i] + inst.lengths[i] - 1);
         }
         for (int t = t_lo; t <= t_hi; ++t) {
             int load = 0;
             for (size_t i = 0; i < n; ++i)
-                if (starts[i] <= t && t < starts[i] + inst.lengths[i])
+                if (present(i) && assignment[i] <= t && t < assignment[i] + inst.lengths[i])
                     load += inst.heights[i];
             if (load > inst.capacity)
                 return false;
@@ -301,9 +319,20 @@ namespace
         return true;
     }
 
+    /// The ranges build_expected has to enumerate to produce what is_satisfying
+    /// and the solution callback both expect.
+    auto assignment_ranges(const Instance & inst) -> vector<pair<int, int>>
+    {
+        auto ranges = inst.start_ranges;
+        ranges.insert(ranges.end(), inst.presence_ranges.begin(), inst.presence_ranges.end());
+        return ranges;
+    }
+
     struct Posted
     {
         vector<IntegerVariableID> starts;
+        /// Empty unless the instance asked for optional tasks.
+        vector<IntegerVariableID> presences;
         optional<IntegerVariableID> makespan;
         /// The demo presolver's record of what its derived constraint's
         /// initialiser inferred, if anything.
@@ -329,11 +358,25 @@ namespace
                 p.post(LinearGreaterThanEqual{WeightedSum{} + 1_i * *makespan + -1_i * starts[i], lengths[i]});
         }
 
-        p.post(Cumulative{starts, lengths, heights, Integer{inst.capacity}}.with_rules(donor_rules));
+        vector<IntegerVariableID> presences;
+        for (auto & [lo, hi] : inst.presence_ranges)
+            presences.push_back(p.create_integer_variable(Integer{lo}, Integer{hi}, "present" + std::to_string(presences.size())));
+
+        if (presences.empty())
+            p.post(Cumulative{starts, lengths, heights, Integer{inst.capacity}}.with_rules(donor_rules));
+        else {
+            vector<IntegerVariableID> length_vars, height_vars;
+            for (auto l : lengths)
+                length_vars.push_back(constant_variable(l));
+            for (auto h : heights)
+                height_vars.push_back(constant_variable(h));
+            p.post(Cumulative{starts, length_vars, height_vars, presences, constant_variable(Integer{inst.capacity})}.with_rules(donor_rules));
+        }
+
         auto presolver = DerivedDemoPresolver{demo.value_or(Demo::Duplicate), makespan};
         if (demo)
             p.add_presolver(presolver);
-        return Posted{move(starts), makespan, presolver.bound_reached};
+        return Posted{move(starts), move(presences), makespan, presolver.bound_reached};
     }
 
     struct Outcome
@@ -359,6 +402,8 @@ namespace
                                found_a_solution = true;
                                vector<int> solution;
                                for (const auto & v : starts)
+                                   solution.push_back(s(v).raw_value);
+                               for (const auto & v : posted.presences)
                                    solution.push_back(s(v).raw_value);
                                outcome.solutions.insert(move(solution));
                                return true;
@@ -437,7 +482,7 @@ auto main(int argc, char * argv[]) -> int
 
         set<vector<int>> expected;
         build_expected(
-            expected, [&](const vector<int> & starts) { return is_satisfying(duplicate_instance, starts); }, duplicate_instance.start_ranges);
+            expected, [&](const vector<int> & starts) { return is_satisfying(duplicate_instance, starts); }, assignment_ranges(duplicate_instance));
         if (expected != with_derived.solutions)
             fail("duplicate demo: solutions do not match brute force");
     }
@@ -483,7 +528,7 @@ auto main(int argc, char * argv[]) -> int
 
         set<vector<int>> expected;
         build_expected(
-            expected, [&](const vector<int> & starts) { return is_satisfying(duplicate_instance, starts); }, duplicate_instance.start_ranges);
+            expected, [&](const vector<int> & starts) { return is_satisfying(duplicate_instance, starts); }, assignment_ranges(duplicate_instance));
         if (derived_working.solutions != expected)
             fail("carrying demo: solutions do not match brute force with the donor silent");
         if (derived_working.recursions >= donor_silent.recursions)
@@ -514,7 +559,7 @@ auto main(int argc, char * argv[]) -> int
 
         set<vector<int>> expected;
         build_expected(
-            expected, [&](const vector<int> & starts) { return is_satisfying(makespan_instance, starts); }, makespan_instance.start_ranges);
+            expected, [&](const vector<int> & starts) { return is_satisfying(makespan_instance, starts); }, assignment_ranges(makespan_instance));
         if (expected != with_bound.solutions)
             fail("makespan demo: solutions do not match brute force");
 
@@ -525,10 +570,61 @@ auto main(int argc, char * argv[]) -> int
             fail("makespan demo: the bound differs with proofs off");
     }
 
+    // The same three tasks, made optional. What a derived constraint over an
+    // optional donor has to get right is not the rows --- an optional task's
+    // presence is a conjunct of its activity flag, so the rows are the same
+    // shape --- but which tasks it may speak for, and with what in the reason.
+    //
+    // The energy argument is where that bites hardest, because an absent task
+    // does no work: count one whose presence is undecided and the bound claims
+    // time the schedule need not need.
+    {
+        auto optional_makespan = makespan_instance;
+        optional_makespan.presence_ranges = vector<pair<int, int>>(3, {1, 1});
+
+        // Declared present, so the argument is the one above, unchanged --- but
+        // now every activity it pins carries a presence conjunct.
+        auto all_present =
+            solve_it(optional_makespan, make_optional(Demo::Makespan), proofs ? make_optional("derived_cumulative_makespan_present") : nullopt);
+        if (all_present.makespan_bound != make_optional(6_i))
+            fail("optional makespan demo: a donor whose tasks are all declared present lost its bound");
+
+        set<vector<int>> expected;
+        build_expected(expected, [&](const vector<int> & a) { return is_satisfying(optional_makespan, a); }, assignment_ranges(optional_makespan));
+        if (expected != all_present.solutions)
+            fail("optional makespan demo: solutions do not match brute force, all present");
+
+        // Undecided, so no task carries guaranteed energy and there is no bound
+        // to reach. Inferring one anyway would be unsound, and the proof says so
+        // --- the window-energy lemma's presence terms have nothing to cancel
+        // against without a `presence = 1` in the reason, so the wrapping RUP
+        // cannot close and VeriPB rejects. This is the fixture that would catch
+        // it.
+        optional_makespan.presence_ranges = vector<pair<int, int>>(3, {0, 1});
+        auto undecided =
+            solve_it(optional_makespan, make_optional(Demo::Makespan), proofs ? make_optional("derived_cumulative_makespan_optional") : nullopt);
+        if (undecided.makespan_bound)
+            fail("optional makespan demo: a bound of " + std::to_string(undecided.makespan_bound->raw_value) +
+                " was inferred from tasks that need not be scheduled at all");
+
+        expected.clear();
+        build_expected(expected, [&](const vector<int> & a) { return is_satisfying(optional_makespan, a); }, assignment_ranges(optional_makespan));
+        if (expected != undecided.solutions)
+            fail("optional makespan demo: solutions do not match brute force, presences undecided");
+    }
+
     // Nothing above may have reached the OPB.
     check_opb_unaffected("duplicate", duplicate_instance, Demo::Duplicate);
     check_opb_unaffected("strengthened", strengthened_instance, Demo::Strengthened);
     check_opb_unaffected("makespan", makespan_instance, Demo::Makespan);
+    {
+        // Including over an optional donor, where the derived constraint now
+        // has a presence to carry: carrying one is a thing to say in a reason,
+        // never a row to add.
+        auto optional_makespan = makespan_instance;
+        optional_makespan.presence_ranges = vector<pair<int, int>>(3, {0, 1});
+        check_opb_unaffected("optional makespan", optional_makespan, Demo::Makespan);
+    }
 
     // A derived constraint is implied, so it must not cost solutions. Random
     // instances, against brute force, with the duplicate recipe (which keeps
@@ -551,7 +647,7 @@ auto main(int argc, char * argv[]) -> int
             inst.capacity = cap_dist(rand);
 
             set<vector<int>> expected;
-            build_expected(expected, [&](const vector<int> & starts) { return is_satisfying(inst, starts); }, inst.start_ranges);
+            build_expected(expected, [&](const vector<int> & starts) { return is_satisfying(inst, starts); }, assignment_ranges(inst));
 
             for (auto demo : {Demo::Duplicate, Demo::Strengthened}) {
                 auto outcome = solve_it(inst, make_optional(demo), nullopt);
@@ -607,10 +703,15 @@ auto main(int argc, char * argv[]) -> int
     // verifies whatever it concludes, so only a refusal says this one is tight.
     for (auto [demo, what] : {pair{Demo::MakespanClaimHigher, "a makespan one larger than the energy supports"},
              pair{Demo::MakespanOmitRow, "a makespan bound counting the window one capacity row short"},
-             pair{Demo::MakespanForgetDeadline, "a makespan bound whose window energy forgets the deadline"}}) {
+             pair{Demo::MakespanForgetDeadline, "a makespan bound whose window energy forgets the deadline"},
+             pair{Demo::MakespanForgetPresence, "a makespan bound over optional tasks that forgets they are optional"}}) {
         const string name = "derived_cumulative_makespan_mutation";
+        auto instance = makespan_instance;
+        if (demo == Demo::MakespanForgetPresence)
+            instance.presence_ranges = vector<pair<int, int>>(3, {0, 1});
+
         Problem p;
-        post(p, makespan_instance, make_optional(demo));
+        post(p, instance, make_optional(demo));
         solve_with(p, SolveCallbacks{.trace = [](const CurrentState &) -> bool { return true; }}, make_optional<ProofOptions>(ProofFileNames{name}));
 
         if (run_veripb(name + ".opb", name + ".pbp"))
@@ -630,7 +731,7 @@ auto main(int argc, char * argv[]) -> int
             fail("backtracking soak: the instance did not search, so it soaked nothing");
 
         set<vector<int>> expected;
-        build_expected(expected, [&](const vector<int> & starts) { return is_satisfying(soak, starts); }, soak.start_ranges);
+        build_expected(expected, [&](const vector<int> & starts) { return is_satisfying(soak, starts); }, assignment_ranges(soak));
         if (expected != outcome.solutions)
             fail("backtracking soak: solutions do not match brute force");
     }

--- a/gcs/constraints/cumulative/propagate.hh
+++ b/gcs/constraints/cumulative/propagate.hh
@@ -21,6 +21,47 @@
 namespace gcs::innards
 {
     /**
+     * \brief What a Cumulative's presence argument for one task comes to: what
+     * its activity flags are reified on, and whether it has any at all.
+     *
+     * \sa cumulative_task_presence
+     *
+     * \ingroup Innards
+     */
+    struct CumulativeTaskPresence
+    {
+        /// The {0, 1} variable the task's active flag carries as a third
+        /// conjunct, or nullopt when the task is unconditionally present and
+        /// the flag is the two-way AND.
+        std::optional<IntegerVariableID> literal;
+
+        /// Whether the task was posted as constantly absent, in which case
+        /// Cumulative leaves it out of the constraint altogether: it has no
+        /// flags, no terms in any capacity row, and nothing may cite it.
+        bool never_present = false;
+    };
+
+    /**
+     * \brief How a Cumulative resolves the presence argument it was posted
+     * with for one task, given that argument (nullopt for a constraint posted
+     * without presences at all).
+     *
+     * Only a *constant* argument resolves away: a variable presence keeps its
+     * conjunct even when its domain is already a singleton, because the
+     * encoding has to say what it means without appealing to a domain the OPB
+     * does not record.
+     *
+     * Shared, and deliberately so. A derived Cumulative pins its donor's
+     * activity flags, so it has to reach exactly the same verdict about which
+     * of them carry a presence literal as the donor did when it built them; a
+     * second copy of this rule would be one edit away from disagreeing, and the
+     * disagreement would show up as a rejected proof a long way from here.
+     *
+     * \ingroup Innards
+     */
+    [[nodiscard]] auto cumulative_task_presence(const std::optional<IntegerVariableID> & posted) -> CumulativeTaskPresence;
+
+    /**
      * \brief Everything Cumulative's propagator reads: the task data, the
      * per-time proof flags it pins, and the per-time capacity lines it builds
      * its `pol`s on.
@@ -46,9 +87,10 @@ namespace gcs::innards
 
         /// Sized to the task count. nullopt for a task that is unconditionally
         /// present; otherwise the {0, 1} variable saying whether it is
-        /// scheduled at all. A derived Cumulative fills this with nullopts:
-        /// deriving over an optional donor would need the presence literals in
-        /// its own reasons, which is future work (see DerivedCumulativeSpec).
+        /// scheduled at all, as cumulative_task_presence resolves it. A derived
+        /// Cumulative fills this in from its donors', so that the reasons it
+        /// gives carry the same presence literals the flags it pins were
+        /// reified on.
         std::vector<std::optional<IntegerVariableID>> presence;
 
         /// The tasks that can raise the load profile at all: those whose length

--- a/gcs/presolvers/cumulative_strengthening/cumulative_strengthening.cc
+++ b/gcs/presolvers/cumulative_strengthening/cumulative_strengthening.cc
@@ -1,6 +1,7 @@
 #include <gcs/constraint_id.hh>
 #include <gcs/constraints/cumulative.hh>
 #include <gcs/constraints/cumulative/derived_cumulative.hh>
+#include <gcs/constraints/cumulative/propagate.hh>
 #include <gcs/exception.hh>
 #include <gcs/innards/proofs/am1_from_row.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
@@ -26,6 +27,7 @@
 using namespace gcs;
 using namespace gcs::innards;
 
+using std::make_optional;
 using std::make_unique;
 using std::map;
 using std::max;
@@ -46,15 +48,20 @@ namespace
     /// with a variable height the donor's row is over bit-linearised
     /// contribution flags rather than `height * active`, so a subset sum of the
     /// heights is not what the row's coefficients are.
+    ///
+    /// A presence is not one of those: it is not a coefficient at all, so the
+    /// only thing that has to be read off it here is which tasks the donor
+    /// dropped for being constantly absent.
     struct ConstantTaskData
     {
         vector<Integer> lengths, heights;
+        vector<bool> never_present;
         Integer capacity;
     };
 
     [[nodiscard]] auto constant_task_data(const Cumulative & donor) -> optional<ConstantTaskData>
     {
-        ConstantTaskData data{{}, {}, 0_i};
+        ConstantTaskData data{{}, {}, {}, 0_i};
 
         auto value_of = [](const IntegerVariableID & v) -> optional<Integer> {
             if (! is_constant_variable(v))
@@ -80,6 +87,10 @@ namespace
                 return std::nullopt;
             data.heights.push_back(*height);
         }
+
+        for (size_t i = 0; i < donor.starts().size(); ++i)
+            data.never_present.push_back(
+                cumulative_task_presence(donor.presences().empty() ? std::nullopt : make_optional(donor.presences()[i])).never_present);
 
         return data;
     }
@@ -183,17 +194,6 @@ auto CumulativeStrengthening::run(Problem & problem, Propagators & propagators, 
     for (const auto & donor : problem.each_constraint_of_type<Cumulative>()) {
         bump(&CumulativeStrengtheningStats::donors_seen);
 
-        // A derived Cumulative over an optional donor would need the donor's
-        // presence literals in every reason it gives, which DerivedCumulativeSpec
-        // says it does not have. Loudly, because a model that turned optional
-        // would otherwise just quietly stop being strengthened.
-        if (! donor.presences().empty()) {
-            bump(&CumulativeStrengtheningStats::declined_optional);
-            if (logger)
-                logger->emit_proof_comment("presolve cumulative: declining " + as_string(donor.constraint_id()) + ", optional tasks");
-            continue;
-        }
-
         auto data = constant_task_data(donor);
         if (! data) {
             bump(&CumulativeStrengtheningStats::declined_variable_arguments);
@@ -209,10 +209,21 @@ auto CumulativeStrengthening::run(Problem & problem, Propagators & propagators, 
         // The same windowing install_derived_cumulative resolves, and the same
         // windowing the donor encoded: a task can be active from its earliest
         // start to its latest finish. This is the paper's `t in [est_j, lct_j)`.
+        //
+        // Optional tasks need nothing further here. The whole strengthening is
+        // an argument about the donor's rows `Σ h_i·active_{i,t} ≤ C`, and an
+        // optional task's presence lives *inside* its active flag rather than
+        // beside it, so those rows are the same shape either way and every
+        // subset sum, at-most-one and raise below reads them the same. What the
+        // presence does change is the reasons the derived propagator gives,
+        // which install_derived_cumulative handles from the arguments passed to
+        // derived_cumulative_tasks_from below.
         vector<Integer> t_lo(n, 0_i), t_hi(n, 0_i);
         vector<size_t> active_tasks;
         for (size_t i = 0; i < n; ++i) {
-            if (data->lengths[i] <= 0_i || data->heights[i] <= 0_i)
+            // A constantly absent task is one the donor dropped outright, so it
+            // has no flags and no term in any row to argue over.
+            if (data->lengths[i] <= 0_i || data->heights[i] <= 0_i || data->never_present[i])
                 continue;
             active_tasks.push_back(i);
             auto [s_lo, s_hi] = state.bounds(starts[i]);
@@ -390,7 +401,7 @@ auto CumulativeStrengthening::run(Problem & problem, Propagators & propagators, 
             _mutation);
         auto raise_too_fast = std::holds_alternative<cumulative_strengthening_mutation::RaiseTooFast>(_mutation);
 
-        DerivedCumulativeSpec spec{.tasks = derived_cumulative_tasks_from(donor_id, starts, data->lengths, derived_heights),
+        DerivedCumulativeSpec spec{.tasks = derived_cumulative_tasks_from(donor_id, starts, data->lengths, derived_heights, donor.presences()),
             .capacity = kappa,
             .row_donors = {donor_id},
             .recipe = [donor_id, heights, capacity, kappa, by_time, stats, subset_sum_corruption, raise_too_fast, unentitled_raise](

--- a/gcs/presolvers/cumulative_strengthening/cumulative_strengthening.hh
+++ b/gcs/presolvers/cumulative_strengthening/cumulative_strengthening.hh
@@ -49,13 +49,17 @@ namespace gcs
         /**
          * \name Why a donor was passed over.
          *
-         * Broken out because they mean different things to a caller: the first
-         * two are the v1 restrictions, the third is a proof-size budget that a
+         * Broken out because they mean different things to a caller: the
+         * first is the v1 restriction, the next two are proof-size budgets a
          * caller may want to raise, and the last is the honest and common
          * answer that the capacity was already the largest reachable load.
+         *
+         * Optional tasks are not among them. The strengthening argues about
+         * the donor's capacity rows, which an optional task's presence does not
+         * change the shape of --- it is a conjunct of the activity flag, not a
+         * term beside it.
          */
         ///@{
-        std::size_t declined_optional = 0;
         std::size_t declined_variable_arguments = 0;
         std::size_t declined_over_budget = 0;
         std::size_t declined_over_raise_budget = 0;

--- a/gcs/presolvers/cumulative_strengthening/cumulative_strengthening_test.cc
+++ b/gcs/presolvers/cumulative_strengthening/cumulative_strengthening_test.cc
@@ -117,6 +117,47 @@ namespace
         return true;
     }
 
+    /// An instance whose tasks are optional. Deliberately not folded into
+    /// Instance: a solution then carries a presence per task as well as a
+    /// start, which every other fixture in this file would have to account for
+    /// and none of them cares about.
+    struct OptionalInstance
+    {
+        vector<pair<int, int>> start_ranges;
+        vector<int> lengths;
+        vector<int> heights;
+        /// Per task, the domain its presence variable is declared over.
+        vector<pair<int, int>> presence_ranges;
+        int capacity;
+    };
+
+    /// Over an assignment that is every start followed by every presence, which
+    /// is the shape build_expected produces and the shape the solution callback
+    /// records.
+    auto is_satisfying(const OptionalInstance & inst, const vector<int> & assignment) -> bool
+    {
+        auto n = inst.start_ranges.size();
+        auto start = [&](size_t i) { return assignment[i]; };
+        auto present = [&](size_t i) { return assignment[n + i] != 0; };
+
+        int t_lo = INT_MAX, t_hi = INT_MIN;
+        for (size_t i = 0; i < n; ++i) {
+            if (inst.lengths[i] == 0 || inst.heights[i] == 0 || ! present(i))
+                continue;
+            t_lo = min(t_lo, start(i));
+            t_hi = max(t_hi, start(i) + inst.lengths[i] - 1);
+        }
+        for (int t = t_lo; t <= t_hi; ++t) {
+            int load = 0;
+            for (size_t i = 0; i < n; ++i)
+                if (present(i) && start(i) <= t && t < start(i) + inst.lengths[i])
+                    load += inst.heights[i];
+            if (load > inst.capacity)
+                return false;
+        }
+        return true;
+    }
+
     /// How a solve was set up: whether the presolver ran, with which rules on
     /// both sides, and with what corruption.
     struct Setup
@@ -190,6 +231,50 @@ namespace
         outcome.refuted_at_root = ! reached_a_node && ! found_a_solution;
 
         if (proof_name && verify)
+            verify_proof_and_clean_up(*proof_name);
+        return outcome;
+    }
+
+    /// Solve an optional instance, collecting the same (starts, presences)
+    /// tuples brute force produces.
+    auto solve_optional(const OptionalInstance & inst, const shared_ptr<CumulativeStrengtheningStats> & stats, const optional<string> & proof_name)
+        -> Outcome
+    {
+        Problem p;
+        vector<IntegerVariableID> starts, presences, lengths, heights;
+        for (size_t i = 0; i < inst.start_ranges.size(); ++i) {
+            starts.push_back(p.create_integer_variable(Integer{inst.start_ranges[i].first}, Integer{inst.start_ranges[i].second}));
+            presences.push_back(p.create_integer_variable(Integer{inst.presence_ranges[i].first}, Integer{inst.presence_ranges[i].second}));
+            lengths.push_back(constant_variable(Integer{inst.lengths[i]}));
+            heights.push_back(constant_variable(Integer{inst.heights[i]}));
+        }
+
+        p.post(Cumulative{starts, lengths, heights, presences, constant_variable(Integer{inst.capacity})});
+        if (stats)
+            p.add_presolver(CumulativeStrengthening{stats});
+
+        Outcome outcome;
+        bool reached_a_node = false, found_a_solution = false;
+        solve_with(p,
+            SolveCallbacks{.solution = [&](const CurrentState & s) -> bool {
+                               found_a_solution = true;
+                               vector<int> solution;
+                               for (const auto & v : starts)
+                                   solution.push_back(s(v).raw_value);
+                               for (const auto & v : presences)
+                                   solution.push_back(s(v).raw_value);
+                               outcome.solutions.insert(move(solution));
+                               return true;
+                           },
+                .trace = [&](const CurrentState &) -> bool {
+                    reached_a_node = true;
+                    return true;
+                }},
+            proof_name ? make_optional<ProofOptions>(ProofFileNames{*proof_name}) : nullopt);
+
+        outcome.refuted_at_root = ! reached_a_node && ! found_a_solution;
+
+        if (proof_name)
             verify_proof_and_clean_up(*proof_name);
         return outcome;
     }
@@ -592,28 +677,64 @@ auto main(int argc, char * argv[]) -> int
             fail("negative control: solutions do not match brute force");
     }
 
-    // v1 restrictions, each declined loudly rather than quietly mis-derived.
-    {
+    // Optional donors, which are not a restriction: the presence is a conjunct
+    // of the activity flag rather than a term beside it, so the rows this
+    // presolver argues over are the same shape either way.
+    //
+    // Two of them, because they exercise different halves. With presences
+    // declared over {1, 1} every rule fires exactly where it would with no
+    // presences at all --- and every flag still carries a presence conjunct
+    // that every reason has to carry too, so this is the fixture that would
+    // catch a pin emitted without one. With them over {0, 1} the rules mostly
+    // hold off until the search decides a presence, and what is checked is that
+    // no solution was lost on the way.
+    //
+    // Five tasks of height three and length two, over a window four time points
+    // wide. Eight units of capacity supply thirty-two there, and the
+    // strengthened six supply twenty-four, which is short of the thirty the
+    // tasks need --- the energy gap that rounding a capacity by integrality
+    // opens up, and one the donor cannot reach for itself. So the refutation
+    // below is exclusively the derived constraint's, drawn over the donor's
+    // flags, and every activity it pins has to name a presence.
+    //
+    // The starts span three values rather than two on purpose: a {0, 1} domain
+    // is direct-only encoded, and prepare_cumulative_overload_check leaves such
+    // a task out of the energy set for want of order literals.
+    for (const auto & [what, presence_range] : {pair<string, pair<int, int>>{"present", {1, 1}}, {"undecided", {0, 1}}}) {
         auto stats = make_shared<CumulativeStrengtheningStats>();
+        const OptionalInstance inst{
+            {{0, 2}, {0, 2}, {0, 2}, {0, 2}, {0, 2}}, {2, 2, 2, 2, 2}, {3, 3, 3, 3, 3}, vector<pair<int, int>>(5, presence_range), 8};
 
-        Problem p;
-        vector<IntegerVariableID> starts, presences;
-        for (int i = 0; i < 3; ++i) {
-            starts.push_back(p.create_integer_variable(0_i, 3_i));
-            presences.push_back(p.create_integer_variable(0_i, 1_i));
+        auto outcome = solve_optional(inst, stats, proofs ? make_optional("cumulative_strengthening_optional_" + what) : nullopt);
+
+        // The donor's heights are all multiples of three and its capacity is
+        // not, so the subset sum rounds eight down to six. Assert it: a fixture
+        // that quietly stopped strengthening would pass everything else here.
+        if (stats->donors_strengthened != 1)
+            fail("an optional-task donor was not strengthened, on " + what);
+        if (stats->capacity_units_removed != 2_i)
+            fail("an optional-task donor was strengthened by the wrong amount, on " + what);
+
+        set<vector<int>> expected;
+        auto ranges = inst.start_ranges;
+        ranges.insert(ranges.end(), inst.presence_ranges.begin(), inst.presence_ranges.end());
+        build_expected(expected, [&](const vector<int> & assignment) { return is_satisfying(inst, assignment); }, ranges);
+        if (expected != outcome.solutions)
+            fail("optional-task solutions do not match brute force, on " + what);
+
+        // With every task present the energy argument runs at the root and
+        // refutes there --- and the donor on its own does not, which is what
+        // says the derived constraint did the work rather than merely riding
+        // along behind it.
+        if (what == "present") {
+            if (! outcome.refuted_at_root)
+                fail("the strengthened energy check did not refute the all-present instance at the root");
+            if (solve_optional(inst, nullptr, nullopt).refuted_at_root)
+                fail("the donor alone refuted at the root, so the fixture proves nothing");
         }
-        vector<IntegerVariableID> lengths{constant_variable(2_i), constant_variable(2_i), constant_variable(2_i)},
-            heights{constant_variable(6_i), constant_variable(10_i), constant_variable(15_i)};
-        p.post(Cumulative{starts, lengths, heights, presences, constant_variable(14_i)});
-        p.add_presolver(CumulativeStrengthening{stats});
-        solve_with(p, SolveCallbacks{.trace = [](const CurrentState &) -> bool { return false; }}, nullopt);
-
-        if (stats->declined_optional != 1)
-            fail("an optional-task donor was not declined");
-        if (stats->donors_strengthened != 0)
-            fail("an optional-task donor was strengthened anyway");
     }
 
+    // v1 restrictions, each declined loudly rather than quietly mis-derived.
     {
         auto stats = make_shared<CumulativeStrengtheningStats>();
 

--- a/gcs/presolvers/inferred_cumulative/inferred_cumulative.cc
+++ b/gcs/presolvers/inferred_cumulative/inferred_cumulative.cc
@@ -456,6 +456,14 @@ auto InferredCumulative::run(Problem & problem, Propagators & propagators, State
     for (const auto & donor : problem.each_constraint_of_type<Cumulative>()) {
         bump(&InferredCumulativeStats::donors_seen);
 
+        // The mechanism no longer minds an optional donor --- a presence is a
+        // conjunct of the activity flag, so the rows this argues over are the
+        // same shape, and install_derived_cumulative carries the literal into
+        // the reasons. What is still open here is the *cross-donor* half: this
+        // presolver draws tasks from several Cumulatives and bridges one
+        // donor's flags to another's, and two donors' activity flags cancel
+        // against each other only if their presence conjuncts do too. Declined
+        // until that has a rule of its own rather than a hopeful `pol`.
         if (! donor.presences().empty()) {
             bump(&InferredCumulativeStats::declined_optional);
             if (logger)

--- a/gcs/presolvers/inferred_cumulative/inferred_cumulative.hh
+++ b/gcs/presolvers/inferred_cumulative/inferred_cumulative.hh
@@ -138,6 +138,11 @@ namespace gcs
          * \name Why a candidate or a donor was passed over.
          */
         ///@{
+        /// Donors passed over for having optional tasks. Not because a derived
+        /// Cumulative cannot reason over them --- it can, see
+        /// install_derived_cumulative --- but because this presolver bridges
+        /// flags between donors, and a presence conjunct has to cancel across
+        /// that bridge before it may.
         std::size_t declined_optional = 0;
         std::size_t declined_variable_arguments = 0;
         /// Covers already inside the support of something lifted earlier, which

--- a/gcs/presolvers/inferred_disjunctive/inferred_disjunctive.cc
+++ b/gcs/presolvers/inferred_disjunctive/inferred_disjunctive.cc
@@ -169,6 +169,14 @@ auto InferredDisjunctive::run(Problem & problem, Propagators & propagators, Stat
     for (const auto & donor : problem.each_constraint_of_type<Cumulative>()) {
         bump(&InferredDisjunctiveStats::donors_seen);
 
+        // The mechanism no longer minds an optional donor --- a presence is a
+        // conjunct of the activity flag, so the rows this argues over are the
+        // same shape, and install_derived_cumulative carries the literal into
+        // the reasons. What is still open here is the *cross-donor* half: this
+        // presolver draws tasks from several Cumulatives and bridges one
+        // donor's flags to another's, and two donors' activity flags cancel
+        // against each other only if their presence conjuncts do too. Declined
+        // until that has a rule of its own rather than a hopeful `pol`.
         if (! donor.presences().empty()) {
             bump(&InferredDisjunctiveStats::declined_optional);
             if (logger)

--- a/gcs/presolvers/inferred_disjunctive/inferred_disjunctive.hh
+++ b/gcs/presolvers/inferred_disjunctive/inferred_disjunctive.hh
@@ -94,6 +94,11 @@ namespace gcs
          * \name Why a candidate or a donor was passed over.
          */
         ///@{
+        /// Donors passed over for having optional tasks. Not because a derived
+        /// Cumulative cannot reason over them --- it can, see
+        /// install_derived_cumulative --- but because this presolver bridges
+        /// flags between donors, and a presence conjunct has to cancel across
+        /// that bridge before it may.
         std::size_t declined_optional = 0;
         std::size_t declined_variable_arguments = 0;
         std::size_t dropped_too_small = 0;


### PR DESCRIPTION
Stacked on #681 (`cumulative-16-hinted-replay`).

The first half of "optional tasks and variable arguments in all three
presolvers". The headline is how little the proofs needed.

## Why nothing had to change in the derivations

An optional task's presence is a conjunct *inside* its activity flag:

```
active_{i,t}  <->  before_{i,t} /\ after_{i,t} /\ (presences[i] = 1)
```

so a donor's per-time capacity row `sum_i h_i*active_{i,t} <= C` is the same
shape whether or not the donor was posted with presences. Every recipe built on
one — the subset sums, the at-most-ones, the coefficient raising, and (later)
the cover cuts — reads it identically. **Not one of them is touched by this
PR.**

## What did have to change

What the derived propagator may *say*. Pinning `active_{i,t} = 1` now needs
`presences[i] = 1` in the reason too, so `DerivedCumulativeTask` carries the
donor's presence argument and `install_derived_cumulative` resolves it through
`cumulative_task_presence`. That function is lifted out of `Cumulative::prepare`
and shared deliberately: a derived constraint pins its donor's flags, so it has
to reach exactly the same verdict about which of them carry a literal, and a
second copy of the rule would be one edit from disagreeing — with the
disagreement showing up as a rejected proof a long way from the edit.

From there `propagate_cumulative` is the code that has known how to handle
optional tasks since #660, and `reason_with_presence()` supplies the literals.

## The window-energy lemma comes out right for free

Its per-time step adds `active`'s `[f]` half, which for an optional task *is*
`active \/ ~before \/ ~after \/ ~p`. Summing the window's worth gives

```
sum_{t in [a,b)} active_{i,t}  +  activity*~p_i  >=  activity
```

— the conditional form, with no code change. That leftover `activity*~p` rides
through the consuming `pol`, which therefore does not contradict on its own; the
wrapping RUP disposes of it because `p_i = 1` is in the reason. Which is exactly
why the rule may only speak for tasks *known* present, and why both consumers
filter on `is_present`.

At the root usually nothing is known present, so the makespan bound drops an
undecided task rather than counting its energy. Weaker, not wrong: what it gives
up is `capacity x window >= sum_i energy_i * p_i`, an implied linear constraint
over the presences rather than anything a lower bound can hold. That belongs
with the conditional-bounds follow-up.

## Presolvers

`CumulativeStrengthening` stops declining optional donors, and its
`declined_optional` counter goes with the restriction.

`InferredDisjunctive` and `InferredCumulative` still decline, for a reason that
is now theirs rather than inherited: they bridge flags *between* donors, and
`recover_conjunction_flag_bridge` cancels a presence conjunct only when both
donors carry the same literal — mixed arities change the degree arithmetic
outright. Both the code and the stats docs now say so.

## Testing

- `cumulative_strengthening_presolver`: an optional donor whose strengthened
  capacity (8 rounded to 6 by integrality) refutes at the root where the donor
  alone provably cannot, run with presences declared both `{1, 1}` and `{0, 1}`,
  enumerated against brute force. The `{0, 1}` one is the sharp case: dropping
  the presence plumbing gets its proof rejected by VeriPB.
- `derived_cumulative`: the makespan bound over an optional donor — 6 when the
  presences are declared present, and *no bound at all* when they are undecided
  — plus the OPB-unaffected check over an optional instance.
- A new `MakespanForgetPresence` mutation leaves the presences off the spec, so
  the derived constraint counts energy for tasks that need not be scheduled.
  VeriPB rejects it.

Full `ctest` green (632/632) under GCC; the affected tests also built and run
green under clang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173hT2hFo3MyGRBon8SHt2p