### PR TITLE
Set a Cumulative's variable arguments aside per task, not per donor

### DIFF
--- a/dev_docs/cumulative-proof-logging.md
+++ b/dev_docs/cumulative-proof-logging.md
@@ -733,6 +733,65 @@ at the point of use.
 Falsifying a presence *by* an energy argument, rather than by the
 profile, is issue 09's extension and is not here.
 
+### Deriving over a donor that is not all constants
+
+Everything a derived constraint's recipe does is an argument about rows of the
+form `Σ h_i·active_{i,t} ≤ C`, and a donor only writes those when its arguments
+are constants. `CumulativeDonorView`
+([`donor_view.hh`](../gcs/constraints/cumulative/donor_view.hh)) is what reduces
+a donor to the part of itself that is, and the reduction is per **task**: one
+task with a variable length no longer costs a whole donor its strengthening, it
+costs that task its term.
+
+`recover_constant_argument_row` does the proof half, and it is one `pol`:
+
+- **A set-aside task** — variable length or variable height — is weakened out of
+  the row with `w`. For a constant height that is one `w` on its activity flag;
+  for a variable height the row's terms for it are the bits of the linearised
+  contribution, so every one of them goes, which is what
+  `ConstraintProofModelData<Cumulative>::contribution_flag_key` is published for.
+  How many bits there are is not published: ask for bit zero, one, two and so on
+  until the tracker has none, the same "is it there?" question a citer asks of
+  every other key.
+
+  Only the variable-height half is a tripwire. Remove the constant-height `w` and
+  every proof still verifies, because a recipe pins what it returns with an `ia`
+  and dropping a non-negative term from the left of a `≤` is a valid implication
+  — the pin weakens it away for free. It is written anyway so that the row a
+  recipe argues over is the row it claims. **Do not delete it as untested.**
+
+- **A variable capacity** is replaced by a number. The row has `− capacity` on
+  its left, so the bits have to cancel against something, and the something is
+  the *order literal* for the bound the capacity has now:
+  `need_pol_item_defining_literal` hands back the definition of
+  `[capacity ≥ b+1]`, whose bits cancel exactly and which leaves the atom behind
+  with a coefficient of its own. Going through the literal rather than citing the
+  capacity's OPB bound row is what lets this use the bound the capacity has *now*
+  — a presolver reads a live `State`, and the declared bound is a weaker number
+  the moment anything has tightened it.
+
+  What is left is paid off in the same `pol`, by the unit line saying the atom is
+  false, added as many times as its coefficient. That coefficient is
+  `(everything the encoding could reach) − b`, worked out with
+  `get_bits_encoding_coeffs` over the range `tracked_bounds` says the variable
+  was encoded over — the same primitive the encoding is built with, rather than
+  anything this file assumes about its shape. Get it wrong and the recipe's `ia`
+  refuses the row immediately, which is what
+  `cumulative_strengthening_var_capacity` checks.
+
+  The unit line holds *permanently*: the bound it denies is the one the capacity
+  had before the search started. So what comes back is an unconditional row, not
+  one carrying a condition into every reason — which it has to be, since the
+  propagator's `pol`s cancel against it term by term.
+
+With nothing to do — the all-constant case, and so the common one — the row is
+handed back untouched: no `pol`, no line, and a proof byte-identical to the one
+written before any of this existed.
+
+What stays declined is a capacity that is a **view**, whose bits are not the ones
+the row mentions, so there is no order literal whose definition would cancel
+them.
+
 ### Deriving over an optional donor
 
 A *derived* Cumulative (issue 04) works over an optional donor, and the
@@ -787,6 +846,10 @@ against each other, and a presence conjunct cancels only when both donors
 carry the same literal. Mixed arities change the degree arithmetic
 outright. The presolvers of issues 07 and 08 bridge between donors, so
 they still decline an optional one; issue 06's does not, and does not.
+
+The same two are the ones still declining a donor with variable arguments,
+which is a wiring gap rather than anything unsolved: `CumulativeDonorView`
+and `recover_constant_argument_row` are theirs to call too.
 
 `constraint_type()` is `cumulative_optional` for the optional form, so
 the verified-encoding chain does not silently match it against

--- a/dev_docs/cumulative-strengthening.md
+++ b/dev_docs/cumulative-strengthening.md
@@ -311,6 +311,15 @@ Each is declined rather than worked around, and counted in
 `CumulativeStrengtheningStats` so that a model drifting into one does not simply
 stop being strengthened in silence:
 
+Variable lengths and heights are deliberately **not** on this list either, and
+nor is a variable capacity. `CumulativeDonorView`
+([`donor_view.hh`](../gcs/constraints/cumulative/donor_view.hh)) reduces a donor
+to the part of itself the argument can be made over, per *task*: one task with a
+variable length or height is set aside and weakened out of every row, and the
+rest of the donor is strengthened exactly as before. `donors_with_set_aside_tasks`
+counts the donors that happened to, because one strengthened over four of its
+five tasks otherwise looks just like one strengthened in full.
+
 Optional tasks are deliberately **not** on this list. The whole strengthening is
 an argument about the donor's per-time rows, and an optional task's presence is a
 conjunct inside its activity flag rather than a term beside it, so those rows are
@@ -323,9 +332,10 @@ and `InferredCumulative` still decline, for a reason that is theirs rather than
 this one's: they bridge flags between donors, and a presence conjunct has to
 cancel across that bridge first.
 
-- **Variable lengths, heights or capacity.** With a variable height the donor's
-  row is over bit-linearised contribution flags rather than `height × active`, so
-  a subset sum of the heights is not a subset sum of the row's coefficients.
+- **A capacity that is a view.** Its bits are not the ones the donor's rows
+  mention, so there is no order literal whose definition would cancel them, and
+  nothing to reduce a row against. A *variable* capacity is fine, and a variable
+  length or height costs its own task rather than the donor — see below.
 - **A height above the capacity**, as above.
 - **Every task full**, which makes `kappa` zero: a disjunctive rather than a
   strengthening, and `InferredDisjunctive`'s to find.

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -34,6 +34,7 @@ add_library(glasgow_constraint_solver
         constraints/count/count.cc
         constraints/cumulative/cumulative.cc
         constraints/cumulative/derived_cumulative.cc
+        constraints/cumulative/donor_view.cc
         constraints/difference/difference_constraints.cc
         constraints/difference/difference_graph.cc
         constraints/difference/difference_incremental.cc

--- a/gcs/constraints/cumulative/cumulative.cc
+++ b/gcs/constraints/cumulative/cumulative.cc
@@ -1269,6 +1269,11 @@ auto ConstraintProofModelData<Cumulative>::active_flag_key(size_t task, Integer 
     return ProofFlagKey{{static_cast<long long>(task), t.raw_value}, "cact"};
 }
 
+auto ConstraintProofModelData<Cumulative>::contribution_flag_key(size_t task, Integer t, Integer bit) -> ProofFlagKey
+{
+    return ProofFlagKey{{static_cast<long long>(task), t.raw_value, bit.raw_value}, "cc"};
+}
+
 auto Cumulative::constraint_type() const -> std::string
 {
     // The optional form is a different constraint, not a variant of this one:

--- a/gcs/constraints/cumulative/cumulative.hh
+++ b/gcs/constraints/cumulative/cumulative.hh
@@ -283,6 +283,20 @@ namespace gcs
         [[nodiscard]] static auto after_flag_key(std::size_t task, Integer t) -> innards::ProofFlagKey;
         [[nodiscard]] static auto active_flag_key(std::size_t task, Integer t) -> innards::ProofFlagKey;
         ///@}
+
+        /**
+         * \brief The key of one bit of a variable-height task's linearised load
+         * contribution at time `t`: the row's terms for such a task are
+         * `2^bit` times these, rather than `height x active`.
+         *
+         * How many bits there are is a fact about the height's initial upper
+         * bound, and is not published separately: ask
+         * NamesAndIDsTracker::find_proof_flag_values for bit zero, one, two and
+         * so on until it has none, which is the same "is it there?" question a
+         * citer asks about every other key here. A constant-height task has
+         * none at all.
+         */
+        [[nodiscard]] static auto contribution_flag_key(std::size_t task, Integer t, Integer bit) -> innards::ProofFlagKey;
     };
 }
 

