### PR TITLE
Pin a variable-duration task's activity, instead of setting it aside (#685)

### DIFF
--- a/dev_docs/cumulative-proof-logging.md
+++ b/dev_docs/cumulative-proof-logging.md
@@ -740,14 +740,20 @@ form `Σ h_i·active_{i,t} ≤ C`, and a donor only writes those when its argume
 are constants. `CumulativeDonorView`
 ([`donor_view.hh`](../gcs/constraints/cumulative/donor_view.hh)) is what reduces
 a donor to the part of itself that is, and the reduction is per **task**: one
-task with a variable length no longer costs a whole donor its strengthening, it
+task with a variable height no longer costs a whole donor its strengthening, it
 costs that task its term.
+
+A variable **length** is not a reduction at all, and the difference is worth
+being clear about. No length appears in a capacity row, so the rows are the same
+rows and a recipe reads them identically. What a variable length costs is the
+`after` pin, and that is bought back rather than given up — see *A task whose
+length is a variable*, below.
 
 `recover_constant_argument_row` does the proof half, and it is one `pol`:
 
-- **A set-aside task** — variable length or variable height — is weakened out of
-  the row with `w`. For a constant height that is one `w` on its activity flag;
-  for a variable height the row's terms for it are the bits of the linearised
+- **A set-aside task** — a variable height — is weakened out of the row with
+  `w`. For a constant height that is one `w` on its activity flag; for a
+  variable height the row's terms for it are the bits of the linearised
   contribution, so every one of them goes, which is what
   `ConstraintProofModelData<Cumulative>::contribution_flag_key` is published for.
   How many bits there are is not published: ask for bit zero, one, two and so on
@@ -791,6 +797,75 @@ written before any of this existed.
 What stays declined is a capacity that is a **view**, whose bits are not the ones
 the row mentions, so there is no order literal whose definition would cancel
 them.
+
+### A task whose length is a variable
+
+Nothing in a capacity row mentions a length, so a derived constraint over such a
+task derives exactly the row it would otherwise. What breaks is the pin.
+`after_{i,t}` for a constant length is `s_i ≥ t − l + 1`, single-variable and
+RUP-closable from the start's bounds; for a variable one it is reified on
+`s_i + l_i ≥ t+1`, which no RUP reaches from the operands' bounds separately —
+the VeriPB linear-combination limit.
+
+`Cumulative` already solves that for itself, with a proof-only
+`end = s_i + l_i` introduced by `ProofLogger::introduce_bits_of` and a
+per-`(i, t)` bridge lemma `end ≥ t+1 → after`. Almost all of it was already
+reachable by a citer:
+
+- **The bridge lemmas need no publishing.** They go out at `ProofLevel::Top` for
+  every `(i, t)` in the donor's window, unit propagation finds them, and a
+  derived constraint's flag lookups have already established that its window is
+  inside the donor's — `find_proof_flag_values` declines otherwise.
+- **`materialise_after_sum` reads one line**, `end ≥ s + l`, plus two order
+  literals any citer makes for itself. So the whole publication requirement is
+  **one `ProofLine` per task**.
+
+That line is a **third kind of citable thing**. A labelled OPB row is found by
+`NamesAndIDsTracker::constraint_row_label` and a flag by `find_proof_flag_values`;
+a line an install initialiser *derived* has no row to label and no reification to
+key. `publish_derived_line` / `find_derived_line` is the pair for it, under a
+role `ConstraintProofModelData<Cumulative>::end_lower_bound_role` publishes like
+any other, and it hands back a line number because that is all there is to hand
+back — per-solve state, exactly as `boundary_pin_line` already keeps.
+
+It could not have been a getter on `Cumulative`. A presolver sees the constraint
+`Problem` stored, and `create_propagators` installs a *clone*; the clone is what
+ran the initialiser and the clone is what the tracker heard from. Everything a
+citer reaches goes through the tracker keyed by `ConstraintID`, and this is no
+exception.
+
+What a citer then does:
+
+- widen the task's length to an `IntegerVariableID` and window with `ub(l)`, as
+  the donor did, or the flag lookups do not line up;
+- ask `find_derived_line` for a task whose start *and* length both vary, and
+  decline if it comes back empty. Empty means the donor had a constant somewhere
+  after all, or the proof is being written with assertions on, which omits
+  definitions. Either way there is no pin to be had.
+
+`CumulativeDonorView` sets such a task aside when the answer is empty, and keeps
+it otherwise. It asks "can this task load the resource at all?" *first*: a task
+the donor gave no window — a zero height on this resource — published no proxy
+either, and would otherwise be counted as set aside for the wrong reason.
+
+The energy rules need no thought. `prepare_cumulative_overload_check` keeps only
+constant-length tasks, a window-energy lemma needing a task's energy to be a
+number, so a variable-duration task takes part in the rows and the time-tabling
+and stays out of the lemma. Where it *does* earn its place in a presolver that
+runs the energy rules alone is the (TTOC) profile term, which counts a task's
+mandatory part whether or not the lemma can speak for it — and those pins are the
+ones that go through the proxy. `cumulative_strengthening_var_length` is that
+case: four tasks of energy six fill a window of four at the strengthened capacity
+exactly, and one compulsory time point of a fifth, variable-duration task is the
+whole of the overshoot.
+
+**A tripwire.** No fixture in the tree catches the *wrong* line being published.
+Publish `end ≤ s + l` in place of `end ≥ s + l` and every proof still verifies:
+VeriPB's unit propagation reaches these `after` pins without the `pol` at all,
+the reasons instantiating the lengths and an eq atom pinning the bits the
+reification row wants. That the `pol` is load-bearing in general is pinned by
+`cumulative`'s own `len_wide` case, which fails without it. What does catch a
+broken citation here is the install declining, and nothing else.
 
 ### Deriving over an optional donor
 
@@ -855,6 +930,14 @@ anything out of it. Both then weaken over the donor's **usable** positions
 only, since a set-aside task's terms went out with the reduction and `w`
 on a variable the constraint no longer mentions is refused.
 
+A variable duration they take too, and it costs them nothing but a choice
+of bound. A window takes `ub(l)`, which is what the donor encoded its
+flags over and so the only thing that finds them; an energy sum or a
+ranking takes `lb(l)`, which is the work every solution has to contain.
+Tasks are matched across donors by the length *variable*, since the same
+variable is the same duration whatever its bounds come to, and two
+different ones are not even where their bounds agree today.
+
 `constraint_type()` is `cumulative_optional` for the optional form, so
 the verified-encoding chain does not silently match it against
 `cake_pb_cp`'s `cumulative` encoder, which would re-derive a strictly
