### PR TITLE
Fix what the stack's later PRs left behind: warnings and stale comments

### DIFF
--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -599,10 +599,14 @@ if(GCS_BUILD_TESTS)
 
     add_executable(flag_bridge_test innards/proofs/flag_bridge_test.cc)
     target_link_libraries(flag_bridge_test PRIVATE glasgow_constraint_solver)
+    # Verifies (and deliberately fails to verify) its own proofs internally, so
+    # it needs no wrapper.
     add_test(NAME flag_bridge_test COMMAND $<TARGET_FILE:flag_bridge_test>)
 
     add_executable(am1_from_pairs_test innards/proofs/am1_from_pairs_test.cc)
     target_link_libraries(am1_from_pairs_test PRIVATE glasgow_constraint_solver)
+    # Verifies (and deliberately fails to verify) its own proofs internally, so
+    # it needs no wrapper.
     add_test(NAME am1_from_pairs_test COMMAND $<TARGET_FILE:am1_from_pairs_test>)
 
     add_executable(am1_from_row_test innards/proofs/am1_from_row_test.cc)

--- a/gcs/constraints/cumulative/cumulative.cc
+++ b/gcs/constraints/cumulative/cumulative.cc
@@ -278,10 +278,14 @@ auto gcs::innards::prepare_cumulative_overload_check(const vector<IntegerVariabl
     // away, and need not be: the same conversion would serve. The length half
     // is the one that genuinely binds, and #689 is what it would take.
     //
-    // Seam for optional tasks (#543): once a task can be absent, only one
-    // whose presence is fixed true may join the energy set or the profile, and
-    // its presence literal joins the reason. Nothing here consults a presence
-    // variable yet because there is not one to consult.
+    // Presence is not among the tests, and deliberately so. What is asked here
+    // is whether the lemma could *ever* speak about a task, which is a question
+    // about how it was posted and is settled once; whether it may speak about
+    // it now is a question about the search, and is asked at every node, where
+    // the propagator skips a task not yet known present and carries the
+    // presence literals of the ones it did use into the reason. A task that can
+    // never be present at all is gone before this is called, `active_tasks`
+    // having dropped it.
     result.overload_tasks.clear();
     for (auto i : active_tasks) {
         if (! is_constant_variable(lengths[i]) || ! is_constant_variable(heights[i]))

--- a/gcs/constraints/cumulative/cumulative.hh
+++ b/gcs/constraints/cumulative/cumulative.hh
@@ -224,8 +224,9 @@ namespace gcs
         [[nodiscard]] auto lengths() const -> const std::vector<IntegerVariableID> &;
         [[nodiscard]] auto heights() const -> const std::vector<IntegerVariableID> &;
         /// Empty for the non-optional constructors, which is how a caller asks
-        /// "is this an optional-task Cumulative?" --- DerivedCumulativeSpec
-        /// requires a donor for which this is empty.
+        /// "is this an optional-task Cumulative?" --- and what a deriver hands
+        /// straight to derived_cumulative_tasks_from, whose default argument
+        /// says the same thing.
         [[nodiscard]] auto presences() const -> const std::vector<IntegerVariableID> &;
         [[nodiscard]] auto capacity() const -> IntegerVariableID;
         ///@}

--- a/gcs/constraints/cumulative/derived_cumulative.hh
+++ b/gcs/constraints/cumulative/derived_cumulative.hh
@@ -65,10 +65,15 @@ namespace gcs::innards
         /// wrong sum and nothing here can tell.
         IntegerVariableID length;
 
-        /// Constant by type, which is the v1 restriction made structural: a
-        /// variable height enters a donor's capacity row as a bit-linearised
-        /// contribution rather than as `height x active`, and a derived row
-        /// would have to speak about those bits too.
+        /// A number, by type, and not because a variable height is out of
+        /// reach: it is because the reduction to one has already happened by
+        /// the time a task is built. A variable height enters a donor's
+        /// capacity row as a bit-linearised contribution rather than as
+        /// `height x active`, and recover_constant_argument_row is what turns
+        /// those bits back into a coefficient on the activity flag --- at the
+        /// task's *guaranteed* demand, `lb(height)`, which is the number
+        /// cumulative_donor_view puts here. So a derived row speaks about a
+        /// constant however its donor was posted, and so does the propagator.
         Integer height;
 
         /// The presence argument the donor was posted with at `position`, or

--- a/gcs/presolvers/cumulative_strengthening/cumulative_strengthening.cc
+++ b/gcs/presolvers/cumulative_strengthening/cumulative_strengthening.cc
@@ -173,10 +173,9 @@ auto CumulativeStrengthening::run(Problem & problem, Propagators & propagators, 
         // that sets it aside. Nullopt means this candidate has nothing to say.
         struct Assessment
         {
-            vector<Integer> t_lo, t_hi;
             vector<size_t> full_tasks;
             vector<TimePoint> time_points;
-            Integer kappa;
+            Integer kappa = 0_i;
         };
 
         auto assess = [&](const CumulativeDonorView & candidate) -> optional<Assessment> {
@@ -188,10 +187,11 @@ auto CumulativeStrengthening::run(Problem & problem, Propagators & propagators, 
             // same windowing the donor encoded: a task can be active from its
             // earliest start to its latest finish, which for a variable
             // duration is the largest one still allowed. This is the paper's
-            // `t in [est_j, lct_j)`.
-            Assessment assessment{vector<Integer>(n, 0_i), vector<Integer>(n, 0_i), {}, {}, 0_i};
-            auto & t_lo = assessment.t_lo;
-            auto & t_hi = assessment.t_hi;
+            // `t in [est_j, lct_j)`. Local to the assessment: what comes out of
+            // it is the time points, which is where the windows have already
+            // been applied, so nothing downstream asks about them again.
+            Assessment assessment;
+            vector<Integer> t_lo(n, 0_i), t_hi(n, 0_i);
             for (auto i : active_tasks) {
                 auto [s_lo, s_hi] = state.bounds(starts[i]);
                 t_lo[i] = s_lo;
@@ -335,8 +335,6 @@ auto CumulativeStrengthening::run(Problem & problem, Propagators & propagators, 
             if (view->height_bounded_by[i])
                 bump(&CumulativeStrengtheningStats::converted_heights);
 
-        const auto & t_lo = assessed->t_lo;
-        const auto & t_hi = assessed->t_hi;
         const auto & full_tasks = assessed->full_tasks;
         auto & time_points = assessed->time_points;
         auto kappa = assessed->kappa;

--- a/gcs/presolvers/cumulative_strengthening/cumulative_strengthening.cc
+++ b/gcs/presolvers/cumulative_strengthening/cumulative_strengthening.cc
@@ -156,7 +156,7 @@ auto CumulativeStrengthening::run(Problem & problem, Propagators & propagators, 
         // flag rather than a term beside it.
         auto view = cumulative_donor_view(donor, state, logger);
         if (! view) {
-            bump(&CumulativeStrengtheningStats::declined_variable_arguments);
+            bump(&CumulativeStrengtheningStats::declined_irreducible_capacity);
             if (logger)
                 logger->emit_proof_comment("presolve cumulative: declining " + as_string(donor.constraint_id()) + ", capacity is not reducible");
             continue;

--- a/gcs/presolvers/cumulative_strengthening/cumulative_strengthening.hh
+++ b/gcs/presolvers/cumulative_strengthening/cumulative_strengthening.hh
@@ -73,20 +73,28 @@ namespace gcs
         /**
          * \name Why a donor was passed over.
          *
-         * Broken out because they mean different things to a caller: the
-         * first is the v1 restriction, the next two are proof-size budgets a
-         * caller may want to raise, and the last is the honest and common
-         * answer that the capacity was already the largest reachable load.
+         * Broken out because they mean different things to a caller: an
+         * argument this presolver cannot reduce, a proof-size budget a caller
+         * may want to raise, the honest and common answer that there was
+         * nothing to say, and a bug.
          *
-         * Optional tasks are not among them. The strengthening argues about
-         * the donor's capacity rows, which an optional task's presence does not
-         * change the shape of --- it is a conjunct of the activity flag, not a
-         * term beside it.
+         * What is *not* among them is anything about a task. A variable
+         * height, a variable length and an optional task each cost at most the
+         * task itself --- its term is weakened out, or converted, and the donor
+         * keeps its strengthening. The capacity is the one argument still able
+         * to turn a whole donor away.
          */
         ///@{
-        std::size_t declined_variable_arguments = 0;
+        /// Donors whose capacity could not be reduced to a number to argue
+        /// against, which today means a view capacity: its reification is over
+        /// its own bit vector, so the bound rows do not cancel against the
+        /// row's. Named for the condition rather than for today's only instance
+        /// of it --- see cumulative_donor_view.
+        std::size_t declined_irreducible_capacity = 0;
         std::size_t declined_over_budget = 0;
         std::size_t declined_over_raise_budget = 0;
+        /// The capacity was already the largest load the tasks can reach, and
+        /// no height moved either, so there was nothing to strengthen.
         std::size_t declined_nothing_to_gain = 0;
         /// Declined by install_derived_cumulative itself, which is a bug rather
         /// than a restriction: the presolver derives its rows over the donor's

--- a/gcs/presolvers/cumulative_strengthening/cumulative_strengthening_test.cc
+++ b/gcs/presolvers/cumulative_strengthening/cumulative_strengthening_test.cc
@@ -1009,7 +1009,7 @@ auto main(int argc, char * argv[]) -> int
         p.add_presolver(CumulativeStrengthening{stats});
         solve_with(p, SolveCallbacks{.trace = [](const CurrentState &) -> bool { return false; }}, nullopt);
 
-        if (stats->declined_variable_arguments != 1)
+        if (stats->declined_irreducible_capacity != 1)
             fail("a view-capacity donor was not declined");
         if (stats->donors_strengthened != 0)
             fail("a view-capacity donor was strengthened anyway");

--- a/gcs/presolvers/inferred_cumulative/inferred_cumulative.cc
+++ b/gcs/presolvers/inferred_cumulative/inferred_cumulative.cc
@@ -487,7 +487,7 @@ auto InferredCumulative::run(Problem & problem, Propagators & propagators, State
         // works over a row no length appears in.
         auto view = cumulative_donor_view(donor, state, logger);
         if (! view) {
-            bump(&InferredCumulativeStats::declined_variable_arguments);
+            bump(&InferredCumulativeStats::declined_irreducible_capacity);
             if (logger)
                 logger->emit_proof_comment("presolve lifted cover: declining " + as_string(donor.constraint_id()) + ", capacity is not reducible");
             continue;

--- a/gcs/presolvers/inferred_cumulative/inferred_cumulative.cc
+++ b/gcs/presolvers/inferred_cumulative/inferred_cumulative.cc
@@ -116,13 +116,6 @@ namespace
         }
     };
 
-    [[nodiscard]] auto constant_value_of(const IntegerVariableID & v) -> optional<Integer>
-    {
-        if (! is_constant_variable(v))
-            return std::nullopt;
-        return std::get<ConstantIntegerVariableID>(v).const_value;
-    }
-
     /// A task's activity flag on a donor at one time, absent when that donor
     /// never encoded the pair --- which is how a task outside its window looks,
     /// and is also how it looks in the donor's own capacity row.

--- a/gcs/presolvers/inferred_cumulative/inferred_cumulative.hh
+++ b/gcs/presolvers/inferred_cumulative/inferred_cumulative.hh
@@ -144,7 +144,12 @@ namespace gcs
         /// flags between donors, and a presence conjunct has to cancel across
         /// that bridge before it may.
         std::size_t declined_optional = 0;
-        std::size_t declined_variable_arguments = 0;
+        /// Donors whose capacity could not be reduced to a number to argue
+        /// against, which today means a view capacity. Named for the condition
+        /// rather than for today's only instance of it: a variable height and a
+        /// variable length cost a task its column, not a donor its row --- see
+        /// cumulative_donor_view.
+        std::size_t declined_irreducible_capacity = 0;
 
         /// Donors that could only be lifted out of in part, because a task
         /// could not be argued about at all: a height that is a view, or one

--- a/gcs/presolvers/inferred_cumulative/inferred_cumulative_test.cc
+++ b/gcs/presolvers/inferred_cumulative/inferred_cumulative_test.cc
@@ -547,7 +547,7 @@ auto main(int argc, char * argv[]) -> int
             fail("variable arguments: the variable-height task was not converted to its guaranteed demand");
         if (stats->donors_with_set_aside_tasks != 0)
             fail("variable arguments: a variable height set its task aside, rather than being converted");
-        if (stats->declined_variable_arguments != 0)
+        if (stats->declined_irreducible_capacity != 0)
             fail("variable arguments: the donor was declined rather than reduced");
 
         set<vector<int>> expected;

--- a/gcs/presolvers/inferred_disjunctive/inferred_disjunctive.cc
+++ b/gcs/presolvers/inferred_disjunctive/inferred_disjunctive.cc
@@ -96,13 +96,6 @@ namespace
         Integer demand_u, demand_v, capacity;
     };
 
-    [[nodiscard]] auto constant_value_of(const IntegerVariableID & v) -> optional<Integer>
-    {
-        if (! is_constant_variable(v))
-            return std::nullopt;
-        return std::get<ConstantIntegerVariableID>(v).const_value;
-    }
-
     /// The flags a task's activity is expressed in, on one resource, at one
     /// time. Absent when that resource never encoded the pair.
     [[nodiscard]] auto flags_for(const NamesAndIDsTracker & tracker, const ConstraintID & donor, size_t position, Integer t)

--- a/gcs/presolvers/inferred_disjunctive/inferred_disjunctive.cc
+++ b/gcs/presolvers/inferred_disjunctive/inferred_disjunctive.cc
@@ -202,7 +202,7 @@ auto InferredDisjunctive::run(Problem & problem, Propagators & propagators, Stat
         // rows say nothing about how long anything runs for.
         auto view = cumulative_donor_view(donor, state, logger);
         if (! view) {
-            bump(&InferredDisjunctiveStats::declined_variable_arguments);
+            bump(&InferredDisjunctiveStats::declined_irreducible_capacity);
             if (logger)
                 logger->emit_proof_comment("presolve disjunctive: declining " + as_string(donor.constraint_id()) + ", capacity is not reducible");
             continue;

--- a/gcs/presolvers/inferred_disjunctive/inferred_disjunctive.hh
+++ b/gcs/presolvers/inferred_disjunctive/inferred_disjunctive.hh
@@ -116,7 +116,12 @@ namespace gcs
         /// flags between donors, and a presence conjunct has to cancel across
         /// that bridge before it may.
         std::size_t declined_optional = 0;
-        std::size_t declined_variable_arguments = 0;
+        /// Donors whose capacity could not be reduced to a number to argue
+        /// against, which today means a view capacity. Named for the condition
+        /// rather than for today's only instance of it: a variable height and a
+        /// variable length cost a task its place, not a donor its resource ---
+        /// see cumulative_donor_view.
+        std::size_t declined_irreducible_capacity = 0;
         std::size_t dropped_too_small = 0;
         std::size_t dropped_subset = 0;
         std::size_t dropped_over_budget = 0;

--- a/gcs/presolvers/inferred_disjunctive/inferred_disjunctive_test.cc
+++ b/gcs/presolvers/inferred_disjunctive/inferred_disjunctive_test.cc
@@ -467,7 +467,7 @@ auto main(int argc, char * argv[]) -> int
             fail("the variable-height task was not converted on every resource");
         if (stats->resources_with_set_aside_tasks != 0)
             fail("a variable height set its task aside, rather than being converted to its guaranteed demand");
-        if (stats->declined_variable_arguments != 0)
+        if (stats->declined_irreducible_capacity != 0)
             fail("a resource was declined for a task's variable height, which is now a conversion");
 
         // Brute force over the same model: the fourth task takes part or not

--- a/gcs/presolvers/innards/cumulative_strengthening_mutations.hh
+++ b/gcs/presolvers/innards/cumulative_strengthening_mutations.hh
@@ -6,11 +6,11 @@
 /**
  * \file
  *
- * Deliberate corruptions of `CumulativeStrengthening`'s proof steps, which exist so that a test can
- * show the honest derivation is tight to what it claims. They live here, in the
- * innards, rather than beside the presolver they corrupt: the header a user
- * includes to run it should not also advertise a way to make the solver emit
- * deliberately wrong proofs. Issue #669; see
+ * Deliberate corruptions of `CumulativeStrengthening`'s proof steps, which
+ * exist so that a test can show the honest derivation is tight to what it
+ * claims. They live here, in the innards, rather than beside the presolver they
+ * corrupt: the header a user includes to run it should not also advertise a way
+ * to make the solver emit deliberately wrong proofs. Issue #669; see
  * gcs/constraints/innards/cumulative_mutations.hh for why compiling them out of
  * release builds was rejected.
  */

--- a/gcs/presolvers/innards/inferred_cumulative_mutations.hh
+++ b/gcs/presolvers/innards/inferred_cumulative_mutations.hh
@@ -6,11 +6,11 @@
 /**
  * \file
  *
- * Deliberate corruptions of `InferredCumulative`'s proof steps, which exist so that a test can
- * show the honest derivation is tight to what it claims. They live here, in the
- * innards, rather than beside the presolver they corrupt: the header a user
- * includes to run it should not also advertise a way to make the solver emit
- * deliberately wrong proofs. Issue #669; see
+ * Deliberate corruptions of `InferredCumulative`'s proof steps, which exist so
+ * that a test can show the honest derivation is tight to what it claims. They
+ * live here, in the innards, rather than beside the presolver they corrupt: the
+ * header a user includes to run it should not also advertise a way to make the
+ * solver emit deliberately wrong proofs. Issue #669; see
  * gcs/constraints/innards/cumulative_mutations.hh for why compiling them out of
  * release builds was rejected.
  */

--- a/gcs/presolvers/innards/inferred_disjunctive_mutations.hh
+++ b/gcs/presolvers/innards/inferred_disjunctive_mutations.hh
@@ -6,11 +6,11 @@
 /**
  * \file
  *
- * Deliberate corruptions of `InferredDisjunctive`'s proof steps, which exist so that a test can
- * show the honest derivation is tight to what it claims. They live here, in the
- * innards, rather than beside the presolver they corrupt: the header a user
- * includes to run it should not also advertise a way to make the solver emit
- * deliberately wrong proofs. Issue #669; see
+ * Deliberate corruptions of `InferredDisjunctive`'s proof steps, which exist so
+ * that a test can show the honest derivation is tight to what it claims. They
+ * live here, in the innards, rather than beside the presolver they corrupt: the
+ * header a user includes to run it should not also advertise a way to make the
+ * solver emit deliberately wrong proofs. Issue #669; see
  * gcs/constraints/innards/cumulative_mutations.hh for why compiling them out of
  * release builds was rejected.
  */


### PR DESCRIPTION
First of five follow-ups to a whole-design audit of the Cumulative stack. This one is the group the audit called "do before merge": three compiler warnings and four comments that a later PR in the same stack made false.

**Warnings.** Both inferred presolvers carry a `constant_value_of` with no caller, left over from before `cumulative_donor_view` took on the "is this argument a constant?" question. `Assessment` carries the per-task windows and two bindings pick them up again, but nothing reads them --- what comes out of `assess` is the time points, where the windows have already been applied.

**Comments falsified inside the stack.** `Cumulative::presences()` said a derived Cumulative requires a donor with no optional tasks (#682 made that false, and its own "no derivation changed at all" headline is what made it easy to miss). `DerivedCumulativeTask::height` gave, as the reason it is a constant, the thing `recover_constant_argument_row` now does. The energy set's filter said there is no presence variable to consult; there is, and the rule it describes is implemented in the propagator, which is the only place that can know.

**The counter.** `declined_variable_arguments` counts donors `cumulative_donor_view` turned away, which after #683/#687/#688 means an irreducible *capacity* and nothing else --- a variable height, a variable length and an optional task now each cost a task its term at most. Renamed `declined_irreducible_capacity` in all three presolvers, and the strengthening presolver's group doc, which described four fields of a group that has five, rewritten.

**Cosmetic.** The three copied mutation headers had a mis-wrapped first line each (the substituted class name pushed it past ninety characters; `ReflowComments` is off so nothing catches it). Two proof-primitive tests that run veripb internally now say so, like their three neighbours.

Rejected from the audit: its claim that registering the presolver tests through `run_test_only.bash` with no mode argument is anomalous. That is what almost every constraint test in the file does; the bare registrations are the exception.

Built clean with `-W -Wall` on GCC 15.2; the 59 cumulative/presolver/proof-primitive ctest entries pass with veripb on PATH.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173hT2hFo3MyGRBon8SHt2p