--- a/gcs/constraints/cumulative/donor_view.cc
+++ b/gcs/constraints/cumulative/donor_view.cc
@@ -1,0 +1,158 @@
+#include <gcs/constraints/cumulative/donor_view.hh>
+#include <gcs/constraints/cumulative/propagate.hh>
+#include <gcs/innards/proofs/bits_encoding.hh>
+#include <gcs/innards/proofs/names_and_ids_tracker.hh>
+#include <gcs/innards/proofs/pol_builder.hh>
+#include <gcs/innards/proofs/proof_logger.hh>
+#include <gcs/innards/proofs/pseudo_boolean.hh>
+#include <gcs/innards/state.hh>
+
+#include <optional>
+#include <variant>
+#include <vector>
+
+using namespace gcs;
+using namespace gcs::innards;
+
+namespace
+{
+    auto const_value_of(const IntegerVariableID & v) -> Integer
+    {
+        return std::get<ConstantIntegerVariableID>(v).const_value;
+    }
+}
+
+using std::make_optional;
+using std::nullopt;
+using std::optional;
+using std::size_t;
+using std::vector;
+
+auto gcs::innards::cumulative_donor_view(const Cumulative & donor, const State & state) -> optional<CumulativeDonorView>
+{
+    CumulativeDonorView view;
+    auto n = donor.starts().size();
+
+    // A view capacity has no bits of its own to cancel the row's against, so
+    // there is no order literal to resolve and nothing to reduce it to. The
+    // constant and simple-variable cases are what every model in reach uses.
+    if (! is_constant_variable(donor.capacity()) && ! std::holds_alternative<SimpleIntegerVariableID>(donor.capacity()))
+        return nullopt;
+
+    if (is_constant_variable(donor.capacity()))
+        view.capacity = const_value_of(donor.capacity());
+    else {
+        view.capacity = state.upper_bound(donor.capacity());
+        view.capacity_bounded_by = donor.capacity();
+    }
+
+    view.lengths.assign(n, 0_i);
+    view.heights.assign(n, 0_i);
+    view.presences = donor.presences();
+
+    for (size_t i = 0; i < n; ++i) {
+        auto length = donor.lengths()[i], height = donor.heights()[i];
+
+        // A variable length or height is what a set-aside is for. The height
+        // is the sharper of the two: it makes the donor's row terms the bits of
+        // a linearised contribution rather than `height x active`, so a subset
+        // sum of the heights is not a subset sum of the row's coefficients. A
+        // variable length leaves the row alone but not the pins, whose `after`
+        // is then reified on `start + length` and no longer single-variable.
+        if (! is_constant_variable(length) || ! is_constant_variable(height)) {
+            view.set_aside.push_back(i);
+            continue;
+        }
+
+        // A task that can never load the resource, or that was posted as
+        // constantly absent, has no flags and no term in any row: nothing to
+        // set aside, because there is nothing there.
+        auto presence = cumulative_task_presence(view.presences.empty() ? nullopt : make_optional(view.presences[i]));
+        if (const_value_of(length) <= 0_i || const_value_of(height) <= 0_i || presence.never_present)
+            continue;
+
+        view.lengths[i] = const_value_of(length);
+        view.heights[i] = const_value_of(height);
+        view.usable.push_back(i);
+    }
+
+    return view;
+}
+
+auto gcs::innards::recover_constant_argument_row(ProofLogger & logger, const CumulativeDonorView & view, const ConstraintID & donor, ProofLine row,
+    Integer t, ProofLevel level) -> optional<ProofLine>
+{
+    auto & tracker = logger.names_and_ids_tracker();
+
+    // Which of the set-aside tasks have a term in *this* row: one only appears
+    // where the donor gave it a window, so asking for the flag is also asking
+    // whether there is anything here to weaken.
+    vector<ProofFlag> weaken_out;
+    for (auto i : view.set_aside) {
+        if (auto active = tracker.find_proof_flag_values(donor, ConstraintProofModelData<Cumulative>::active_flag_key(i, t))) {
+            // A constant height puts `height x active` in the row, so the one
+            // flag is the whole term. A variable one puts the bits of a
+            // linearised contribution there instead, and every one of them has
+            // to go; how many there are is the donor's business, so ask for bit
+            // zero, one, two and so on until it has no more.
+            auto bits = 0;
+            for (;; ++bits) {
+                auto cc = tracker.find_proof_flag_values(donor, ConstraintProofModelData<Cumulative>::contribution_flag_key(i, t, Integer{bits}));
+                if (! cc)
+                    break;
+                weaken_out.push_back(*cc);
+            }
+            // A constant height puts the whole term on the one flag, so that
+            // is what goes. Worth knowing before someone deletes it as
+            // untested: no test can catch its absence, because a recipe pins
+            // what it returns with an `ia` and dropping a non-negative term
+            // from the left of a `<=` is a valid implication --- the pin
+            // weakens the term away for free. It is here so that the row a
+            // recipe argues over is the row it claims, which is what everything
+            // downstream assumes; the variable-height case above is the one
+            // that fails loudly without it, its terms not being on a flag any
+            // recipe mentions.
+            if (0 == bits)
+                weaken_out.push_back(*active);
+        }
+    }
+
+    // The all-constant case, which is the common one: the row already says what
+    // a recipe needs, so it is handed back untouched and the proof is
+    // byte-identical to one written without any of this.
+    if (weaken_out.empty() && ! view.capacity_bounded_by)
+        return row;
+
+    PolBuilder reduced;
+    reduced.add(row);
+
+    if (view.capacity_bounded_by) {
+        // How much of the order literal is left once its definition has handed
+        // over the bits: the definition says `capacity <= bound` *or* the atom
+        // holds, and the atom's coefficient is the rest of what the encoding
+        // could have reached. Worked out from the same primitive the encoding
+        // itself is built with, over the range the tracker says the variable
+        // was encoded over, rather than from anything this file assumes about
+        // the shape.
+        auto [lo, hi] = tracker.tracked_bounds(std::get<SimpleIntegerVariableID>(*view.capacity_bounded_by));
+        auto [shift, highest_bit, negative_bit] = get_bits_encoding_coeffs(lo, hi);
+        if (0_i != negative_bit)
+            return nullopt; // a signed capacity, which Cumulative rejects anyway
+        auto atom_coefficient = 2_i * highest_bit - 1_i - view.capacity;
+
+        // And what pays it off: the atom is false, permanently. The bound it
+        // denies is the one the capacity had before the search started, so
+        // nothing below can undo it, and a unit RUP reaches it from the
+        // definition and the variable's own bound row.
+        auto atom_is_false = logger.emit_rup_proof_line(WPBSum{} + 1_i * (*view.capacity_bounded_by < view.capacity + 1_i) >= 1_i, level);
+
+        reduced.add_for_literal(tracker, *view.capacity_bounded_by < view.capacity + 1_i);
+        if (atom_coefficient > 0_i)
+            reduced.add(atom_is_false, atom_coefficient);
+    }
+
+    for (const auto & flag : weaken_out)
+        reduced.weaken(flag, tracker);
+
+    return reduced.emit(logger, level);
+}

--- a/gcs/constraints/cumulative/donor_view.cc
+++ b/gcs/constraints/cumulative/donor_view.cc
@@ -140,20 +140,26 @@ auto gcs::innards::recover_constant_argument_row(ProofLogger & logger, const Cum
             return nullopt; // a signed capacity, which Cumulative rejects anyway
         auto atom_coefficient = 2_i * highest_bit - 1_i - view.capacity;
 
-        // And what pays it off: the atom is false, permanently. The bound it
-        // denies is the one the capacity had before the search started, so
-        // nothing below can undo it, and a unit RUP reaches it from the
-        // definition and the variable's own bound row.
-        //
-        // Working, and so Temporary whatever level the caller wants the *row*
-        // at: it is cited once, by the `pol` below, and a caller asking for its
-        // row at Top has not asked for this line to live there too.
-        auto atom_is_false =
-            logger.emit_rup_proof_line(WPBSum{} + 1_i * (*view.capacity_bounded_by < view.capacity + 1_i) >= 1_i, ProofLevel::Temporary);
+        // The definition, which is what brings the capacity's bits over to
+        // cancel against the row's, and what leaves the atom behind.
+        auto capacity_at_most = *view.capacity_bounded_by < view.capacity + 1_i;
+        reduced.add_for_literal(tracker, capacity_at_most);
 
-        reduced.add_for_literal(tracker, *view.capacity_bounded_by < view.capacity + 1_i);
+        // And what pays the atom off: the line saying it is false. Where the
+        // bound is the capacity's declared one, need_gevar has already pinned
+        // that as a persistent top-of-proof line --- the pin exists to be
+        // cited, so cite it rather than emit the same unit again per row.
+        // Anywhere else the fact is still permanent, the bound having been
+        // reached before the search started, but nothing has written it down:
+        // a unit RUP does, as working, and so at Temporary whatever level the
+        // caller wants the row itself at.
+        auto capacity_variable = std::get<SimpleIntegerVariableID>(*view.capacity_bounded_by);
+        auto atom_is_false = tracker.boundary_pin_line(capacity_variable, view.capacity + 1_i);
+        if (! atom_is_false)
+            atom_is_false = logger.emit_rup_proof_line(WPBSum{} + 1_i * capacity_at_most >= 1_i, ProofLevel::Temporary);
+
         if (atom_coefficient > 0_i)
-            reduced.add(atom_is_false, atom_coefficient);
+            reduced.add(*atom_is_false, atom_coefficient);
     }
 
     for (const auto & flag : weaken_out)

