### PR TITLE
Reduce the witness rows in the two multi-donor presolvers too

### DIFF
--- a/dev_docs/cumulative-proof-logging.md
+++ b/dev_docs/cumulative-proof-logging.md
@@ -847,9 +847,13 @@ carry the same literal. Mixed arities change the degree arithmetic
 outright. The presolvers of issues 07 and 08 bridge between donors, so
 they still decline an optional one; issue 06's does not, and does not.
 
-The same two are the ones still declining a donor with variable arguments,
-which is a wiring gap rather than anything unsolved: `CumulativeDonorView`
-and `recover_constant_argument_row` are theirs to call too.
+Variable arguments they *do* take, by the same route: each reduces the row
+it is about to argue over before doing so --- `InferredDisjunctive` its
+witness's, before recovering the pairwise at-most-one from it;
+`InferredCumulative` each row of the lifting programme, before lifting
+anything out of it. Both then weaken over the donor's **usable** positions
+only, since a set-aside task's terms went out with the reduction and `w`
+on a variable the constraint no longer mentions is refused.
 
 `constraint_type()` is `cumulative_optional` for the optional form, so
 the verified-encoding chain does not silently match it against

--- a/gcs/presolvers/inferred_cumulative/inferred_cumulative.cc
+++ b/gcs/presolvers/inferred_cumulative/inferred_cumulative.cc
@@ -1,6 +1,7 @@
 #include <gcs/constraint_id.hh>
 #include <gcs/constraints/cumulative.hh>
 #include <gcs/constraints/cumulative/derived_cumulative.hh>
+#include <gcs/constraints/cumulative/donor_view.hh>
 #include <gcs/innards/proofs/flag_bridge.hh>
 #include <gcs/innards/proofs/lifted_cover_cut.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
@@ -48,6 +49,10 @@ namespace
         ConstraintID id;
         size_t size;
         Integer capacity;
+        /// What of this donor can be argued over: which of its tasks have a
+        /// constant term in its rows, and what its capacity comes to. A recipe
+        /// needs it to reduce those rows before lifting anything out of them.
+        CumulativeDonorView view;
     };
 
     /// One task, as it appears across every donor.
@@ -471,32 +476,26 @@ auto InferredCumulative::run(Problem & problem, Propagators & propagators, State
             continue;
         }
 
