### PR TITLE
Convert a variable-height task's contribution to a constant, instead of setting it aside (#686)

### DIFF
--- a/dev_docs/certified-makespan-bounds.md
+++ b/dev_docs/certified-makespan-bounds.md
@@ -178,7 +178,9 @@ stage — 227 runs, no failures — 92 of the 110 instances get a certified boun
 every one of them beating the critical path, and **29 are closed**: the bound
 equals the best makespan anybody found, so no search is needed at all. The
 paper's §5.1 claims "no less than twelve". The largest is 3050; the median
-`.pbp` is 28 MB and the largest 504 MB, and `veripb` takes 45 s on that one.
+`.pbp` is 28 MB and the largest 504 MB, and `veripb` took 45 s on that one *at
+the time* --- see the note below, which the checking figure needs even more than
+the bounds do.
 
 Some instances fall short of Sidorov's `L`, and on every one of them it is this
 presolver's *own* `L` that falls short while the derivation reaches it exactly:
@@ -193,6 +195,11 @@ to their best known makespan, so closing the gap closes them.
 **These numbers predate that change and have not been rerun.** They are the
 single-resource lifting's, and the artefact's `run.bash` is what regenerates
 them.
+
+The *checking times* above are staler still, and for a second reason: hinting the
+replay's RUPs made verification six to fourteen times faster on exactly these
+certificates (see [inferred-cumulative.md](inferred-cumulative.md)), so the 45 s
+is an upper bound on an upper bound. Rerunning the artefact fixes both at once.
 
 Note the makespan rows have to be there to be cited: `--variant=global` puts the
 whole temporal network into one `DifferenceConstraints` propagator, so there is

--- a/dev_docs/cumulative-proof-logging.md
+++ b/dev_docs/cumulative-proof-logging.md
@@ -1027,6 +1027,13 @@ anything out of it. Both then weaken over the donor's **usable** positions
 only, since a set-aside task's terms went out with the reduction and `w`
 on a variable the constraint no longer mentions is refused.
 
+A variable **height** they take by converting it, not by setting it aside:
+its bits become `lb(h) x active` before anything is lifted or recovered,
+so the task keeps a column in the matrix and an edge in the conflict
+graph. Neither presolver has a choice to make about it --- a converted
+task can only add one of those --- which is what separates them from
+issue 06's, whose argument is a subset sum and can be made worse by one.
+
 A variable duration they take too, and it costs them nothing but a choice
 of bound. A window takes `ub(l)`, which is what the donor encoded its
 flags over and so the only thing that finds them; an energy sum or a

--- a/dev_docs/cumulative-proof-logging.md
+++ b/dev_docs/cumulative-proof-logging.md
@@ -749,12 +749,16 @@ rows and a recipe reads them identically. What a variable length costs is the
 `after` pin, and that is bought back rather than given up — see *A task whose
 length is a variable*, below.
 
+A variable **height** is a restriction, but a payable one — see *A task whose
+height is a variable*, below. What is left as a genuine set-aside is a height
+that cannot be argued about at all: a view, or one whose lower bound is zero.
+
 `recover_constant_argument_row` does the proof half, and it is one `pol`:
 
-- **A set-aside task** — a variable height — is weakened out of the row with
-  `w`. For a constant height that is one `w` on its activity flag; for a
-  variable height the row's terms for it are the bits of the linearised
-  contribution, so every one of them goes, which is what
+- **A set-aside task** is weakened out of the row with `w`. For a constant
+  height that is one `w` on its activity flag; for a variable height the row's
+  terms for it are the bits of the linearised contribution, so every one of them
+  goes, which is what
   `ConstraintProofModelData<Cumulative>::contribution_flag_key` is published for.
   How many bits there are is not published: ask for bit zero, one, two and so on
   until the tracker has none, the same "is it there?" question a citer asks of
@@ -867,6 +871,99 @@ reification row wants. That the `pol` is load-bearing in general is pinned by
 `cumulative`'s own `len_wide` case, which fails without it. What does catch a
 broken citation here is the install declining, and nothing else.
 
+### A task whose height is a variable
+
+A variable height is the one that touches the rows. A donor's capacity row does
+not contain `height × active` for such a task; it contains the bits of a
+linearised contribution:
+
+```
+C_t :   Σ_{i const} h_i·active_{i,t}  +  Σ_{i var} Σ_k 2^k·cc_{i,t,k}   ≤   capacity
+```
+
+so a subset sum of the heights is not a subset sum of the row's coefficients,
+and nothing a recipe says about that row is a statement about that task. What
+takes it back is the row saying the contribution is *at least* the height, which
+turns those bits into a coefficient on the activity flag again — at the height's
+lower bound, which is the demand the task is guaranteed to make.
+
+**The rows are citable, with cake's names.** `cake_pb_cp` already labels all
+three halves of the contribution definition, as `@c[id][<i>_<t>_cge]`,
+`[<i>_<t>_cle]` and `[<i>_<t>_cz]`, over the same terms and keyed by absolute
+`(task, time)` exactly as the flags are. Ours went out unlabelled, which is what
+made them uncitable; labelling them with cake's names is therefore a conformance
+improvement rather than a divergence, and
+`ConstraintProofModelData<Cumulative>::contribution_ge_row_role` and its two
+siblings publish them.
+
+**The conversion is one hinted RUP** per (variable-height task, time), with `L`
+the height's lower bound:
+
+```
+rup  Σ_k 2^k·cc_{i,t,k} + L·¬active_{i,t} >= L   :  @c[id][<i>_<t>_cge]  <the height's lower-bound line> ;
+```
+
+added to the capacity row with coefficient one, so the bits cancel exactly and
+what is left on that task is `L·active_{i,t}`.
+
+It closes for a reason, which is worth writing down because the alternative is
+believing a pass rate. Negating the target forces `¬active` to zero — its
+coefficient `L` exceeds the slack `L−1` — leaving
+`{Σ2^k·cc_k ≤ L−1, Σ2^k·cc_k ≥ Σ2^j·hb_j, Σ2^j·hb_j ≥ L}` over two
+power-of-two bit counters. Induct on the top bit `2^s`: if `L ≤ 2^s` the negated
+target zeroes `cc_s`, the `cge` row then zeroes `hb_s`, and the same system
+recurs one bit narrower; if `L > 2^s` the bound row forces `hb_s = 1`, `cge`
+forces `cc_s = 1`, and it recurs with `L' = L − 2^s`. Every step is
+single-constraint slack propagation, so any unit-propagation fixpoint finds it
+whatever the order — which is also why the hint order does not matter, and why
+the negated target does not need to be named in the hints.
+
+Swept over several thousand `(L, ub(h), bit width)` shapes before being believed,
+including contribution bits narrower than the height's, which is what happens
+when the install-time upper bound is tighter than the declared one. The negative
+controls fail: a target one stronger than justified is refused, and so is one
+with the bound line withheld from the hints.
+
+The `pol` this replaces is the `cge` row plus the bound, then a **saturate** to
+cap the reification constant down to the degree, then a literal axiom
+`(2^k − min(2^k, L))·cc_k ≥ 0` per bit to put the coefficients back. It works —
+and needs less than it looks, since `ia`'s implication check performs the
+saturate-and-restore itself, so `pol <cge> <lb> + ;` with an `ia` pin is enough.
+It is three times the code and O(bits) more addends than the RUP.
+
+**Which bound.** The one the height has *now*, through
+`need_pol_item_defining_literal`, exactly as the capacity's reduction does and
+for the same reason: the declared bound is a weaker number the moment anything
+has tightened it, and a declared zero would give the conversion up altogether on
+models that reach a height through an `Element` over a mode variable. The unit
+saying the atom holds is what makes the resulting row unconditional, permanently,
+the bound having been reached before the search started.
+
+**What stays set aside** is a height that cannot be argued about at all: a
+**view**, whose reification is emitted over its own bit vector so the height's
+bound rows have nothing to cancel against — and which `bound_rows` cannot even be
+asked about — or a lower bound of zero, which guarantees nothing.
+
+**Converting is not always a gain**, which is the one thing here that is
+arithmetic rather than proof. `kappa` is the largest subset sum of the heights
+the capacity allows, so adding a task can only push it up: heights `{3, 3}` under
+a capacity of eight give six, and converting a task at a guaranteed demand of two
+gives `{3, 3, 2}`, whose largest subset sum at most eight is eight — no
+strengthening where there used to be two units of one. Against that, the
+converted task's energy joins the overload check. `CumulativeStrengthening`
+therefore assesses the donor both ways and keeps the bigger reduction;
+`CumulativeDonorView::with_converted_heights_set_aside` is the other candidate.
+The two multi-donor presolvers need no such choice: a converted task can only add
+a conflict edge or a column.
+
+Unlike the end-proxy publication of the length half, this one has a tripwire. A
+recipe pins what `recover_constant_argument_row` returns with an `ia`, whose
+implication check is syntactic, so a conversion landing on the wrong row is
+refused immediately — which is what `cumulative_strengthening_var_capacity`
+already checks for the capacity half, and what two deliberate corruptions of the
+conversion (claiming one more than the demand, and using `ub(h)` in place of
+`lb(h)`) are caught by in all three presolvers' fixtures.
+
 ### Deriving over an optional donor
 
 A *derived* Cumulative (issue 04) works over an optional donor, and the