--- a/gcs/constraints/cumulative/donor_view.cc
+++ b/gcs/constraints/cumulative/donor_view.cc
@@ -144,7 +144,12 @@ auto gcs::innards::recover_constant_argument_row(ProofLogger & logger, const Cum
         // denies is the one the capacity had before the search started, so
         // nothing below can undo it, and a unit RUP reaches it from the
         // definition and the variable's own bound row.
-        auto atom_is_false = logger.emit_rup_proof_line(WPBSum{} + 1_i * (*view.capacity_bounded_by < view.capacity + 1_i) >= 1_i, level);
+        //
+        // Working, and so Temporary whatever level the caller wants the *row*
+        // at: it is cited once, by the `pol` below, and a caller asking for its
+        // row at Top has not asked for this line to live there too.
+        auto atom_is_false =
+            logger.emit_rup_proof_line(WPBSum{} + 1_i * (*view.capacity_bounded_by < view.capacity + 1_i) >= 1_i, ProofLevel::Temporary);
 
         reduced.add_for_literal(tracker, *view.capacity_bounded_by < view.capacity + 1_i);
         if (atom_coefficient > 0_i)

--- a/gcs/constraints/cumulative/donor_view.hh
+++ b/gcs/constraints/cumulative/donor_view.hh
@@ -1,0 +1,120 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_CUMULATIVE_DONOR_VIEW_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_CUMULATIVE_DONOR_VIEW_HH
+
+#include <gcs/constraint_id.hh>
+#include <gcs/constraints/cumulative/cumulative.hh>
+#include <gcs/innards/proofs/proof_line.hh>
+#include <gcs/innards/proofs/proof_logger-fwd.hh>
+#include <gcs/innards/state-fwd.hh>
+#include <gcs/integer.hh>
+#include <gcs/variable_id.hh>
+
+#include <cstddef>
+#include <optional>
+#include <vector>
+
+namespace gcs::innards
+{
+    /**
+     * \brief A posted Cumulative as a would-be deriver can speak about it: its
+     * arguments reduced to constants, and the tasks that reduction had to set
+     * aside.
+     *
+     * Everything a derived Cumulative does is an argument about the donor's
+     * per-time capacity rows, and those rows are only over `height x active`
+     * with a constant right hand side when every argument is a constant. This
+     * is what a presolver builds to find out how much of a donor it can work
+     * with, and every presolver in the tree builds the same one rather than a
+     * fourth copy of the same three tests.
+     *
+     * The restrictions are made per *task* rather than per donor, which is the
+     * whole point: one task with a variable length no longer costs a donor its
+     * strengthening. A set-aside task is weakened out of every row derived from
+     * this donor and given a zero length in the derived constraint, so it has
+     * no flags to pin and no term to argue over --- see
+     * recover_constant_argument_row.
+     *
+     * \ingroup Innards
+     */
+    struct CumulativeDonorView
+    {
+        /// Per task, in the donor's own order, and **zero for a set-aside
+        /// task**: a length or height that is not a constant is not a number
+        /// this constraint may quote. Pass these straight to
+        /// derived_cumulative_tasks_from, whose zero-length tasks are excluded
+        /// exactly as a posted Cumulative excludes its own.
+        std::vector<Integer> lengths, heights;
+
+        /// Per task, the presence argument as posted, for
+        /// derived_cumulative_tasks_from.
+        std::vector<IntegerVariableID> presences;
+
+        /// The task positions a derived constraint may speak about: a constant
+        /// non-zero length and height, and not constantly absent.
+        std::vector<std::size_t> usable;
+
+        /// The task positions set aside for a variable length or height, whose
+        /// terms every derived row has to be weakened over. Not an error and
+        /// not a decline: what is lost is those tasks' contribution to the
+        /// argument, which makes it weaker rather than wrong.
+        std::vector<std::size_t> set_aside;
+
+        /// The capacity to argue against: the posted constant, or a variable
+        /// capacity's upper bound as it stands now.
+        Integer capacity = 0_i;
+
+        /// Set when \ref capacity came from a variable rather than being
+        /// posted, in which case every derived row has to buy it. See
+        /// recover_constant_argument_row.
+        std::optional<IntegerVariableID> capacity_bounded_by;
+    };
+
+    /**
+     * \brief Build the view of a donor, or nullopt if its capacity cannot be
+     * reduced to a number at all --- which today means a view capacity, whose
+     * bits are not the ones the row mentions.
+     *
+     * `state` supplies a variable capacity's current upper bound, which is the
+     * number the rows will be derived against. A view with an empty \ref usable
+     * is not an error: it says the donor has nothing a derived constraint could
+     * speak about, which is the caller's own "nothing to gain" answer.
+     *
+     * \ingroup Innards
+     */
+    [[nodiscard]] auto cumulative_donor_view(const Cumulative & donor, const State & state) -> std::optional<CumulativeDonorView>;
+
+    /**
+     * \brief Reduce one of a donor's capacity rows to the form a recipe argues
+     * over: constant coefficients on activity flags, and a constant right hand
+     * side.
+     *
+     * Two things happen, and both are the same one `pol`. A set-aside task's
+     * terms are weakened away --- `w` on its activity flag, or on each bit of
+     * its linearised contribution where its height is a variable, which is what
+     * ConstraintProofModelData<Cumulative>::contribution_flag_key is published
+     * for. And a variable capacity is replaced by a number, by resolving the
+     * order literal for the bound it currently has and letting the capacity's
+     * bits cancel against the row's.
+     *
+     * Working from the bound the capacity has *now* rather than from its
+     * declared one is the point of going through the order literal: a
+     * presolver reads a live State, and the root bound row would be a
+     * different, weaker number the moment anything had tightened it. The
+     * literal's definition brings the bits, and what is left over is the
+     * literal itself, paid off in the same `pol` by the unit line saying it is
+     * false --- which holds permanently, the bound having been reached before
+     * the search started, so the row that comes back is unconditional and
+     * exact. It has to be exact: a recipe pins what it returns with an `ia`,
+     * and every `pol` the propagator later builds on it cancels term by term.
+     *
+     * Returns the row unchanged when there is nothing to do, which is the
+     * all-constant case and so the common one: no `pol`, no line, and a proof
+     * byte-identical to the one written before any of this existed.
+     *
+     * \ingroup Innards
+     */
+    [[nodiscard]] auto recover_constant_argument_row(
+        ProofLogger &, const CumulativeDonorView &, const ConstraintID & donor, ProofLine row, Integer t, ProofLevel) -> std::optional<ProofLine>;
+}
+
+#endif

--- a/gcs/constraints/cumulative/donor_view.hh
+++ b/gcs/constraints/cumulative/donor_view.hh
@@ -107,6 +107,10 @@ namespace gcs::innards
      * exact. It has to be exact: a recipe pins what it returns with an `ia`,
      * and every `pol` the propagator later builds on it cancels term by term.
      *
+     * The ProofLevel is where the row that comes back goes. The one working
+     * line this needs is Temporary regardless, being cited once and by nothing
+     * else.
+     *
      * Returns the row unchanged when there is nothing to do, which is the
      * all-constant case and so the common one: no `pol`, no line, and a proof
      * byte-identical to the one written before any of this existed.

--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -116,6 +116,11 @@ namespace
         // variable's values). Value-keyed like the literal tables.
         std::unordered_map<long long, AtomDefs> eq_defs;
         std::unordered_map<long long, AtomDefs> ge_defs;
+        // The line pinning a boundary ge atom to the value the variable's
+        // declared bounds force, for the atoms that got one (see fix_bound in
+        // need_gevar). Filled when the pin is actually emitted, which for an
+        // atom needed during model building is at proof start rather than here.
+        std::unordered_map<long long, ProofLine> ge_pins;
     };
 
     struct HashView
@@ -476,6 +481,17 @@ auto NamesAndIDsTracker::need_constraint_saying_variable_takes_at_least_one_valu
         } //
     }
         .visit(var);