@@ -871,7 +954,12 @@ that gap is now named rather than hidden.
   (#550) build on the clipped form, and the lifted-constraint
   presolvers (#549) on the contained one.
 - **Variable lengths, heights and capacity in the energy set.** Staged
-  deliberately; the extensions are sketched in #542.
+  deliberately; the extensions are sketched in #542. A variable-duration
+  task now takes part in a derived Cumulative's rows and time-tabling
+  (#685), and contributes its mandatory part to the (TTOC) profile term,
+  but the window-energy lemma still cannot count its energy: that needs a
+  task's energy to be a number. A variable **height** is still set aside
+  from a derived constraint altogether (#686 is the height half of #685).
 - **Conditional bounds for optional tasks.** An undecided task's start
   bounds are never pruned, because there is no conditional-bounds store
   and an unconditional prune would be unsound if the task turns out

--- a/dev_docs/cumulative-strengthening.md
+++ b/dev_docs/cumulative-strengthening.md
@@ -315,10 +315,18 @@ Variable lengths and heights are deliberately **not** on this list either, and
 nor is a variable capacity. `CumulativeDonorView`
 ([`donor_view.hh`](../gcs/constraints/cumulative/donor_view.hh)) reduces a donor
 to the part of itself the argument can be made over, per *task*: one task with a
-variable length or height is set aside and weakened out of every row, and the
-rest of the donor is strengthened exactly as before. `donors_with_set_aside_tasks`
-counts the donors that happened to, because one strengthened over four of its
-five tasks otherwise looks just like one strengthened in full.
+variable height is set aside and weakened out of every row, and the rest of the
+donor is strengthened exactly as before. `donors_with_set_aside_tasks` counts the
+donors that happened to, because one strengthened over four of its five tasks
+otherwise looks just like one strengthened in full.
+
+A variable **length** is not set aside at all. No length appears in a capacity
+row, so the rows are the same rows; what it costs is the `after` pin, and the
+donor's proof-only end proxy is what that goes through, published for the purpose
+(#685). Such a task therefore keeps its term, its window and its mandatory part
+— which is what earns it a place here, this presolver running the energy rules
+alone and the (TTOC) profile term being the one that can count a task the
+window-energy lemma cannot.
 
 Optional tasks are deliberately **not** on this list. The whole strengthening is
 an argument about the donor's per-time rows, and an optional task's presence is a
@@ -334,8 +342,9 @@ cancel across that bridge first.
 
 - **A capacity that is a view.** Its bits are not the ones the donor's rows
   mention, so there is no order literal whose definition would cancel them, and
-  nothing to reduce a row against. A *variable* capacity is fine, and a variable
-  length or height costs its own task rather than the donor — see below.
+  nothing to reduce a row against. A *variable* capacity is fine, a variable
+  height costs its own task rather than the donor, and a variable length costs
+  nothing — see below.
 - **A height above the capacity**, as above.
 - **Every task full**, which makes `kappa` zero: a disjunctive rather than a
   strengthening, and `InferredDisjunctive`'s to find.

--- a/gcs/constraints/cumulative/cumulative.cc
+++ b/gcs/constraints/cumulative/cumulative.cc
@@ -486,13 +486,15 @@ auto Cumulative::install_propagators(Propagators & propagators) -> void
         if (_presence[i] && ! is_constant_variable(*_presence[i]))
             triggers.on_instantiated.emplace_back(*_presence[i]);
 
-    // Per variable-duration task, the in-proof end = s + l definition lines
-    // {end_ge, end_le}, filled by the initialiser and read by the propagator's
-    // materialise_after_sum. Shared so the cache survives across propagator calls.
-    auto end_lines = make_shared<vector<std::optional<std::pair<ProofLine, ProofLine>>>>(_starts.size());
+    // Per variable-duration task, the in-proof `end ≥ s + l` line, filled by the
+    // initialiser and read by the propagator's materialise_after_sum. Shared so
+    // the cache survives across propagator calls --- and so that the
+    // propagator, whose inputs are built here and now, gets a line the
+    // initialiser has not derived yet.
+    auto end_ge_lines = make_shared<vector<std::optional<ProofLine>>>(_starts.size());
 
-    propagators.install_initialiser([starts = _starts, lengths = _lengths, ends = _end, active_tasks = _active_tasks, after_flags = _after_flags,
-                                        end_lines](State &, auto &, ProofLogger * const logger) -> void {
+    propagators.install_initialiser([id = constraint_id(), starts = _starts, lengths = _lengths, ends = _end, active_tasks = _active_tasks,
+                                        after_flags = _after_flags, end_ge_lines](State &, auto &, ProofLogger * const logger) -> void {
         if (! logger || logger->get_assertion_level() > AssertionLevel::Off)
             return;
         auto & tracker = logger->names_and_ids_tracker();
@@ -500,23 +502,37 @@ auto Cumulative::install_propagators(Propagators & propagators) -> void
         // extension FIRST (introduce_bits_of needs end's bits fresh for its
         // witnesses), caching end's {end_ge, end_le}. cake has no end variable,
         // so this lives entirely in the proof --- nothing in the OPB to match.
+        //
+        // end_ge is published, because a derived Cumulative over this task pins
+        // its `after` flags the same way and through the same line; end_le is
+        // the bridge lemma's business alone, and stays here.
+        vector<std::optional<ProofLine>> end_le(starts.size());
         for (auto i : active_tasks)
-            if (ends[i].has_value())
-                (*end_lines)[i] = logger->introduce_bits_of(WPBSum{} + 1_i * starts[i] + 1_i * lengths[i], *ends[i], ProofLevel::Top);
+            if (ends[i].has_value()) {
+                auto lines = logger->introduce_bits_of(WPBSum{} + 1_i * starts[i] + 1_i * lengths[i], *ends[i], ProofLevel::Top);
+                (*end_ge_lines)[i] = lines.first;
+                end_le[i] = lines.second;
+                tracker.publish_derived_line(id, ConstraintProofModelData<Cumulative>::end_lower_bound_role(i), lines.first);
+            }
         // Then, per (i, t), emit the bridge lemma `end ≥ t+1 → after`:
         //   pol( @v[id][i_t][ca][f] : ¬after → s+l ≤ t )  +  ( end ≤ s+l )
         //   = ( M·after − end + t ≥ 0 ).
         // The s+l bits cancel exactly, leaving a single-variable-in-end handle
         // that makes the propagator's after pin RUP-closable even though after
         // is reified on the two-variable s+l. end_le is the cancelling term.
+        //
+        // These need no publishing at all: they go out at ProofLevel::Top over
+        // exactly the (i, t) pairs this constraint gave the task a window for,
+        // so unit propagation finds them for whoever pins one of those flags,
+        // and a citer that could ask about a wider window would already have
+        // been turned away by the flag lookup.
         for (auto i : active_tasks) {
             if (! ends[i].has_value())
                 continue;
-            auto end_le = (*end_lines)[i]->second;
             for (const auto & after : after_flags[i]) {
                 PolBuilder lemma;
                 lemma.add(ProofLineLabel{tracker.name_of(after) + "[f]"});
-                lemma.add(end_le);
+                lemma.add(*end_le[i]);
                 lemma.emit(*logger, ProofLevel::Top);
             }
         }
@@ -534,8 +550,7 @@ auto Cumulative::install_propagators(Propagators & propagators) -> void
         .active_flags = move(_active_flags),
         .contrib_flags = move(_contrib_flags),
         .per_task_t_lo = move(_per_task_t_lo),
-        .ends = move(_end),
-        .end_lines = end_lines,
+        .end_ge_lines = end_ge_lines,
         .capacity_lines = move(_capacity_lines),
         .rules = _rules,
         .proof_mutation = _proof_mutation,
@@ -568,7 +583,7 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
     const auto & active_flags = inputs.active_flags;
     const auto & contrib_flags = inputs.contrib_flags;
     const auto & per_task_t_lo = inputs.per_task_t_lo;
-    const auto & end_lines = inputs.end_lines;
+    const auto & end_ge_lines = inputs.end_ge_lines;
     const auto & capacity_lines = inputs.capacity_lines;
     const auto & rules = inputs.rules;
     const auto & mutation = inputs.proof_mutation;
@@ -625,7 +640,7 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
         if (! (l_is_var(i) && s_is_var(i)))
             return;
         PolBuilder sp;
-        sp.add((*end_lines)[i]->first);
+        sp.add(*(*end_ge_lines)[i]);
         sp.add_for_literal(logger->names_and_ids_tracker(), starts[i] >= s_lo);
         sp.add_for_literal(logger->names_and_ids_tracker(), lengths_var[i] >= llb(i));
         sp.emit(*logger, ProofLevel::Temporary);
@@ -1272,6 +1287,12 @@ auto ConstraintProofModelData<Cumulative>::active_flag_key(size_t task, Integer 
 auto ConstraintProofModelData<Cumulative>::contribution_flag_key(size_t task, Integer t, Integer bit) -> ProofFlagKey
 {
     return ProofFlagKey{{static_cast<long long>(task), t.raw_value, bit.raw_value}, "cc"};
+}
+
+auto ConstraintProofModelData<Cumulative>::end_lower_bound_role(size_t task) -> string
+{
+    // Must stay the string install_propagators' initialiser publishes under.
+    return "end_ge_" + std::to_string(task);
 }
 
 auto Cumulative::constraint_type() const -> std::string

--- a/gcs/constraints/cumulative/cumulative.hh
+++ b/gcs/constraints/cumulative/cumulative.hh
@@ -297,6 +297,28 @@ namespace gcs
          * none at all.
          */
         [[nodiscard]] static auto contribution_flag_key(std::size_t task, Integer t, Integer bit) -> innards::ProofFlagKey;
+
+        /**
+         * \brief The role of the line saying the proof-only end proxy for this
+         * task is at least its start plus its length.
+         *
+         * This is the one publication here that is not about the OPB: a task
+         * whose start and length both vary has its `after` flag reified on the
+         * two-variable `start + length`, which no RUP reaches from the
+         * operands' bounds, so the propagator goes through a proof-only
+         * `end = start + length` instead --- and the line handing it that
+         * variable's lower bound is what any pin of `after` has to be built on.
+         * The install initialiser derives it, so ask
+         * NamesAndIDsTracker::find_derived_line rather than
+         * constraint_row_label.
+         *
+         * Nullopt from there means the same thing it means for a flag: there is
+         * nothing to cite, so do not do the thing that would need citing. A
+         * constant length or a constant start needs no proxy and publishes
+         * none; nor does a proof written with assertions on, which omits the
+         * definition along with everything else it asserts.
+         */
+        [[nodiscard]] static auto end_lower_bound_role(std::size_t task) -> std::string;
     };
 }
 

--- a/gcs/constraints/cumulative/derived_cumulative.cc
+++ b/gcs/constraints/cumulative/derived_cumulative.cc
@@ -30,7 +30,8 @@ using std::to_string;
 using std::vector;
 
 auto gcs::innards::derived_cumulative_tasks_from(const ConstraintID & donor, const vector<IntegerVariableID> & starts,
-    const vector<Integer> & lengths, const vector<Integer> & heights, const vector<IntegerVariableID> & presences) -> vector<DerivedCumulativeTask>
+    const vector<IntegerVariableID> & lengths, const vector<Integer> & heights, const vector<IntegerVariableID> & presences)
+    -> vector<DerivedCumulativeTask>
 {
     if (starts.size() != lengths.size() || starts.size() != heights.size())
         throw InvalidProblemDefinitionException{"derived Cumulative: starts, lengths, heights must have the same size"};
@@ -52,7 +53,7 @@ auto gcs::innards::install_derived_cumulative(
     if (spec.capacity < 0_i)
         throw InvalidProblemDefinitionException{"derived Cumulative: capacity must be non-negative"};
     for (const auto & task : spec.tasks)
-        if (task.length < 0_i || task.height < 0_i)
+        if (initial_state.lower_bound(task.length) < 0_i || task.height < 0_i)
             throw InvalidProblemDefinitionException{"derived Cumulative: lengths and heights must be non-negative"};
     if (! spec.recipe)
         throw InvalidProblemDefinitionException{"derived Cumulative: no recipe for deriving the capacity rows"};
@@ -76,23 +77,28 @@ auto gcs::innards::install_derived_cumulative(
 
     for (const auto & task : spec.tasks) {
         inputs->starts.push_back(task.start);
-        inputs->lengths.push_back(constant_variable(task.length));
+        inputs->lengths.push_back(task.length);
         inputs->heights.push_back(constant_variable(task.height));
     }
 
     // The same windowing a posted Cumulative resolves in prepare(): a task can
-    // be active from its earliest start to its latest finish, and one whose
-    // length or height is zero, or which can never be present at all, never
-    // raises the profile.
+    // be active from its earliest start to its latest finish, so the window
+    // takes the *largest* duration still allowed, and one whose length or
+    // height can only be zero, or which can never be present at all, never
+    // raises the profile. Reading the length's bound rather than a number is
+    // what makes this the donor's own window for a variable-duration task: the
+    // donor windowed with ub(l) too, and only the same window finds the same
+    // flags.
     inputs->per_task_t_lo.assign(n, 0_i);
     vector<Integer> per_task_t_hi(n, 0_i);
     for (size_t i = 0; i < n; ++i) {
-        if (spec.tasks[i].length <= 0_i || spec.tasks[i].height <= 0_i || never_present[i])
+        auto length_ub = initial_state.upper_bound(spec.tasks[i].length);
+        if (length_ub <= 0_i || spec.tasks[i].height <= 0_i || never_present[i])
             continue;
         inputs->active_tasks.push_back(i);
         auto [s_lo, s_hi] = initial_state.bounds(spec.tasks[i].start);
         inputs->per_task_t_lo[i] = s_lo;
-        per_task_t_hi[i] = s_hi + spec.tasks[i].length - 1_i;
+        per_task_t_hi[i] = s_hi + length_ub - 1_i;
     }
 
     if (inputs->active_tasks.empty())
@@ -118,12 +124,34 @@ auto gcs::innards::install_derived_cumulative(
         inputs->after_flags.assign(n, {});
         inputs->active_flags.assign(n, {});
         inputs->contrib_flags.assign(n, {});
-        inputs->ends.assign(n, std::nullopt);
-        inputs->end_lines = make_shared<vector<std::optional<std::pair<ProofLine, ProofLine>>>>(n);
+        inputs->end_ge_lines = make_shared<vector<std::optional<ProofLine>>>(n);
 
         for (auto i : inputs->active_tasks) {
             const auto & task = spec.tasks[i];
             auto position = task.position;
+
+            // A task whose start and length both vary has its `after` reified
+            // on the two-variable `start + length`, so pinning one goes through
+            // the donor's proof-only end proxy --- and through the line giving
+            // that proxy its lower bound, which is the donor's to publish and
+            // ours only to cite. Missing means the donor derived none: it has a
+            // constant somewhere after all, or the proof is being written with
+            // assertions on, which omits definitions. Either way there is
+            // nothing to pin `after` with, so decline rather than reach for a
+            // RUP that cannot close.
+            //
+            // The bridge lemmas that make the pin land, `end >= t+1 -> after`,
+            // need no such lookup: the donor emitted one at ProofLevel::Top for
+            // every (i, t) it gave the task a window for, unit propagation
+            // finds them, and the flag lookups below have already established
+            // that this constraint's window is inside that one.
+            if (! is_constant_variable(task.start) && ! is_constant_variable(task.length)) {
+                auto end_ge = tracker.find_derived_line(task.donor, ConstraintProofModelData<Cumulative>::end_lower_bound_role(position));
+                if (! end_ge)
+                    return false;
+                (*inputs->end_ge_lines)[i] = *end_ge;
+            }
+
             for (Integer t = inputs->per_task_t_lo[i]; t <= per_task_t_hi[i]; ++t) {
                 auto before = tracker.find_proof_flag_values(task.donor, ConstraintProofModelData<Cumulative>::before_flag_key(position, t));
                 auto after = tracker.find_proof_flag_values(task.donor, ConstraintProofModelData<Cumulative>::after_flag_key(position, t));
@@ -216,8 +244,13 @@ auto gcs::innards::install_derived_cumulative(
         vector<std::optional<IntegerVariableID>> energy_presences;
         for (auto i : inputs->overload_tasks) {
             energy_presences.push_back(inputs->presence[i]);
+            // A constant, and by construction: prepare_cumulative_overload_check
+            // keeps only tasks whose length and height are, the window-energy
+            // lemma needing a task's energy to be a number before it can count
+            // it. So a variable-duration task takes part in the time-tabling
+            // and in the rows, and stays out of the energy argument.
             energy_tasks.push_back(makespan_energy::EnergyTask{.start = std::get<SimpleIntegerVariableID>(spec.tasks[i].start),
-                .length = spec.tasks[i].length,
+                .length = std::get<ConstantIntegerVariableID>(spec.tasks[i].length).const_value,
                 .height = spec.tasks[i].height,
                 .t_lo = inputs->per_task_t_lo[i],
                 .t_hi = per_task_t_hi[i],

--- a/gcs/constraints/cumulative/derived_cumulative.hh
+++ b/gcs/constraints/cumulative/derived_cumulative.hh
@@ -57,6 +57,12 @@ namespace gcs::innards
         /// longer single-variable --- so such a task is only usable where its
         /// donor published the `end >= start + length` line the propagator pins
         /// through, which is what install_derived_cumulative goes looking for.
+        ///
+        /// The same caller's-job warning \ref start carries, and only half
+        /// checkable: naming a variable where the donor had a constant is
+        /// declined, there being no proxy to pin through, but naming a
+        /// *different* variable where the donor had one is a proxy for the
+        /// wrong sum and nothing here can tell.
         IntegerVariableID length;
 
         /// Constant by type, which is the v1 restriction made structural: a

--- a/gcs/constraints/cumulative/derived_cumulative.hh
+++ b/gcs/constraints/cumulative/derived_cumulative.hh
@@ -50,11 +50,20 @@ namespace gcs::innards
         /// would silently mean something else.
         IntegerVariableID start;
 
+        /// The length as the donor was posted with it at `position`, which may
+        /// be a variable: nothing about a length appears in a capacity row, so
+        /// a derived row is the same row either way. What a variable one costs
+        /// is the `after` pin, which is then reified on `start + length` and no
+        /// longer single-variable --- so such a task is only usable where its
+        /// donor published the `end >= start + length` line the propagator pins
+        /// through, which is what install_derived_cumulative goes looking for.
+        IntegerVariableID length;
+
         /// Constant by type, which is the v1 restriction made structural: a
         /// variable height enters a donor's capacity row as a bit-linearised
         /// contribution rather than as `height x active`, and a derived row
         /// would have to speak about those bits too.
-        Integer length, height;
+        Integer height;
 
         /// The presence argument the donor was posted with at `position`, or
         /// nullopt when the donor is not an optional-task Cumulative. As
@@ -182,7 +191,7 @@ namespace gcs::innards
      * \ingroup Innards
      */
     [[nodiscard]] auto derived_cumulative_tasks_from(const ConstraintID & donor, const std::vector<IntegerVariableID> & starts,
-        const std::vector<Integer> & lengths, const std::vector<Integer> & heights, const std::vector<IntegerVariableID> & presences = {})
+        const std::vector<IntegerVariableID> & lengths, const std::vector<Integer> & heights, const std::vector<IntegerVariableID> & presences = {})
         -> std::vector<DerivedCumulativeTask>;
 
     /**

--- a/gcs/constraints/cumulative/derived_cumulative_test.cc
+++ b/gcs/constraints/cumulative/derived_cumulative_test.cc
@@ -135,9 +135,8 @@ namespace
         [[nodiscard]] auto run(Problem & problem, Propagators & propagators, State & state, ProofLogger * const logger) -> bool override
         {
             for (const auto & donor : problem.each_constraint_of_type<Cumulative>()) {
-                vector<Integer> lengths, heights;
-                for (const auto & l : donor.lengths())
-                    lengths.push_back(constant_value_of(l));
+                const auto & lengths = donor.lengths();
+                vector<Integer> heights;
                 for (const auto & h : donor.heights())
                     heights.push_back(constant_value_of(h));
                 auto capacity = constant_value_of(donor.capacity());
@@ -147,7 +146,7 @@ namespace
                 // loads has no term in the row to divide.
                 auto divisor = 0_i;
                 for (size_t i = 0; i < heights.size(); ++i)
-                    if (lengths[i] > 0_i && heights[i] > 0_i)
+                    if (state.upper_bound(lengths[i]) > 0_i && heights[i] > 0_i)
                         divisor = Integer{std::gcd(divisor.raw_value, heights[i].raw_value)};
 
                 auto donor_id = donor.constraint_id();
@@ -191,12 +190,15 @@ namespace
                     // contract.
                     auto starts = donor.starts();
                     auto claim_one_lower = (demo == Demo::ClaimOneLower);
-                    spec.recipe = [starts, heights, lengths, capacity, donor_id, claim_one_lower, row_of, &state](
+                    vector<Integer> length_ubs;
+                    for (const auto & l : lengths)
+                        length_ubs.push_back(state.upper_bound(l));
+                    spec.recipe = [starts, heights, length_ubs, capacity, donor_id, claim_one_lower, row_of, &state](
                                       ProofLogger & logger, const DerivedCumulativeRows & rows, Integer t) -> optional<ProofLine> {
                         auto donor_row = row_of(rows);
                         vector<SubsetSumItem> items;
                         for (size_t i = 0; i < starts.size(); ++i) {
-                            if (lengths[i] <= 0_i || heights[i] <= 0_i)
+                            if (length_ubs[i] <= 0_i || heights[i] <= 0_i)
                                 continue;
                             auto active = logger.names_and_ids_tracker().find_proof_flag_values(
                                 donor_id, ConstraintProofModelData<Cumulative>::active_flag_key(i, t));
@@ -253,7 +255,7 @@ namespace
                     // constraint's last time point is one the donor never
                     // encoded a flag for.
                     for (auto & task : spec.tasks)
-                        task.length += 1_i;
+                        task.length = constant_variable(constant_value_of(task.length) + 1_i);
                     spec.recipe = [row_of](ProofLogger & logger, const DerivedCumulativeRows & rows, Integer) -> optional<ProofLine> {
                         PolBuilder copy;
                         copy.add(row_of(rows));
@@ -272,6 +274,67 @@ namespace
             auto result = make_unique<DerivedDemoPresolver>(demo, makespan);
             result->installed = installed;
             result->bound_reached = bound_reached;
+            return result;
+        }
+    };
+
+    /// Duplicates each donor's rows and each donor's tasks, lengths included ---
+    /// so where a donor was posted with a variable duration, so is this, and
+    /// every pin of that task's `after` has to go through the proof-only end
+    /// proxy the donor published.
+    ///
+    /// Kept apart from DerivedDemoPresolver, whose Instance says what a length
+    /// is with an `int`, and which therefore cannot express the thing being
+    /// tested here.
+    struct DerivedVariableLengthPresolver : Presolver
+    {
+        /// A length to substitute for every task's, for the fixture that names
+        /// a variable where its donor had a constant: there is then no proxy
+        /// for the pins to go through, and installing must be declined rather
+        /// than left to fail at the first inference.
+        optional<IntegerVariableID> length_override;
+
+        /// Set by run(), read by the test: whether anything was installed.
+        std::shared_ptr<bool> installed = std::make_shared<bool>(false);
+
+        explicit DerivedVariableLengthPresolver(optional<IntegerVariableID> o = nullopt) : length_override(o)
+        {
+        }
+
+        [[nodiscard]] auto run(Problem & problem, Propagators & propagators, State & state, ProofLogger * const logger) -> bool override
+        {
+            for (const auto & donor : problem.each_constraint_of_type<Cumulative>()) {
+                auto lengths = donor.lengths();
+                if (length_override)
+                    lengths.assign(lengths.size(), *length_override);
+
+                vector<Integer> heights;
+                for (const auto & h : donor.heights())
+                    heights.push_back(constant_value_of(h));
+
+                auto donor_id = donor.constraint_id();
+                DerivedCumulativeSpec spec{.tasks = derived_cumulative_tasks_from(donor_id, donor.starts(), lengths, heights),
+                    .capacity = constant_value_of(donor.capacity()),
+                    .row_donors = {donor_id},
+                    .recipe = [donor_id](ProofLogger & recipe_logger, const DerivedCumulativeRows & rows, Integer) -> optional<ProofLine> {
+                        auto at = rows.find(donor_id);
+                        if (at == rows.end())
+                            fail("the donor had no capacity row where the derived constraint has one");
+                        PolBuilder copy;
+                        copy.add(at->second);
+                        return copy.emit(recipe_logger, ProofLevel::Top);
+                    },
+                    .rules = CumulativeRules{}};
+
+                *installed = install_derived_cumulative(propagators, state, logger, move(spec));
+            }
+            return true;
+        }
+
+        [[nodiscard]] auto clone() const -> unique_ptr<Presolver> override
+        {
+            auto result = make_unique<DerivedVariableLengthPresolver>(length_override);
+            result->installed = installed;
             return result;
         }
     };
@@ -677,6 +740,128 @@ auto main(int argc, char * argv[]) -> int
             if (*installed)
                 fail("a derived constraint reaching past the donor's windows was installed anyway");
             dispose_of_proof_files("derived_cumulative_beyond_window");
+        }
+    }
+
+    /* A donor with variable durations, which the derived constraint takes as
+     * they are. Nothing about a length appears in a capacity row, so the
+     * duplicate recipe is the same one line as ever; what changes is every
+     * *pin*, `after` being reified on the two-variable `start + length`, which
+     * no RUP reaches from the operands' bounds. The propagator goes through the
+     * donor's proof-only `end = start + length` instead, and the line handing
+     * that proxy its lower bound is what the donor publishes and this cites.
+     *
+     * All three lengths are variables, so there is no pin here that does *not*
+     * go that way. The donor has every rule turned off, so every inference in
+     * the proof is the derived constraint's --- and the three tasks each demand
+     * two of a capacity of three, so they may not overlap and there is plenty to
+     * infer: at length two apiece over starts in [0, 4] the only schedules left
+     * are the permutations of {0, 2, 4}, and the first task's shorter option
+     * opens up a handful more.
+     */
+    {
+        const vector<pair<int, int>> length_ranges{{1, 2}, {2, 2}, {2, 2}};
+
+        auto solve_variable_lengths = [&](bool derive, const optional<string> & proof_name) {
+            Problem p;
+            vector<IntegerVariableID> starts, lengths;
+            for (size_t i = 0; i < length_ranges.size(); ++i) {
+                starts.push_back(p.create_integer_variable(0_i, 4_i, "start" + std::to_string(i)));
+                lengths.push_back(
+                    p.create_integer_variable(Integer{length_ranges[i].first}, Integer{length_ranges[i].second}, "length" + std::to_string(i)));
+            }
+            vector<IntegerVariableID> heights(length_ranges.size(), constant_variable(2_i));
+
+            p.post(Cumulative{starts, lengths, heights, constant_variable(3_i)}.with_rules(
+                CumulativeRules{.time_table = false, .overload = false, .profile_overload = false}));
+
+            DerivedVariableLengthPresolver presolver;
+            auto installed = presolver.installed;
+            if (derive)
+                p.add_presolver(presolver);
+
+            set<vector<int>> solutions;
+            solve_with(p, SolveCallbacks{.solution = [&](const CurrentState & s) -> bool {
+                vector<int> solution;
+                for (const auto & v : starts)
+                    solution.push_back(s(v).raw_value);
+                for (const auto & v : lengths)
+                    solution.push_back(s(v).raw_value);
+                solutions.insert(move(solution));
+                return true;
+            }},
+                proof_name ? make_optional<ProofOptions>(ProofFileNames{*proof_name}) : nullopt);
+            return pair{move(solutions), installed};
+        };
+
+        auto [with_derived, installed] = solve_variable_lengths(true, proofs ? make_optional("derived_cumulative_variable_lengths") : nullopt);
+        if (proofs) {
+            if (! *installed)
+                fail("a derived constraint over a variable-duration donor was not installed");
+            verify_proof_and_clean_up("derived_cumulative_variable_lengths");
+        }
+
+        // Against brute force rather than against the donor: with every rule
+        // off the donor is not even a checker, so what the derived constraint
+        // has to agree with is the model, not it.
+        set<vector<int>> expected;
+        vector<pair<int, int>> ranges{{0, 4}, {0, 4}, {0, 4}};
+        ranges.insert(ranges.end(), length_ranges.begin(), length_ranges.end());
+        build_expected(
+            expected,
+            [&](const vector<int> & assignment) {
+                for (int t = 0; t <= 6; ++t) {
+                    int load = 0;
+                    for (size_t i = 0; i < 3; ++i)
+                        if (assignment[i] <= t && t < assignment[i] + assignment[i + 3])
+                            load += 2;
+                    if (load > 3)
+                        return false;
+                }
+                return true;
+            },
+            ranges);
+        if (with_derived != expected)
+            fail("a derived constraint over a variable-duration donor does not agree with brute force");
+
+        // Not a no-op: with every rule off the donor prunes nothing, so every
+        // node the search did not have to visit is the derived constraint's
+        // doing, and its pins are what wrote the proof above.
+        auto without_derived = solve_variable_lengths(false, nullopt).first;
+        if (without_derived.size() <= with_derived.size())
+            fail("the donor rejected as much as the derived constraint did, so the fixture proves nothing");
+    }
+
+    /* And the caller error the publication makes catchable: a derived task that
+     * claims a variable length where its donor was posted with a constant one.
+     * The donor introduced no end proxy for such a task and published no line,
+     * so there is nothing for a pin of its `after` to be built on --- and
+     * installing anyway would mean a propagator whose first inference has no
+     * justification to write. Declined, exactly as a task reaching past the
+     * donor's windows is.
+     */
+    {
+        Problem p;
+        vector<IntegerVariableID> starts;
+        for (int i = 0; i < 3; ++i)
+            starts.push_back(p.create_integer_variable(0_i, 4_i, "start" + std::to_string(i)));
+        // Only a variable is one, whatever its domain: a length of exactly two
+        // says the same thing the donor's constant two does, so what the
+        // decline is about is unmistakably the missing proxy.
+        auto length = p.create_integer_variable(2_i, 2_i, "length");
+        vector<IntegerVariableID> lengths(3, constant_variable(2_i)), heights(3, constant_variable(2_i));
+
+        p.post(Cumulative{starts, lengths, heights, constant_variable(3_i)});
+        DerivedVariableLengthPresolver presolver{make_optional(length)};
+        auto installed = presolver.installed;
+        p.add_presolver(presolver);
+
+        solve_with(p, SolveCallbacks{.trace = [](const CurrentState &) -> bool { return false; }},
+            proofs ? make_optional<ProofOptions>(ProofFileNames{"derived_cumulative_length_without_proxy"}) : nullopt);
+        if (proofs) {
+            if (*installed)
+                fail("a derived task claiming a variable length its donor never gave a proxy was installed anyway");
+            dispose_of_proof_files("derived_cumulative_length_without_proxy");
         }
     }
 

--- a/gcs/constraints/cumulative/derived_cumulative_test.cc
+++ b/gcs/constraints/cumulative/derived_cumulative_test.cc
@@ -746,33 +746,42 @@ auto main(int argc, char * argv[]) -> int
     /* A donor with variable durations, which the derived constraint takes as
      * they are. Nothing about a length appears in a capacity row, so the
      * duplicate recipe is the same one line as ever; what changes is every
-     * *pin*, `after` being reified on the two-variable `start + length`, which
-     * no RUP reaches from the operands' bounds. The propagator goes through the
-     * donor's proof-only `end = start + length` instead, and the line handing
-     * that proxy its lower bound is what the donor publishes and this cites.
+     * *pin*, `after` being reified on the two-variable `start + length`. The
+     * propagator goes through the donor's proof-only `end = start + length`
+     * instead, and the line handing that proxy its lower bound is what the
+     * donor publishes and this cites.
      *
-     * All three lengths are variables, so there is no pin here that does *not*
-     * go that way. The donor has every rule turned off, so every inference in
-     * the proof is the derived constraint's --- and the three tasks each demand
-     * two of a capacity of three, so they may not overlap and there is plenty to
-     * infer: at length two apiece over starts in [0, 4] the only schedules left
-     * are the permutations of {0, 2, 4}, and the first task's shorter option
-     * opens up a handful more.
+     * Both lengths are variables, so there is no pin here that does not go that
+     * way, and the donor has every rule turned off, so every inference in the
+     * proof is the derived constraint's. Two unit-demand tasks on a unit
+     * resource may not overlap, and over starts in [0, 6] at durations in
+     * [3, 5] that leaves plenty to infer.
+     *
+     * What this fixture does *not* establish, and a tripwire for whoever
+     * assumes it does: that the published line is the right one. Publish
+     * `end <= start + length` instead of `end >= start + length` and every
+     * proof here still verifies, because VeriPB's unit propagation reaches
+     * these `after` pins without the `pol` at all --- the reasons instantiate
+     * the lengths, and an eq atom pins the bits the reification row needs. That
+     * the `pol` is load-bearing in general is pinned instead by cumulative's
+     * own len_wide case, which fails without it. So: a change here that stops
+     * this citing what materialise_after_sum needs will be caught by the
+     * install declining (below) and by nothing else in this file.
      */
     {
-        const vector<pair<int, int>> length_ranges{{1, 2}, {2, 2}, {2, 2}};
+        const vector<pair<int, int>> length_ranges{{3, 5}, {3, 5}};
 
         auto solve_variable_lengths = [&](bool derive, const optional<string> & proof_name) {
             Problem p;
             vector<IntegerVariableID> starts, lengths;
             for (size_t i = 0; i < length_ranges.size(); ++i) {
-                starts.push_back(p.create_integer_variable(0_i, 4_i, "start" + std::to_string(i)));
+                starts.push_back(p.create_integer_variable(0_i, 6_i, "start" + std::to_string(i)));
                 lengths.push_back(
                     p.create_integer_variable(Integer{length_ranges[i].first}, Integer{length_ranges[i].second}, "length" + std::to_string(i)));
             }
-            vector<IntegerVariableID> heights(length_ranges.size(), constant_variable(2_i));
+            vector<IntegerVariableID> heights(length_ranges.size(), constant_variable(1_i));
 
-            p.post(Cumulative{starts, lengths, heights, constant_variable(3_i)}.with_rules(
+            p.post(Cumulative{starts, lengths, heights, constant_variable(1_i)}.with_rules(
                 CumulativeRules{.time_table = false, .overload = false, .profile_overload = false}));
 
             DerivedVariableLengthPresolver presolver;
@@ -805,17 +814,17 @@ auto main(int argc, char * argv[]) -> int
         // off the donor is not even a checker, so what the derived constraint
         // has to agree with is the model, not it.
         set<vector<int>> expected;
-        vector<pair<int, int>> ranges{{0, 4}, {0, 4}, {0, 4}};
+        vector<pair<int, int>> ranges{{0, 6}, {0, 6}};
         ranges.insert(ranges.end(), length_ranges.begin(), length_ranges.end());
         build_expected(
             expected,
             [&](const vector<int> & assignment) {
-                for (int t = 0; t <= 6; ++t) {
+                for (int t = 0; t <= 11; ++t) {
                     int load = 0;
-                    for (size_t i = 0; i < 3; ++i)
-                        if (assignment[i] <= t && t < assignment[i] + assignment[i + 3])
-                            load += 2;
-                    if (load > 3)
+                    for (size_t i = 0; i < 2; ++i)
+                        if (assignment[i] <= t && t < assignment[i] + assignment[i + 2])
+                            load += 1;
+                    if (load > 1)
                         return false;
                 }
                 return true;
@@ -844,7 +853,7 @@ auto main(int argc, char * argv[]) -> int
         Problem p;
         vector<IntegerVariableID> starts;
         for (int i = 0; i < 3; ++i)
-            starts.push_back(p.create_integer_variable(0_i, 4_i, "start" + std::to_string(i)));
+            starts.push_back(p.create_integer_variable(0_i, 6_i, "start" + std::to_string(i)));
         // Only a variable is one, whatever its domain: a length of exactly two
         // says the same thing the donor's constant two does, so what the
         // decline is about is unmistakably the missing proxy.

--- a/gcs/constraints/cumulative/donor_view.cc
+++ b/gcs/constraints/cumulative/donor_view.cc
@@ -64,31 +64,35 @@ auto gcs::innards::cumulative_donor_view(const Cumulative & donor, const State &
             continue;
         }
 
-        // A variable length is not. It leaves the row untouched --- no length
-        // appears in one --- and costs the *pins* instead: `after` is then
-        // reified on the two-variable `start + length`, which no RUP reaches
-        // from the operands' bounds, so pinning it goes through the donor's
-        // proof-only end proxy and through the line giving that proxy its lower
-        // bound. That line is the donor's to publish, and asking for it is the
-        // whole test: a constant start needs no proxy and publishes none, and a
-        // proof written with assertions on omits the definition along with
-        // everything else it asserts. With no logger there is nothing to pin
-        // and nothing to ask.
+        // A task that can never load the resource, or that was posted as
+        // constantly absent, has no flags and no term in any row: nothing to
+        // set aside, because there is nothing there. Asked before the length
+        // test below, and that is not an ordering nicety: the donor gave such a
+        // task no window, so it published no end proxy for it either, and
+        // asking would come back with the same nullopt a genuinely unusable
+        // duration does. The largest duration still allowed is what says
+        // whether it can run at all, and is the same bound the donor windowed
+        // its flags with.
+        auto presence = cumulative_task_presence(view.presences.empty() ? nullopt : make_optional(view.presences[i]));
+        if (state.upper_bound(length) <= 0_i || const_value_of(height) <= 0_i || presence.never_present)
+            continue;
+
+        // A variable length is not a set-aside. It leaves the row untouched ---
+        // no length appears in one --- and costs the *pins* instead: `after` is
+        // then reified on the two-variable `start + length`, which no RUP
+        // reaches from the operands' bounds, so pinning it goes through the
+        // donor's proof-only end proxy and through the line giving that proxy
+        // its lower bound. That line is the donor's to publish, and asking for
+        // it is the whole test: a constant start needs no proxy and publishes
+        // none, and a proof written with assertions on omits the definition
+        // along with everything else it asserts. With no logger there is
+        // nothing to pin and nothing to ask.
         if (logger && ! is_constant_variable(length) && ! is_constant_variable(donor.starts()[i]) &&
             ! logger->names_and_ids_tracker().find_derived_line(
                 donor.constraint_id(), ConstraintProofModelData<Cumulative>::end_lower_bound_role(i))) {
             view.set_aside.push_back(i);
             continue;
         }
-
-        // A task that can never load the resource, or that was posted as
-        // constantly absent, has no flags and no term in any row: nothing to
-        // set aside, because there is nothing there. The largest duration still
-        // allowed is what says whether it can run at all, and is the same bound
-        // the donor windowed its flags with.
-        auto presence = cumulative_task_presence(view.presences.empty() ? nullopt : make_optional(view.presences[i]));
-        if (state.upper_bound(length) <= 0_i || const_value_of(height) <= 0_i || presence.never_present)
-            continue;
 
         view.lengths[i] = length;
         view.heights[i] = const_value_of(height);

--- a/gcs/constraints/cumulative/donor_view.cc
+++ b/gcs/constraints/cumulative/donor_view.cc
@@ -28,7 +28,8 @@ using std::optional;
 using std::size_t;
 using std::vector;
 
-auto gcs::innards::cumulative_donor_view(const Cumulative & donor, const State & state) -> optional<CumulativeDonorView>
+auto gcs::innards::cumulative_donor_view(const Cumulative & donor, const State & state, const ProofLogger * const logger)
+    -> optional<CumulativeDonorView>
 {
     CumulativeDonorView view;
     auto n = donor.starts().size();
@@ -46,32 +47,50 @@ auto gcs::innards::cumulative_donor_view(const Cumulative & donor, const State &
         view.capacity_bounded_by = donor.capacity();
     }
 
-    view.lengths.assign(n, 0_i);
+    view.lengths.assign(n, constant_variable(0_i));
     view.heights.assign(n, 0_i);
     view.presences = donor.presences();
 
     for (size_t i = 0; i < n; ++i) {
         auto length = donor.lengths()[i], height = donor.heights()[i];
 
-        // A variable length or height is what a set-aside is for. The height
-        // is the sharper of the two: it makes the donor's row terms the bits of
-        // a linearised contribution rather than `height x active`, so a subset
-        // sum of the heights is not a subset sum of the row's coefficients. A
-        // variable length leaves the row alone but not the pins, whose `after`
-        // is then reified on `start + length` and no longer single-variable.
-        if (! is_constant_variable(length) || ! is_constant_variable(height)) {
+        // A variable height is what a set-aside is for: it makes the donor's
+        // row terms the bits of a linearised contribution rather than
+        // `height x active`, so a subset sum of the heights is not a subset sum
+        // of the row's coefficients, and nothing a recipe does to that row is
+        // an argument about this task.
+        if (! is_constant_variable(height)) {
+            view.set_aside.push_back(i);
+            continue;
+        }
+
+        // A variable length is not. It leaves the row untouched --- no length
+        // appears in one --- and costs the *pins* instead: `after` is then
+        // reified on the two-variable `start + length`, which no RUP reaches
+        // from the operands' bounds, so pinning it goes through the donor's
+        // proof-only end proxy and through the line giving that proxy its lower
+        // bound. That line is the donor's to publish, and asking for it is the
+        // whole test: a constant start needs no proxy and publishes none, and a
+        // proof written with assertions on omits the definition along with
+        // everything else it asserts. With no logger there is nothing to pin
+        // and nothing to ask.
+        if (logger && ! is_constant_variable(length) && ! is_constant_variable(donor.starts()[i]) &&
+            ! logger->names_and_ids_tracker().find_derived_line(
+                donor.constraint_id(), ConstraintProofModelData<Cumulative>::end_lower_bound_role(i))) {
             view.set_aside.push_back(i);
             continue;
         }
 
         // A task that can never load the resource, or that was posted as
         // constantly absent, has no flags and no term in any row: nothing to
-        // set aside, because there is nothing there.
+        // set aside, because there is nothing there. The largest duration still
+        // allowed is what says whether it can run at all, and is the same bound
+        // the donor windowed its flags with.
         auto presence = cumulative_task_presence(view.presences.empty() ? nullopt : make_optional(view.presences[i]));
-        if (const_value_of(length) <= 0_i || const_value_of(height) <= 0_i || presence.never_present)
+        if (state.upper_bound(length) <= 0_i || const_value_of(height) <= 0_i || presence.never_present)
             continue;
 
-        view.lengths[i] = const_value_of(length);
+        view.lengths[i] = length;
         view.heights[i] = const_value_of(height);
         view.usable.push_back(i);
     }

--- a/gcs/constraints/cumulative/donor_view.hh
+++ b/gcs/constraints/cumulative/donor_view.hh
@@ -28,35 +28,52 @@ namespace gcs::innards
      * fourth copy of the same three tests.
      *
      * The restrictions are made per *task* rather than per donor, which is the
-     * whole point: one task with a variable length no longer costs a donor its
+     * whole point: one task with a variable height no longer costs a donor its
      * strengthening. A set-aside task is weakened out of every row derived from
      * this donor and given a zero length in the derived constraint, so it has
      * no flags to pin and no term to argue over --- see
      * recover_constant_argument_row.
      *
+     * A variable *length* is not a restriction at all, which is the difference
+     * between this and a height: nothing about a length appears in a capacity
+     * row, so the rows are the same rows and the recipes read them the same
+     * way. What it costs is the `after` pin, which is then reified on
+     * `start + length` and no longer single-variable, and the donor's
+     * proof-only end proxy is what pins go through instead --- so such a task
+     * is kept exactly where the donor published the line giving that proxy its
+     * lower bound, and set aside where it did not.
+     *
      * \ingroup Innards
      */
     struct CumulativeDonorView
     {
+        /// Per task, in the donor's own order, as posted --- so a variable
+        /// length comes back as the variable, a caller wanting a number having
+        /// to say which of its bounds it means. **The constant zero for a
+        /// set-aside task**, which is what excludes it: pass these straight to
+        /// derived_cumulative_tasks_from, whose zero-length tasks are dropped
+        /// exactly as a posted Cumulative drops its own.
+        std::vector<IntegerVariableID> lengths;
+
         /// Per task, in the donor's own order, and **zero for a set-aside
-        /// task**: a length or height that is not a constant is not a number
-        /// this constraint may quote. Pass these straight to
-        /// derived_cumulative_tasks_from, whose zero-length tasks are excluded
-        /// exactly as a posted Cumulative excludes its own.
-        std::vector<Integer> lengths, heights;
+        /// task**: a height that is not a constant is not a number this
+        /// constraint may quote, its terms in a capacity row being the bits of
+        /// a linearised contribution rather than a coefficient on a flag.
+        std::vector<Integer> heights;
 
         /// Per task, the presence argument as posted, for
         /// derived_cumulative_tasks_from.
         std::vector<IntegerVariableID> presences;
 
         /// The task positions a derived constraint may speak about: a constant
-        /// non-zero length and height, and not constantly absent.
+        /// non-zero height, a length that can be non-zero, and not constantly
+        /// absent.
         std::vector<std::size_t> usable;
 
-        /// The task positions set aside for a variable length or height, whose
-        /// terms every derived row has to be weakened over. Not an error and
-        /// not a decline: what is lost is those tasks' contribution to the
-        /// argument, which makes it weaker rather than wrong.
+        /// The task positions set aside, whose terms every derived row has to
+        /// be weakened over. Not an error and not a decline: what is lost is
+        /// those tasks' contribution to the argument, which makes it weaker
+        /// rather than wrong.
         std::vector<std::size_t> set_aside;
 
         /// The capacity to argue against: the posted constant, or a variable
@@ -79,9 +96,15 @@ namespace gcs::innards
      * is not an error: it says the donor has nothing a derived constraint could
      * speak about, which is the caller's own "nothing to gain" answer.
      *
+     * `logger` is what a variable-duration task is judged by --- whether the
+     * donor published the `end >= start + length` line a pin of its `after`
+     * would need. Null means proofs are off, in which case there is nothing to
+     * pin and nothing to decline over, and every such task is kept.
+     *
      * \ingroup Innards
      */
-    [[nodiscard]] auto cumulative_donor_view(const Cumulative & donor, const State & state) -> std::optional<CumulativeDonorView>;
+    [[nodiscard]] auto cumulative_donor_view(const Cumulative & donor, const State & state, const ProofLogger * const logger)
+        -> std::optional<CumulativeDonorView>;
 
     /**
      * \brief Reduce one of a donor's capacity rows to the form a recipe argues

--- a/gcs/constraints/cumulative/propagate.hh
+++ b/gcs/constraints/cumulative/propagate.hh
@@ -107,11 +107,13 @@ namespace gcs::innards
         std::vector<std::vector<std::vector<ProofFlag>>> contrib_flags;
         std::vector<Integer> per_task_t_lo;
 
-        /// The proof-only `end = start + length` proxy for a task whose start
-        /// and length both vary, and the `{end >= s + l, end <= s + l}` lines
-        /// its initialiser cached. Shared, so the cache survives across calls.
-        std::vector<std::optional<ProofOnlySimpleIntegerVariableID>> ends;
-        std::shared_ptr<std::vector<std::optional<std::pair<ProofLine, ProofLine>>>> end_lines;
+        /// Per task, the `end >= start + length` line for the proof-only end
+        /// proxy a task whose start and length both vary is pinned through, and
+        /// nullopt for every other task. Shared, because a posted Cumulative's
+        /// install initialiser derives it after these inputs are built; a
+        /// derived Cumulative fills in its own, from what each donor published
+        /// under ConstraintProofModelData<Cumulative>::end_lower_bound_role.
+        std::shared_ptr<std::vector<std::optional<ProofLine>>> end_ge_lines;
 
         /// t -> the row saying the load at t is within the capacity. A posted
         /// constraint's are OPB rows; a derived constraint's are derived from

--- a/gcs/constraints/cumulative/propagate.hh
+++ b/gcs/constraints/cumulative/propagate.hh
@@ -15,7 +15,6 @@
 #include <map>
 #include <memory>
 #include <optional>
-#include <utility>
 #include <vector>
 
 namespace gcs::innards

--- a/gcs/innards/proofs/constraint_proof_model_data.hh
+++ b/gcs/innards/proofs/constraint_proof_model_data.hh
@@ -12,8 +12,8 @@
 namespace gcs::innards
 {
     /**
-     * \brief How a constraint publishes the parts of its OPB output that other
-     * code is allowed to build proof steps on.
+     * \brief How a constraint publishes the parts of its proof output that
+     * other code is allowed to build proof steps on.
      *
      * Every labelled row a define_proof_model emits is, today, implicitly public
      * API: anything can construct the label `c[id][role]` and cite it. That is
@@ -39,8 +39,21 @@ namespace gcs::innards
      * NamesAndIDsTracker::constraint_row_label is the other half, and returns
      * nullopt in exactly that case.
      *
+     * Three kinds of thing get published this way, and they differ only in
+     * which half of the tracker answers. A **row** is named by a role and found
+     * by NamesAndIDsTracker::constraint_row_label. A **flag** is named by a
+     * ProofFlagKey and found by NamesAndIDsTracker::find_proof_flag_values. And
+     * a **line the constraint derived inside the proof** --- an install
+     * initialiser's work, which has no OPB row to label and no reification to
+     * key --- is named by a role and found by
+     * NamesAndIDsTracker::find_derived_line. Only the third hands back a line
+     * number, because only the third has nothing else to hand back; what is
+     * published is a role either way.
+     *
      * \ingroup Innards
      * \sa NamesAndIDsTracker::constraint_row_label
+     * \sa NamesAndIDsTracker::find_proof_flag_values
+     * \sa NamesAndIDsTracker::find_derived_line
      * \sa Problem::each_constraint_of_type_with_proof_data
      */
     template <typename Constraint_>

--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -196,6 +196,13 @@ struct NamesAndIDsTracker::Imp
     // emitted_constraint_row_labels, and for the same reason.
     map<string, optional<ProofFlag>> constraint_keyed_flags;
 
+    // Every line an install initialiser published for someone else to cite, by
+    // (id, role); see publish_derived_line. Unlike the two above this holds
+    // proof line numbers, so it is per-solve state rather than a set derived
+    // from names --- the same story as the boundary pins a few fields down, and
+    // written at the same point in the solve, before the search starts.
+    map<string, ProofLine> published_derived_lines;
+
     unordered_map<SimpleOrProofOnlyIntegerVariableID, ProofLine, HashSimpleOrProofOnlyVariable> variable_at_least_one_constraints;
     // Indexed by variable index (variables are allocated with sequential
     // indices, so these stay dense), one per id kind.
@@ -1682,6 +1689,33 @@ auto NamesAndIDsTracker::find_proof_flag_values(const ConstraintID & id, const P
     // (id, values, annotation) rather than a lookup into per-solve state.
     auto found = _imp->constraint_keyed_flags.find(bracketed_flag_name('v', id, key.values, key.annotation));
     if (found == _imp->constraint_keyed_flags.end())
+        return nullopt;
+    return found->second;
+}
+
+namespace
+{
+    [[nodiscard]] auto derived_line_key(const ConstraintID & id, const string & role) -> string
+    {
+        return as_string(id) + "[" + role + "]";
+    }
+}
+
+auto NamesAndIDsTracker::publish_derived_line(const ConstraintID & id, const string & role, ProofLine line) -> void
+{
+    // Two lines under one role is the row-label defect (#613) in the namespace
+    // next door: a citer asking for the role gets one of them and has no way of
+    // knowing which, so the role does not name everything the emitting loop
+    // varies over. A hard error, for the same reason it is one there.
+    if (! _imp->published_derived_lines.emplace(derived_line_key(id, role), line).second)
+        throw ProofError{"two proof lines published under the role '" + derived_line_key(id, role) +
+            "': a role must name everything that varies, so that each line can be cited unambiguously"};
+}
+
+auto NamesAndIDsTracker::find_derived_line(const ConstraintID & id, const string & role) const -> optional<ProofLine>
+{
+    auto found = _imp->published_derived_lines.find(derived_line_key(id, role));
+    if (found == _imp->published_derived_lines.end())
         return nullopt;
     return found->second;
 }

--- a/gcs/innards/proofs/names_and_ids_tracker.hh
+++ b/gcs/innards/proofs/names_and_ids_tracker.hh
@@ -587,6 +587,55 @@ namespace gcs::innards
         [[nodiscard]] auto find_proof_flag_values(const ConstraintID & id, const ProofFlagKey & key) const -> std::optional<ProofFlag>;
 
         /**
+         * \brief Record a line this constraint established *inside the proof*,
+         * under a role, so that another constraint may build on it.
+         *
+         * The third kind of citable thing, beside a labelled OPB row
+         * (\ref constraint_row_label) and a flag (\ref find_proof_flag_values),
+         * and the one neither of those can express: a line an install
+         * initialiser derived, which has no OPB row to label and no reification
+         * to key. Cumulative's proof-only `end >= start + length` is the
+         * motivating case.
+         *
+         * A line number rather than a label, because there is no label: what
+         * comes back is a position in one particular proof file, so unlike the
+         * other two this is per-solve state --- the same state
+         * \ref boundary_pin_line already keeps, and kept for the same reason,
+         * that a caller wanting the fact should cite the line rather than derive
+         * it again.
+         *
+         * The role is in a namespace of its own, so it neither collides with a
+         * `c[id][role]` label nor makes one; that a constraint uses the same
+         * word for both is the constraint's business.
+         *
+         * \throws ProofError if this `(id, role)` has already published a line,
+         * which means a role that does not name everything the emitting loop
+         * varies over (#613, one namespace over).
+         */
+        auto publish_derived_line(const ConstraintID & id, const std::string & role, ProofLine line) -> void;
+
+        /**
+         * \brief The line a constraint published under this role, if it
+         * published one.
+         *
+         * The same "may I cite this?" answer \ref constraint_row_label and
+         * \ref find_proof_flag_values give, and nullopt means the same thing it
+         * means there: the constraint was never installed, or proofs are off,
+         * or it had nothing to publish under that role --- and in each case
+         * there is nothing to cite, so do not do the thing that would need
+         * citing.
+         *
+         * The one extra way of getting nullopt is *timing*: this is filled in by
+         * an install initialiser, so a caller running before initialisers do
+         * gets nothing. Presolvers run after (#658), which is what makes this
+         * reachable for them at all.
+         *
+         * Pair it with innards::ConstraintProofModelData, which is how a
+         * constraint publishes which role names the line a citer wants.
+         */
+        [[nodiscard]] auto find_derived_line(const ConstraintID & id, const std::string & role) const -> std::optional<ProofLine>;
+
+        /**
          * Create a proof flag with a new identifier, named `f[index][stem]`.
          */
         [[nodiscard]] auto create_proof_flag(const std::string & stem) -> ProofFlag;

--- a/gcs/presolvers/cumulative_strengthening/cumulative_strengthening.cc
+++ b/gcs/presolvers/cumulative_strengthening/cumulative_strengthening.cc
@@ -147,11 +147,13 @@ auto CumulativeStrengthening::run(Problem & problem, Propagators & propagators, 
         // `Σ h_i·active_{i,t} ≤ C`, which only says that when every argument is
         // a constant --- so this is where a donor that is not all constants
         // gets reduced to the part of itself that is. The reduction is per
-        // *task*: one variable length no longer costs a whole donor its
-        // strengthening, it costs that task its term. Optional tasks need
+        // *task*: one variable height no longer costs a whole donor its
+        // strengthening, it costs that task its term. A variable length costs
+        // nothing at all --- no length is in a row --- so long as the donor
+        // published what a pin of that task's `after` needs. Optional tasks need
         // nothing at all, their presence being a conjunct inside the activity
         // flag rather than a term beside it.
-        auto view = cumulative_donor_view(donor, state);
+        auto view = cumulative_donor_view(donor, state, logger);
         if (! view) {
             bump(&CumulativeStrengtheningStats::declined_variable_arguments);
             if (logger)
@@ -167,13 +169,14 @@ auto CumulativeStrengthening::run(Problem & problem, Propagators & propagators, 
 
         // The same windowing install_derived_cumulative resolves, and the same
         // windowing the donor encoded: a task can be active from its earliest
-        // start to its latest finish. This is the paper's `t in [est_j, lct_j)`.
+        // start to its latest finish, which for a variable duration is the
+        // largest one still allowed. This is the paper's `t in [est_j, lct_j)`.
         vector<Integer> t_lo(n, 0_i), t_hi(n, 0_i);
         const auto & active_tasks = view->usable;
         for (auto i : active_tasks) {
             auto [s_lo, s_hi] = state.bounds(starts[i]);
             t_lo[i] = s_lo;
-            t_hi[i] = s_hi + view->lengths[i] - 1_i;
+            t_hi[i] = s_hi + state.upper_bound(view->lengths[i]) - 1_i;
         }
 
         if (active_tasks.empty()) {

--- a/gcs/presolvers/cumulative_strengthening/cumulative_strengthening.hh
+++ b/gcs/presolvers/cumulative_strengthening/cumulative_strengthening.hh
@@ -41,11 +41,12 @@ namespace gcs
         Integer capacity_units_removed = 0_i;
 
         /// Donors that were strengthened over only part of themselves, because
-        /// a task's length or height is a variable and so has no constant term
-        /// in the rows the argument is made over. Its terms are weakened away
-        /// and it takes no part; what that costs is a weaker strengthening,
-        /// never a wrong one. Counted because a donor drifting into this looks
-        /// exactly like one that was strengthened in full.
+        /// a task's height is a variable and so has no constant term in the rows
+        /// the argument is made over. Its terms are weakened away and it takes
+        /// no part; what that costs is a weaker strengthening, never a wrong
+        /// one. Counted because a donor drifting into this looks exactly like
+        /// one that was strengthened in full. A variable *length* is not one of
+        /// these: no length appears in a row, so such a task keeps its term.
         std::size_t donors_with_set_aside_tasks = 0;
 
         /// Tasks whose height was raised to the strengthened capacity, over

--- a/gcs/presolvers/cumulative_strengthening/cumulative_strengthening_test.cc
+++ b/gcs/presolvers/cumulative_strengthening/cumulative_strengthening_test.cc
@@ -899,21 +899,44 @@ auto main(int argc, char * argv[]) -> int
             check_solutions("variable height", inst, outcome);
         }
 
-        // A variable length, which leaves the rows alone --- lengths are not in
-        // them --- and breaks the pins instead, `after` being reified on
-        // `start + length` and no longer single-variable. Set aside for that,
-        // and weakened out by its one activity flag rather than by any bits.
+        // A variable length, which is not a restriction on the argument at
+        // all: no length appears in a capacity row, so the rows a recipe is
+        // made over are the same rows and the subset sum is the same subset
+        // sum. What it costs is the *pin* --- `after` is then reified on
+        // `start + length`, which no RUP reaches from the operands' bounds ---
+        // and the donor's proof-only end proxy is what a pin goes through
+        // instead. So this fixture is not about the reduction; it is about the
+        // task being kept, and about the line the donor publishes for it being
+        // enough to pin with.
+        //
+        // The fifth task's start is a unit tighter than the rest so that it has
+        // a mandatory part at the root, which is where a variable-duration task
+        // earns its place here. A strengthened Cumulative runs the energy rules
+        // only, and the window-energy lemma cannot speak for a task whose
+        // energy is not a number --- but the (TTOC) profile term can, and that
+        // is the term whose pins go through the proxy.
+        //
+        // Four tasks of energy six fill a window of four at the strengthened
+        // capacity of six exactly, so the fifth task's one compulsory time
+        // point is the whole of the overshoot: refuting at the root is the
+        // set-aside being taken back and nothing else.
         {
             auto stats = make_shared<CumulativeStrengtheningStats>();
-            const auto inst = base({1, 2}, {3, 3}, {8, 8});
+            const GeneralInstance inst{{{0, 2}, {0, 2}, {0, 2}, {0, 2}, {1, 2}}, {{2, 2}, {2, 2}, {2, 2}, {2, 2}, {2, 3}},
+                {{3, 3}, {3, 3}, {3, 3}, {3, 3}, {3, 3}}, {}, {8, 8}};
             auto outcome = solve_general(inst, stats, proofs ? make_optional("cumulative_strengthening_var_length") : nullopt);
 
             if (stats->donors_strengthened != 1)
-                fail("a donor with one variable length was not strengthened over the rest of itself");
-            if (stats->donors_with_set_aside_tasks != 1)
-                fail("a variable length did not set its task aside");
+                fail("a donor with one variable length was not strengthened");
+            if (stats->donors_with_set_aside_tasks != 0)
+                fail("a variable length set its task aside, which is what the published end proxy is there to avoid");
 
             check_solutions("variable length", inst, outcome);
+
+            if (! outcome.refuted_at_root)
+                fail("the strengthened energy check did not refute the variable-length instance at the root");
+            if (solve_general(inst, nullptr, nullopt).refuted_at_root)
+                fail("the donor alone refuted the variable-length instance at the root");
         }
     }
 

--- a/gcs/presolvers/inferred_cumulative/inferred_cumulative.cc
+++ b/gcs/presolvers/inferred_cumulative/inferred_cumulative.cc
@@ -67,7 +67,16 @@ namespace
     struct Task
     {
         IntegerVariableID start;
-        Integer length;
+        /// As posted, which may be a variable: it is what the lifted constraint
+        /// is given, so that its propagator reads the same duration the donors'
+        /// flags were reified on. Two tasks are the same column only if this is
+        /// the *same* variable, whatever its bounds happen to be.
+        IntegerVariableID length;
+        /// The duration this task is guaranteed to occupy, lb(length). A cover
+        /// is a statement about work every solution has to contain, so the
+        /// energy a cut carries and the order the covers are ranked in both
+        /// count the smallest duration still allowed.
+        Integer least_length;
         Integer t_lo, t_hi;
 
         /// Per donor: what this task takes, and where it sits in that donor's
@@ -169,7 +178,7 @@ namespace
         for (const auto & [demand, group] : by_demand) {
             auto longest = group.front();
             for (auto i : group)
-                if (tasks[i].length > tasks[longest].length)
+                if (tasks[i].least_length > tasks[longest].least_length)
                     longest = i;
             longest_of_demand.emplace(demand, longest);
         }
@@ -206,7 +215,7 @@ namespace
         auto bound_of = [&](const vector<size_t> & cover) {
             auto total = 0_i;
             for (auto i : cover)
-                total += tasks[i].length;
+                total += tasks[i].least_length;
             return pair{total, Integer{static_cast<long long>(cover.size()) - 1}};
         };
         std::sort(covers.begin(), covers.end(), [&](const vector<size_t> & a, const vector<size_t> & b) {
@@ -235,8 +244,8 @@ namespace
                     continue;
                 auto by_length = group;
                 std::sort(by_length.begin(), by_length.end(), [&](size_t a, size_t b) {
-                    if (tasks[a].length != tasks[b].length)
-                        return tasks[a].length > tasks[b].length;
+                    if (tasks[a].least_length != tasks[b].least_length)
+                        return tasks[a].least_length > tasks[b].least_length;
                     return a < b;
                 });
                 remember(vector<size_t>(by_length.begin(), by_length.begin() + static_cast<long>(size)));
@@ -456,7 +465,7 @@ auto InferredCumulative::run(Problem & problem, Propagators & propagators, State
     // reference implementation does with its single matrix.
     vector<Donor> donors;
     vector<Task> tasks;
-    map<pair<IntegerVariableID, Integer>, size_t> task_of;
+    map<pair<IntegerVariableID, IntegerVariableID>, size_t> task_of;
 
     for (const auto & donor : problem.each_constraint_of_type<Cumulative>()) {
         bump(&InferredCumulativeStats::donors_seen);
@@ -477,11 +486,13 @@ auto InferredCumulative::run(Problem & problem, Propagators & propagators, State
         }
 
         // What of this donor a cut can be lifted out of: its capacity as a
-        // number, and the tasks whose length and height are the constants its
-        // rows put on them. A task with a variable one is set aside rather than
-        // costing the whole donor its column in the matrix --- it takes no part
-        // in any cover, and its terms come out of every row first.
-        auto view = cumulative_donor_view(donor, state);
+        // number, and the tasks whose height is the constant its rows put on
+        // them. A task with a variable one is set aside rather than costing the
+        // whole donor its column in the matrix --- it takes no part in any
+        // cover, and its terms come out of every row first. A variable duration
+        // is no obstacle: a cover is a statement about demands, and lifting
+        // works over a row no length appears in.
+        auto view = cumulative_donor_view(donor, state, logger);
         if (! view) {
             bump(&InferredCumulativeStats::declined_variable_arguments);
             if (logger)
@@ -527,7 +538,8 @@ auto InferredCumulative::run(Problem & problem, Propagators & propagators, State
             }
 
             auto [s_lo, s_hi] = state.bounds(starts[i]);
-            Task task{starts[i], length, s_lo, s_hi + length - 1_i, vector<Integer>(donors.size(), 0_i),
+            auto [l_lo, l_hi] = state.bounds(length);
+            Task task{starts[i], length, l_lo, s_lo, s_hi + l_hi - 1_i, vector<Integer>(donors.size(), 0_i),
                 vector<optional<size_t>>(donors.size(), std::nullopt), which};
             task.demands[which] = demand;
             task.positions[which] = i;
@@ -544,7 +556,7 @@ auto InferredCumulative::run(Problem & problem, Propagators & propagators, State
     for (const auto & donor : donors)
         capacities.push_back(donor.capacity);
     for (const auto & task : tasks)
-        durations.push_back(task.length);
+        durations.push_back(task.least_length);
 
     vector<vector<Integer>> demands(donors.size());
     for (size_t row = 0; row < donors.size(); ++row)
@@ -567,7 +579,7 @@ auto InferredCumulative::run(Problem & problem, Propagators & propagators, State
         auto bound_of = [&](const vector<size_t> & cover) {
             auto total = 0_i;
             for (auto i : cover)
-                total += tasks[i].length;
+                total += tasks[i].least_length;
             return pair{total, Integer{static_cast<long long>(cover.size()) - 1}};
         };
         std::sort(pooled.begin(), pooled.end(), [&](const vector<size_t> & a, const vector<size_t> & b) {

--- a/gcs/presolvers/inferred_cumulative/inferred_cumulative.hh
+++ b/gcs/presolvers/inferred_cumulative/inferred_cumulative.hh
@@ -147,11 +147,12 @@ namespace gcs
         std::size_t declined_variable_arguments = 0;
 
         /// Donors that could only be lifted out of in part, because a task's
-        /// length or height is a variable and so has no constant term in their
-        /// rows. Such a task takes no part in any cover and its terms are
-        /// weakened out of every row first; what that costs is a smaller matrix,
-        /// never a wrong cut. Counted because a donor drifting into it looks
-        /// exactly like one used in full.
+        /// height is a variable and so has no constant term in their rows. Such
+        /// a task takes no part in any cover and its terms are weakened out of
+        /// every row first; what that costs is a smaller matrix, never a wrong
+        /// cut. Counted because a donor drifting into it looks exactly like one
+        /// used in full. A variable *length* is not one of these: no length
+        /// appears in a row, so such a task keeps its column.
         std::size_t donors_with_set_aside_tasks = 0;
         /// Covers already inside the support of something lifted earlier, which
         /// would re-derive it and waste the subproblems (paper, Example 12).

--- a/gcs/presolvers/inferred_cumulative/inferred_cumulative_test.cc
+++ b/gcs/presolvers/inferred_cumulative/inferred_cumulative_test.cc
@@ -576,6 +576,86 @@ auto main(int argc, char * argv[]) -> int
         println(cerr, "variable arguments: cut posted over a variable capacity, one task set aside, {} solutions", solutions.size());
     }
 
+    /* And the same cut with a variable *duration* in it, which unlike a
+     * variable height costs nothing: no length appears in a capacity row, so
+     * lifting works over the same row and the task stays a column of the
+     * matrix. What it costs is the `after` pin, and the donor's published end
+     * proxy is what that goes through.
+     *
+     * The first task's duration is [3, 5], and the bound the cut reports is
+     * five --- nine units of work against a supply of two per step, counting
+     * the *smallest* duration still allowed, which is the only one every
+     * solution has to contain. Count the largest instead and it would be six,
+     * which is why the number is asserted rather than the cut merely being
+     * present.
+     */
+    {
+        const int horizon = 9, length = 3, latest = 4;
+        auto stats = make_shared<InferredCumulativeStats>();
+
+        Problem p;
+        vector<IntegerVariableID> starts;
+        for (int i = 0; i < 3; ++i)
+            starts.push_back(p.create_integer_variable(0_i, Integer{latest}, "s" + to_string(i)));
+        auto varying = p.create_integer_variable(Integer{length}, 5_i, "l0");
+
+        vector<IntegerVariableID> lengths{varying, constant_variable(Integer{length}), constant_variable(Integer{length})};
+        vector<IntegerVariableID> heights(3, constant_variable(4_i));
+        p.post(Cumulative{starts, lengths, heights, constant_variable(10_i)});
+        p.add_presolver(InferredCumulative{stats});
+
+        set<vector<int>> solutions;
+        solve_with(p, SolveCallbacks{.solution = [&](const CurrentState & s) -> bool {
+            vector<int> solution;
+            for (const auto & v : starts)
+                solution.push_back(s(v).raw_value);
+            solution.push_back(s(varying).raw_value);
+            solutions.insert(move(solution));
+            return true;
+        }},
+            proofs ? make_optional<ProofOptions>(ProofFileNames{"inferred_cumulative_variable_length"}) : nullopt);
+        if (proofs)
+            verify_proof_and_clean_up("inferred_cumulative_variable_length");
+
+        if (stats->cuts_posted != 1)
+            fail("variable duration: posted " + to_string(stats->cuts_posted) + " cuts, not the one over the three tasks");
+        if (stats->donors_with_set_aside_tasks != 0)
+            fail("variable duration: the task was set aside, which is what the published end proxy is there to avoid");
+        if (stats->largest_capacity_bound != 5_i)
+            fail("variable duration: reported a bound of " + to_string(stats->largest_capacity_bound.raw_value) +
+                ", not the five the smallest durations carry");
+
+        set<vector<int>> expected;
+        vector<int> assignment(4, 0);
+        std::function<auto(std::size_t)->void> enumerate = [&](std::size_t at) {
+            if (at == assignment.size()) {
+                for (int t = 0; t < horizon; ++t) {
+                    int load = 0;
+                    for (int i = 0; i < 3; ++i) {
+                        auto duration = i == 0 ? assignment.back() : length;
+                        if (assignment[static_cast<std::size_t>(i)] <= t && t < assignment[static_cast<std::size_t>(i)] + duration)
+                            load += 4;
+                    }
+                    if (load > 10)
+                        return;
+                }
+                expected.insert(assignment);
+                return;
+            }
+            auto lo = at == assignment.size() - 1 ? length : 0;
+            auto hi = at == assignment.size() - 1 ? 5 : latest;
+            for (auto v = lo; v <= hi; ++v) {
+                assignment[at] = v;
+                enumerate(at + 1);
+            }
+        };
+        enumerate(0);
+
+        if (expected != solutions)
+            fail("variable duration: solutions do not match brute force");
+        println(cerr, "variable duration: cut posted over a task the donor gave a duration variable, {} solutions", solutions.size());
+    }
+
     // The window edges, which is the only place a programme is built over
     // fewer than all of the members. Pinning the big task into the first half of the horizon leaves
     // the second half holding only the three small ones, so those time points

--- a/gcs/presolvers/inferred_disjunctive/inferred_disjunctive.cc
+++ b/gcs/presolvers/inferred_disjunctive/inferred_disjunctive.cc
@@ -56,7 +56,15 @@ namespace
     struct Task
     {
         IntegerVariableID start;
-        Integer length;
+        /// As posted, which may be a variable: it is what the derived
+        /// constraint is given, so that its propagator reads the same duration
+        /// the donor's flags were reified on.
+        IntegerVariableID length;
+        /// The duration this task is guaranteed to occupy, lb(length). What a
+        /// clique can *say* about the schedule is a statement about durations
+        /// every solution has to contain, so it is the smallest one still
+        /// allowed that every energy sum and every ranking here counts.
+        Integer least_length;
         Integer t_lo, t_hi;
         vector<Appearance> appearances;
     };
@@ -192,12 +200,14 @@ auto InferredDisjunctive::run(Problem & problem, Propagators & propagators, Stat
         }
 
         // What of this donor an inferred constraint can argue over: its
-        // capacity as a number, and the tasks whose length and height are the
-        // constants its rows put on them. A task with a variable one is set
-        // aside rather than costing the whole resource its place in the
-        // conflict graph --- it simply cannot be a clique member, and every row
-        // this resource witnesses is weakened over it first.
-        auto view = cumulative_donor_view(donor, state);
+        // capacity as a number, and the tasks whose height is the constant its
+        // rows put on them. A task with a variable one is set aside rather than
+        // costing the whole resource its place in the conflict graph --- it
+        // simply cannot be a clique member, and every row this resource
+        // witnesses is weakened over it first. A variable duration is no
+        // obstacle: a conflict is a statement about heights, and a clique's
+        // rows say nothing about how long anything runs for.
+        auto view = cumulative_donor_view(donor, state, logger);
         if (! view) {
             bump(&InferredDisjunctiveStats::declined_variable_arguments);
             if (logger)
@@ -217,13 +227,16 @@ auto InferredDisjunctive::run(Problem & problem, Propagators & propagators, Stat
             auto found = task_of_start.find(starts[i]);
             if (found == task_of_start.end()) {
                 auto [s_lo, s_hi] = state.bounds(starts[i]);
+                auto [l_lo, l_hi] = state.bounds(lengths[i]);
                 found = task_of_start.emplace(starts[i], tasks.size()).first;
-                tasks.push_back(Task{starts[i], lengths[i], s_lo, s_hi + lengths[i] - 1_i, {}});
+                tasks.push_back(Task{starts[i], lengths[i], l_lo, s_lo, s_hi + l_hi - 1_i, {}});
             }
             else if (tasks[found->second].length != lengths[i]) {
                 // Two resources disagreeing about a duration is not something
                 // to average over: the flags would reify different conditions
-                // and no bridge between them exists.
+                // and no bridge between them exists. The same variable is the
+                // same duration, whatever its bounds come to; two different
+                // ones are not, even where their bounds agree today.
                 continue;
             }
 
@@ -281,8 +294,8 @@ auto InferredDisjunctive::run(Problem & problem, Propagators & propagators, Stat
                 candidates.push_back(w);
 
         std::sort(candidates.begin(), candidates.end(), [&](size_t a, size_t b) {
-            if (tasks[a].length != tasks[b].length)
-                return tasks[a].length > tasks[b].length;
+            if (tasks[a].least_length != tasks[b].least_length)
+                return tasks[a].least_length > tasks[b].least_length;
             return a < b;
         });
 
@@ -385,7 +398,7 @@ auto InferredDisjunctive::run(Problem & problem, Propagators & propagators, Stat
     auto capacity_bound = [&](const vector<size_t> & c) {
         auto sum = 0_i;
         for (auto i : c)
-            sum += tasks[i].length;
+            sum += tasks[i].least_length;
         return sum;
     };
 

--- a/gcs/presolvers/inferred_disjunctive/inferred_disjunctive.hh
+++ b/gcs/presolvers/inferred_disjunctive/inferred_disjunctive.hh
@@ -87,11 +87,13 @@ namespace gcs
         Integer certified_makespan_bound{0};
 
         /// Resources that could only be argued over in part, because a task's
-        /// length or height is a variable and so has no constant term in their
-        /// rows. Such a task takes no part in the conflict graph and its terms
-        /// are weakened out of every row the resource witnesses; what that
-        /// costs is a smaller graph, never a wrong one. Counted because a
-        /// resource drifting into it looks exactly like one used in full.
+        /// height is a variable and so has no constant term in their rows. Such
+        /// a task takes no part in the conflict graph and its terms are weakened
+        /// out of every row the resource witnesses; what that costs is a smaller
+        /// graph, never a wrong one. Counted because a resource drifting into it
+        /// looks exactly like one used in full. A variable *length* is not one
+        /// of these: no length appears in a row, so such a task can still be a
+        /// clique member.
         std::size_t resources_with_set_aside_tasks = 0;
 
         /// Flag bridges emitted, one per (task, time) that had to be carried

--- a/gcs/presolvers/inferred_disjunctive/inferred_disjunctive_test.cc
+++ b/gcs/presolvers/inferred_disjunctive/inferred_disjunctive_test.cc
@@ -502,6 +502,93 @@ auto main(int argc, char * argv[]) -> int
         println(cerr, "variable arguments: clique posted, {} solutions", solutions.size());
     }
 
+    /* A variable duration, which unlike a variable height is not a restriction
+     * at all. A conflict is a statement about demands, and a clique's rows say
+     * nothing about how long anything runs for --- so what used to cost a task
+     * its place in the conflict graph now costs it nothing, provided its donor
+     * published the line a pin of its `after` goes through.
+     *
+     * Four tasks, pairwise conflicting on the four resources `(i + j) mod 4`
+     * covers between them, and the last one's duration a variable. The clique
+     * is a clique of *four*: three is what it would be with that task set
+     * aside, and the difference is the whole point.
+     */
+    {
+        const int k = 4, length = 2, horizon = 9, latest = horizon - length;
+        auto stats = make_shared<InferredDisjunctiveStats>();
+
+        Problem p;
+        vector<IntegerVariableID> starts;
+        for (int i = 0; i < k; ++i)
+            starts.push_back(p.create_integer_variable(0_i, Integer{latest}, "s" + to_string(i)));
+        // Only the last, so that what the fixture counts is one task joining a
+        // clique it could not have joined, rather than a clique of tasks none
+        // of which the energy rules could have counted anyway.
+        auto varying = p.create_integer_variable(Integer{length}, Integer{length + 1}, "l3");
+
+        vector<IntegerVariableID> lengths(static_cast<size_t>(k), constant_variable(Integer{length}));
+        lengths.back() = varying;
+        for (int r = 0; r < k; ++r) {
+            vector<IntegerVariableID> heights(static_cast<size_t>(k), constant_variable(0_i));
+            for (int i = 0; i < k; ++i)
+                for (int j = i + 1; j < k; ++j)
+                    if ((i + j) % k == r) {
+                        heights[static_cast<size_t>(i)] = constant_variable(1_i);
+                        heights[static_cast<size_t>(j)] = constant_variable(1_i);
+                    }
+            p.post(Cumulative{starts, lengths, heights, constant_variable(1_i)});
+        }
+        p.add_presolver(InferredDisjunctive{stats});
+
+        set<vector<int>> solutions;
+        solve_with(p, SolveCallbacks{.solution = [&](const CurrentState & s) -> bool {
+            vector<int> solution;
+            for (const auto & v : starts)
+                solution.push_back(s(v).raw_value);
+            solution.push_back(s(varying).raw_value);
+            solutions.insert(move(solution));
+            return true;
+        }},
+            proofs ? make_optional<ProofOptions>(ProofFileNames{"inferred_disjunctive_variable_length"}) : nullopt);
+        if (proofs)
+            verify_proof_and_clean_up("inferred_disjunctive_variable_length");
+
+        if (stats->cliques_posted != 1)
+            fail("a clique was not posted over a resource with a variable duration");
+        if (stats->clique_members_posted != static_cast<size_t>(k))
+            fail("the variable-duration task did not join the clique, which is the whole gain");
+        if (stats->resources_with_set_aside_tasks != 0)
+            fail("a variable duration set its task aside, which is what the published end proxy is there to avoid");
+
+        // Brute force over the same model: no two tasks may overlap, and the
+        // last one's duration is part of the assignment.
+        set<vector<int>> expected;
+        vector<int> assignment(static_cast<size_t>(k) + 1, 0);
+        auto duration = [&](int i) { return i == k - 1 ? assignment.back() : length; };
+        std::function<auto(size_t)->void> enumerate = [&](size_t at) {
+            if (at == assignment.size()) {
+                for (int i = 0; i < k; ++i)
+                    for (int j = i + 1; j < k; ++j)
+                        if (assignment[static_cast<size_t>(i)] < assignment[static_cast<size_t>(j)] + duration(j) &&
+                            assignment[static_cast<size_t>(j)] < assignment[static_cast<size_t>(i)] + duration(i))
+                            return;
+                expected.insert(assignment);
+                return;
+            }
+            auto lo = at == assignment.size() - 1 ? length : 0;
+            auto hi = at == assignment.size() - 1 ? length + 1 : latest;
+            for (auto v = lo; v <= hi; ++v) {
+                assignment[at] = v;
+                enumerate(at + 1);
+            }
+        };
+        enumerate(0);
+
+        if (expected != solutions)
+            fail("variable-duration solutions do not match brute force");
+        println(cerr, "variable duration: a clique of {} tasks, {} solutions", stats->clique_members_posted, solutions.size());
+    }
+
     if (! proofs) {
         println(cerr, "veripb is not available, so the proof-level checks are skipped");
         return EXIT_SUCCESS;


### PR DESCRIPTION
Closes #685.

A task whose length is a variable used to be set aside from every derived
Cumulative — weakened out of the rows, given a zero length, taking no part in the
argument. That was never about the rows: no length appears in one, so a recipe
reads them identically either way. It was about the **pin**. For a constant
length `after_{i,t}` is `s_i ≥ t − l + 1`, which RUPs from the start's bounds;
for a variable one it is reified on `s_i + l_i ≥ t+1`, which no RUP reaches from
the operands' bounds separately.

`Cumulative` already solved that for itself, with a proof-only `end = s + l` and
a per-`(i, t)` bridge lemma `end ≥ t+1 → after`. The bridge lemmas needed no
publishing at all — they go out at `ProofLevel::Top` over exactly the pairs the
donor gave the task a window for, unit propagation finds them, and a citer that
could ask about a wider window has already been turned away by the flag lookup.
What was missing was the **one line per task** that hands the proxy its lower
bound, which is all `materialise_after_sum` reads besides two order literals a
citer makes for itself.

### The design question: where the line gets published

It is a third kind of citable thing. A labelled OPB row is found by
`NamesAndIDsTracker::constraint_row_label` and a flag by `find_proof_flag_values`;
a line an install initialiser *derived* has no row to label and no reification to
key. `publish_derived_line` / `find_derived_line` is the pair for it, under a role
`ConstraintProofModelData` publishes like any other, and it hands back a line
number because that is all there is to hand back — per-solve state, exactly as
`boundary_pin_line` already keeps.

It could not have been a getter on `Cumulative`, and that is what settles it
rather than taste: a presolver sees the constraint `Problem` stored, and
`create_propagators` installs a **clone** — the clone ran the initialiser and the
clone is what the tracker heard from. Everything a citer reaches goes through the
tracker keyed by `ConstraintID`, and this is no exception.

### What else changed

- `DerivedCumulativeTask::length` widens to an `IntegerVariableID`;
  `install_derived_cumulative` windows with `ub(l)` as the donor does, and looks
  the donor's published line up for a task whose start *and* length both vary,
  declining if it finds nothing. Nothing means the donor had a constant somewhere
  after all, or the proof is being written with assertions on, which omits
  definitions — either way there is no pin to be had.
- `CumulativeInputs::ends` was written and never read, so it goes; `end_lines`
  narrows to the one `end ≥ s + l` line per task, `end ≤ s + l` having only ever
  been the bridge lemma's business.
- `CumulativeDonorView` sets a task aside for a variable **height** only, and its
  `lengths` become `IntegerVariableID`s, as posted — which makes each caller say
  which bound it means. A window takes `ub(l)`, the only thing that finds the
  donor's flags; an energy sum or a ranking takes `lb(l)`, the work every solution
  has to contain. The two multi-donor presolvers match tasks across donors by the
  length *variable*, the same variable being the same duration whatever its bounds
  come to.
- The energy rules needed no thought: `prepare_cumulative_overload_check` keeps
  only constant-length tasks, so such a task takes part in the rows and the
  time-tabling and stays out of the window-energy lemma. Where it earns its place
  in a presolver running the energy rules alone is the (TTOC) profile term.

### Fixtures

- `derived_cumulative`: two unit-demand tasks on a unit resource with durations
  in `[3, 5]`, the donor's every rule turned off so the derived duplicate is the
  only thing propagating and no pin goes any way but through a proxy. Plus a
  derived task naming a variable length where its donor had a constant, which is
  declined rather than installed.
- `cumulative_strengthening`: the fixture that used to check a variable length set
  its task aside now checks the opposite, and checks it is worth having. Four
  tasks of energy six fill a window of four at the strengthened capacity of six
  exactly, so the fifth, variable-duration task's one compulsory time point is the
  whole of the overshoot — the root refutation is the set-aside being taken back
  and nothing else, and the donor on its own does not reach it.
- `inferred_disjunctive`: a clique of **four**, three being what it would be with
  the variable-duration task set aside.
- `inferred_cumulative`: the cardinality cut with a variable duration among its
  members, asserting the bound it reports is five rather than six — counting the
  smallest duration still allowed, which is the only one every solution has to
  contain.

The disjunctive fixture found an ordering bug on the way in: the donor view asked
whether a variable-duration task had a published proxy before asking whether it
could load the resource at all, so a task the donor gave no window came back with
the same nullopt a genuinely unusable duration does and was counted as set aside.
Nothing was wrong with the rows; the count was saying something false.

### One thing written down rather than left to be found

**No fixture in the tree catches the *wrong* line being published.** Publish
`end ≤ s + l` in place of `end ≥ s + l` and every proof still verifies — VeriPB's
unit propagation reaches these `after` pins without the `pol` at all, the reasons
instantiating the lengths and an eq atom pinning the bits the reification row
wants. I tried a good few shapes, including the one `cumulative`'s own
`len_wide` case uses, which *does* fail without the `pol` when the posted
constraint makes the pin. That case is what pins the `pol` as load-bearing in
general; what catches a broken citation here is the install declining, and
nothing else. It is in the fixture comment and in the dev doc.

Green on GCC release, clang, and the sanitize build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173hT2hFo3MyGRBon8SHt2p