-        // Variable arguments are the same story, and the same wiring gap:
-        // CumulativeDonorView reduces a donor to the tasks a derived constraint
-        // can speak about and recover_constant_argument_row weakens the rest
-        // out of every row, which is what CumulativeStrengthening now uses.
-        // Nothing here needs anything more than being pointed at them.
-        auto capacity = constant_value_of(donor.capacity());
-        if (! capacity) {
+        // What of this donor a cut can be lifted out of: its capacity as a
+        // number, and the tasks whose length and height are the constants its
+        // rows put on them. A task with a variable one is set aside rather than
+        // costing the whole donor its column in the matrix --- it takes no part
+        // in any cover, and its terms come out of every row first.
+        auto view = cumulative_donor_view(donor, state);
+        if (! view) {
             bump(&InferredCumulativeStats::declined_variable_arguments);
             if (logger)
-                logger->emit_proof_comment("presolve lifted cover: declining " + as_string(donor.constraint_id()) + ", variable capacity");
+                logger->emit_proof_comment("presolve lifted cover: declining " + as_string(donor.constraint_id()) + ", capacity is not reducible");
             continue;
         }
+        if (! view->set_aside.empty())
+            bump(&InferredCumulativeStats::donors_with_set_aside_tasks);
 
         const auto & starts = donor.starts();
-        auto constant = true;
-        for (size_t i = 0; i < starts.size() && constant; ++i)
-            constant = is_constant_variable(donor.lengths()[i]) && is_constant_variable(donor.heights()[i]);
-        if (! constant) {
-            bump(&InferredCumulativeStats::declined_variable_arguments);
-            if (logger)
-                logger->emit_proof_comment("presolve lifted cover: declining " + as_string(donor.constraint_id()) + ", variable lengths or heights");
-            continue;
-        }
+        auto capacity = view->capacity;
 
         auto which = donors.size();
-        donors.push_back(Donor{donor.constraint_id(), starts.size(), *capacity});
+        donors.push_back(Donor{donor.constraint_id(), starts.size(), capacity, *view});
 
         // Every task already found needs a slot for the donor just added,
         // whether or not it turns out to appear in it --- and before the loop
@@ -506,15 +505,14 @@ auto InferredCumulative::run(Problem & problem, Propagators & propagators, State
             task.positions.resize(donors.size(), std::nullopt);
         }
 
-        for (size_t i = 0; i < starts.size(); ++i) {
-            auto length = *constant_value_of(donor.lengths()[i]);
-            auto demand = *constant_value_of(donor.heights()[i]);
-            // A task with nothing to contribute has no term in this donor's row
-            // and no flags there, and one that alone exceeds the capacity can
-            // never run at all --- the donor's own row says so, and including it
-            // would pad every cover it touched. Either way it is this *donor*
-            // that has nothing to say about it, and another may still have.
-            if (length <= 0_i || demand <= 0_i || demand > *capacity)
+        for (auto i : view->usable) {
+            auto length = view->lengths[i];
+            auto demand = view->heights[i];
+            // A task that alone exceeds the capacity can never run at all --- the
+            // donor's own row says so, and including it would pad every cover it
+            // touched. That is this *donor* having nothing to say about it, and
+            // another may still have.
+            if (demand > capacity)
                 continue;
 
             // Matched across donors by start and length, and a donor's second
@@ -832,8 +830,18 @@ auto InferredCumulative::run(Problem & problem, Propagators & propagators, State
                 auto give_up = false;
                 for (auto row : programme->row_indices) {
                     const auto & donor = recipe.donors[row];
-                    auto line = rows.find(donor.id);
-                    if (line == rows.end()) {
+                    auto found_row = rows.find(donor.id);
+                    if (found_row == rows.end()) {
+                        give_up = true;
+                        break;
+                    }
+
+                    // Reduced to the constant-argument form everything below
+                    // lifts out of: this donor's set-aside tasks weakened away,
+                    // and a variable capacity replaced by the number
+                    // `donor.capacity` already holds.
+                    auto line = recover_constant_argument_row(recipe_logger, donor.view, donor.id, found_row->second, t, ProofLevel::Temporary);
+                    if (! line) {
                         give_up = true;
                         break;
                     }
@@ -896,7 +904,7 @@ auto InferredCumulative::run(Problem & problem, Propagators & propagators, State
                     // neither a term nor a flag, and stopping there would leave
                     // the later tasks' terms in.
                     vector<ProofFlag> weaken_out;
-                    for (size_t position = 0; position < donor.size; ++position) {
+                    for (auto position : donor.view.usable) {
                         if (in_the_row.contains(position))
                             continue;
                         if (auto flag = active_flag_for(tracker, donor.id, position, t))
@@ -905,12 +913,11 @@ auto InferredCumulative::run(Problem & problem, Propagators & propagators, State
 
                     auto bridged = any_of(terms, [](const BridgedRowTerm & term) { return term.implies_row_flag.has_value(); });
                     if (! bridged) {
-                        kept_rows.push_back(line->second);
+                        kept_rows.push_back(*line);
                         kept_weaken_out.push_back(move(weaken_out));
                     }
                     else {
-                        kept_rows.push_back(
-                            recover_bridged_row(recipe_logger, line->second, terms, weaken_out, donor.capacity, ProofLevel::Temporary));
+                        kept_rows.push_back(recover_bridged_row(recipe_logger, *line, terms, weaken_out, donor.capacity, ProofLevel::Temporary));
                         kept_weaken_out.emplace_back();
                     }
                 }

--- a/gcs/presolvers/inferred_cumulative/inferred_cumulative.hh
+++ b/gcs/presolvers/inferred_cumulative/inferred_cumulative.hh
@@ -145,6 +145,14 @@ namespace gcs
         /// that bridge before it may.
         std::size_t declined_optional = 0;
         std::size_t declined_variable_arguments = 0;
+
+        /// Donors that could only be lifted out of in part, because a task's
+        /// length or height is a variable and so has no constant term in their
+        /// rows. Such a task takes no part in any cover and its terms are
+        /// weakened out of every row first; what that costs is a smaller matrix,
+        /// never a wrong cut. Counted because a donor drifting into it looks
+        /// exactly like one used in full.
+        std::size_t donors_with_set_aside_tasks = 0;
         /// Covers already inside the support of something lifted earlier, which
         /// would re-derive it and waste the subproblems (paper, Example 12).
         std::size_t dropped_visited = 0;

--- a/gcs/presolvers/inferred_cumulative/inferred_cumulative_test.cc
+++ b/gcs/presolvers/inferred_cumulative/inferred_cumulative_test.cc
@@ -53,6 +53,7 @@
 #include <algorithm>
 #include <cstdlib>
 #include <fstream>
+#include <functional>
 #include <iostream>
 #include <memory>
 #include <optional>
@@ -495,6 +496,84 @@ auto main(int argc, char * argv[]) -> int
         if (stats->largest_capacity_bound != 5_i)
             fail("cardinality: reported a bound of " + to_string(stats->largest_capacity_bound.raw_value) + ", not five");
         println(cerr, "cardinality cut: posted over three mutually compatible tasks, bound 5");
+    }
+
+    /* The same cardinality cut, over a donor that is not all constants: the
+     * capacity is a variable over [9, 10] rather than a posted ten, and a
+     * fourth task carries a variable height.
+     *
+     * The cut is argued against ten, the weakest the capacity can be, and ten
+     * is not one less than a power of two --- so the order atom the reduction
+     * resolves really does come back with a coefficient to pay off. The fourth
+     * task's terms in the row are the bits of a linearised contribution rather
+     * than `height x active`, so all of them have to come out before anything
+     * is lifted out of what is left; it takes no part in the cover, and the
+     * three demand-four tasks still fit in twos and not in threes at either
+     * capacity, so the cut is the same one.
+     */
+    {
+        const int horizon = 7, length = 3, latest = horizon - length;
+        auto stats = make_shared<InferredCumulativeStats>();
+
+        Problem p;
+        vector<IntegerVariableID> starts;
+        for (int i = 0; i < 4; ++i)
+            starts.push_back(p.create_integer_variable(0_i, Integer{latest}, "s" + to_string(i)));
+        auto capacity = p.create_integer_variable(9_i, 10_i, "capacity");
+        auto varying = p.create_integer_variable(1_i, 1_i, "h3");
+
+        vector<IntegerVariableID> lengths(4, constant_variable(Integer{length})),
+            heights{constant_variable(4_i), constant_variable(4_i), constant_variable(4_i), varying};
+        p.post(Cumulative{starts, lengths, heights, capacity});
+        p.add_presolver(InferredCumulative{stats});
+
+        set<vector<int>> solutions;
+        solve_with(p, SolveCallbacks{.solution = [&](const CurrentState & s) -> bool {
+            vector<int> solution;
+            for (const auto & v : starts)
+                solution.push_back(s(v).raw_value);
+            solution.push_back(s(capacity).raw_value);
+            solutions.insert(move(solution));
+            return true;
+        }},
+            proofs ? make_optional<ProofOptions>(ProofFileNames{"inferred_cumulative_variable_arguments"}) : nullopt);
+        if (proofs)
+            verify_proof_and_clean_up("inferred_cumulative_variable_arguments");
+
+        if (stats->cuts_posted != 1)
+            fail("variable arguments: posted " + to_string(stats->cuts_posted) + " cuts, not the one over the three constant tasks");
+        if (stats->donors_with_set_aside_tasks != 1)
+            fail("variable arguments: the variable-height task was not set aside");
+        if (stats->declined_variable_arguments != 0)
+            fail("variable arguments: the donor was declined rather than reduced");
+
+        set<vector<int>> expected;
+        vector<int> assignment(5, 0);
+        std::function<auto(std::size_t)->void> enumerate = [&](std::size_t at) {
+            if (at == assignment.size()) {
+                for (int t = 0; t < horizon; ++t) {
+                    int load = 0;
+                    for (int i = 0; i < 4; ++i)
+                        if (assignment[static_cast<std::size_t>(i)] <= t && t < assignment[static_cast<std::size_t>(i)] + length)
+                            load += (i == 3 ? 1 : 4);
+                    if (load > assignment.back())
+                        return;
+                }
+                expected.insert(assignment);
+                return;
+            }
+            auto lo = at == assignment.size() - 1 ? 9 : 0;
+            auto hi = at == assignment.size() - 1 ? 10 : latest;
+            for (auto v = lo; v <= hi; ++v) {
+                assignment[at] = v;
+                enumerate(at + 1);
+            }
+        };
+        enumerate(0);
+
+        if (expected != solutions)
+            fail("variable arguments: solutions do not match brute force");
+        println(cerr, "variable arguments: cut posted over a variable capacity, one task set aside, {} solutions", solutions.size());
     }
 
     // The window edges, which is the only place a programme is built over

--- a/gcs/presolvers/inferred_disjunctive/inferred_disjunctive.cc
+++ b/gcs/presolvers/inferred_disjunctive/inferred_disjunctive.cc
@@ -1,6 +1,7 @@
 #include <gcs/constraint_id.hh>
 #include <gcs/constraints/cumulative.hh>
 #include <gcs/constraints/cumulative/derived_cumulative.hh>
+#include <gcs/constraints/cumulative/donor_view.hh>
 #include <gcs/exception.hh>
 #include <gcs/innards/proofs/am1_from_pairs.hh>
 #include <gcs/innards/proofs/am1_from_row.hh>
@@ -69,6 +70,11 @@ namespace
         /// sweep has to go: positions with no flags are simply skipped.
         size_t size;
     };
+
+    /// The witness resources' views, by donor, as a recipe needs them: to
+    /// reduce a row to the constant-argument form build_am1_from_row reads, and
+    /// to know which of that resource's positions still have a term in it.
+    using DonorViews = map<ConstraintID, CumulativeDonorView>;
 
     /// Why a pair conflicts: the resource that cannot hold both, and the
     /// numbers saying it cannot. The demands and the capacity rather than the
@@ -165,6 +171,7 @@ auto InferredDisjunctive::run(Problem & problem, Propagators & propagators, Stat
     vector<Task> tasks;
     map<IntegerVariableID, size_t> task_of_start;
     vector<Resource> resources;
+    DonorViews views;
 
     for (const auto & donor : problem.each_constraint_of_type<Cumulative>()) {
         bump(&InferredDisjunctiveStats::donors_seen);
@@ -184,47 +191,29 @@ auto InferredDisjunctive::run(Problem & problem, Propagators & propagators, Stat
             continue;
         }
 
-        // Variable arguments are the same story, and the same wiring gap:
-        // CumulativeDonorView reduces a donor to the tasks a derived constraint
-        // can speak about and recover_constant_argument_row weakens the rest
-        // out of every row, which is what CumulativeStrengthening now uses.
-        // Nothing here needs anything more than being pointed at them.
-        auto capacity = constant_value_of(donor.capacity());
-        if (! capacity) {
+        // What of this donor an inferred constraint can argue over: its
+        // capacity as a number, and the tasks whose length and height are the
+        // constants its rows put on them. A task with a variable one is set
+        // aside rather than costing the whole resource its place in the
+        // conflict graph --- it simply cannot be a clique member, and every row
+        // this resource witnesses is weakened over it first.
+        auto view = cumulative_donor_view(donor, state);
+        if (! view) {
             bump(&InferredDisjunctiveStats::declined_variable_arguments);
             if (logger)
-                logger->emit_proof_comment("presolve disjunctive: declining " + as_string(donor.constraint_id()) + ", variable capacity");
+                logger->emit_proof_comment("presolve disjunctive: declining " + as_string(donor.constraint_id()) + ", capacity is not reducible");
             continue;
         }
-
-        vector<Integer> lengths, heights;
-        bool constant = true;
-        for (const auto & l : donor.lengths()) {
-            auto value = constant_value_of(l);
-            constant = constant && value.has_value();
-            lengths.push_back(value.value_or(0_i));
-        }
-        for (const auto & h : donor.heights()) {
-            auto value = constant_value_of(h);
-            constant = constant && value.has_value();
-            heights.push_back(value.value_or(0_i));
-        }
-        if (! constant) {
-            bump(&InferredDisjunctiveStats::declined_variable_arguments);
-            if (logger)
-                logger->emit_proof_comment("presolve disjunctive: declining " + as_string(donor.constraint_id()) + ", variable lengths or heights");
-            continue;
-        }
+        if (! view->set_aside.empty())
+            bump(&InferredDisjunctiveStats::resources_with_set_aside_tasks);
 
         const auto & starts = donor.starts();
-        resources.push_back(Resource{donor.constraint_id(), *capacity, starts.size()});
+        resources.push_back(Resource{donor.constraint_id(), view->capacity, starts.size()});
+        const auto & lengths = view->lengths;
+        const auto & heights = view->heights;
+        views.emplace(donor.constraint_id(), *view);
 
-        for (size_t i = 0; i < starts.size(); ++i) {
-            // A task that cannot load this resource has no flags on it, so it
-            // is not reachable through it even if it is listed.
-            if (lengths[i] <= 0_i || heights[i] <= 0_i)
-                continue;
-
+        for (auto i : view->usable) {
             auto found = task_of_start.find(starts[i]);
             if (found == task_of_start.end()) {
                 auto [s_lo, s_hi] = state.bounds(starts[i]);
@@ -250,11 +239,8 @@ auto InferredDisjunctive::run(Problem & problem, Propagators & propagators, Stat
     // both; the first such resource found is the witness the certificate will
     // use, since any of them proves the same at-most-one.
     map<ConstraintID, Integer> capacity_of;
-    map<ConstraintID, size_t> resource_size;
-    for (const auto & resource : resources) {
+    for (const auto & resource : resources)
         capacity_of.emplace(resource.id, resource.capacity);
-        resource_size.emplace(resource.id, resource.size);
-    }
 
     vector<vector<optional<Conflict>>> conflict(tasks.size(), vector<optional<Conflict>>(tasks.size()));
     vector<pair<size_t, size_t>> candidate_pairs;
@@ -458,7 +444,7 @@ auto InferredDisjunctive::run(Problem & problem, Propagators & propagators, Stat
         DerivedCumulativeSpec spec{.tasks = derived_tasks,
             .capacity = 1_i,
             .row_donors = vector<ConstraintID>{row_donors.begin(), row_donors.end()},
-            .recipe = [members, task_data, conflicts, resource_size, stats, claim_rhs_zero, bridge_wrong_task](
+            .recipe = [members, task_data, conflicts, views, stats, claim_rhs_zero, bridge_wrong_task](
                           ProofLogger & recipe_logger, const DerivedCumulativeRows & rows, Integer t) -> optional<ProofLine> {
                 auto & tracker = recipe_logger.names_and_ids_tracker();
 
@@ -544,19 +530,30 @@ auto InferredDisjunctive::run(Problem & problem, Propagators & propagators, Stat
                         if (row == rows.end())
                             return give_back(std::nullopt);
 
+                        // Reduced to the constant-argument form the at-most-one
+                        // program reads it as: the witness's set-aside tasks
+                        // weakened away, and a variable capacity replaced by the
+                        // number `c.capacity` already holds.
+                        const auto & witness_view = views.at(c.witness);
+                        auto reduced = recover_constant_argument_row(recipe_logger, witness_view, c.witness, row->second, t, ProofLevel::Temporary);
+                        if (! reduced)
+                            return give_back(std::nullopt);
+
                         auto u_flags = flags_for(tracker, c.witness, c.witness_position_u, t);
                         auto v_flags = flags_for(tracker, c.witness, c.witness_position_v, t);
                         if (! u_flags || ! v_flags)
                             return give_back(std::nullopt);
 
                         // Everything else on that resource that could be running
-                        // now has to come out of the row first. Over every
-                        // position, not up to the first one without flags: a
-                        // task that demands nothing of this resource has no
-                        // term in the row and no flags either, and stopping
-                        // there would leave the later tasks' terms in.
+                        // now has to come out of the row first. Over the
+                        // witness's *usable* positions: a task that demands
+                        // nothing of this resource has no term in the row and no
+                        // flags either, and one that was set aside had its terms
+                        // taken out by the reduction above --- weakening either
+                        // again would be `w` on a variable the constraint does
+                        // not mention, which VeriPB refuses.
                         vector<ProofFlag> weaken_out;
-                        for (size_t other = 0; other < resource_size.at(c.witness); ++other) {
+                        for (auto other : witness_view.usable) {
                             if (other == c.witness_position_u || other == c.witness_position_v)
                                 continue;
                             auto other_flags = flags_for(tracker, c.witness, other, t);
@@ -573,7 +570,7 @@ auto InferredDisjunctive::run(Problem & problem, Propagators & propagators, Stat
                         // is about.
                         PolBuilder pair_amo;
                         [[maybe_unused]] auto at_most =
-                            build_am1_from_row(pair_amo, row->second, {c.demand_u, c.demand_v}, weaken_out, c.capacity, tracker);
+                            build_am1_from_row(pair_amo, *reduced, {c.demand_u, c.demand_v}, weaken_out, c.capacity, tracker);
 
                         // Bridging a task onto the *other* task's flags leaves
                         // its own term uncancelled, so what is merged is not the

--- a/gcs/presolvers/inferred_disjunctive/inferred_disjunctive.hh
+++ b/gcs/presolvers/inferred_disjunctive/inferred_disjunctive.hh
@@ -86,6 +86,14 @@ namespace gcs
          */
         Integer certified_makespan_bound{0};
 
+        /// Resources that could only be argued over in part, because a task's
+        /// length or height is a variable and so has no constant term in their
+        /// rows. Such a task takes no part in the conflict graph and its terms
+        /// are weakened out of every row the resource witnesses; what that
+        /// costs is a smaller graph, never a wrong one. Counted because a
+        /// resource drifting into it looks exactly like one used in full.
+        std::size_t resources_with_set_aside_tasks = 0;
+
         /// Flag bridges emitted, one per (task, time) that had to be carried
         /// from a witnessing resource to the one holding the task's flags.
         std::size_t bridges_derived = 0;

--- a/gcs/presolvers/inferred_disjunctive/inferred_disjunctive_test.cc
+++ b/gcs/presolvers/inferred_disjunctive/inferred_disjunctive_test.cc
@@ -23,6 +23,7 @@
 
 #include <cstdlib>
 #include <fstream>
+#include <functional>
 #include <iostream>
 #include <memory>
 #include <optional>
@@ -396,6 +397,110 @@ auto main(int argc, char * argv[]) -> int
             fail("an optional-task donor was used anyway");
     }
     println(cerr, "an optional-task donor is declined");
+
+    /* Variable arguments, which are a restriction on a *task* rather than on a
+     * resource. Three tasks of length two, pairwise conflicting on three
+     * resources exactly as the family above, but with two things that family
+     * cannot say: the capacity is one shared variable over [3, 5] rather than a
+     * posted constant, and a fourth task carries a variable height.
+     *
+     * Both are the derived side of the same reduction. The capacity's rows are
+     * argued against five, the weakest it can be, which every witness's
+     * at-most-one is recovered from --- and five is not one less than a power of
+     * two, so the order atom really does come back with a coefficient to pay
+     * off. The fourth task's terms in those rows are the bits of a linearised
+     * contribution rather than `height x active`, so the reduction has to take
+     * all of them out before the at-most-one program weakens over what is left.
+     *
+     * A demand of three conflicts with another three at any capacity up to five,
+     * so the clique is the same one; the fourth task demands one, which does not
+     * conflict with three at five but does at three, so it stays a decision the
+     * search makes rather than one the presolver has taken.
+     */
+    {
+        const int k = 3, length = 2, horizon = 6, latest = horizon - length;
+        auto stats = make_shared<InferredDisjunctiveStats>();
+
+        Problem p;
+        vector<IntegerVariableID> starts;
+        for (int i = 0; i <= k; ++i)
+            starts.push_back(p.create_integer_variable(0_i, Integer{latest}, "s" + to_string(i)));
+        auto capacity = p.create_integer_variable(3_i, 5_i, "capacity");
+        auto varying = p.create_integer_variable(1_i, 1_i, "h3");
+
+        vector<IntegerVariableID> lengths(static_cast<size_t>(k) + 1, constant_variable(Integer{length}));
+        for (int r = 0; r < k; ++r) {
+            vector<IntegerVariableID> heights(static_cast<size_t>(k) + 1, constant_variable(0_i));
+            for (int i = 0; i < k; ++i)
+                for (int j = i + 1; j < k; ++j)
+                    if ((i + j) % k == r) {
+                        heights[static_cast<size_t>(i)] = constant_variable(3_i);
+                        heights[static_cast<size_t>(j)] = constant_variable(3_i);
+                    }
+            heights[static_cast<size_t>(k)] = varying;
+            p.post(Cumulative{starts, lengths, heights, capacity});
+        }
+        p.add_presolver(InferredDisjunctive{stats});
+
+        set<vector<int>> solutions;
+        solve_with(p, SolveCallbacks{.solution = [&](const CurrentState & s) -> bool {
+            vector<int> solution;
+            for (const auto & v : starts)
+                solution.push_back(s(v).raw_value);
+            solution.push_back(s(capacity).raw_value);
+            solutions.insert(move(solution));
+            return true;
+        }},
+            proofs ? make_optional<ProofOptions>(ProofFileNames{"inferred_disjunctive_variable_arguments"}) : nullopt);
+        if (proofs)
+            verify_proof_and_clean_up("inferred_disjunctive_variable_arguments");
+
+        if (stats->cliques_posted != 1)
+            fail("a clique was not posted over resources with variable arguments");
+        if (stats->resources_with_set_aside_tasks != static_cast<size_t>(k))
+            fail("the variable-height task was not set aside on every resource");
+        if (stats->declined_variable_arguments != 0)
+            fail("a resource was declined for a task's variable height, which is now a set-aside");
+
+        // Brute force over the same model: the fourth task takes part or not
+        // depending on the capacity, which is why it is in the tuple.
+        set<vector<int>> expected;
+        vector<int> assignment(static_cast<size_t>(k) + 2, 0);
+        std::function<auto(size_t)->void> enumerate = [&](size_t at) {
+            if (at == assignment.size()) {
+                for (int r = 0; r < k; ++r)
+                    for (int t = 0; t < horizon; ++t) {
+                        int load = 0;
+                        for (int i = 0; i <= k; ++i) {
+                            if (assignment[static_cast<size_t>(i)] > t || t >= assignment[static_cast<size_t>(i)] + length)
+                                continue;
+                            if (i == k)
+                                load += 1;
+                            else
+                                for (int a = 0; a < k; ++a)
+                                    for (int b = a + 1; b < k; ++b)
+                                        if ((a + b) % k == r && (i == a || i == b))
+                                            load += 3;
+                        }
+                        if (load > assignment.back())
+                            return;
+                    }
+                expected.insert(assignment);
+                return;
+            }
+            auto lo = at == assignment.size() - 1 ? 3 : 0;
+            auto hi = at == assignment.size() - 1 ? 5 : latest;
+            for (auto v = lo; v <= hi; ++v) {
+                assignment[at] = v;
+                enumerate(at + 1);
+            }
+        };
+        enumerate(0);
+
+        if (expected != solutions)
+            fail("variable-argument solutions do not match brute force");
+        println(cerr, "variable arguments: clique posted, {} solutions", solutions.size());
+    }
 
     if (! proofs) {
         println(cerr, "veripb is not available, so the proof-level checks are skipped");


### PR DESCRIPTION
Stacked on #683. Finishes "variable arguments in **all three** presolvers".

#683 built `CumulativeDonorView` and `recover_constant_argument_row` but only
pointed `CumulativeStrengthening` at them, so `InferredDisjunctive` and
`InferredCumulative` still turned a donor away for one variable length. They no
longer do.

## The wiring

The insertion point is the same in both — reduce the row before arguing over it:

- **`InferredDisjunctive`**: the witness's row, before `build_am1_from_row`
  recovers the pairwise at-most-one from it.
- **`InferredCumulative`**: each row of the lifting programme, before anything
  is lifted out of it.

The weakening sweeps then go over the donor's **usable** positions rather than
all of them. That is not tidying: a set-aside task's terms left with the
reduction, and `w` on a variable the constraint no longer mentions is refused,
so sweeping the full range would break every row it touched.

`InferredCumulative::Donor` carries its view, since the recipe needs it per row
donor; `InferredDisjunctive` keeps a `map<ConstraintID, CumulativeDonorView>`
for the same reason. Both gained a `*_with_set_aside_tasks` counter, because a
resource used in part looks exactly like one used in full.

Optional donors are still declined in both, for the reason #682 gave: they
bridge flags *between* donors, and a presence conjunct cancels across that bridge
only when both carry the same literal.

## Testing

A fixture each, built on a shape those presolvers already have a
constant-argument fixture for — so what is under test is the reduction, not the
rule:

- **`inferred_disjunctive_variable_arguments`**: the same three-task,
  three-resource conflict family, but the capacity is one shared variable over
  `[3, 5]` and a fourth task carries a variable height. Five is not one less
  than a power of two, so the order atom really does come back with a
  coefficient to pay off.
- **`inferred_cumulative_variable_arguments`**: the cardinality-cut fixture with
  a capacity over `[9, 10]` and a fourth variable-height task. Ten likewise.

Both check the clique or cut is still found, that the task was *set aside*
rather than the donor declined, and that no solution moved (60 and 600
solutions against brute force). Dropping the reduction gets each one's proof
rejected by VeriPB — `inferred_disjunctive_variable_arguments.pbp:24` and
`inferred_cumulative_variable_arguments.pbp:99` — which is how I know they are
load-bearing rather than decorative.

Full `ctest` green (632/632) under GCC; all four presolver and derived-constraint
tests also built and run green under clang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173hT2hFo3MyGRBon8SHt2p