+}
+
+auto NamesAndIDsTracker::boundary_pin_line(const SimpleOrProofOnlyIntegerVariableID & id, Integer v) const -> optional<ProofLine>
+{
+    auto atoms = _imp->find_atoms(id);
+    if (! atoms)
+        return nullopt;
+    auto pin = atoms->ge_pins.find(v.raw_value);
+    if (pin == atoms->ge_pins.end())
+        return nullopt;
+    return pin->second;
 }
 
 auto NamesAndIDsTracker::need_pol_item_defining_literal(const IntegerVariableCondition & cond) -> variant<ProofLine, XLiteral>
@@ -945,17 +961,21 @@ auto NamesAndIDsTracker::need_gevar(SimpleOrProofOnlyIntegerVariableID id, Integ
         // throughout both enumeration and refutation. emit_proof_line_now_or_at_start
         // queues it to proof start when the logger is not yet attached (model
         // building) and emits it immediately otherwise.
-        emit_proof_line_now_or_at_start([id, v, negated](ProofLogger * const logger) {
+        emit_proof_line_now_or_at_start([this, id, v, negated](ProofLogger * const logger) {
             if (logger->get_assertion_level() > AssertionLevel::Links)
                 return;
             ProofRule assert_or_rup =
                 logger->get_assertion_level() == AssertionLevel::Links ? ProofRule(AssertProofRule{}) : ProofRule(RUPProofRule{});
             auto annotation = AssertionAnnotation{.hint_name = hints::InitialBound::hint_name};
-            visit(
+            auto line = visit(
                 [&](auto vid) {
-                    logger->emit(assert_or_rup, WPBSum{} + 1_i * (negated ? ! (vid >= v) : (vid >= v)) >= 1_i, ProofLevel::Top, annotation);
+                    return logger->emit(assert_or_rup, WPBSum{} + 1_i * (negated ? ! (vid >= v) : (vid >= v)) >= 1_i, ProofLevel::Top, annotation);
                 },
                 id);
+            // Remembered so that a step wanting this fact can cite it instead of
+            // emitting the same unit again --- which is what the pin being a
+            // persistent top-of-proof line is for.
+            _imp->atoms_for(id).ge_pins.insert_or_assign(v.raw_value, line);
         });
     };
 

--- a/gcs/innards/proofs/names_and_ids_tracker.hh
+++ b/gcs/innards/proofs/names_and_ids_tracker.hh
@@ -301,6 +301,28 @@ namespace gcs::innards
         [[nodiscard]] auto need_pol_item_defining_literal(const IntegerVariableCondition &) -> std::variant<ProofLine, XLiteral>;
 
         /**
+         * The line pinning the order atom `id >= v` to the value the variable's
+         * declared bounds already force, if there is one.
+         *
+         * need_gevar pins the boundary atoms --- `id >= v` for a `v` at or
+         * below the declared lower bound, `!(id >= v)` for a `v` above the
+         * declared upper --- once, as a persistent top-of-proof line, precisely
+         * so that a step wanting the fact can cite it. Ask for it rather than
+         * emitting the same unit again: a `pol` that needs it needs it once per
+         * use, and re-deriving it per use is what the pin exists to avoid.
+         *
+         * Nullopt when there is no such fact (a `v` strictly inside the
+         * declared bounds), when the pin was suppressed (see
+         * note_bounds_not_trivially_derivable), when assertions are on above
+         * AssertionLevel::Links, and while the pin is still queued for proof
+         * start --- so a caller during model building gets nothing and must
+         * derive the fact itself. Call this after whatever made the atom
+         * exist, since a pin for an atom nobody has asked for has not been
+         * emitted.
+         */
+        [[nodiscard]] auto boundary_pin_line(const SimpleOrProofOnlyIntegerVariableID & id, Integer v) const -> std::optional<ProofLine>;
+
+        /**
          * Set things up internally as if the specified variable was a real
          * variable, so that proof_name() etc will work with it.
          */

--- a/gcs/presolvers/cumulative_strengthening/cumulative_strengthening.cc
+++ b/gcs/presolvers/cumulative_strengthening/cumulative_strengthening.cc
@@ -1,6 +1,7 @@
 #include <gcs/constraint_id.hh>
 #include <gcs/constraints/cumulative.hh>
 #include <gcs/constraints/cumulative/derived_cumulative.hh>
+#include <gcs/constraints/cumulative/donor_view.hh>
 #include <gcs/constraints/cumulative/propagate.hh>
 #include <gcs/exception.hh>
 #include <gcs/innards/proofs/am1_from_row.hh>
@@ -43,58 +44,6 @@ using std::vector;
 
 namespace
 {
-    /// The donor's arguments, once every one of them has been confirmed
-    /// constant. A variable length, height or capacity is a v1 restriction:
-    /// with a variable height the donor's row is over bit-linearised
-    /// contribution flags rather than `height * active`, so a subset sum of the
-    /// heights is not what the row's coefficients are.
-    ///
-    /// A presence is not one of those: it is not a coefficient at all, so the
-    /// only thing that has to be read off it here is which tasks the donor
-    /// dropped for being constantly absent.
-    struct ConstantTaskData
-    {
-        vector<Integer> lengths, heights;
-        vector<bool> never_present;
-        Integer capacity;
-    };
-
-    [[nodiscard]] auto constant_task_data(const Cumulative & donor) -> optional<ConstantTaskData>
-    {
-        ConstantTaskData data{{}, {}, {}, 0_i};
-
-        auto value_of = [](const IntegerVariableID & v) -> optional<Integer> {
-            if (! is_constant_variable(v))
-                return std::nullopt;
-            return std::get<ConstantIntegerVariableID>(v).const_value;
-        };
-
-        auto capacity = value_of(donor.capacity());
-        if (! capacity)
-            return std::nullopt;
-        data.capacity = *capacity;
-
-        for (const auto & l : donor.lengths()) {
-            auto length = value_of(l);
-            if (! length)
-                return std::nullopt;
-            data.lengths.push_back(*length);
-        }
-
-        for (const auto & h : donor.heights()) {
-            auto height = value_of(h);
-            if (! height)
-                return std::nullopt;
-            data.heights.push_back(*height);
-        }
-
-        for (size_t i = 0; i < donor.starts().size(); ++i)
-            data.never_present.push_back(
-                cumulative_task_presence(donor.presences().empty() ? std::nullopt : make_optional(donor.presences()[i])).never_present);
-
-        return data;
-    }
-
     /// What the presolver worked out for one time point: the tasks that can be
     /// running then, split into the ones that fill the resource on their own
     /// and the ones that do not, and the largest load the latter can actually
@@ -194,41 +143,37 @@ auto CumulativeStrengthening::run(Problem & problem, Propagators & propagators, 
     for (const auto & donor : problem.each_constraint_of_type<Cumulative>()) {
         bump(&CumulativeStrengtheningStats::donors_seen);
 
-        auto data = constant_task_data(donor);
-        if (! data) {
+        // Everything below is an argument about the donor's per-time rows
+        // `Σ h_i·active_{i,t} ≤ C`, which only says that when every argument is
+        // a constant --- so this is where a donor that is not all constants
+        // gets reduced to the part of itself that is. The reduction is per
+        // *task*: one variable length no longer costs a whole donor its
+        // strengthening, it costs that task its term. Optional tasks need
+        // nothing at all, their presence being a conjunct inside the activity
+        // flag rather than a term beside it.
+        auto view = cumulative_donor_view(donor, state);
+        if (! view) {
             bump(&CumulativeStrengtheningStats::declined_variable_arguments);
             if (logger)
-                logger->emit_proof_comment("presolve cumulative: declining " + as_string(donor.constraint_id()) + ", non-constant arguments");
+                logger->emit_proof_comment("presolve cumulative: declining " + as_string(donor.constraint_id()) + ", capacity is not reducible");
             continue;
         }
+        if (! view->set_aside.empty())
+            bump(&CumulativeStrengtheningStats::donors_with_set_aside_tasks);
 
         const auto & starts = donor.starts();
         auto n = starts.size();
-        auto capacity = data->capacity;
+        auto capacity = view->capacity;
 
         // The same windowing install_derived_cumulative resolves, and the same
         // windowing the donor encoded: a task can be active from its earliest
         // start to its latest finish. This is the paper's `t in [est_j, lct_j)`.
-        //
-        // Optional tasks need nothing further here. The whole strengthening is
-        // an argument about the donor's rows `Σ h_i·active_{i,t} ≤ C`, and an
-        // optional task's presence lives *inside* its active flag rather than
-        // beside it, so those rows are the same shape either way and every
-        // subset sum, at-most-one and raise below reads them the same. What the
-        // presence does change is the reasons the derived propagator gives,
-        // which install_derived_cumulative handles from the arguments passed to
-        // derived_cumulative_tasks_from below.
         vector<Integer> t_lo(n, 0_i), t_hi(n, 0_i);
-        vector<size_t> active_tasks;
-        for (size_t i = 0; i < n; ++i) {
-            // A constantly absent task is one the donor dropped outright, so it
-            // has no flags and no term in any row to argue over.
-            if (data->lengths[i] <= 0_i || data->heights[i] <= 0_i || data->never_present[i])
-                continue;
-            active_tasks.push_back(i);
+        const auto & active_tasks = view->usable;
+        for (auto i : active_tasks) {
             auto [s_lo, s_hi] = state.bounds(starts[i]);
             t_lo[i] = s_lo;
-            t_hi[i] = s_hi + data->lengths[i] - 1_i;
+            t_hi[i] = s_hi + view->lengths[i] - 1_i;
         }
 
         if (active_tasks.empty()) {
@@ -239,7 +184,7 @@ auto CumulativeStrengthening::run(Problem & problem, Propagators & propagators, 
         // A height above the capacity means the donor is infeasible on its own,
         // which is the donor's business to detect and not something to build a
         // subset sum over.
-        if (std::any_of(active_tasks.begin(), active_tasks.end(), [&](size_t i) { return data->heights[i] > capacity; })) {
+        if (std::any_of(active_tasks.begin(), active_tasks.end(), [&](size_t i) { return view->heights[i] > capacity; })) {
             bump(&CumulativeStrengtheningStats::declined_nothing_to_gain);
             continue;
         }
@@ -266,7 +211,7 @@ auto CumulativeStrengthening::run(Problem & problem, Propagators & propagators, 
         vector<size_t> full_tasks, other_tasks;
         for (auto i : active_tasks) {
             auto conflicts_with_everything = std::all_of(active_tasks.begin(), active_tasks.end(),
-                [&](size_t j) { return i == j || t_hi[i] < t_lo[j] || t_hi[j] < t_lo[i] || data->heights[i] + data->heights[j] > capacity; });
+                [&](size_t j) { return i == j || t_hi[i] < t_lo[j] || t_hi[j] < t_lo[i] || view->heights[i] + view->heights[j] > capacity; });
             (conflicts_with_everything ? full_tasks : other_tasks).push_back(i);
         }
 
@@ -277,7 +222,7 @@ auto CumulativeStrengthening::run(Problem & problem, Propagators & propagators, 
         auto unentitled_raise = std::holds_alternative<cumulative_strengthening_mutation::RaiseUnentitled>(_mutation);
         if (unentitled_raise && ! other_tasks.empty()) {
             auto tallest =
-                std::max_element(other_tasks.begin(), other_tasks.end(), [&](size_t a, size_t b) { return data->heights[a] < data->heights[b]; });
+                std::max_element(other_tasks.begin(), other_tasks.end(), [&](size_t a, size_t b) { return view->heights[a] < view->heights[b]; });
             full_tasks.push_back(*tallest);
             other_tasks.erase(tallest);
             std::sort(full_tasks.begin(), full_tasks.end());
@@ -296,7 +241,7 @@ auto CumulativeStrengthening::run(Problem & problem, Propagators & propagators, 
             for (auto i : other_tasks)
                 if (t >= t_lo[i] && t <= t_hi[i]) {
                     point.tasks.push_back(i);
-                    point.heights.push_back(data->heights[i]);
+                    point.heights.push_back(view->heights[i]);
                 }
             for (auto i : full_tasks)
                 if (t >= t_lo[i] && t <= t_hi[i])
@@ -332,7 +277,7 @@ auto CumulativeStrengthening::run(Problem & problem, Propagators & propagators, 
         // capacity really is. If that is the capacity already, and no task's
         // height changes either, the donor was posted with the numbers it
         // deserved and there is nothing here.
-        auto raises_a_height = std::any_of(full_tasks.begin(), full_tasks.end(), [&](size_t i) { return data->heights[i] != kappa; });
+        auto raises_a_height = std::any_of(full_tasks.begin(), full_tasks.end(), [&](size_t i) { return view->heights[i] != kappa; });
         if (kappa >= capacity && ! raises_a_height) {
             bump(&CumulativeStrengtheningStats::declined_nothing_to_gain);
             continue;
@@ -383,7 +328,7 @@ auto CumulativeStrengthening::run(Problem & problem, Propagators & propagators, 
             by_time.emplace(point.t, move(point));
 
         auto donor_id = donor.constraint_id();
-        auto heights = data->heights;
+        auto heights = view->heights;
         auto stats = _stats;
 
         // The raised tasks occupy the whole of the strengthened resource, which
@@ -401,10 +346,10 @@ auto CumulativeStrengthening::run(Problem & problem, Propagators & propagators, 
             _mutation);
         auto raise_too_fast = std::holds_alternative<cumulative_strengthening_mutation::RaiseTooFast>(_mutation);
 
-        DerivedCumulativeSpec spec{.tasks = derived_cumulative_tasks_from(donor_id, starts, data->lengths, derived_heights, donor.presences()),
+        DerivedCumulativeSpec spec{.tasks = derived_cumulative_tasks_from(donor_id, starts, view->lengths, derived_heights, view->presences),
             .capacity = kappa,
             .row_donors = {donor_id},
-            .recipe = [donor_id, heights, capacity, kappa, by_time, stats, subset_sum_corruption, raise_too_fast, unentitled_raise](
+            .recipe = [donor_id, view = *view, heights, capacity, kappa, by_time, stats, subset_sum_corruption, raise_too_fast, unentitled_raise](
                           ProofLogger & recipe_logger, const DerivedCumulativeRows & rows, Integer t) -> optional<ProofLine> {
                 auto point = by_time.find(t);
                 if (point == by_time.end())
@@ -416,7 +361,6 @@ auto CumulativeStrengthening::run(Problem & problem, Propagators & propagators, 
                 if (donor_row_at == rows.end())
                     throw ProofError{"cumulative strengthening: the donor has no capacity row at time " + to_string(t.raw_value) +
                         ", which cannot happen for a constraint derived over all of its tasks"};
-                auto donor_row = donor_row_at->second;
 
                 auto & tracker = recipe_logger.names_and_ids_tracker();
                 auto flag_for = [&](size_t i) -> ProofFlag {
@@ -454,6 +398,16 @@ auto CumulativeStrengthening::run(Problem & problem, Propagators & propagators, 
                     recipe_logger.forget_proof_level(saved_level + 2);
                     return line;
                 };
+
+                // The row everything below argues from, reduced to the
+                // constant-argument form it reads it as: the set-aside tasks'
+                // terms weakened away, and a variable capacity replaced by the
+                // number `capacity` already holds. Working like the rest, so it
+                // goes inside the level that gets forgotten.
+                auto reduced_row = recover_constant_argument_row(recipe_logger, view, donor_id, donor_row_at->second, t, ProofLevel::Temporary);
+                if (! reduced_row)
+                    return give_back(std::nullopt);
+                auto donor_row = *reduced_row;
 
                 auto strengthen_to_kappa = [&](ProofLine source) -> ProofLine {
                     recipe_logger.emit_proof_comment(point->second.by_division ? "presolve cumulative gcd" : "presolve cumulative kappa");

--- a/gcs/presolvers/cumulative_strengthening/cumulative_strengthening.hh
+++ b/gcs/presolvers/cumulative_strengthening/cumulative_strengthening.hh
@@ -40,6 +40,14 @@ namespace gcs
         /// off each", which are different claims about the fixture.
         Integer capacity_units_removed = 0_i;
 
+        /// Donors that were strengthened over only part of themselves, because
+        /// a task's length or height is a variable and so has no constant term
+        /// in the rows the argument is made over. Its terms are weakened away
+        /// and it takes no part; what that costs is a weaker strengthening,
+        /// never a wrong one. Counted because a donor drifting into this looks
+        /// exactly like one that was strengthened in full.
+        std::size_t donors_with_set_aside_tasks = 0;
+
         /// Tasks whose height was raised to the strengthened capacity, over
         /// those donors: the other half of what the presolver does, and the
         /// only record that it happened, since a raise can leave the capacity

--- a/gcs/presolvers/cumulative_strengthening/cumulative_strengthening_test.cc
+++ b/gcs/presolvers/cumulative_strengthening/cumulative_strengthening_test.cc
@@ -117,42 +117,88 @@ namespace
         return true;
     }
 
-    /// An instance whose tasks are optional. Deliberately not folded into
-    /// Instance: a solution then carries a presence per task as well as a
-    /// start, which every other fixture in this file would have to account for
-    /// and none of them cares about.
-    struct OptionalInstance
+    /// An instance whose arguments a plain Instance cannot express: optional
+    /// tasks, and lengths, heights or a capacity that are variables rather than
+    /// constants. Kept apart from Instance because a solution then carries a
+    /// value for each of those as well as a start, which every other fixture in
+    /// this file would have to account for and none of them cares about.
+    struct GeneralInstance
     {
         vector<pair<int, int>> start_ranges;
-        vector<int> lengths;
-        vector<int> heights;
-        /// Per task, the domain its presence variable is declared over.
+        /// Per task. A range of one value posts the constant, exactly as the
+        /// plain fixtures do, so a variable only appears where one is wanted.
+        vector<pair<int, int>> length_ranges, height_ranges;
+        /// Empty for the non-optional constructor. Otherwise per task, and
+        /// always a *variable*, even for the range {1, 1}: only a constant
+        /// presence resolves away, so this is how a fixture gets a flag that
+        /// carries a presence conjunct while every rule still fires.
         vector<pair<int, int>> presence_ranges;
-        int capacity;
+        /// A range of one value posts the constant.
+        pair<int, int> capacity_range;
     };
 
-    /// Over an assignment that is every start followed by every presence, which
-    /// is the shape build_expected produces and the shape the solution callback
-    /// records.
-    auto is_satisfying(const OptionalInstance & inst, const vector<int> & assignment) -> bool
+    [[nodiscard]] auto varies(const pair<int, int> & range) -> bool
     {
+        return range.first != range.second;
+    }
+
+    /// Where each of an instance's decision variables sits in an assignment
+    /// tuple. build_expected and the solution callback both go through this, so
+    /// they cannot come to disagree about the layout.
+    struct Layout
+    {
+        vector<pair<int, int>> ranges;
+        vector<size_t> start_at;
+        vector<optional<size_t>> length_at, height_at, presence_at;
+        optional<size_t> capacity_at;
+    };
+
+    auto layout_of(const GeneralInstance & inst) -> Layout
+    {
+        Layout layout;
+        auto place = [&](const pair<int, int> & range) {
+            layout.ranges.push_back(range);
+            return layout.ranges.size() - 1;
+        };
+
+        for (const auto & range : inst.start_ranges)
+            layout.start_at.push_back(place(range));
+        for (const auto & range : inst.length_ranges)
+            layout.length_at.push_back(varies(range) ? make_optional(place(range)) : nullopt);
+        for (const auto & range : inst.height_ranges)
+            layout.height_at.push_back(varies(range) ? make_optional(place(range)) : nullopt);
+        for (const auto & range : inst.presence_ranges)
+            layout.presence_at.push_back(make_optional(place(range)));
+        if (varies(inst.capacity_range))
+            layout.capacity_at = place(inst.capacity_range);
+        return layout;
+    }
+
+    auto is_satisfying(const GeneralInstance & inst, const vector<int> & assignment) -> bool
+    {
+        auto layout = layout_of(inst);
         auto n = inst.start_ranges.size();
-        auto start = [&](size_t i) { return assignment[i]; };
-        auto present = [&](size_t i) { return assignment[n + i] != 0; };
+
+        auto at = [&](const optional<size_t> & where, const pair<int, int> & range) { return where ? assignment[*where] : range.first; };
+        auto start = [&](size_t i) { return assignment[layout.start_at[i]]; };
+        auto length = [&](size_t i) { return at(layout.length_at[i], inst.length_ranges[i]); };
+        auto height = [&](size_t i) { return at(layout.height_at[i], inst.height_ranges[i]); };
+        auto present = [&](size_t i) { return layout.presence_at.empty() || assignment[*layout.presence_at[i]] != 0; };
+        auto capacity = at(layout.capacity_at, inst.capacity_range);
 
         int t_lo = INT_MAX, t_hi = INT_MIN;
         for (size_t i = 0; i < n; ++i) {
-            if (inst.lengths[i] == 0 || inst.heights[i] == 0 || ! present(i))
+            if (length(i) == 0 || height(i) == 0 || ! present(i))
                 continue;
             t_lo = min(t_lo, start(i));
-            t_hi = max(t_hi, start(i) + inst.lengths[i] - 1);
+            t_hi = max(t_hi, start(i) + length(i) - 1);
         }
         for (int t = t_lo; t <= t_hi; ++t) {
             int load = 0;
             for (size_t i = 0; i < n; ++i)
-                if (present(i) && start(i) <= t && t < start(i) + inst.lengths[i])
-                    load += inst.heights[i];
-            if (load > inst.capacity)
+                if (present(i) && start(i) <= t && t < start(i) + length(i))
+                    load += height(i);
+            if (load > capacity)
                 return false;
         }
         return true;
@@ -235,21 +281,47 @@ namespace
         return outcome;
     }
 
-    /// Solve an optional instance, collecting the same (starts, presences)
-    /// tuples brute force produces.
-    auto solve_optional(const OptionalInstance & inst, const shared_ptr<CumulativeStrengtheningStats> & stats, const optional<string> & proof_name)
+    /// Solve a general instance, collecting the same tuples brute force
+    /// produces. A null `stats` leaves the presolver off, which is how a
+    /// fixture asks what the donor manages on its own.
+    auto solve_general(const GeneralInstance & inst, const shared_ptr<CumulativeStrengtheningStats> & stats, const optional<string> & proof_name)
         -> Outcome
     {
-        Problem p;
-        vector<IntegerVariableID> starts, presences, lengths, heights;
-        for (size_t i = 0; i < inst.start_ranges.size(); ++i) {
-            starts.push_back(p.create_integer_variable(Integer{inst.start_ranges[i].first}, Integer{inst.start_ranges[i].second}));
-            presences.push_back(p.create_integer_variable(Integer{inst.presence_ranges[i].first}, Integer{inst.presence_ranges[i].second}));
-            lengths.push_back(constant_variable(Integer{inst.lengths[i]}));
-            heights.push_back(constant_variable(Integer{inst.heights[i]}));
-        }
+        auto layout = layout_of(inst);
 
-        p.post(Cumulative{starts, lengths, heights, presences, constant_variable(Integer{inst.capacity})});
+        Problem p;
+        vector<IntegerVariableID> starts, lengths, heights, presences;
+        // In the same order layout_of places them, so that the tuples recorded
+        // below line up with the ones build_expected produces.
+        vector<IntegerVariableID> recorded;
+
+        for (const auto & [lo, hi] : inst.start_ranges)
+            starts.push_back(p.create_integer_variable(Integer{lo}, Integer{hi}));
+        recorded = starts;
+
+        auto argument = [&](const pair<int, int> & range) -> IntegerVariableID {
+            if (! varies(range))
+                return constant_variable(Integer{range.first});
+            auto v = p.create_integer_variable(Integer{range.first}, Integer{range.second});
+            recorded.push_back(v);
+            return v;
+        };
+
+        for (const auto & range : inst.length_ranges)
+            lengths.push_back(argument(range));
+        for (const auto & range : inst.height_ranges)
+            heights.push_back(argument(range));
+        // A presence is always a variable: only a constant one resolves away,
+        // and a fixture asking for presences wants the conjunct.
+        for (const auto & [lo, hi] : inst.presence_ranges)
+            presences.push_back(p.create_integer_variable(Integer{lo}, Integer{hi}));
+        recorded.insert(recorded.end(), presences.begin(), presences.end());
+        auto capacity = argument(inst.capacity_range);
+
+        if (presences.empty())
+            p.post(Cumulative{starts, lengths, heights, capacity});
+        else
+            p.post(Cumulative{starts, lengths, heights, presences, capacity});
         if (stats)
             p.add_presolver(CumulativeStrengthening{stats});
 
@@ -259,9 +331,7 @@ namespace
             SolveCallbacks{.solution = [&](const CurrentState & s) -> bool {
                                found_a_solution = true;
                                vector<int> solution;
-                               for (const auto & v : starts)
-                                   solution.push_back(s(v).raw_value);
-                               for (const auto & v : presences)
+                               for (const auto & v : recorded)
                                    solution.push_back(s(v).raw_value);
                                outcome.solutions.insert(move(solution));
                                return true;
@@ -277,6 +347,16 @@ namespace
         if (proof_name)
             verify_proof_and_clean_up(*proof_name);
         return outcome;
+    }
+
+    /// Everything a general fixture checks that is not specific to it: the
+    /// proof verified (solve_general did that), and no solution was lost.
+    auto check_solutions(const string & what, const GeneralInstance & inst, const Outcome & outcome) -> void
+    {
+        set<vector<int>> expected;
+        build_expected(expected, [&](const vector<int> & assignment) { return is_satisfying(inst, assignment); }, layout_of(inst).ranges);
+        if (expected != outcome.solutions)
+            fail("solutions do not match brute force, on " + what);
     }
 
     auto read_file(const string & name) -> string
@@ -702,10 +782,10 @@ auto main(int argc, char * argv[]) -> int
     // a task out of the energy set for want of order literals.
     for (const auto & [what, presence_range] : {pair<string, pair<int, int>>{"present", {1, 1}}, {"undecided", {0, 1}}}) {
         auto stats = make_shared<CumulativeStrengtheningStats>();
-        const OptionalInstance inst{
-            {{0, 2}, {0, 2}, {0, 2}, {0, 2}, {0, 2}}, {2, 2, 2, 2, 2}, {3, 3, 3, 3, 3}, vector<pair<int, int>>(5, presence_range), 8};
+        const GeneralInstance inst{{{0, 2}, {0, 2}, {0, 2}, {0, 2}, {0, 2}}, vector<pair<int, int>>(5, {2, 2}), vector<pair<int, int>>(5, {3, 3}),
+            vector<pair<int, int>>(5, presence_range), {8, 8}};
 
-        auto outcome = solve_optional(inst, stats, proofs ? make_optional("cumulative_strengthening_optional_" + what) : nullopt);
+        auto outcome = solve_general(inst, stats, proofs ? make_optional("cumulative_strengthening_optional_" + what) : nullopt);
 
         // The donor's heights are all multiples of three and its capacity is
         // not, so the subset sum rounds eight down to six. Assert it: a fixture
@@ -715,12 +795,7 @@ auto main(int argc, char * argv[]) -> int
         if (stats->capacity_units_removed != 2_i)
             fail("an optional-task donor was strengthened by the wrong amount, on " + what);
 
-        set<vector<int>> expected;
-        auto ranges = inst.start_ranges;
-        ranges.insert(ranges.end(), inst.presence_ranges.begin(), inst.presence_ranges.end());
-        build_expected(expected, [&](const vector<int> & assignment) { return is_satisfying(inst, assignment); }, ranges);
-        if (expected != outcome.solutions)
-            fail("optional-task solutions do not match brute force, on " + what);
+        check_solutions("optional tasks, " + what, inst, outcome);
 
         // With every task present the energy argument runs at the root and
         // refutes there --- and the donor on its own does not, which is what
@@ -729,12 +804,103 @@ auto main(int argc, char * argv[]) -> int
         if (what == "present") {
             if (! outcome.refuted_at_root)
                 fail("the strengthened energy check did not refute the all-present instance at the root");
-            if (solve_optional(inst, nullptr, nullopt).refuted_at_root)
+            if (solve_general(inst, nullptr, nullopt).refuted_at_root)
                 fail("the donor alone refuted at the root, so the fixture proves nothing");
         }
     }
 
-    // v1 restrictions, each declined loudly rather than quietly mis-derived.
+    // Variable arguments, which are a restriction on a *task* rather than on a
+    // donor. A task whose length or height is a variable has no constant term
+    // in the rows the argument is made over, so it is set aside and weakened
+    // out of them; the rest of the donor is strengthened as usual. A variable
+    // capacity is not a task at all: the whole row is reduced against the bound
+    // the capacity has at presolve time, which every inference then carries as
+    // a condition.
+    //
+    // The base is the same five-task energy gap as above, so the strengthening
+    // still bites; the fifth task is what each fixture varies.
+    {
+        auto base = [](pair<int, int> fifth_length, pair<int, int> fifth_height, pair<int, int> capacity) {
+            return GeneralInstance{{{0, 2}, {0, 2}, {0, 2}, {0, 2}, {0, 2}}, {{2, 2}, {2, 2}, {2, 2}, {2, 2}, fifth_length},
+                {{3, 3}, {3, 3}, {3, 3}, {3, 3}, fifth_height}, {}, capacity};
+        };
+
+        // A variable capacity, with every task constant. The rows are reduced
+        // against eight, which is the bound it has when the presolver looks,
+        // and the subset sum then rounds that down to six exactly as it would
+        // for a posted eight. Nothing is set aside.
+        {
+            auto stats = make_shared<CumulativeStrengtheningStats>();
+            const auto inst = base({2, 2}, {3, 3}, {6, 8});
+            auto outcome = solve_general(inst, stats, proofs ? make_optional("cumulative_strengthening_var_capacity") : nullopt);
+
+            if (stats->donors_strengthened != 1)
+                fail("a variable-capacity donor was not strengthened");
+            if (stats->capacity_units_removed != 2_i)
+                fail("a variable-capacity donor was strengthened by the wrong amount");
+            if (stats->donors_with_set_aside_tasks != 0)
+                fail("a variable capacity set a task aside, which is not what it is");
+
+            check_solutions("variable capacity", inst, outcome);
+
+            // The donor's own overload check is off for a variable capacity ---
+            // it would leave a `(b - a) * capacity` term for the wrapping RUP
+            // to dispose of over the capacity's bits --- so every energy
+            // inference here is the derived constraint's, made over a row that
+            // only holds under the condition it carries.
+            if (! outcome.refuted_at_root)
+                fail("the strengthened energy check did not refute the variable-capacity instance at the root");
+            if (solve_general(inst, nullptr, nullopt).refuted_at_root)
+                fail("the donor alone refuted the variable-capacity instance at the root");
+        }
+
+        // A variable height on the fifth task, which is the sharper of the two
+        // set-asides: its terms in the donor's rows are the bits of a
+        // linearised contribution rather than `height x active`, so all of them
+        // have to be weakened away and the published contribution key is what
+        // finds them.
+        //
+        // Four tasks of energy six need twenty-four in a window four wide,
+        // which six supplies exactly and so does not refute --- the fifth task
+        // is what tipped it over, and it no longer counts. The check here is
+        // that the donor is still strengthened over the other four, and that
+        // nothing is lost.
+        {
+            auto stats = make_shared<CumulativeStrengtheningStats>();
+            const auto inst = base({2, 2}, {1, 3}, {8, 8});
+            auto outcome = solve_general(inst, stats, proofs ? make_optional("cumulative_strengthening_var_height") : nullopt);
+
+            if (stats->donors_strengthened != 1)
+                fail("a donor with one variable height was not strengthened over the rest of itself");
+            if (stats->donors_with_set_aside_tasks != 1)
+                fail("a variable height did not set its task aside");
+
+            check_solutions("variable height", inst, outcome);
+        }
+
+        // A variable length, which leaves the rows alone --- lengths are not in
+        // them --- and breaks the pins instead, `after` being reified on
+        // `start + length` and no longer single-variable. Set aside for that,
+        // and weakened out by its one activity flag rather than by any bits.
+        {
+            auto stats = make_shared<CumulativeStrengtheningStats>();
+            const auto inst = base({1, 2}, {3, 3}, {8, 8});
+            auto outcome = solve_general(inst, stats, proofs ? make_optional("cumulative_strengthening_var_length") : nullopt);
+
+            if (stats->donors_strengthened != 1)
+                fail("a donor with one variable length was not strengthened over the rest of itself");
+            if (stats->donors_with_set_aside_tasks != 1)
+                fail("a variable length did not set its task aside");
+
+            check_solutions("variable length", inst, outcome);
+        }
+    }
+
+    // What is still declined outright: a capacity that is a *view*, whose bits
+    // are not the ones the donor's rows mention, so there is no order literal
+    // whose definition would cancel them and nothing to reduce the row against.
+    // Loudly, because a model drifting into this would otherwise just quietly
+    // stop being strengthened.
     {
         auto stats = make_shared<CumulativeStrengtheningStats>();
 
@@ -742,17 +908,16 @@ auto main(int argc, char * argv[]) -> int
         vector<IntegerVariableID> starts;
         for (int i = 0; i < 3; ++i)
             starts.push_back(p.create_integer_variable(0_i, 3_i));
-        auto varying_height = p.create_integer_variable(1_i, 6_i);
         vector<IntegerVariableID> lengths{constant_variable(2_i), constant_variable(2_i), constant_variable(2_i)},
-            heights{varying_height, constant_variable(10_i), constant_variable(15_i)};
-        p.post(Cumulative{starts, lengths, heights, constant_variable(14_i)});
+            heights{constant_variable(3_i), constant_variable(3_i), constant_variable(3_i)};
+        p.post(Cumulative{starts, lengths, heights, p.create_integer_variable(4_i, 7_i) + 1_i});
         p.add_presolver(CumulativeStrengthening{stats});
         solve_with(p, SolveCallbacks{.trace = [](const CurrentState &) -> bool { return false; }}, nullopt);
 
         if (stats->declined_variable_arguments != 1)
-            fail("a variable-height donor was not declined");
+            fail("a view-capacity donor was not declined");
         if (stats->donors_strengthened != 0)
-            fail("a variable-height donor was strengthened anyway");
+            fail("a view-capacity donor was strengthened anyway");
     }
 
     // The budget. Set to zero, the dynamic programming path is unaffordable and

--- a/gcs/presolvers/cumulative_strengthening/cumulative_strengthening_test.cc
+++ b/gcs/presolvers/cumulative_strengthening/cumulative_strengthening_test.cc
@@ -284,8 +284,8 @@ namespace
     /// Solve a general instance, collecting the same tuples brute force
     /// produces. A null `stats` leaves the presolver off, which is how a
     /// fixture asks what the donor manages on its own.
-    auto solve_general(const GeneralInstance & inst, const shared_ptr<CumulativeStrengtheningStats> & stats, const optional<string> & proof_name)
-        -> Outcome
+    auto solve_general(const GeneralInstance & inst, const shared_ptr<CumulativeStrengtheningStats> & stats, const optional<string> & proof_name,
+        bool verify = true) -> Outcome
     {
         auto layout = layout_of(inst);
 
@@ -344,7 +344,7 @@ namespace
 
         outcome.refuted_at_root = ! reached_a_node && ! found_a_solution;
 
-        if (proof_name)
+        if (proof_name && verify)
             verify_proof_and_clean_up(*proof_name);
         return outcome;
     }
@@ -852,6 +852,27 @@ auto main(int argc, char * argv[]) -> int
                 fail("the strengthened energy check did not refute the variable-capacity instance at the root");
             if (solve_general(inst, nullptr, nullopt).refuted_at_root)
                 fail("the donor alone refuted the variable-capacity instance at the root");
+
+            // The atom saying the capacity is at most its bound is *cited*, not
+            // re-derived: need_gevar pins it once as a persistent top-of-proof
+            // line and NamesAndIDsTracker::boundary_pin_line hands it over.
+            // Nothing about verification would notice a regression here --- the
+            // fallback derives the same unit and the proof still checks --- so
+            // the only way to say "once" is to count. `ge9` is the capacity's
+            // upper bound of eight plus one, and `>= 1;` is what the pin says
+            // about it; the definitions above it say `>= 9` and `>= -8`.
+            if (proofs) {
+                const string name = "cumulative_strengthening_var_capacity_pin";
+                solve_general(inst, make_shared<CumulativeStrengtheningStats>(), make_optional(name), false);
+                auto proof = read_file(name + ".pbp");
+                if (! run_veripb(name + ".opb", name + ".pbp"))
+                    fail("variable capacity: veripb rejected the proof");
+                auto pins = count_occurrences(proof, "[ge9] >= 1;");
+                if (1 != pins)
+                    fail("variable capacity: the capacity bound was written down " + std::to_string(pins) +
+                        " times, not once --- the pin is not being reused");
+                dispose_of_proof_files(name);
+            }
         }
 
         // A variable height on the fifth task, which is the sharper of the two

--- a/gcs/presolvers/inferred_cumulative/inferred_cumulative.cc
+++ b/gcs/presolvers/inferred_cumulative/inferred_cumulative.cc
@@ -471,6 +471,11 @@ auto InferredCumulative::run(Problem & problem, Propagators & propagators, State
             continue;
         }
 
+        // Variable arguments are the same story, and the same wiring gap:
+        // CumulativeDonorView reduces a donor to the tasks a derived constraint
+        // can speak about and recover_constant_argument_row weakens the rest
+        // out of every row, which is what CumulativeStrengthening now uses.
+        // Nothing here needs anything more than being pointed at them.
         auto capacity = constant_value_of(donor.capacity());
         if (! capacity) {
             bump(&InferredCumulativeStats::declined_variable_arguments);

--- a/gcs/presolvers/inferred_disjunctive/inferred_disjunctive.cc
+++ b/gcs/presolvers/inferred_disjunctive/inferred_disjunctive.cc
@@ -184,6 +184,11 @@ auto InferredDisjunctive::run(Problem & problem, Propagators & propagators, Stat
             continue;
         }
 
+        // Variable arguments are the same story, and the same wiring gap:
+        // CumulativeDonorView reduces a donor to the tasks a derived constraint
+        // can speak about and recover_constant_argument_row weakens the rest
+        // out of every row, which is what CumulativeStrengthening now uses.
+        // Nothing here needs anything more than being pointed at them.
         auto capacity = constant_value_of(donor.capacity());
         if (! capacity) {
             bump(&InferredDisjunctiveStats::declined_variable_arguments);


### PR DESCRIPTION
Stacked on #682.

The second half of "optional tasks and variable arguments in all three
presolvers": the per-task v1.

## The idea

A derived Cumulative's recipes all argue about rows of the form
`Σ h_i·active_{i,t} ≤ C`, and a donor only writes those when its arguments are
constants. So a single variable length used to cost a whole donor its
strengthening. `CumulativeDonorView` reduces a donor to the part of itself the
argument can be made over — per **task**, so the one task loses its term and the
rest of the donor is strengthened exactly as before.

`recover_constant_argument_row` does the proof half, in one `pol`.

## Set-aside tasks

Weakened out with `w`. For a constant height that is one `w` on the activity
flag; for a variable height the row's terms for that task are the bits of the
linearised contribution instead, so all of them go — which is what the newly
published `contribution_flag_key` is for. How many bits there are is *not*
published: ask for bit zero, one, two and so on until the tracker has none, the
same "is it there?" question a citer already asks of every other key.

Only the variable-height half is a tripwire. Remove the constant-height `w` and
every proof still verifies, because a recipe pins what it returns with an `ia`
and dropping a non-negative term from the left of a `≤` is a valid implication —
the pin weakens it away for free. It is written anyway so the row a recipe argues
over is the row it claims, and the code says so where someone would otherwise
delete it as untested.

## A variable capacity

The row carries `− capacity`, so its bits have to cancel against something. That
something is the **order literal for the bound the capacity has now**, not the
capacity's OPB bound row: a presolver reads a live `State`, and the declared
bound is a weaker number the moment anything has tightened it.

The literal's definition brings the bits and leaves the atom behind with a
coefficient of its own. That is paid off in the same `pol` by the unit line
saying the atom is false, added as many times as its coefficient —
`(everything the encoding could reach) − b`, worked out with
`get_bits_encoding_coeffs` over the range `tracked_bounds` reports, rather than
from anything this file assumes about the encoding's shape. The unit line holds
*permanently*, the bound having been reached before the search started, so what
comes back is unconditional and exact.

It has to be exact — recipes pin what they return, and the propagator's `pol`s
cancel against the row term by term. A conditional row carried in the reason
instead does not survive the recipe's own division: the leftover atom's
coefficient gets rounded with everything else, and the `ia` refuses it.

With nothing to do, the row is handed back untouched, so an all-constant donor's
proof is byte-identical to the one written before any of this existed. What stays
declined is a capacity that is a **view**, whose bits are not the ones the row
mentions.

## Presolvers

Wired into `CumulativeStrengthening`. `declined_variable_arguments` now means
only the view capacity; `donors_with_set_aside_tasks` counts donors strengthened
over only part of themselves, since otherwise they look exactly like donors
strengthened in full.

`InferredDisjunctive` and `InferredCumulative` still decline. That is now a
wiring gap rather than anything unsolved — the helper is theirs to call — and
their comments say so.

## Testing

Three fixtures, each built on the same five-task energy gap the donor cannot
reach for itself, so the inference is exclusively the derived constraint's:

- **variable capacity** — strengthened against the bound it has at presolve
  time, refutes at the root, donor alone does not, nothing set aside;
- **variable height** on one task — still strengthened over the other four,
  `donors_with_set_aside_tasks == 1`, enumeration matches brute force;
- **variable length** on one task — same, weakened out by its activity flag
  rather than by any bits.

The corruptions were run by hand rather than assumed: a wrong atom coefficient
gets `cumulative_strengthening_var_capacity` rejected by VeriPB, and a missing
contribution weakening gets `cumulative_strengthening_var_height` rejected. The
constant-height weakening is *not* catchable, and that is recorded rather than
papered over.

Full `ctest` green (632/632) under GCC; the cumulative and presolver tests also
built and run green under clang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173hT2hFo3MyGRBon8SHt2p