@@ -958,8 +1055,10 @@ that gap is now named rather than hidden.
   task now takes part in a derived Cumulative's rows and time-tabling
   (#685), and contributes its mandatory part to the (TTOC) profile term,
   but the window-energy lemma still cannot count its energy: that needs a
-  task's energy to be a number. A variable **height** is still set aside
-  from a derived constraint altogether (#686 is the height half of #685).
+  task's energy to be a number. A variable **height** is converted to the
+  demand it guarantees (#686), which *is* a number — so such a task does
+  join the energy set, and a task with a variable duration and a variable
+  height gets its demand counted but not its energy.
 - **Conditional bounds for optional tasks.** An undecided task's start
   bounds are never pruned, because there is no conditional-bounds store
   and an unconditional prune would be unsound if the task turns out

--- a/dev_docs/cumulative-proof-logging.md
+++ b/dev_docs/cumulative-proof-logging.md
@@ -1057,15 +1057,19 @@ that gap is now named rather than hidden.
   piece of it: horizontally elastic and knapsack-augmented checking
   (#550) build on the clipped form, and the lifted-constraint
   presolvers (#549) on the contained one.
-- **Variable lengths, heights and capacity in the energy set.** Staged
-  deliberately; the extensions are sketched in #542. A variable-duration
-  task now takes part in a derived Cumulative's rows and time-tabling
-  (#685), and contributes its mandatory part to the (TTOC) profile term,
-  but the window-energy lemma still cannot count its energy: that needs a
-  task's energy to be a number. A variable **height** is converted to the
-  demand it guarantees (#686), which *is* a number — so such a task does
-  join the energy set, and a task with a variable duration and a variable
-  height gets its demand counted but not its energy.
+- **A variable duration in the energy set (#689).** The window-energy
+  lemma's eligibility filter turns away a task whose length or height is
+  not a constant, and those two halves are now in different states. The
+  **height** one has resolved itself: a task #686 converted arrives at the
+  filter as a constant and passes, which
+  `cumulative_strengthening_all_var_heights` demonstrates by refuting at
+  the root through the energy check. The **length** one still binds, since
+  #685 passes a length through as the variable it was posted with — so a
+  multi-mode RCPSP task gets its demand counted and its energy discarded,
+  and it is the duration that discards it. Loosening it is not free: the
+  lemma telescopes order literals over ranges fixed by a constant length,
+  and a variable-duration task's `after` is reified on `start + length`
+  instead. #689 has the sketch. The rest of #542's staging is unchanged.
 - **Conditional bounds for optional tasks.** An undecided task's start
   bounds are never pruned, because there is no conditional-bounds store
   and an unconditional prune would be unsound if the task turns out

--- a/dev_docs/cumulative-strengthening.md
+++ b/dev_docs/cumulative-strengthening.md
@@ -314,11 +314,29 @@ stop being strengthened in silence:
 Variable lengths and heights are deliberately **not** on this list either, and
 nor is a variable capacity. `CumulativeDonorView`
 ([`donor_view.hh`](../gcs/constraints/cumulative/donor_view.hh)) reduces a donor
-to the part of itself the argument can be made over, per *task*: one task with a
-variable height is set aside and weakened out of every row, and the rest of the
-donor is strengthened exactly as before. `donors_with_set_aside_tasks` counts the
-donors that happened to, because one strengthened over four of its five tasks
+to the part of itself the argument can be made over, per *task*, and what is left
+as a set-aside is a task that cannot be argued about at all: a height that is a
+view, or one whose lower bound is zero. `donors_with_set_aside_tasks` counts the
+donors that had one, because one strengthened over four of its five tasks
 otherwise looks just like one strengthened in full.
+
+An ordinary variable height is **converted** rather than set aside: its terms in
+a row are the bits of a linearised contribution, and the row saying the
+contribution is at least the height turns them back into a coefficient on the
+activity flag, at the demand the task is guaranteed to make. That is not always a
+gain here, and it is the one place in this presolver where the answer is a
+judgement rather than a rule. `kappa` is the largest subset sum the capacity
+allows, so adding a task can only push it up: heights `{3, 3}` under a capacity
+of eight give six, and converting a fifth task at a guaranteed demand of one
+gives seven — a unit of strengthening surrendered to gain one task's energy in
+the overload check. Both are arithmetic and neither dominates, so the donor is
+assessed both ways and the bigger reduction kept, with
+`donors_better_off_setting_heights_aside` recording when the conversion lost.
+
+Where *every* height is a variable — the multi-mode RCPSP shape, a task picking a
+mode that fixes its duration and its demand — there is no "without" to lose to:
+before conversion such a donor had no usable task at all and was declined
+outright.
 
 A variable **length** is not set aside at all. No length appears in a capacity
 row, so the rows are the same rows; what it costs is the `after` pin, and the
@@ -343,7 +361,7 @@ cancel across that bridge first.
 - **A capacity that is a view.** Its bits are not the ones the donor's rows
   mention, so there is no order literal whose definition would cancel them, and
   nothing to reduce a row against. A *variable* capacity is fine, a variable
-  height costs its own task rather than the donor, and a variable length costs
+  height is converted to the demand it guarantees, and a variable length costs
   nothing — see below.
 - **A height above the capacity**, as above.
 - **Every task full**, which makes `kappa` zero: a disjunctive rather than a

--- a/gcs/constraints/cumulative/cumulative.cc
+++ b/gcs/constraints/cumulative/cumulative.cc
@@ -270,6 +270,14 @@ auto gcs::innards::prepare_cumulative_overload_check(const vector<IntegerVariabl
     // eligible is not lost to the check: whatever it must occupy still counts,
     // through the profile term of the (TTOC) strengthening.
     //
+    // The height half is looser than it reads. A *derived* Cumulative's tasks
+    // carry constant heights by construction, so one whose donor height was a
+    // variable arrives here already converted to the demand it guarantees and
+    // passes --- which is how an all-variable-height donor's energy gets
+    // counted at all. A posted constraint's variable height is still turned
+    // away, and need not be: the same conversion would serve. The length half
+    // is the one that genuinely binds, and #689 is what it would take.
+    //
     // Seam for optional tasks (#543): once a task can be absent, only one
     // whose presence is fixed true may join the energy set or the profile, and
     // its presence literal joins the reason. Nothing here consults a presence

--- a/gcs/constraints/cumulative/cumulative.cc
+++ b/gcs/constraints/cumulative/cumulative.cc
@@ -418,10 +418,21 @@ auto Cumulative::define_proof_model(ProofModel & model, const State &) -> void
                 for (Integer k = 0_i; k <= highest_bit_shift; ++k)
                     cc.push_back(model.names_and_ids_tracker().create_proof_flag_values(
                         _constraint_id, std::vector<long long>{static_cast<long long>(i), t.raw_value, k.raw_value}, "cc"));
+                // Labelled, with cake's own names for them: it emits all three
+                // under @c[id][i_t_cge] / [_cle] / [_cz], with the coefficients
+                // we do, so these are the labels a citer of ours resolves
+                // against cake's OPB as well as our own. The `cge` half is what
+                // converts a variable height into a constant one for a derived
+                // constraint (recover_constant_argument_row); the other two are
+                // labelled to keep the family whole rather than because
+                // anything cites them yet.
                 auto contrib = contrib_sum_of(cc);
-                model.add_constraint(contrib + -1_i * _heights[i] >= 0_i, HalfReifyOnConjunctionOf{active});
-                model.add_constraint(contrib + -1_i * _heights[i] <= 0_i, HalfReifyOnConjunctionOf{active});
-                model.add_constraint(contrib <= 0_i, HalfReifyOnConjunctionOf{! active});
+                model.add_labelled_constraint(_constraint_id, ConstraintProofModelData<Cumulative>::contribution_ge_row_role(i, t),
+                    contrib + -1_i * _heights[i] >= 0_i, HalfReifyOnConjunctionOf{active});
+                model.add_labelled_constraint(_constraint_id, ConstraintProofModelData<Cumulative>::contribution_le_row_role(i, t),
+                    contrib + -1_i * _heights[i] <= 0_i, HalfReifyOnConjunctionOf{active});
+                model.add_labelled_constraint(_constraint_id, ConstraintProofModelData<Cumulative>::contribution_zero_row_role(i, t), contrib <= 0_i,
+                    HalfReifyOnConjunctionOf{! active});
                 _contrib_flags[i].push_back(move(cc));
             }
         }
@@ -1287,6 +1298,23 @@ auto ConstraintProofModelData<Cumulative>::active_flag_key(size_t task, Integer 
 auto ConstraintProofModelData<Cumulative>::contribution_flag_key(size_t task, Integer t, Integer bit) -> ProofFlagKey
 {
     return ProofFlagKey{{static_cast<long long>(task), t.raw_value, bit.raw_value}, "cc"};
+}
+
+auto ConstraintProofModelData<Cumulative>::contribution_ge_row_role(size_t task, Integer t) -> string
+{
+    // cake_pb_cp's own name for this row. Must stay the string
+    // define_proof_model labels it with, and must stay cake's.
+    return std::to_string(task) + "_" + std::to_string(t.raw_value) + "_cge";
+}
+
+auto ConstraintProofModelData<Cumulative>::contribution_le_row_role(size_t task, Integer t) -> string
+{
+    return std::to_string(task) + "_" + std::to_string(t.raw_value) + "_cle";
+}
+
+auto ConstraintProofModelData<Cumulative>::contribution_zero_row_role(size_t task, Integer t) -> string
+{
+    return std::to_string(task) + "_" + std::to_string(t.raw_value) + "_cz";
 }
 
 auto ConstraintProofModelData<Cumulative>::end_lower_bound_role(size_t task) -> string

--- a/gcs/constraints/cumulative/cumulative.hh
+++ b/gcs/constraints/cumulative/cumulative.hh
@@ -299,6 +299,34 @@ namespace gcs
         [[nodiscard]] static auto contribution_flag_key(std::size_t task, Integer t, Integer bit) -> innards::ProofFlagKey;
 
         /**
+         * \name The rows defining a variable-height task's linearised load
+         * contribution at time `t`.
+         *
+         * Three halves of one statement: `ge` and `le` say the contribution
+         * *is* the height while the task is active, and `zero` says it is
+         * nothing while it is not. The `ge` one is what converts such a task's
+         * bit terms back into `lb(height) x active` for a constraint derived
+         * over this one, which is all anything cites today; the other two are
+         * published because they are the same family, in the way `before` and
+         * `after` are published beside `active`.
+         *
+         * These are `cake_pb_cp`'s own names for the rows, as
+         * \ref capacity_row_role is: cake emits all three under the same
+         * labels, over the same terms, so a proof citing one resolves against
+         * its re-derived OPB as well as against ours. Renaming them is
+         * therefore a cross-tool break rather than an internal one.
+         *
+         * A constant-height task has none. Ask
+         * NamesAndIDsTracker::constraint_row_label, which is how a citer
+         * discovers that.
+         */
+        ///@{
+        [[nodiscard]] static auto contribution_ge_row_role(std::size_t task, Integer t) -> std::string;
+        [[nodiscard]] static auto contribution_le_row_role(std::size_t task, Integer t) -> std::string;
+        [[nodiscard]] static auto contribution_zero_row_role(std::size_t task, Integer t) -> std::string;
+        ///@}
+
+        /**
          * \brief The role of the line saying the proof-only end proxy for this
          * task is at least its start plus its length.
          *

--- a/gcs/constraints/cumulative/donor_view.cc
+++ b/gcs/constraints/cumulative/donor_view.cc
@@ -1,5 +1,6 @@
 #include <gcs/constraints/cumulative/donor_view.hh>
 #include <gcs/constraints/cumulative/propagate.hh>
+#include <gcs/innards/power.hh>
 #include <gcs/innards/proofs/bits_encoding.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
 #include <gcs/innards/proofs/pol_builder.hh>
@@ -7,7 +8,9 @@
 #include <gcs/innards/proofs/pseudo_boolean.hh>
 #include <gcs/innards/state.hh>
 
+#include <algorithm>
 #include <optional>
+#include <utility>
 #include <variant>
 #include <vector>
 
@@ -23,8 +26,10 @@ namespace
 }
 
 using std::make_optional;
+using std::move;
 using std::nullopt;
 using std::optional;
+using std::pair;
 using std::size_t;
 using std::vector;
 
@@ -49,19 +54,34 @@ auto gcs::innards::cumulative_donor_view(const Cumulative & donor, const State &
 
     view.lengths.assign(n, constant_variable(0_i));
     view.heights.assign(n, 0_i);
+    view.height_bounded_by.assign(n, nullopt);
     view.presences = donor.presences();
 
     for (size_t i = 0; i < n; ++i) {
         auto length = donor.lengths()[i], height = donor.heights()[i];
 
-        // A variable height is what a set-aside is for: it makes the donor's
-        // row terms the bits of a linearised contribution rather than
-        // `height x active`, so a subset sum of the heights is not a subset sum
-        // of the row's coefficients, and nothing a recipe does to that row is
-        // an argument about this task.
-        if (! is_constant_variable(height)) {
-            view.set_aside.push_back(i);
-            continue;
+        // A variable height makes the donor's row terms the bits of a
+        // linearised contribution rather than `height x active`, so a subset
+        // sum of the heights is not a subset sum of the row's coefficients ---
+        // until the contribution is converted back into a coefficient on the
+        // activity flag, which recover_constant_argument_row does with the row
+        // saying the contribution is at least the height. What that leaves is
+        // the *guaranteed* demand, which is the height's lower bound.
+        auto height_value = 0_i;
+        if (is_constant_variable(height))
+            height_value = const_value_of(height);
+        else {
+            // A view's reification is over its own bit vector rather than the
+            // underlying variable's, so the height's bound rows have nothing to
+            // cancel against and there is no conversion to make. A zero lower
+            // bound guarantees nothing, which is the same as having no term.
+            // Either way, what is left is the set-aside this used to be.
+            if (! std::holds_alternative<SimpleIntegerVariableID>(height) || state.lower_bound(height) <= 0_i) {
+                view.set_aside.push_back(i);
+                continue;
+            }
+            height_value = state.lower_bound(height);
+            view.height_bounded_by[i] = height;
         }
 
         // A task that can never load the resource, or that was posted as
@@ -74,8 +94,10 @@ auto gcs::innards::cumulative_donor_view(const Cumulative & donor, const State &
         // whether it can run at all, and is the same bound the donor windowed
         // its flags with.
         auto presence = cumulative_task_presence(view.presences.empty() ? nullopt : make_optional(view.presences[i]));
-        if (state.upper_bound(length) <= 0_i || const_value_of(height) <= 0_i || presence.never_present)
+        if (state.upper_bound(length) <= 0_i || height_value <= 0_i || presence.never_present) {
+            view.height_bounded_by[i] = nullopt;
             continue;
+        }
 
         // A variable length is not a set-aside. It leaves the row untouched ---
         // no length appears in one --- and costs the *pins* instead: `after` is
@@ -90,16 +112,38 @@ auto gcs::innards::cumulative_donor_view(const Cumulative & donor, const State &
         if (logger && ! is_constant_variable(length) && ! is_constant_variable(donor.starts()[i]) &&
             ! logger->names_and_ids_tracker().find_derived_line(
                 donor.constraint_id(), ConstraintProofModelData<Cumulative>::end_lower_bound_role(i))) {
+            view.height_bounded_by[i] = nullopt;
             view.set_aside.push_back(i);
             continue;
         }
 
         view.lengths[i] = length;
-        view.heights[i] = const_value_of(height);
+        view.heights[i] = height_value;
         view.usable.push_back(i);
     }
 
     return view;
+}
+
+auto CumulativeDonorView::with_converted_heights_set_aside() const -> CumulativeDonorView
+{
+    CumulativeDonorView result = *this;
+    result.usable.clear();
+    for (auto i : usable) {
+        if (! height_bounded_by[i]) {
+            result.usable.push_back(i);
+            continue;
+        }
+        // Back to what it was before the conversion: no length and no height to
+        // quote, its position among the ones every derived row is weakened
+        // over, and nothing left saying it was ever convertible.
+        result.lengths[i] = constant_variable(0_i);
+        result.heights[i] = 0_i;
+        result.height_bounded_by[i] = nullopt;
+        result.set_aside.push_back(i);
+    }
+    std::sort(result.set_aside.begin(), result.set_aside.end());
+    return result;
 }
 
 auto gcs::innards::recover_constant_argument_row(ProofLogger & logger, const CumulativeDonorView & view, const ConstraintID & donor, ProofLine row,
@@ -140,14 +184,88 @@ auto gcs::innards::recover_constant_argument_row(ProofLogger & logger, const Cum
         }
     }
 
+    // And which of the *converted* tasks have one: same question, same answer,
+    // and the bits are what the conversion is about rather than what it weakens
+    // away. A task the donor gave no window here has nothing to convert.
+    vector<pair<size_t, vector<ProofFlag>>> convert;
+    for (auto i : view.usable) {
+        if (! view.height_bounded_by[i])
+            continue;
+        vector<ProofFlag> cc;
+        for (auto bit = 0;; ++bit) {
+            auto flag = tracker.find_proof_flag_values(donor, ConstraintProofModelData<Cumulative>::contribution_flag_key(i, t, Integer{bit}));
+            if (! flag)
+                break;
+            cc.push_back(*flag);
+        }
+        if (! cc.empty())
+            convert.emplace_back(i, move(cc));
+    }
+
     // The all-constant case, which is the common one: the row already says what
     // a recipe needs, so it is handed back untouched and the proof is
     // byte-identical to one written without any of this.
-    if (weaken_out.empty() && ! view.capacity_bounded_by)
+    if (weaken_out.empty() && convert.empty() && ! view.capacity_bounded_by)
         return row;
 
     PolBuilder reduced;
     reduced.add(row);
+
+    // Convert each variable-height task's bit terms into `lb(h) x active`,
+    // which is a coefficient on a flag again and so a term a recipe can argue
+    // about. One line each:
+    //
+    //     Sum_k 2^k cc_k  +  lb(h) ~active  >=  lb(h)
+    //
+    // added to the row with coefficient one, so the bits cancel exactly and
+    // what is left on the task is `lb(h) x active`. It is a RUP rather than a
+    // `pol`, and that is not laziness: negating it forces `~active` to zero,
+    // and what remains is the `cge` row and the height's lower bound over two
+    // power-of-two bit counters, which unit propagation walks down a bit at a
+    // time. Every step is single-constraint, so any fixpoint finds it --- I
+    // swept it over several thousand (bound, upper bound, bit width) shapes,
+    // including contribution bits narrower than the height's, before believing
+    // it. The `pol` it replaces would be the `cge` row plus the bound, then a
+    // saturate to cap the reification constant down to the bound, then a
+    // literal axiom per bit to put the coefficients back.
+    for (const auto & [i, cc] : convert) {
+        auto height = std::get<SimpleIntegerVariableID>(*view.height_bounded_by[i]);
+        auto active = tracker.find_proof_flag_values(donor, ConstraintProofModelData<Cumulative>::active_flag_key(i, t));
+        auto contribution_row = tracker.constraint_row_label(donor, ConstraintProofModelData<Cumulative>::contribution_ge_row_role(i, t));
+        // The flags exist, so the donor gave this task a window here and both
+        // of these went out with them. Missing means the donor is not the
+        // Cumulative these keys were published by.
+        if (! active || ! contribution_row)
+            return nullopt;
+
+        // The bound the height has *now*, by the same route the capacity takes
+        // and for the same reason: the declared one is a weaker number the
+        // moment anything has tightened it, and a declared zero would give up
+        // the conversion altogether. The atom's definition supplies the bits,
+        // and the unit saying the atom holds is what makes the row
+        // unconditional --- permanently, the bound having been reached before
+        // the search started.
+        auto at_least = height >= view.heights[i];
+        auto definition = tracker.need_pol_item_defining_literal(at_least);
+        auto holds = tracker.boundary_pin_line(height, view.heights[i]);
+        if (! holds)
+            holds = logger.emit_rup_proof_line(WPBSum{} + 1_i * at_least >= 1_i, ProofLevel::Temporary);
+
+        // Hints, where the definition came back as a line: they are what makes
+        // this cheap to check, and they are exactly the three facts the
+        // argument above uses. A zero-one height resolves to a bare literal
+        // instead, which a hint list cannot carry --- so that one goes
+        // unhinted, which is slower to check and no less true.
+        std::optional<vector<ProofLine>> hints;
+        if (auto line = std::get_if<ProofLine>(&definition))
+            hints = vector<ProofLine>{ProofLine{*contribution_row}, *line, *holds};
+
+        WPBSum guaranteed;
+        for (Integer k = 0_i; k.raw_value < static_cast<long long>(cc.size()); ++k)
+            guaranteed += power2(k) * cc[k.raw_value];
+        guaranteed += view.heights[i] * ! *active;
+        reduced.add(logger.emit(RUPProofRule{hints}, move(guaranteed) >= view.heights[i], ProofLevel::Temporary));
+    }
 
     if (view.capacity_bounded_by) {
         // How much of the order literal is left once its definition has handed

--- a/gcs/constraints/cumulative/donor_view.hh
+++ b/gcs/constraints/cumulative/donor_view.hh
@@ -43,6 +43,17 @@ namespace gcs::innards
      * is kept exactly where the donor published the line giving that proxy its
      * lower bound, and set aside where it did not.
      *
+     * A variable *height* is a restriction, but a payable one. Its terms in a
+     * capacity row are the bits of a linearised contribution rather than a
+     * coefficient on the activity flag, so a recipe cannot say anything about
+     * it as the row stands --- but the row saying the contribution is at least
+     * the height turns those bits back into `lb(height) x active`, which is a
+     * coefficient on the flag again, and the task's guaranteed demand. Such a
+     * task is kept whenever that is available, and what stays set aside is a
+     * height that cannot be argued about at all: a view (whose reification is
+     * over its own bit vector, so the height's bound rows do not cancel against
+     * it), or one whose lower bound is zero, which guarantees nothing.
+     *
      * \ingroup Innards
      */
     struct CumulativeDonorView
@@ -56,10 +67,20 @@ namespace gcs::innards
         std::vector<IntegerVariableID> lengths;
 
         /// Per task, in the donor's own order, and **zero for a set-aside
-        /// task**: a height that is not a constant is not a number this
-        /// constraint may quote, its terms in a capacity row being the bits of
-        /// a linearised contribution rather than a coefficient on a flag.
+        /// task**. A height that is not a constant is a number this constraint
+        /// may quote only after its terms in a capacity row --- the bits of a
+        /// linearised contribution --- have been converted into a coefficient
+        /// on the activity flag, which is what \ref height_bounded_by marks.
         std::vector<Integer> heights;
+
+        /// Per task, the height variable \ref heights came from, where it came
+        /// from one rather than being posted as a constant. Such a task's terms
+        /// in a derived row are the bits of a linearised contribution, and
+        /// recover_constant_argument_row converts them into
+        /// `heights[i] x active` --- the task's *guaranteed* demand, which is
+        /// what its lower bound is. Nullopt for a posted constant, and for a
+        /// set-aside task.
+        std::vector<std::optional<IntegerVariableID>> height_bounded_by;
 
         /// Per task, the presence argument as posted, for
         /// derived_cumulative_tasks_from.
@@ -84,6 +105,21 @@ namespace gcs::innards
         /// posted, in which case every derived row has to buy it. See
         /// recover_constant_argument_row.
         std::optional<IntegerVariableID> capacity_bounded_by;
+
+        /**
+         * \brief This view with every converted task set aside instead, as it
+         * would have been before the conversion existed.
+         *
+         * Converting is not always a gain, and the presolver that has to know
+         * is the one whose argument is a subset sum: kappa is the largest
+         * subset sum of the heights that the capacity allows, so *adding* a
+         * task can only push it up, and a converted task can therefore cost a
+         * donor its strengthening. What it buys, against that, is the task's
+         * energy in the overload check. Neither dominates and both are
+         * arithmetic, so a caller that cares works out both and keeps the
+         * better --- which is what this is for.
+         */
+        [[nodiscard]] auto with_converted_heights_set_aside() const -> CumulativeDonorView;
     };
 
     /**

--- a/gcs/presolvers/cumulative_strengthening/cumulative_strengthening.cc
+++ b/gcs/presolvers/cumulative_strengthening/cumulative_strengthening.cc
@@ -34,6 +34,7 @@ using std::map;
 using std::max;
 using std::min;
 using std::move;
+using std::nullopt;
 using std::optional;
 using std::pair;
 using std::shared_ptr;
@@ -160,131 +161,185 @@ auto CumulativeStrengthening::run(Problem & problem, Propagators & propagators, 
                 logger->emit_proof_comment("presolve cumulative: declining " + as_string(donor.constraint_id()) + ", capacity is not reducible");
             continue;
         }
-        if (! view->set_aside.empty())
-            bump(&CumulativeStrengtheningStats::donors_with_set_aside_tasks);
-
         const auto & starts = donor.starts();
         auto n = starts.size();
         auto capacity = view->capacity;
-
-        // The same windowing install_derived_cumulative resolves, and the same
-        // windowing the donor encoded: a task can be active from its earliest
-        // start to its latest finish, which for a variable duration is the
-        // largest one still allowed. This is the paper's `t in [est_j, lct_j)`.
-        vector<Integer> t_lo(n, 0_i), t_hi(n, 0_i);
-        const auto & active_tasks = view->usable;
-        for (auto i : active_tasks) {
-            auto [s_lo, s_hi] = state.bounds(starts[i]);
-            t_lo[i] = s_lo;
-            t_hi[i] = s_hi + state.upper_bound(view->lengths[i]) - 1_i;
-        }
-
-        if (active_tasks.empty()) {
-            bump(&CumulativeStrengtheningStats::declined_nothing_to_gain);
-            continue;
-        }
-
-        // A height above the capacity means the donor is infeasible on its own,
-        // which is the donor's business to detect and not something to build a
-        // subset sum over.
-        if (std::any_of(active_tasks.begin(), active_tasks.end(), [&](size_t i) { return view->heights[i] > capacity; })) {
-            bump(&CumulativeStrengtheningStats::declined_nothing_to_gain);
-            continue;
-        }
-
-        // Schulz's coefficient raising, as the set of tasks it applies to. A
-        // task that cannot run beside any *other* task that consumes anything
-        // occupies the resource whenever it runs, whatever its height says, so
-        // its height is really the capacity --- and, once the capacity comes
-        // down to kappa below, really kappa.
-        //
-        // Stated as the pairwise test rather than as the paper's
-        // `c_i > C - min_j c_j`, because the two are the same condition and the
-        // pairwise one is what the certificate needs anyway: it is one
-        // at-most-one per pair, each derived from the donor's own row. Tasks
-        // whose windows cannot overlap are not part of it, which is a little
-        // more than the paper claims and costs nothing --- if they can never be
-        // active together, no row ever mentions both.
-        //
-        // Deliberately *not* per time point, even though fewer tasks can run at
-        // one time point than over the whole horizon and the set would be
-        // larger for it: a Cumulative has one height per task, not one per time
-        // point, so a task that only fills the resource at some of them cannot
-        // be given a raised height at all.
-        vector<size_t> full_tasks, other_tasks;
-        for (auto i : active_tasks) {
-            auto conflicts_with_everything = std::all_of(active_tasks.begin(), active_tasks.end(),
-                [&](size_t j) { return i == j || t_hi[i] < t_lo[j] || t_hi[j] < t_lo[i] || view->heights[i] + view->heights[j] > capacity; });
-            (conflicts_with_everything ? full_tasks : other_tasks).push_back(i);
-        }
-
-        // The mutation that says the pairwise test is the load-bearing part:
-        // take the tallest task that did *not* qualify and raise it anyway.
-        // Everything downstream then runs honestly on a set that is wrong, and
-        // the row it lands on is a row the donor does not imply.
         auto unentitled_raise = std::holds_alternative<cumulative_strengthening_mutation::RaiseUnentitled>(_mutation);
-        if (unentitled_raise && ! other_tasks.empty()) {
-            auto tallest =
-                std::max_element(other_tasks.begin(), other_tasks.end(), [&](size_t a, size_t b) { return view->heights[a] < view->heights[b]; });
-            full_tasks.push_back(*tallest);
-            other_tasks.erase(tallest);
-            std::sort(full_tasks.begin(), full_tasks.end());
+
+        // Everything about a candidate view that decides whether it is worth
+        // strengthening over, and what the strengthening would be. A candidate
+        // rather than *the* view, because a donor with a variable height has
+        // two: one that converts such a task into its guaranteed demand and one
+        // that sets it aside. Nullopt means this candidate has nothing to say.
+        struct Assessment
+        {
+            vector<Integer> t_lo, t_hi;
+            vector<size_t> full_tasks;
+            vector<TimePoint> time_points;
+            Integer kappa;
+        };
+
+        auto assess = [&](const CumulativeDonorView & candidate) -> optional<Assessment> {
+            const auto & active_tasks = candidate.usable;
+            if (active_tasks.empty())
+                return nullopt;
+
+            // The same windowing install_derived_cumulative resolves, and the
+            // same windowing the donor encoded: a task can be active from its
+            // earliest start to its latest finish, which for a variable
+            // duration is the largest one still allowed. This is the paper's
+            // `t in [est_j, lct_j)`.
+            Assessment assessment{vector<Integer>(n, 0_i), vector<Integer>(n, 0_i), {}, {}, 0_i};
+            auto & t_lo = assessment.t_lo;
+            auto & t_hi = assessment.t_hi;
+            for (auto i : active_tasks) {
+                auto [s_lo, s_hi] = state.bounds(starts[i]);
+                t_lo[i] = s_lo;
+                t_hi[i] = s_hi + state.upper_bound(candidate.lengths[i]) - 1_i;
+            }
+
+            // A height above the capacity means the donor is infeasible on its
+            // own, which is the donor's business to detect and not something to
+            // build a subset sum over.
+            if (std::any_of(active_tasks.begin(), active_tasks.end(), [&](size_t i) { return candidate.heights[i] > capacity; }))
+                return nullopt;
+
+            // Schulz's coefficient raising, as the set of tasks it applies to.
+            // A task that cannot run beside any *other* task that consumes
+            // anything occupies the resource whenever it runs, whatever its
+            // height says, so its height is really the capacity --- and, once
+            // the capacity comes down to kappa below, really kappa.
+            //
+            // Stated as the pairwise test rather than as the paper's
+            // `c_i > C - min_j c_j`, because the two are the same condition and
+            // the pairwise one is what the certificate needs anyway: it is one
+            // at-most-one per pair, each derived from the donor's own row.
+            // Tasks whose windows cannot overlap are not part of it, which is a
+            // little more than the paper claims and costs nothing --- if they
+            // can never be active together, no row ever mentions both.
+            //
+            // Deliberately *not* per time point, even though fewer tasks can
+            // run at one time point than over the whole horizon and the set
+            // would be larger for it: a Cumulative has one height per task, not
+            // one per time point, so a task that only fills the resource at
+            // some of them cannot be given a raised height at all.
+            auto & full_tasks = assessment.full_tasks;
+            vector<size_t> other_tasks;
+            for (auto i : active_tasks) {
+                auto conflicts_with_everything = std::all_of(active_tasks.begin(), active_tasks.end(), [&](size_t j) {
+                    return i == j || t_hi[i] < t_lo[j] || t_hi[j] < t_lo[i] || candidate.heights[i] + candidate.heights[j] > capacity;
+                });
+                (conflicts_with_everything ? full_tasks : other_tasks).push_back(i);
+            }
+
+            // The mutation that says the pairwise test is the load-bearing
+            // part: take the tallest task that did *not* qualify and raise it
+            // anyway. Everything downstream then runs honestly on a set that is
+            // wrong, and the row it lands on is a row the donor does not imply.
+            if (unentitled_raise && ! other_tasks.empty()) {
+                auto tallest = std::max_element(
+                    other_tasks.begin(), other_tasks.end(), [&](size_t a, size_t b) { return candidate.heights[a] < candidate.heights[b]; });
+                full_tasks.push_back(*tallest);
+                other_tasks.erase(tallest);
+                std::sort(full_tasks.begin(), full_tasks.end());
+            }
+
+            auto global_lo = t_lo[active_tasks.front()], global_hi = t_hi[active_tasks.front()];
+            for (auto i : active_tasks) {
+                global_lo = min(global_lo, t_lo[i]);
+                global_hi = max(global_hi, t_hi[i]);
+            }
+
+            for (Integer t = global_lo; t <= global_hi; ++t) {
+                TimePoint point{t, {}, {}, {}, 0_i, false};
+                for (auto i : other_tasks)
+                    if (t >= t_lo[i] && t <= t_hi[i]) {
+                        point.tasks.push_back(i);
+                        point.heights.push_back(candidate.heights[i]);
+                    }
+                for (auto i : full_tasks)
+                    if (t >= t_lo[i] && t <= t_hi[i])
+                        point.full_tasks.push_back(i);
+
+                // No task can be active here, so the donor wrote no row and
+                // there is nothing to derive from.
+                if (point.tasks.empty() && point.full_tasks.empty())
+                    continue;
+
+                point.kappa = largest_subset_sum_at_most(point.heights, capacity);
+
+                auto divisor = 0_i;
+                for (const auto & h : point.heights)
+                    divisor = Integer{std::gcd(divisor.raw_value, h.raw_value)};
+                point.by_division = (divisor > 1_i && divisor * (capacity / divisor) == point.kappa);
+
+                assessment.kappa = max(assessment.kappa, point.kappa);
+                assessment.time_points.push_back(move(point));
+            }
+
+            // Every task fills the resource on its own, so the tasks the
+            // capacity is a subset sum *of* are none of them and kappa is zero.
+            // That is not a strengthening but a disjunctive, and inferring
+            // those from conflict cliques is what the InferredDisjunctive
+            // presolver does.
+            if (assessment.kappa <= 0_i)
+                return nullopt;
+
+            // kappa is the largest load reachable at any one time point once
+            // the tasks that fill the resource are set aside, so it is what the
+            // capacity really is. If that is the capacity already, and no
+            // task's height changes either, the donor was posted with the
+            // numbers it deserved and there is nothing here.
+            auto raises_a_height =
+                std::any_of(full_tasks.begin(), full_tasks.end(), [&](size_t i) { return candidate.heights[i] != assessment.kappa; });
+            if (assessment.kappa >= capacity && ! raises_a_height)
+                return nullopt;
+
+            return assessment;
+        };
+
+        auto assessed = assess(*view);
+
+        // Converting a variable height is not free. kappa is the largest subset
+        // sum of the heights the capacity allows, so *adding* a task can only
+        // push it up, and a converted task can therefore cost this donor the
+        // very reduction the presolver exists to make: heights {3, 3} under a
+        // capacity of eight give six, and converting a task at a guaranteed
+        // demand of two gives {3, 3, 2}, whose largest subset sum at most eight
+        // is eight --- no strengthening at all where there used to be two units
+        // of one. Against that, the converted task's energy joins the derived
+        // constraint's overload check, which is the only rule it runs.
+        //
+        // Neither direction dominates and both are arithmetic, so work out both
+        // and keep the bigger reduction rather than assuming. A tie goes to the
+        // converted one, which says the same about the capacity over more tasks.
+        if (std::any_of(view->height_bounded_by.begin(), view->height_bounded_by.end(), [](const auto & h) { return h.has_value(); })) {
+            auto without = view->with_converted_heights_set_aside();
+            if (auto set_aside_instead = assess(without); set_aside_instead && (! assessed || set_aside_instead->kappa < assessed->kappa)) {
+                bump(&CumulativeStrengtheningStats::donors_better_off_setting_heights_aside);
+                assessed = move(set_aside_instead);
+                *view = move(without);
+            }
         }
 
-        auto global_lo = t_lo[active_tasks.front()], global_hi = t_hi[active_tasks.front()];
-        for (auto i : active_tasks) {
-            global_lo = min(global_lo, t_lo[i]);
-            global_hi = max(global_hi, t_hi[i]);
-        }
-
-        vector<TimePoint> time_points;
-        auto kappa = 0_i;
-        for (Integer t = global_lo; t <= global_hi; ++t) {
-            TimePoint point{t, {}, {}, {}, 0_i, false};
-            for (auto i : other_tasks)
-                if (t >= t_lo[i] && t <= t_hi[i]) {
-                    point.tasks.push_back(i);
-                    point.heights.push_back(view->heights[i]);
-                }
-            for (auto i : full_tasks)
-                if (t >= t_lo[i] && t <= t_hi[i])
-                    point.full_tasks.push_back(i);
-
-            // No task can be active here, so the donor wrote no row and there is
-            // nothing to derive from.
-            if (point.tasks.empty() && point.full_tasks.empty())
-                continue;
-
-            point.kappa = largest_subset_sum_at_most(point.heights, capacity);
-
-            auto divisor = 0_i;
-            for (const auto & h : point.heights)
-                divisor = Integer{std::gcd(divisor.raw_value, h.raw_value)};
-            point.by_division = (divisor > 1_i && divisor * (capacity / divisor) == point.kappa);
-
-            kappa = max(kappa, point.kappa);
-            time_points.push_back(move(point));
-        }
-
-        // Every task fills the resource on its own, so the tasks the capacity
-        // is a subset sum *of* are none of them and kappa is zero. That is not
-        // a strengthening but a disjunctive, and inferring those from conflict
-        // cliques is what the InferredDisjunctive presolver does.
-        if (kappa <= 0_i) {
+        if (! assessed) {
             bump(&CumulativeStrengtheningStats::declined_nothing_to_gain);
             continue;
         }
 
-        // kappa is the largest load reachable at any one time point once the
-        // tasks that fill the resource are set aside, so it is what the
-        // capacity really is. If that is the capacity already, and no task's
-        // height changes either, the donor was posted with the numbers it
-        // deserved and there is nothing here.
-        auto raises_a_height = std::any_of(full_tasks.begin(), full_tasks.end(), [&](size_t i) { return view->heights[i] != kappa; });
-        if (kappa >= capacity && ! raises_a_height) {
-            bump(&CumulativeStrengtheningStats::declined_nothing_to_gain);
-            continue;
-        }
+        // Counted from the view that was actually used, since the choice above
+        // can turn a converted task back into a set-aside one.
+        if (! view->set_aside.empty())
+            bump(&CumulativeStrengtheningStats::donors_with_set_aside_tasks);
+        for (auto i : view->usable)
+            if (view->height_bounded_by[i])
+                bump(&CumulativeStrengtheningStats::converted_heights);
+
+        const auto & t_lo = assessed->t_lo;
+        const auto & t_hi = assessed->t_hi;
+        const auto & full_tasks = assessed->full_tasks;
+        auto & time_points = assessed->time_points;
+        auto kappa = assessed->kappa;
 
         // Budget the expensive derivations. The dynamic program has a state per
         // reachable partial sum per item, so `items * capacity` bounds it; the

--- a/gcs/presolvers/cumulative_strengthening/cumulative_strengthening.hh
+++ b/gcs/presolvers/cumulative_strengthening/cumulative_strengthening.hh
@@ -41,13 +41,28 @@ namespace gcs
         Integer capacity_units_removed = 0_i;
 
         /// Donors that were strengthened over only part of themselves, because
-        /// a task's height is a variable and so has no constant term in the rows
-        /// the argument is made over. Its terms are weakened away and it takes
-        /// no part; what that costs is a weaker strengthening, never a wrong
-        /// one. Counted because a donor drifting into this looks exactly like
-        /// one that was strengthened in full. A variable *length* is not one of
-        /// these: no length appears in a row, so such a task keeps its term.
+        /// a task could not be argued about at all: a height that is a view,
+        /// whose reification is over its own bit vector, or one whose lower
+        /// bound is zero and so guarantees nothing. Its terms are weakened away
+        /// and it takes no part; what that costs is a weaker strengthening,
+        /// never a wrong one. Counted because a donor drifting into this looks
+        /// exactly like one that was strengthened in full. Neither a variable
+        /// *length* nor an ordinary variable height is one of these any more.
         std::size_t donors_with_set_aside_tasks = 0;
+
+        /// Donors where converting a variable-height task into its guaranteed
+        /// demand would have made the strengthening *worse*, so it was set
+        /// aside after all. Adding a task can only push the largest subset sum
+        /// up, so a conversion can cost a donor the very reduction this
+        /// presolver exists to make; both are worked out and the bigger
+        /// reduction kept. Counted because the two look identical from outside
+        /// and this is the only thing that says the choice was made.
+        std::size_t donors_better_off_setting_heights_aside = 0;
+
+        /// Tasks kept by converting a variable height into its lower bound ---
+        /// the demand the task is guaranteed to make --- rather than setting
+        /// them aside, summed over the donors that kept them.
+        std::size_t converted_heights = 0;
 
         /// Tasks whose height was raised to the strengthened capacity, over
         /// those donors: the other half of what the presolver does, and the

--- a/gcs/presolvers/cumulative_strengthening/cumulative_strengthening_test.cc
+++ b/gcs/presolvers/cumulative_strengthening/cumulative_strengthening_test.cc
@@ -875,17 +875,25 @@ auto main(int argc, char * argv[]) -> int
             }
         }
 
-        // A variable height on the fifth task, which is the sharper of the two
-        // set-asides: its terms in the donor's rows are the bits of a
-        // linearised contribution rather than `height x active`, so all of them
-        // have to be weakened away and the published contribution key is what
-        // finds them.
+        // A variable height on the fifth task, which a derived constraint can
+        // take at the demand it is *guaranteed* to make --- its lower bound ---
+        // by converting the bits of its linearised contribution back into a
+        // coefficient on its activity flag. Whether it should is the question
+        // this fixture is about, and here the answer is no.
+        //
+        // kappa is the largest subset sum of the heights the capacity allows,
+        // so adding a task can only push it up. Four tasks of height three
+        // under a capacity of eight give six; converting the fifth at a
+        // guaranteed demand of one gives {3, 3, 3, 3, 1}, whose largest subset
+        // sum at most eight is seven. That is a unit of strengthening lost to
+        // gain one task's energy, and the presolver is meant to work both out
+        // and keep the better --- so what this checks is that it did, and set
+        // the task aside after all.
         //
         // Four tasks of energy six need twenty-four in a window four wide,
-        // which six supplies exactly and so does not refute --- the fifth task
-        // is what tipped it over, and it no longer counts. The check here is
-        // that the donor is still strengthened over the other four, and that
-        // nothing is lost.
+        // which six supplies exactly and so does not refute. The check is that
+        // the donor is still strengthened over the other four, and that nothing
+        // is lost.
         {
             auto stats = make_shared<CumulativeStrengtheningStats>();
             const auto inst = base({2, 2}, {1, 3}, {8, 8});
@@ -893,8 +901,15 @@ auto main(int argc, char * argv[]) -> int
 
             if (stats->donors_strengthened != 1)
                 fail("a donor with one variable height was not strengthened over the rest of itself");
+            if (stats->capacity_units_removed != 2_i)
+                fail("the donor was strengthened by " + std::to_string(stats->capacity_units_removed.raw_value) +
+                    " units, not the two the set-aside reaches --- the conversion's seven was kept instead");
+            if (stats->donors_better_off_setting_heights_aside != 1)
+                fail("converting the variable height was not weighed against setting it aside");
+            if (stats->converted_heights != 0)
+                fail("the variable height was converted even though setting it aside strengthens more");
             if (stats->donors_with_set_aside_tasks != 1)
-                fail("a variable height did not set its task aside");
+                fail("the variable height was not set aside after all");
 
             check_solutions("variable height", inst, outcome);
         }
@@ -938,6 +953,42 @@ auto main(int argc, char * argv[]) -> int
             if (solve_general(inst, nullptr, nullopt).refuted_at_root)
                 fail("the donor alone refuted the variable-length instance at the root");
         }
+    }
+
+    // Every height a variable, which is the shape multi-mode RCPSP has: a task
+    // picks a mode, and the mode fixes both its duration and its demand. Before
+    // a variable height could be converted this donor had *no* usable task at
+    // all, so the presolver declined it outright and inferred nothing; now every
+    // task is there at the demand it is guaranteed to make.
+    //
+    // Five tasks of guaranteed height three under a capacity of eight: the
+    // largest subset sum eight allows is six, so the capacity is really six, and
+    // five tasks of energy six need thirty in a window four wide, which six
+    // supplies twenty-four of. The donor cannot reach that for itself from
+    // either end --- its window-energy lemma takes only tasks whose energy is a
+    // number, so its energy set is empty, and no task has a mandatory part to
+    // put in its profile.
+    {
+        auto stats = make_shared<CumulativeStrengtheningStats>();
+        const GeneralInstance inst{
+            {{0, 2}, {0, 2}, {0, 2}, {0, 2}, {0, 2}}, {{2, 2}, {2, 2}, {2, 2}, {2, 2}, {2, 2}}, {{3, 4}, {3, 4}, {3, 4}, {3, 4}, {3, 4}}, {}, {8, 8}};
+        auto outcome = solve_general(inst, stats, proofs ? make_optional("cumulative_strengthening_all_var_heights") : nullopt);
+
+        if (stats->donors_strengthened != 1)
+            fail("a donor whose every height is a variable was not strengthened");
+        if (stats->converted_heights != 5)
+            fail("only " + std::to_string(stats->converted_heights) + " of the five variable heights were converted");
+        if (stats->donors_with_set_aside_tasks != 0)
+            fail("a task was set aside on a donor every one of whose heights converts");
+        if (stats->capacity_units_removed != 2_i)
+            fail("the donor was strengthened by the wrong amount");
+
+        check_solutions("every height a variable", inst, outcome);
+
+        if (! outcome.refuted_at_root)
+            fail("the strengthened energy check did not refute the all-variable-height instance at the root");
+        if (solve_general(inst, nullptr, nullopt).refuted_at_root)
+            fail("the donor alone refuted the all-variable-height instance at the root");
     }
 
     // What is still declined outright: a capacity that is a *view*, whose bits

--- a/gcs/presolvers/inferred_cumulative/inferred_cumulative.cc
+++ b/gcs/presolvers/inferred_cumulative/inferred_cumulative.cc
@@ -501,6 +501,9 @@ auto InferredCumulative::run(Problem & problem, Propagators & propagators, State
         }
         if (! view->set_aside.empty())
             bump(&InferredCumulativeStats::donors_with_set_aside_tasks);
+        for (auto i : view->usable)
+            if (view->height_bounded_by[i])
+                bump(&InferredCumulativeStats::converted_heights);
 
         const auto & starts = donor.starts();
         auto capacity = view->capacity;

--- a/gcs/presolvers/inferred_cumulative/inferred_cumulative.hh
+++ b/gcs/presolvers/inferred_cumulative/inferred_cumulative.hh
@@ -146,14 +146,20 @@ namespace gcs
         std::size_t declined_optional = 0;
         std::size_t declined_variable_arguments = 0;
 
-        /// Donors that could only be lifted out of in part, because a task's
-        /// height is a variable and so has no constant term in their rows. Such
-        /// a task takes no part in any cover and its terms are weakened out of
-        /// every row first; what that costs is a smaller matrix, never a wrong
-        /// cut. Counted because a donor drifting into it looks exactly like one
-        /// used in full. A variable *length* is not one of these: no length
-        /// appears in a row, so such a task keeps its column.
+        /// Donors that could only be lifted out of in part, because a task
+        /// could not be argued about at all: a height that is a view, or one
+        /// whose lower bound is zero. Such a task takes no part in any cover and
+        /// its terms are weakened out of every row first; what that costs is a
+        /// smaller matrix, never a wrong cut. Counted because a donor drifting
+        /// into it looks exactly like one used in full. Neither a variable
+        /// *length* nor an ordinary variable height is one of these any more.
         std::size_t donors_with_set_aside_tasks = 0;
+
+        /// Task appearances kept by converting a variable height into its lower
+        /// bound --- the demand the task is guaranteed to make --- rather than
+        /// setting them aside. Per (donor, task), since a task can be a variable
+        /// height on one donor and a constant on another.
+        std::size_t converted_heights = 0;
         /// Covers already inside the support of something lifted earlier, which
         /// would re-derive it and waste the subproblems (paper, Example 12).
         std::size_t dropped_visited = 0;

--- a/gcs/presolvers/inferred_cumulative/inferred_cumulative_test.cc
+++ b/gcs/presolvers/inferred_cumulative/inferred_cumulative_test.cc
@@ -506,10 +506,11 @@ auto main(int argc, char * argv[]) -> int
      * is not one less than a power of two --- so the order atom the reduction
      * resolves really does come back with a coefficient to pay off. The fourth
      * task's terms in the row are the bits of a linearised contribution rather
-     * than `height x active`, so all of them have to come out before anything
-     * is lifted out of what is left; it takes no part in the cover, and the
-     * three demand-four tasks still fit in twos and not in threes at either
-     * capacity, so the cut is the same one.
+     * than `height x active`, so those bits are converted into `lb(h) x active`
+     * before anything is lifted out of what is left. At a guaranteed demand of
+     * one it takes no part in the cover --- four and four and one is nine,
+     * which ten holds --- and the three demand-four tasks still fit in twos and
+     * not in threes at either capacity, so the cut is the same one.
      */
     {
         const int horizon = 7, length = 3, latest = horizon - length;
@@ -542,8 +543,10 @@ auto main(int argc, char * argv[]) -> int
 
         if (stats->cuts_posted != 1)
             fail("variable arguments: posted " + to_string(stats->cuts_posted) + " cuts, not the one over the three constant tasks");
-        if (stats->donors_with_set_aside_tasks != 1)
-            fail("variable arguments: the variable-height task was not set aside");
+        if (stats->converted_heights != 1)
+            fail("variable arguments: the variable-height task was not converted to its guaranteed demand");
+        if (stats->donors_with_set_aside_tasks != 0)
+            fail("variable arguments: a variable height set its task aside, rather than being converted");
         if (stats->declined_variable_arguments != 0)
             fail("variable arguments: the donor was declined rather than reduced");
 
@@ -574,6 +577,81 @@ auto main(int argc, char * argv[]) -> int
         if (expected != solutions)
             fail("variable arguments: solutions do not match brute force");
         println(cerr, "variable arguments: cut posted over a variable capacity, one task set aside, {} solutions", solutions.size());
+    }
+
+    /* The same cardinality cut over a donor whose every demand is a variable,
+     * which is the shape multi-mode RCPSP has. Set aside, as they would all
+     * have been, this donor has no column in the matrix at all and the
+     * presolver infers nothing; converted to the demands they are guaranteed to
+     * make --- four, their lower bound --- the three tasks fit in twos and not
+     * in threes exactly as the constant version does, and the same cut comes
+     * out.
+     */
+    {
+        const int horizon = 7, length = 3, latest = horizon - length;
+        auto stats = make_shared<InferredCumulativeStats>();
+
+        Problem p;
+        vector<IntegerVariableID> starts, heights;
+        for (int i = 0; i < 3; ++i) {
+            starts.push_back(p.create_integer_variable(0_i, Integer{latest}, "s" + to_string(i)));
+            heights.push_back(p.create_integer_variable(4_i, 5_i, "h" + to_string(i)));
+        }
+        vector<IntegerVariableID> lengths(3, constant_variable(Integer{length}));
+        p.post(Cumulative{starts, lengths, heights, constant_variable(10_i)});
+        p.add_presolver(InferredCumulative{stats});
+
+        set<vector<int>> solutions;
+        solve_with(p, SolveCallbacks{.solution = [&](const CurrentState & s) -> bool {
+            vector<int> solution;
+            for (const auto & v : starts)
+                solution.push_back(s(v).raw_value);
+            for (const auto & v : heights)
+                solution.push_back(s(v).raw_value);
+            solutions.insert(move(solution));
+            return true;
+        }},
+            proofs ? make_optional<ProofOptions>(ProofFileNames{"inferred_cumulative_converted_heights"}) : nullopt);
+        if (proofs)
+            verify_proof_and_clean_up("inferred_cumulative_converted_heights");
+
+        if (stats->cuts_posted != 1)
+            fail("converted heights: posted " + to_string(stats->cuts_posted) + " cuts, not the one over the three tasks");
+        if (stats->converted_heights != 3)
+            fail("converted heights: only " + to_string(stats->converted_heights) + " of the three variable demands were converted");
+        if (stats->donors_with_set_aside_tasks != 0)
+            fail("converted heights: a task was set aside on a donor every one of whose demands converts");
+        if (stats->largest_capacity_bound != 5_i)
+            fail("converted heights: reported a bound of " + to_string(stats->largest_capacity_bound.raw_value) +
+                ", not the five nine units of work against a supply of two per step carry");
+
+        set<vector<int>> expected;
+        vector<int> assignment(6, 0);
+        std::function<auto(std::size_t)->void> enumerate = [&](std::size_t at) {
+            if (at == assignment.size()) {
+                for (int t = 0; t < horizon; ++t) {
+                    int load = 0;
+                    for (int i = 0; i < 3; ++i)
+                        if (assignment[static_cast<std::size_t>(i)] <= t && t < assignment[static_cast<std::size_t>(i)] + length)
+                            load += assignment[static_cast<std::size_t>(i) + 3];
+                    if (load > 10)
+                        return;
+                }
+                expected.insert(assignment);
+                return;
+            }
+            auto lo = at >= 3 ? 4 : 0;
+            auto hi = at >= 3 ? 5 : latest;
+            for (auto v = lo; v <= hi; ++v) {
+                assignment[at] = v;
+                enumerate(at + 1);
+            }
+        };
+        enumerate(0);
+
+        if (expected != solutions)
+            fail("converted heights: solutions do not match brute force");
+        println(cerr, "converted heights: a cut over three variable demands, {} solutions", solutions.size());
     }
 
     /* And the same cut with a variable *duration* in it, which unlike a

--- a/gcs/presolvers/inferred_disjunctive/inferred_disjunctive.cc
+++ b/gcs/presolvers/inferred_disjunctive/inferred_disjunctive.cc
@@ -216,6 +216,9 @@ auto InferredDisjunctive::run(Problem & problem, Propagators & propagators, Stat
         }
         if (! view->set_aside.empty())
             bump(&InferredDisjunctiveStats::resources_with_set_aside_tasks);
+        for (auto i : view->usable)
+            if (view->height_bounded_by[i])
+                bump(&InferredDisjunctiveStats::converted_heights);
 
         const auto & starts = donor.starts();
         resources.push_back(Resource{donor.constraint_id(), view->capacity, starts.size()});

--- a/gcs/presolvers/inferred_disjunctive/inferred_disjunctive.hh
+++ b/gcs/presolvers/inferred_disjunctive/inferred_disjunctive.hh
@@ -86,15 +86,21 @@ namespace gcs
          */
         Integer certified_makespan_bound{0};
 
-        /// Resources that could only be argued over in part, because a task's
-        /// height is a variable and so has no constant term in their rows. Such
-        /// a task takes no part in the conflict graph and its terms are weakened
-        /// out of every row the resource witnesses; what that costs is a smaller
-        /// graph, never a wrong one. Counted because a resource drifting into it
-        /// looks exactly like one used in full. A variable *length* is not one
-        /// of these: no length appears in a row, so such a task can still be a
-        /// clique member.
+        /// Resources that could only be argued over in part, because a task
+        /// could not be argued about at all: a height that is a view, or one
+        /// whose lower bound is zero. Such a task takes no part in the conflict
+        /// graph and its terms are weakened out of every row the resource
+        /// witnesses; what that costs is a smaller graph, never a wrong one.
+        /// Counted because a resource drifting into it looks exactly like one
+        /// used in full. Neither a variable *length* nor an ordinary variable
+        /// height is one of these any more.
         std::size_t resources_with_set_aside_tasks = 0;
+
+        /// Task appearances kept by converting a variable height into its lower
+        /// bound --- the demand the task is guaranteed to make --- rather than
+        /// setting them aside. Per (resource, task), since a task can be a
+        /// variable height on one resource and a constant on another.
+        std::size_t converted_heights = 0;
 
         /// Flag bridges emitted, one per (task, time) that had to be carried
         /// from a witnessing resource to the one holding the task's flags.

--- a/gcs/presolvers/inferred_disjunctive/inferred_disjunctive_test.cc
+++ b/gcs/presolvers/inferred_disjunctive/inferred_disjunctive_test.cc
@@ -416,6 +416,12 @@ auto main(int argc, char * argv[]) -> int
      * so the clique is the same one; the fourth task demands one, which does not
      * conflict with three at five but does at three, so it stays a decision the
      * search makes rather than one the presolver has taken.
+     *
+     * Its height being a variable no longer keeps it out of the graph: it is
+     * converted to the demand it is guaranteed to make, which is one. What the
+     * reduction still has to do is the capacity, and the fourth task's terms
+     * are still the bits of a linearised contribution --- converted rather than
+     * weakened away now, which is a different `pol` over the same bits.
      */
     {
         const int k = 3, length = 2, horizon = 6, latest = horizon - length;
@@ -457,10 +463,12 @@ auto main(int argc, char * argv[]) -> int
 
         if (stats->cliques_posted != 1)
             fail("a clique was not posted over resources with variable arguments");
-        if (stats->resources_with_set_aside_tasks != static_cast<size_t>(k))
-            fail("the variable-height task was not set aside on every resource");
+        if (stats->converted_heights != static_cast<size_t>(k))
+            fail("the variable-height task was not converted on every resource");
+        if (stats->resources_with_set_aside_tasks != 0)
+            fail("a variable height set its task aside, rather than being converted to its guaranteed demand");
         if (stats->declined_variable_arguments != 0)
-            fail("a resource was declined for a task's variable height, which is now a set-aside");
+            fail("a resource was declined for a task's variable height, which is now a conversion");
 
         // Brute force over the same model: the fourth task takes part or not
         // depending on the capacity, which is why it is in the tuple.
@@ -500,6 +508,98 @@ auto main(int argc, char * argv[]) -> int
         if (expected != solutions)
             fail("variable-argument solutions do not match brute force");
         println(cerr, "variable arguments: clique posted, {} solutions", solutions.size());
+    }
+
+    /* A clique that exists only because a variable height was converted. Three
+     * tasks, pairwise conflicting on the three resources `(i + j) mod 3` covers
+     * between them at a demand of three against a capacity of five --- except
+     * that the third task's demand is a *variable* over [3, 4], so on the two
+     * resources it appears on its terms are the bits of a linearised
+     * contribution rather than a coefficient on its activity flag.
+     *
+     * Set aside, as it would have been, that task has no conflicts at all: one
+     * pair is left, the clique is of two, and the minimum size of three refuses
+     * it. Converted to the demand it is guaranteed to make --- three, its lower
+     * bound --- all three pairs conflict and the clique is the whole family. So
+     * `conflicting_pairs` is the measure here: three with the conversion, one
+     * without.
+     */
+    {
+        const int k = 3, length = 2, horizon = 6, latest = horizon - length;
+        auto stats = make_shared<InferredDisjunctiveStats>();
+
+        Problem p;
+        vector<IntegerVariableID> starts;
+        for (int i = 0; i < k; ++i)
+            starts.push_back(p.create_integer_variable(0_i, Integer{latest}, "s" + to_string(i)));
+        auto varying = p.create_integer_variable(3_i, 4_i, "h2");
+
+        vector<IntegerVariableID> lengths(static_cast<size_t>(k), constant_variable(Integer{length}));
+        for (int r = 0; r < k; ++r) {
+            vector<IntegerVariableID> heights(static_cast<size_t>(k), constant_variable(0_i));
+            for (int i = 0; i < k; ++i)
+                for (int j = i + 1; j < k; ++j)
+                    if ((i + j) % k == r) {
+                        // The last task's demand is the variable one wherever it
+                        // appears; everyone else's is the constant three.
+                        heights[static_cast<size_t>(i)] = i == k - 1 ? varying : constant_variable(3_i);
+                        heights[static_cast<size_t>(j)] = j == k - 1 ? varying : constant_variable(3_i);
+                    }
+            p.post(Cumulative{starts, lengths, heights, constant_variable(5_i)});
+        }
+        p.add_presolver(InferredDisjunctive{stats});
+
+        set<vector<int>> solutions;
+        solve_with(p, SolveCallbacks{.solution = [&](const CurrentState & s) -> bool {
+            vector<int> solution;
+            for (const auto & v : starts)
+                solution.push_back(s(v).raw_value);
+            solution.push_back(s(varying).raw_value);
+            solutions.insert(move(solution));
+            return true;
+        }},
+            proofs ? make_optional<ProofOptions>(ProofFileNames{"inferred_disjunctive_converted_height"}) : nullopt);
+        if (proofs)
+            verify_proof_and_clean_up("inferred_disjunctive_converted_height");
+
+        if (stats->conflicting_pairs != 3)
+            fail("found " + to_string(stats->conflicting_pairs) +
+                " conflicting pairs, not the three the conversion reaches --- one is what setting the task aside would give");
+        if (stats->cliques_posted != 1)
+            fail("no clique was posted over a converted height");
+        if (stats->clique_members_posted != static_cast<size_t>(k))
+            fail("the converted task did not join the clique");
+        if (stats->converted_heights != 2)
+            fail("the variable height was converted on " + to_string(stats->converted_heights) + " resources, not the two it appears on");
+        if (stats->resources_with_set_aside_tasks != 0)
+            fail("a variable height set its task aside rather than converting");
+
+        // Brute force: no two tasks may overlap, whatever the third's demand
+        // turns out to be, since three plus anything at least three is over five.
+        set<vector<int>> expected;
+        vector<int> assignment(static_cast<size_t>(k) + 1, 0);
+        std::function<auto(size_t)->void> enumerate = [&](size_t at) {
+            if (at == assignment.size()) {
+                for (int i = 0; i < k; ++i)
+                    for (int j = i + 1; j < k; ++j)
+                        if (assignment[static_cast<size_t>(i)] < assignment[static_cast<size_t>(j)] + length &&
+                            assignment[static_cast<size_t>(j)] < assignment[static_cast<size_t>(i)] + length)
+                            return;
+                expected.insert(assignment);
+                return;
+            }
+            auto lo = at == assignment.size() - 1 ? 3 : 0;
+            auto hi = at == assignment.size() - 1 ? 4 : latest;
+            for (auto v = lo; v <= hi; ++v) {
+                assignment[at] = v;
+                enumerate(at + 1);
+            }
+        };
+        enumerate(0);
+
+        if (expected != solutions)
+            fail("converted-height solutions do not match brute force");
+        println(cerr, "converted height: {} conflicting pairs, a clique of {}", stats->conflicting_pairs, stats->clique_members_posted);
     }
 
     /* A variable duration, which unlike a variable height is not a restriction


### PR DESCRIPTION
Closes #686. On top of #687.

A task whose height is a variable has no `height × active` term in a donor's
capacity row — it has the bits of a linearised contribution instead, so a subset
sum of the heights is not a subset sum of the row's coefficients and nothing a
recipe says about that row is a statement about that task. That is why it was set
aside. What that cost is the task's demand, and this takes it back: the row saying
the contribution is at least the height turns those bits into `lb(h)·active`, a
coefficient on the activity flag again, and `lb(h)` is the demand the task is
*guaranteed* to make.

**Both of the issue's obstacles dissolved on inspection**; the
[investigation is written up there](https://github.com/ciaranm/glasgow-constraint-solver/issues/686#issuecomment-5208834673).

### Obstacle one: cake already labels the rows

`cake_pb_cp` emits all three halves of the contribution definition as
`@c[id][<i>_<t>_cge]` / `[_cle]` / `[_cz]`, over the same terms, keyed by absolute
`(task, time)` exactly as our flags are. Ours went out unlabelled, which is what
made them uncitable. Labelling them with cake's names is therefore a conformance
*improvement* rather than a divergence — these were the only rows in our
cumulative encoding we left unlabelled while cake labelled them. Also checked:
the indices line up on a model with disjoint start domains, and
`scp_chain_cumulative_var_height_sat` still runs the full workflow 2 and passes.

### Obstacle two: it is a hinted RUP, not normalised-form arithmetic

```
rup  Σ_k 2^k·cc_{i,t,k} + L·¬active_{i,t} >= L   :  @c[id][<i>_<t>_cge]  <the height's lower-bound line> ;
```

One line per (task, time), added to the capacity row with coefficient one so the
bits cancel exactly. No saturation, no literal axioms, no coefficient arithmetic
beyond rendering the target.

It closes for a reason rather than by luck, which matters after #687 — negating
it forces `¬active` to zero (coefficient `L` exceeds the slack `L−1`), leaving the
`cge` row against the height's lower bound over two power-of-two bit counters,
which unit propagation walks down one bit at a time; every step is
single-constraint slack propagation, so any fixpoint finds it whatever the order.
That is also why the hint order does not matter and why the negated target need
not be named.

Swept over several thousand `(L, ub(h), bit width)` shapes before being believed,
including contribution bits narrower than the height's — what happens when the
install-time upper bound is tighter than the declared one — and with negative
controls that do fail: a target one stronger than justified is refused, and so is
one with the bound line withheld from the hints, which is what says the derivation
uses it. A Fable consultant found the RUP and the argument; I re-ran its sweep and
wrote an independent harder one before taking it.

The `pol` the issue sketched also works, and needs less than it says — `ia`'s
implication check performs the saturate-and-restore itself, so
`pol <cge> <lb> + ;` with an `ia` pin suffices. It is three times the code and
O(bits) more addends. Noted in a comment, not taken.

### The rest

- **The bound is the live one**, through `need_pol_item_defining_literal`, exactly
  as the capacity's reduction already does and for the same reason: the declared
  bound is a weaker number the moment anything has tightened it, and a declared
  zero would give the conversion up altogether on models that reach a height
  through an `Element` over a mode variable.
- **What stays set aside** is a height that cannot be argued about at all: a
  **view**, whose reification is emitted over its own bit vector so the height's
  bound rows have nothing to cancel against (and which `bound_rows` cannot even be
  asked about), or a lower bound of zero, which guarantees nothing.
- **Converting is not always a gain**, and that is arithmetic rather than proofs.
  `kappa` is the largest subset sum the capacity allows, so adding a task can only
  push it up: four tasks of height three under a capacity of eight give six, and
  converting a fifth at a guaranteed demand of one gives seven — a unit of
  strengthening surrendered to gain one task's energy. So `CumulativeStrengthening`
  assesses the donor both ways and keeps the bigger reduction, which meant
  extracting the assessment (windowing, the pairwise full-task test, the per-time
  subset sum) into one function so it can run twice. The two multi-donor
  presolvers need no such choice: a converted task can only add a conflict edge or
  a column.

### Why it is worth more than the issue's "rare"

Variable demands are what **multi-mode RCPSP** produces — a task picks a mode, the
mode fixes both duration and demand. In such a model *every* task has a variable
height, so `usable` was empty and all three presolvers declined with "nothing to
gain". #687 gave the durations back; this gives the demands. Three of the new
fixtures are that shape, and each is the difference between inferring something
and inferring nothing.

### Fixtures

- `cumulative_strengthening`: every height a variable — declined outright before,
  now strengthened from eight to six with thirty units of energy against a supply
  of twenty-four refuting at the root, which the donor cannot reach from either
  end (its window-energy lemma takes only tasks whose energy is a number, and no
  task has a mandatory part). Plus the old variable-height fixture, rewritten to
  check the conversion was *weighed* and lost, since that donor is one where
  setting aside strengthens more.
- `inferred_disjunctive`: a clique of three where setting the task aside leaves
  one conflicting pair and no clique at all — `conflicting_pairs` is the measure,
  three with the conversion and one without.
- `inferred_cumulative`: the cardinality cut over a donor whose every demand is a
  variable.

Two deliberate corruptions of the conversion — claiming one more than the
guaranteed demand, and using `ub(h)` in place of `lb(h)` — are each caught by all
three presolvers' fixtures. Unlike #687, this one has a built-in tripwire: the
recipes pin what `recover_constant_argument_row` returns with an `ia`, whose
implication check is syntactic.

Green on GCC release (632/632, including the cake chain cases), clang, and the
sanitize build, plus a twelve-seed sweep over the five affected test binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173hT2hFo3MyGRBon8SHt2p
