### PR TITLE
Write the shared parts of the Cumulative stack once

### DIFF
--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -114,6 +114,7 @@ add_library(glasgow_constraint_solver
         innards/proofs/proof_logger.cc
         innards/proofs/proof_model.cc
         innards/proofs/proof_only_variables.cc
+        innards/proofs/proof_scaffolding_scope.cc
         innards/proofs/scp_writer.cc
         innards/proofs/simplify_literal.cc
         innards/proofs/subset_sum_strengthening.cc

--- a/gcs/constraints/cumulative/cumulative.cc
+++ b/gcs/constraints/cumulative/cumulative.cc
@@ -222,14 +222,15 @@ auto Cumulative::prepare(Propagators &, State & initial_state, ProofModel * cons
     if (_active_tasks.empty())
         return false;
 
-    // The possible-active window of task i is [lb(s_i), ub(s_i)+ub(l_i)-1]; the
-    // per-(i,t) flags span it, so it must use the largest possible duration.
+    // The per-(i,t) flags span the possible-active window, so this is the
+    // windowing everything downstream --- a derived constraint, a presolver ---
+    // has to agree with, and is why it is not written out here.
     _per_task_t_lo.assign(n, 0_i);
     _per_task_t_hi.assign(n, 0_i);
     for (auto i : _active_tasks) {
-        auto [s_lo, s_hi] = initial_state.bounds(_starts[i]);
-        _per_task_t_lo[i] = s_lo;
-        _per_task_t_hi[i] = s_hi + _length_ub[i] - 1_i;
+        auto window = cumulative_task_window(initial_state, _starts[i], _lengths[i]);
+        _per_task_t_lo[i] = window.lo;
+        _per_task_t_hi[i] = window.hi;
     }
 
     if (_rules.overload) {
@@ -241,6 +242,13 @@ auto Cumulative::prepare(Propagators &, State & initial_state, ProofModel * cons
     }
 
     return true;
+}
+
+auto gcs::innards::cumulative_task_window(const State & initial_state, const IntegerVariableID & start, const IntegerVariableID & length)
+    -> CumulativeTaskWindow
+{
+    auto [s_lo, s_hi] = initial_state.bounds(start);
+    return CumulativeTaskWindow{s_lo, s_hi + initial_state.upper_bound(length) - 1_i};
 }
 
 auto gcs::innards::prepare_cumulative_overload_check(const vector<IntegerVariableID> & starts, const vector<IntegerVariableID> & lengths,

--- a/gcs/constraints/cumulative/cumulative.cc
+++ b/gcs/constraints/cumulative/cumulative.cc
@@ -56,20 +56,6 @@ using fmt::print;
 
 namespace
 {
-    auto const_value_of(const IntegerVariableID & v) -> Integer
-    {
-        return std::get<ConstantIntegerVariableID>(v).const_value;
-    }
-
-    auto as_constant_var_ids(const vector<Integer> & vals) -> vector<IntegerVariableID>
-    {
-        vector<IntegerVariableID> result;
-        result.reserve(vals.size());
-        for (const auto & v : vals)
-            result.push_back(constant_variable(v));
-        return result;
-    }
-
     // The variable-height contribution h_i·active is linearised over cake's
     // per-bit contribution flags cc_k (weight 2^k): contrib = Σ 2^k · cc_k.
     auto contrib_sum_of(const vector<ProofFlag> & cc) -> WPBSum
@@ -89,18 +75,18 @@ Cumulative::Cumulative(vector<IntegerVariableID> starts, vector<IntegerVariableI
     // Constant non-negativity is checked here; variable lengths/heights/
     // capacity are checked in prepare(), where their domains first become
     // available.
-    if (is_constant_variable(_capacity) && const_value_of(_capacity) < 0_i)
+    if (is_constant_variable(_capacity) && constant_value_of(_capacity) < 0_i)
         throw InvalidProblemDefinitionException{"Cumulative: capacity must be non-negative"};
     for (const auto & l : _lengths)
-        if (is_constant_variable(l) && const_value_of(l) < 0_i)
+        if (is_constant_variable(l) && constant_value_of(l) < 0_i)
             throw InvalidProblemDefinitionException{"Cumulative: lengths must be non-negative"};
     for (const auto & h : _heights)
-        if (is_constant_variable(h) && const_value_of(h) < 0_i)
+        if (is_constant_variable(h) && constant_value_of(h) < 0_i)
             throw InvalidProblemDefinitionException{"Cumulative: heights must be non-negative"};
 }
 
 Cumulative::Cumulative(vector<IntegerVariableID> starts, vector<Integer> lengths, vector<Integer> heights, Integer capacity) :
-    Cumulative(move(starts), as_constant_var_ids(lengths), as_constant_var_ids(heights), constant_variable(capacity))
+    Cumulative(move(starts), as_constant_variables(lengths), as_constant_variables(heights), constant_variable(capacity))
 {
 }
 
@@ -113,7 +99,7 @@ Cumulative::Cumulative(vector<IntegerVariableID> starts, vector<IntegerVariableI
     // A constant presence is checked here; a variable one is checked in
     // prepare(), where its domain first becomes available.
     for (const auto & p : _presences)
-        if (is_constant_variable(p) && const_value_of(p) != 0_i && const_value_of(p) != 1_i)
+        if (is_constant_variable(p) && constant_value_of(p) != 0_i && constant_value_of(p) != 1_i)
             throw InvalidProblemDefinitionException{"Cumulative: presences must be within {0, 1}"};
 }
 
@@ -153,7 +139,7 @@ auto gcs::innards::cumulative_task_presence(const optional<IntegerVariableID> & 
     if (! is_constant_variable(*posted))
         return CumulativeTaskPresence{*posted, false};
 
-    auto value = const_value_of(*posted);
+    auto value = constant_value_of(*posted);
     if (value == 1_i)
         return CumulativeTaskPresence{};
     if (value == 0_i)
@@ -215,16 +201,16 @@ auto Cumulative::prepare(Propagators &, State & initial_state, ProofModel * cons
     _height_vals.reserve(n);
     _height_ub.reserve(n);
     for (const auto & l : _lengths) {
-        _length_vals.push_back(is_constant_variable(l) ? const_value_of(l) : 0_i);
+        _length_vals.push_back(is_constant_variable(l) ? constant_value_of(l) : 0_i);
         _length_lb.push_back(initial_state.lower_bound(l));
         _length_ub.push_back(initial_state.upper_bound(l));
     }
     for (const auto & h : _heights) {
-        _height_vals.push_back(is_constant_variable(h) ? const_value_of(h) : 0_i);
+        _height_vals.push_back(is_constant_variable(h) ? constant_value_of(h) : 0_i);
         _height_ub.push_back(initial_state.upper_bound(h));
     }
     if (is_constant_variable(_capacity))
-        _capacity_val = const_value_of(_capacity);
+        _capacity_val = constant_value_of(_capacity);
 
     // Tasks whose length can only ever be 0, or whose height can only ever be 0,
     // or which are constantly absent, never raise the load profile.
@@ -290,7 +276,7 @@ auto gcs::innards::prepare_cumulative_overload_check(const vector<IntegerVariabl
     for (auto i : active_tasks) {
         if (! is_constant_variable(lengths[i]) || ! is_constant_variable(heights[i]))
             continue;
-        if (const_value_of(lengths[i]) <= 0_i || const_value_of(heights[i]) <= 0_i)
+        if (constant_value_of(lengths[i]) <= 0_i || constant_value_of(heights[i]) <= 0_i)
             continue;
         if (! std::holds_alternative<SimpleIntegerVariableID>(starts[i]))
             continue;

--- a/gcs/constraints/cumulative/derived_cumulative.cc
+++ b/gcs/constraints/cumulative/derived_cumulative.cc
@@ -81,30 +81,30 @@ auto gcs::innards::install_derived_cumulative(
         inputs->heights.push_back(constant_variable(task.height));
     }
 
-    // The same windowing a posted Cumulative resolves in prepare(): a task can
-    // be active from its earliest start to its latest finish, so the window
-    // takes the *largest* duration still allowed, and one whose length or
-    // height can only be zero, or which can never be present at all, never
-    // raises the profile. Reading the length's bound rather than a number is
-    // what makes this the donor's own window for a variable-duration task: the
-    // donor windowed with ub(l) too, and only the same window finds the same
-    // flags.
+    // The same windowing a posted Cumulative resolves in prepare(), and by the
+    // same function: only the same window finds the same flags, and a window
+    // that disagreed would decline this constraint rather than fail loudly. A
+    // task whose length or height can only be zero, or which can never be
+    // present at all, never raises the profile and is not in it.
     inputs->per_task_t_lo.assign(n, 0_i);
     vector<Integer> per_task_t_hi(n, 0_i);
     for (size_t i = 0; i < n; ++i) {
-        auto length_ub = initial_state.upper_bound(spec.tasks[i].length);
-        if (length_ub <= 0_i || spec.tasks[i].height <= 0_i || never_present[i])
+        if (initial_state.upper_bound(spec.tasks[i].length) <= 0_i || spec.tasks[i].height <= 0_i || never_present[i])
             continue;
         inputs->active_tasks.push_back(i);
-        auto [s_lo, s_hi] = initial_state.bounds(spec.tasks[i].start);
-        inputs->per_task_t_lo[i] = s_lo;
-        per_task_t_hi[i] = s_hi + length_ub - 1_i;
+        auto window = cumulative_task_window(initial_state, spec.tasks[i].start, spec.tasks[i].length);
+        inputs->per_task_t_lo[i] = window.lo;
+        per_task_t_hi[i] = window.hi;
     }
 
     if (inputs->active_tasks.empty())
         return false;
 
-    if (spec.rules.overload) {
+    // Also when the overload rule is off but a makespan was asked for: which
+    // tasks can carry energy is the window-energy lemma's question either way,
+    // and a constraint posted for its energy alone should not go without a
+    // bound for want of asking.
+    if (spec.rules.overload || spec.makespan) {
         auto overload_data = prepare_cumulative_overload_check(
             inputs->starts, inputs->lengths, inputs->heights, inputs->active_tasks, inputs->per_task_t_lo, per_task_t_hi, initial_state);
         inputs->overload_tasks = move(overload_data.overload_tasks);
@@ -225,18 +225,6 @@ auto gcs::innards::install_derived_cumulative(
     // rather than in the propagator: nothing it reads changes below the root
     // that would let it say more.
     if (spec.makespan) {
-        // Which tasks can carry energy is the window-energy lemma's question,
-        // and prepare_cumulative_overload_check is where it is answered. A
-        // constraint posted for its energy alone runs with the overload rule
-        // off, so ask anyway rather than going without a bound.
-        if (! spec.rules.overload) {
-            auto overload_data = prepare_cumulative_overload_check(
-                inputs->starts, inputs->lengths, inputs->heights, inputs->active_tasks, inputs->per_task_t_lo, per_task_t_hi, initial_state);
-            inputs->overload_tasks = move(overload_data.overload_tasks);
-            inputs->time_slot_prefix = move(overload_data.time_slot_prefix);
-            inputs->time_slot_lo = overload_data.time_slot_lo;
-        }
-
         // Everything but the start bounds is settled now: the flag vectors live
         // in `inputs`, which the initialiser holds a share of, and the windows
         // are the ones its rows were derived over.

--- a/gcs/constraints/cumulative/derived_cumulative_test.cc
+++ b/gcs/constraints/cumulative/derived_cumulative_test.cc
@@ -71,11 +71,6 @@ namespace
         std::exit(EXIT_FAILURE);
     }
 
-    auto constant_value_of(const IntegerVariableID & v) -> Integer
-    {
-        return std::get<ConstantIntegerVariableID>(v).const_value;
-    }
-
     /**
      * What the demo presolver derives from each Cumulative it finds.
      */

--- a/gcs/constraints/cumulative/donor_view.cc
+++ b/gcs/constraints/cumulative/donor_view.cc
@@ -17,14 +17,6 @@
 using namespace gcs;
 using namespace gcs::innards;
 
-namespace
-{
-    auto const_value_of(const IntegerVariableID & v) -> Integer
-    {
-        return std::get<ConstantIntegerVariableID>(v).const_value;
-    }
-}
-
 using std::make_optional;
 using std::move;
 using std::nullopt;
@@ -46,7 +38,7 @@ auto gcs::innards::cumulative_donor_view(const Cumulative & donor, const State &
         return nullopt;
 
     if (is_constant_variable(donor.capacity()))
-        view.capacity = const_value_of(donor.capacity());
+        view.capacity = constant_value_of(donor.capacity());
     else {
         view.capacity = state.upper_bound(donor.capacity());
         view.capacity_bounded_by = donor.capacity();
@@ -69,7 +61,7 @@ auto gcs::innards::cumulative_donor_view(const Cumulative & donor, const State &
         // the *guaranteed* demand, which is the height's lower bound.
         auto height_value = 0_i;
         if (is_constant_variable(height))
-            height_value = const_value_of(height);
+            height_value = constant_value_of(height);
         else {
             // A view's reification is over its own bit vector rather than the
             // underlying variable's, so the height's bound rows have nothing to

--- a/gcs/constraints/cumulative/propagate.hh
+++ b/gcs/constraints/cumulative/propagate.hh
@@ -132,6 +132,42 @@ namespace gcs::innards
     };
 
     /**
+     * \brief The time points one of a Cumulative's tasks could possibly be
+     * active at, inclusive at both ends.
+     *
+     * \sa cumulative_task_window
+     *
+     * \ingroup Innards
+     */
+    struct CumulativeTaskWindow
+    {
+        Integer lo, hi;
+    };
+
+    /**
+     * \brief Where a task's per-time flags run from and to: `[lb(start),
+     * ub(start) + ub(length) - 1]`.
+     *
+     * A task can be active from its earliest start to its latest finish, so the
+     * window takes the *largest* duration still allowed --- which for a variable
+     * length means its upper bound, not the number it will turn out to be.
+     *
+     * Shared rather than written out per caller because every caller has to
+     * agree with the donor, and the failure mode when one does not is silence:
+     * install_derived_cumulative looks a donor's flags up by `(position, t)` and
+     * declines when they are not there, so a window that disagrees by one costs
+     * a presolver its inference without anything saying so.
+     *
+     * `initial_state` because these are resolved once, before the search: the
+     * flags exist over this window for the whole of it, whatever the bounds do
+     * later.
+     *
+     * \ingroup Innards
+     */
+    [[nodiscard]] auto cumulative_task_window(const State & initial_state, const IntegerVariableID & start, const IntegerVariableID & length)
+        -> CumulativeTaskWindow;
+
+    /**
      * \brief What the overload check needs resolving once, before the search
      * starts: which tasks its window-energy lemma can speak about, and where a
      * capacity row exists to be cited.

--- a/gcs/constraints/disjunctive/disjunctive.cc
+++ b/gcs/constraints/disjunctive/disjunctive.cc
@@ -33,23 +33,6 @@ using std::size_t;
 using std::unique_ptr;
 using std::vector;
 
-namespace
-{
-    auto const_value_of(const IntegerVariableID & v) -> Integer
-    {
-        return std::get<ConstantIntegerVariableID>(v).const_value;
-    }
-
-    auto as_constant_var_ids(const vector<Integer> & vals) -> vector<IntegerVariableID>
-    {
-        vector<IntegerVariableID> result;
-        result.reserve(vals.size());
-        for (const auto & v : vals)
-            result.push_back(constant_variable(v));
-        return result;
-    }
-}
-
 Disjunctive::Disjunctive(vector<IntegerVariableID> starts, vector<IntegerVariableID> lengths) : _starts(move(starts)), _lengths(move(lengths))
 {
     if (_starts.size() != _lengths.size())
@@ -57,11 +40,11 @@ Disjunctive::Disjunctive(vector<IntegerVariableID> starts, vector<IntegerVariabl
     // Constant durations are checked here; variable durations are checked
     // against their root lower bound in prepare().
     for (const auto & l : _lengths)
-        if (is_constant_variable(l) && const_value_of(l) < 0_i)
+        if (is_constant_variable(l) && constant_value_of(l) < 0_i)
             throw InvalidProblemDefinitionException{"Disjunctive: lengths must be non-negative"};
 }
 
-Disjunctive::Disjunctive(vector<IntegerVariableID> starts, vector<Integer> lengths) : Disjunctive(move(starts), as_constant_var_ids(lengths))
+Disjunctive::Disjunctive(vector<IntegerVariableID> starts, vector<Integer> lengths) : Disjunctive(move(starts), as_constant_variables(lengths))
 {
 }
 
@@ -87,7 +70,7 @@ auto Disjunctive::prepare(Propagators &, State & initial_state, ProofModel * con
     _length_vals.assign(n, 0_i);
     for (size_t i = 0; i < n; ++i) {
         if (is_constant_variable(_lengths[i]))
-            _length_vals[i] = const_value_of(_lengths[i]);
+            _length_vals[i] = constant_value_of(_lengths[i]);
         else if (initial_state.lower_bound(_lengths[i]) < 0_i)
             throw InvalidProblemDefinitionException{"Disjunctive: lengths must be non-negative"};
     }
@@ -609,7 +592,7 @@ auto Disjunctive::s_expr(const ProofModel * const model) const -> SExpr
     for (const auto & v : _starts)
         starts.push_back(tracker.s_expr_term_of(v));
     for (const auto & l : _lengths)
-        lengths.push_back(is_constant_variable(l) ? SExpr::atom(const_value_of(l).to_string()) : tracker.s_expr_term_of(l));
+        lengths.push_back(is_constant_variable(l) ? SExpr::atom(constant_value_of(l).to_string()) : tracker.s_expr_term_of(l));
     return SExpr::list(
         {SExpr::atom(as_string(_constraint_id)), SExpr::atom(constraint_type()), SExpr::list(std::move(starts)), SExpr::list(std::move(lengths))});
 }

--- a/gcs/constraints/disjunctive_2d/disjunctive_2d.cc
+++ b/gcs/constraints/disjunctive_2d/disjunctive_2d.cc
@@ -34,23 +34,6 @@ using std::size_t;
 using std::unique_ptr;
 using std::vector;
 
-namespace
-{
-    auto const_value_of(const IntegerVariableID & v) -> Integer
-    {
-        return get<ConstantIntegerVariableID>(v).const_value;
-    }
-
-    auto as_constant_var_ids(const vector<Integer> & vals) -> vector<IntegerVariableID>
-    {
-        vector<IntegerVariableID> result;
-        result.reserve(vals.size());
-        for (const auto & v : vals)
-            result.push_back(constant_variable(v));
-        return result;
-    }
-}
-
 Disjunctive2D::Disjunctive2D(vector<IntegerVariableID> xs, vector<IntegerVariableID> ys, vector<IntegerVariableID> widths,
     vector<IntegerVariableID> heights) : _xs(move(xs)), _ys(move(ys)), _widths(move(widths)), _heights(move(heights))
 {
@@ -59,15 +42,15 @@ Disjunctive2D::Disjunctive2D(vector<IntegerVariableID> xs, vector<IntegerVariabl
     // Constant non-negativity is checked here; variable sizes are checked in
     // prepare(), where their domains first become available.
     for (const auto & w : _widths)
-        if (is_constant_variable(w) && const_value_of(w) < 0_i)
+        if (is_constant_variable(w) && constant_value_of(w) < 0_i)
             throw InvalidProblemDefinitionException{"Disjunctive2D: widths must be non-negative"};
     for (const auto & h : _heights)
-        if (is_constant_variable(h) && const_value_of(h) < 0_i)
+        if (is_constant_variable(h) && constant_value_of(h) < 0_i)
             throw InvalidProblemDefinitionException{"Disjunctive2D: heights must be non-negative"};
 }
 
 Disjunctive2D::Disjunctive2D(vector<IntegerVariableID> xs, vector<IntegerVariableID> ys, vector<Integer> widths, vector<Integer> heights) :
-    Disjunctive2D(move(xs), move(ys), as_constant_var_ids(widths), as_constant_var_ids(heights))
+    Disjunctive2D(move(xs), move(ys), as_constant_variables(widths), as_constant_variables(heights))
 {
 }
 
@@ -114,9 +97,9 @@ auto Disjunctive2D::prepare(Propagators &, State & initial_state, ProofModel * c
     width_ub.reserve(n);
     height_ub.reserve(n);
     for (size_t i = 0; i < n; ++i) {
-        _width_vals.push_back(is_constant_variable(_widths[i]) ? const_value_of(_widths[i]) : 0_i);
+        _width_vals.push_back(is_constant_variable(_widths[i]) ? constant_value_of(_widths[i]) : 0_i);
         width_ub.push_back(initial_state.upper_bound(_widths[i]));
-        _height_vals.push_back(is_constant_variable(_heights[i]) ? const_value_of(_heights[i]) : 0_i);
+        _height_vals.push_back(is_constant_variable(_heights[i]) ? constant_value_of(_heights[i]) : 0_i);
         height_ub.push_back(initial_state.upper_bound(_heights[i]));
     }
 

--- a/gcs/constraints/innards/recover_am1.cc
+++ b/gcs/constraints/innards/recover_am1.cc
@@ -2,6 +2,7 @@
 #include <gcs/exception.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
 #include <gcs/innards/proofs/pol_builder.hh>
+#include <gcs/innards/proofs/proof_scaffolding_scope.hh>
 #include <gcs/innards/proofs/simplify_literal.hh>
 
 #include <gcs/proof.hh>
@@ -115,20 +116,15 @@ template <typename Literal_>
     // inside recover_am1 deletes the framework's just-emitted lines
     // mid-justification.)
     //
-    // To isolate, we increase active_proof_level by one before emitting
-    // pair_ne lines. They then record at the new active+1, one deeper
-    // than the caller's Temporary depth, and forgetting that deeper depth
-    // on exit cleans up only our own intermediates.
-    //
-    // The result itself is emitted *after* restoring the caller's level, so
-    // it records at the level the caller asked for: Top callers (in
-    // initialisers, caching the line for reuse) get depth 0 as before;
-    // Temporary callers (e.g. inside a JustifyExplicitly{…, ThenRUP::Yes} that folds
-    // the result into a further pol) get the caller's Temporary depth, so
-    // the line survives our own deeper cleanup and is reclaimed when the
-    // caller's scope is forgotten.
-    auto saved_level = logger.proof_level();
-    logger.enter_proof_level(saved_level + 1);
+    // ProofScaffoldingScope is the isolation: the pair_ne lines record one
+    // deeper than the caller's Temporary depth, and only that depth is
+    // forgotten. The result is emitted *after* restoring, so it records at the
+    // level the caller asked for --- Top callers (in initialisers, caching the
+    // line for reuse) get depth 0 as before; Temporary callers (e.g. inside a
+    // JustifyExplicitly{…, ThenRUP::Yes} that folds the result into a further
+    // pol) get the caller's Temporary depth, so the line survives our own
+    // cleanup and is reclaimed when the caller's scope is forgotten.
+    ProofScaffoldingScope scaffolding{logger};
 
     // Build the at-most-one via PolBuilder rather than a hand-written pol
     // string: PolBuilder defers stringifying the pair_ne line references to
@@ -176,15 +172,11 @@ template <typename Literal_>
         }
     }
 
-    // Restore the caller's level, then emit the result there (its level is
-    // resolved at emit time) while the pair_ne lines are still alive — VeriPB
-    // resolves the line-number references during this emit. Finally forget the
-    // inner scope, which removes only our deeper pair_ne intermediates and
-    // leaves the result (at the caller's level) intact.
-    logger.enter_proof_level(saved_level);
-    auto result = am1.emit(logger, level);
-    logger.forget_proof_level(saved_level + 2);
-    return result;
+    // Back at the caller's level to emit the result (its level is resolved at
+    // emit time), while the pair_ne lines are still alive — VeriPB resolves the
+    // line-number references during this emit — and only then forgotten.
+    scaffolding.restore();
+    return am1.emit(logger, level);
 }
 
 template auto gcs::innards::recover_am1<IntegerVariableCondition>(ProofLogger &, ProofLevel, const vector<IntegerVariableCondition> &,

--- a/gcs/innards/proofs/am1_from_pairs.cc
+++ b/gcs/innards/proofs/am1_from_pairs.cc
@@ -2,6 +2,7 @@
 #include <gcs/innards/proofs/pol_builder.hh>
 #include <gcs/innards/proofs/proof_error.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
+#include <gcs/innards/proofs/proof_scaffolding_scope.hh>
 #include <gcs/innards/proofs/pseudo_boolean.hh>
 
 #include <cstddef>
@@ -39,15 +40,9 @@ auto gcs::innards::recover_am1_from_pairs(ProofLogger & logger, const vector<Pro
 
     logger.emit_proof_comment("clique at-most-one over " + to_string(k) + " members");
 
-    // The induction goes one proof level deeper than the caller's own, and is
-    // forgotten on the way out. Only the pin below is ever cited again: every
-    // line between here and it exists to reach it, and at Top every one of them
-    // would stay live for the rest of the proof, taxing every later unhinted RUP
-    // (issue #666). The extra depth rather than plain Temporary is what stops
-    // the forget taking the caller's scope with it, since a caller inside a
-    // JustifyExplicitly is already using its own Temporary depth.
-    auto saved_level = logger.proof_level();
-    logger.enter_proof_level(saved_level + 1);
+    // Only the pin below is ever cited again: every line the induction emits
+    // between here and it exists to reach it. See ProofScaffoldingScope.
+    ProofScaffoldingScope scaffolding{logger};
 
     // The base case is not a derivation: the at-most-one for the first pair
     // already is the clique inequality for those two.
@@ -109,8 +104,6 @@ auto gcs::innards::recover_am1_from_pairs(ProofLogger & logger, const vector<Pro
 
     // Back at the caller's level to pin, while the induction is still alive for
     // VeriPB to resolve the reference against, and only then drop it.
-    logger.enter_proof_level(saved_level);
-    auto result = logger.emit(ImpliesProofRule{current}, move(clique) <= (claim_one_more ? 0_i : 1_i), level);
-    logger.forget_proof_level(saved_level + 2);
-    return result;
+    scaffolding.restore();
+    return logger.emit(ImpliesProofRule{current}, move(clique) <= (claim_one_more ? 0_i : 1_i), level);
 }

--- a/gcs/innards/proofs/lifted_cover_cut.cc
+++ b/gcs/innards/proofs/lifted_cover_cut.cc
@@ -3,6 +3,7 @@
 #include <gcs/innards/proofs/pol_builder.hh>
 #include <gcs/innards/proofs/proof_error.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
+#include <gcs/innards/proofs/proof_scaffolding_scope.hh>
 #include <gcs/innards/proofs/pseudo_boolean.hh>
 
 #include <version>
@@ -239,14 +240,10 @@ auto gcs::innards::derive_lifted_cover_cut(ProofLogger & logger, const vector<Pr
     if (total <= cut.rhs)
         return logger.emit_rup_proof_line(move(claimed) <= claimed_rhs, level);
 
-    // The scaffolding goes one level deeper than the caller's own, so that
-    // forgetting it on the way out cannot take the caller's scope with it ---
-    // the same isolation recover_am1() needs, and for the same reason: a caller
-    // inside a JustifyExplicitly is already using its own Temporary depth. Only
-    // the pin below survives this routine, extension variables included, since
-    // deleting a variable's two defining constraints deletes the variable.
-    auto saved_level = logger.proof_level();
-    logger.enter_proof_level(saved_level + 1);
+    // Only the pin below survives this routine, extension variables included,
+    // since deleting a variable's two defining constraints deletes the
+    // variable. See ProofScaffoldingScope.
+    ProofScaffoldingScope scaffolding{logger};
 
     const auto & tracker = logger.names_and_ids_tracker();
 
@@ -445,8 +442,6 @@ auto gcs::innards::derive_lifted_cover_cut(ProofLogger & logger, const vector<Pr
 
     // Restore the caller's level and pin there, while the scaffolding is still
     // alive for VeriPB to resolve the reference against, then drop it.
-    logger.enter_proof_level(saved_level);
-    auto result = logger.emit(ImpliesProofRule{derived}, move(claimed) <= claimed_rhs, level);
-    logger.forget_proof_level(saved_level + 2);
-    return result;
+    scaffolding.restore();
+    return logger.emit(ImpliesProofRule{derived}, move(claimed) <= claimed_rhs, level);
 }

--- a/gcs/innards/proofs/proof_scaffolding_scope.cc
+++ b/gcs/innards/proofs/proof_scaffolding_scope.cc
@@ -1,0 +1,23 @@
+#include <gcs/innards/proofs/proof_logger.hh>
+#include <gcs/innards/proofs/proof_scaffolding_scope.hh>
+
+using namespace gcs::innards;
+
+ProofScaffoldingScope::ProofScaffoldingScope(ProofLogger & logger) : _logger(logger), _saved(logger.proof_level())
+{
+    _logger.enter_proof_level(_saved + 1);
+}
+
+auto ProofScaffoldingScope::restore() -> void
+{
+    if (! _restored) {
+        _logger.enter_proof_level(_saved);
+        _restored = true;
+    }
+}
+
+ProofScaffoldingScope::~ProofScaffoldingScope()
+{
+    restore();
+    _logger.forget_proof_level(_saved + 2);
+}

--- a/gcs/innards/proofs/proof_scaffolding_scope.hh
+++ b/gcs/innards/proofs/proof_scaffolding_scope.hh
@@ -1,0 +1,63 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_INNARDS_PROOFS_PROOF_SCAFFOLDING_SCOPE_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_INNARDS_PROOFS_PROOF_SCAFFOLDING_SCOPE_HH
+
+#include <gcs/innards/proofs/proof_logger-fwd.hh>
+
+namespace gcs::innards
+{
+    /**
+     * \brief A derivation's working, one proof level below the caller's, and
+     * deleted again on the way out.
+     *
+     * The pattern this replaces was written out six times, and every copy of it
+     * says the same thing: everything between here and the line the routine
+     * finally claims exists only to reach that line, so at Top not one of those
+     * constraints would ever be deleted and each would tax every later unhinted
+     * RUP (issue #666). One level *deeper* than the caller's rather than plain
+     * Temporary, because a caller inside a JustifyExplicitly is already using
+     * its own Temporary depth and would lose it to the forget.
+     *
+     * Constructing enters `caller + 1`; destruction restores the caller's level
+     * and forgets `caller + 2`, which is where the working's Temporary lines
+     * land. A routine with several ways out therefore no longer needs a
+     * give-it-back lambda or a gave-up flag on each of them, and a
+     * ProofError thrown from inside no longer leaves the logger at the deeper
+     * level.
+     *
+     * \sa restore, for the ordering a routine pinning at the *caller's* level
+     * has to observe.
+     *
+     * \ingroup Innards
+     */
+    class ProofScaffoldingScope
+    {
+    private:
+        ProofLogger & _logger;
+        int _saved;
+        bool _restored = false;
+
+    public:
+        explicit ProofScaffoldingScope(ProofLogger &);
+        ~ProofScaffoldingScope();
+
+        ProofScaffoldingScope(const ProofScaffoldingScope &) = delete;
+        auto operator=(const ProofScaffoldingScope &) -> ProofScaffoldingScope & = delete;
+
+        /**
+         * \brief Go back to the caller's level early, with the working still
+         * alive to be cited.
+         *
+         * For a routine whose result is emitted at whatever ProofLevel its
+         * caller asked for: that emit has to happen at the caller's level, and
+         * while the working it cites is still there for VeriPB to resolve the
+         * reference against. So restore, emit, and let the destructor forget. A
+         * routine claiming its result at Top does not need this --- Top is
+         * depth zero whatever the active level is.
+         *
+         * Idempotent, and the destructor does it if nothing else has.
+         */
+        auto restore() -> void;
+    };
+}
+
+#endif

--- a/gcs/presolvers/cumulative_strengthening/cumulative_strengthening.cc
+++ b/gcs/presolvers/cumulative_strengthening/cumulative_strengthening.cc
@@ -9,6 +9,7 @@
 #include <gcs/innards/proofs/pol_builder.hh>
 #include <gcs/innards/proofs/proof_error.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
+#include <gcs/innards/proofs/proof_scaffolding_scope.hh>
 #include <gcs/innards/proofs/subset_sum_strengthening.hh>
 #include <gcs/innards/state.hh>
 #include <gcs/presolvers/cumulative_strengthening/cumulative_strengthening.hh>
@@ -446,13 +447,7 @@ auto CumulativeStrengthening::run(Problem & problem, Propagators & propagators, 
                 // them would ever be deleted (issue #666, which is the same
                 // defect one presolver over). One level deeper, and forgotten
                 // on the way out.
-                auto saved_level = recipe_logger.proof_level();
-                recipe_logger.enter_proof_level(saved_level + 1);
-                auto give_back = [&](optional<ProofLine> line) {
-                    recipe_logger.enter_proof_level(saved_level);
-                    recipe_logger.forget_proof_level(saved_level + 2);
-                    return line;
-                };
+                ProofScaffoldingScope scaffolding{recipe_logger};
 
                 // The row everything below argues from, reduced to the
                 // constant-argument form it reads it as: the set-aside tasks'
@@ -461,7 +456,7 @@ auto CumulativeStrengthening::run(Problem & problem, Propagators & propagators, 
                 // goes inside the level that gets forgotten.
                 auto reduced_row = recover_constant_argument_row(recipe_logger, view, donor_id, donor_row_at->second, t, ProofLevel::Temporary);
                 if (! reduced_row)
-                    return give_back(std::nullopt);
+                    return std::nullopt;
                 auto donor_row = *reduced_row;
 
                 auto strengthen_to_kappa = [&](ProofLine source) -> ProofLine {
@@ -488,7 +483,7 @@ auto CumulativeStrengthening::run(Problem & problem, Propagators & propagators, 
                 // proof would object.
                 if (full_here.empty()) {
                     auto strengthened = strengthen_to_kappa(donor_row);
-                    return give_back(recipe_logger.emit(ImpliesProofRule{strengthened}, move(load) <= kappa, ProofLevel::Top));
+                    return recipe_logger.emit(ImpliesProofRule{strengthened}, move(load) <= kappa, ProofLevel::Top);
                 }
 
                 recipe_logger.emit_proof_comment("presolve cumulative amo");
@@ -650,7 +645,7 @@ auto CumulativeStrengthening::run(Problem & problem, Propagators & propagators, 
                 if (stats)
                     ++stats->rows_with_a_raise;
 
-                return give_back(recipe_logger.emit(ImpliesProofRule{*row}, move(load) <= kappa, ProofLevel::Top));
+                return recipe_logger.emit(ImpliesProofRule{*row}, move(load) <= kappa, ProofLevel::Top);
             },
             .rules = _rules};
 

--- a/gcs/presolvers/cumulative_strengthening/cumulative_strengthening.cc
+++ b/gcs/presolvers/cumulative_strengthening/cumulative_strengthening.cc
@@ -183,19 +183,18 @@ auto CumulativeStrengthening::run(Problem & problem, Propagators & propagators, 
             if (active_tasks.empty())
                 return nullopt;
 
-            // The same windowing install_derived_cumulative resolves, and the
-            // same windowing the donor encoded: a task can be active from its
-            // earliest start to its latest finish, which for a variable
-            // duration is the largest one still allowed. This is the paper's
-            // `t in [est_j, lct_j)`. Local to the assessment: what comes out of
-            // it is the time points, which is where the windows have already
-            // been applied, so nothing downstream asks about them again.
+            // The same windowing install_derived_cumulative resolves, and by
+            // the same function: this is the paper's `t in [est_j, lct_j)`, and
+            // a window disagreeing with the donor's would simply find no flags.
+            // Local to the assessment: what comes out of it is the time points,
+            // which is where the windows have already been applied, so nothing
+            // downstream asks about them again.
             Assessment assessment;
             vector<Integer> t_lo(n, 0_i), t_hi(n, 0_i);
             for (auto i : active_tasks) {
-                auto [s_lo, s_hi] = state.bounds(starts[i]);
-                t_lo[i] = s_lo;
-                t_hi[i] = s_hi + state.upper_bound(candidate.lengths[i]) - 1_i;
+                auto window = cumulative_task_window(state, starts[i], candidate.lengths[i]);
+                t_lo[i] = window.lo;
+                t_hi[i] = window.hi;
             }
 
             // A height above the capacity means the donor is infeasible on its

--- a/gcs/presolvers/inferred_cumulative/inferred_cumulative.cc
+++ b/gcs/presolvers/inferred_cumulative/inferred_cumulative.cc
@@ -7,6 +7,7 @@
 #include <gcs/innards/proofs/lifted_cover_cut.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
+#include <gcs/innards/proofs/proof_scaffolding_scope.hh>
 #include <gcs/innards/state.hh>
 #include <gcs/presolvers/inferred_cumulative/inferred_cumulative.hh>
 #include <gcs/presolvers/innards/makespan_links.hh>
@@ -830,29 +831,23 @@ auto InferredCumulative::run(Problem & problem, Propagators & propagators, State
                 // rest of the working: there are three `pol` per member per
                 // donor per time point, and at Top none of them would ever be
                 // deleted. Only the pin the caller gets back survives.
-                auto saved_level = recipe_logger.proof_level();
-                recipe_logger.enter_proof_level(saved_level + 1);
+                ProofScaffoldingScope scaffolding{recipe_logger};
 
                 vector<ProofLine> kept_rows;
                 vector<vector<ProofFlag>> kept_weaken_out;
-                auto give_up = false;
                 for (auto row : programme->row_indices) {
                     const auto & donor = recipe.donors[row];
                     auto found_row = rows.find(donor.id);
-                    if (found_row == rows.end()) {
-                        give_up = true;
-                        break;
-                    }
+                    if (found_row == rows.end())
+                        return std::nullopt;
 
                     // Reduced to the constant-argument form everything below
                     // lifts out of: this donor's set-aside tasks weakened away,
                     // and a variable capacity replaced by the number
                     // `donor.capacity` already holds.
                     auto line = recover_constant_argument_row(recipe_logger, donor.view, donor.id, found_row->second, t, ProofLevel::Temporary);
-                    if (! line) {
-                        give_up = true;
-                        break;
-                    }
+                    if (! line)
+                        return std::nullopt;
 
                     // Which of the present members this row actually speaks
                     // about, and where they sit in it.
@@ -901,10 +896,8 @@ auto InferredCumulative::run(Problem & problem, Propagators & propagators, State
                         terms.push_back(BridgedRowTerm{member.demands[row], flags[j], bridge});
                     }
 
-                    if (missing || terms.empty()) {
-                        give_up = true;
-                        break;
-                    }
+                    if (missing || terms.empty())
+                        return std::nullopt;
 
                     // Everything else of this donor's that could be running now
                     // has to come out of the row. Over every position, not up to
@@ -930,14 +923,7 @@ auto InferredCumulative::run(Problem & problem, Propagators & propagators, State
                     }
                 }
 
-                optional<ProofLine> result;
-                if (! give_up)
-                    result =
-                        derive_lifted_cover_cut(recipe_logger, kept_rows, *programme, flags, claimed, kept_weaken_out, claimed_rhs, ProofLevel::Top);
-
-                recipe_logger.enter_proof_level(saved_level);
-                recipe_logger.forget_proof_level(saved_level + 2);
-                return result;
+                return derive_lifted_cover_cut(recipe_logger, kept_rows, *programme, flags, claimed, kept_weaken_out, claimed_rhs, ProofLevel::Top);
             },
             .makespan = _makespan,
             .makespan_links = links,

--- a/gcs/presolvers/inferred_cumulative/inferred_cumulative.cc
+++ b/gcs/presolvers/inferred_cumulative/inferred_cumulative.cc
@@ -2,6 +2,7 @@
 #include <gcs/constraints/cumulative.hh>
 #include <gcs/constraints/cumulative/derived_cumulative.hh>
 #include <gcs/constraints/cumulative/donor_view.hh>
+#include <gcs/constraints/cumulative/propagate.hh>
 #include <gcs/innards/proofs/flag_bridge.hh>
 #include <gcs/innards/proofs/lifted_cover_cut.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
@@ -533,9 +534,8 @@ auto InferredCumulative::run(Problem & problem, Propagators & propagators, State
                 continue;
             }
 
-            auto [s_lo, s_hi] = state.bounds(starts[i]);
-            auto [l_lo, l_hi] = state.bounds(length);
-            Task task{starts[i], length, l_lo, s_lo, s_hi + l_hi - 1_i, vector<Integer>(donors.size(), 0_i),
+            auto window = cumulative_task_window(state, starts[i], length);
+            Task task{starts[i], length, state.lower_bound(length), window.lo, window.hi, vector<Integer>(donors.size(), 0_i),
                 vector<optional<size_t>>(donors.size(), std::nullopt), which};
             task.demands[which] = demand;
             task.positions[which] = i;

--- a/gcs/presolvers/inferred_disjunctive/inferred_disjunctive.cc
+++ b/gcs/presolvers/inferred_disjunctive/inferred_disjunctive.cc
@@ -11,6 +11,7 @@
 #include <gcs/innards/proofs/pol_builder.hh>
 #include <gcs/innards/proofs/proof_error.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
+#include <gcs/innards/proofs/proof_scaffolding_scope.hh>
 #include <gcs/innards/proofs/pseudo_boolean.hh>
 #include <gcs/innards/state.hh>
 #include <gcs/presolvers/inferred_disjunctive/inferred_disjunctive.hh>
@@ -492,13 +493,7 @@ auto InferredDisjunctive::run(Problem & problem, Propagators & propagators, Stat
                 // none of which is ever deleted -- 180k live constraints from
                 // one presolver on a realistic instance, taxing every later
                 // unhinted RUP (issue #666).
-                auto saved_level = recipe_logger.proof_level();
-                recipe_logger.enter_proof_level(saved_level + 1);
-                auto give_back = [&](optional<ProofLine> line) {
-                    recipe_logger.enter_proof_level(saved_level);
-                    recipe_logger.forget_proof_level(saved_level + 2);
-                    return line;
-                };
+                ProofScaffoldingScope scaffolding{recipe_logger};
 
                 // Bridges, once per (member, witnessing resource) rather than
                 // once per pair: several pairs of a clique often share a witness.
@@ -537,7 +532,7 @@ auto InferredDisjunctive::run(Problem & problem, Propagators & propagators, Stat
                         const auto & c = *conflicts[here[a]][here[b]];
                         auto row = rows.find(c.witness);
                         if (row == rows.end())
-                            return give_back(std::nullopt);
+                            return std::nullopt;
 
                         // Reduced to the constant-argument form the at-most-one
                         // program reads it as: the witness's set-aside tasks
@@ -546,12 +541,12 @@ auto InferredDisjunctive::run(Problem & problem, Propagators & propagators, Stat
                         const auto & witness_view = views.at(c.witness);
                         auto reduced = recover_constant_argument_row(recipe_logger, witness_view, c.witness, row->second, t, ProofLevel::Temporary);
                         if (! reduced)
-                            return give_back(std::nullopt);
+                            return std::nullopt;
 
                         auto u_flags = flags_for(tracker, c.witness, c.witness_position_u, t);
                         auto v_flags = flags_for(tracker, c.witness, c.witness_position_v, t);
                         if (! u_flags || ! v_flags)
-                            return give_back(std::nullopt);
+                            return std::nullopt;
 
                         // Everything else on that resource that could be running
                         // now has to come out of the row first. Over the
@@ -602,9 +597,9 @@ auto InferredDisjunctive::run(Problem & problem, Propagators & propagators, Stat
                         at_most_ones[b].push_back(pair_amo.emit(recipe_logger, ProofLevel::Temporary));
                     }
 
-                return give_back(recover_am1_from_pairs(recipe_logger, flags, at_most_ones, ProofLevel::Top,
+                return recover_am1_from_pairs(recipe_logger, flags, at_most_ones, ProofLevel::Top,
                     claim_rhs_zero ? Am1FromPairsMutation{am1_from_pairs_mutation::ClaimOneMore{}}
-                                   : Am1FromPairsMutation{am1_from_pairs_mutation::None{}}));
+                                   : Am1FromPairsMutation{am1_from_pairs_mutation::None{}});
             },
             .makespan = _makespan,
             .makespan_links = links,

--- a/gcs/presolvers/inferred_disjunctive/inferred_disjunctive.cc
+++ b/gcs/presolvers/inferred_disjunctive/inferred_disjunctive.cc
@@ -2,6 +2,7 @@
 #include <gcs/constraints/cumulative.hh>
 #include <gcs/constraints/cumulative/derived_cumulative.hh>
 #include <gcs/constraints/cumulative/donor_view.hh>
+#include <gcs/constraints/cumulative/propagate.hh>
 #include <gcs/exception.hh>
 #include <gcs/innards/proofs/am1_from_pairs.hh>
 #include <gcs/innards/proofs/am1_from_row.hh>
@@ -222,10 +223,9 @@ auto InferredDisjunctive::run(Problem & problem, Propagators & propagators, Stat
         for (auto i : view->usable) {
             auto found = task_of_start.find(starts[i]);
             if (found == task_of_start.end()) {
-                auto [s_lo, s_hi] = state.bounds(starts[i]);
-                auto [l_lo, l_hi] = state.bounds(lengths[i]);
+                auto window = cumulative_task_window(state, starts[i], lengths[i]);
                 found = task_of_start.emplace(starts[i], tasks.size()).first;
-                tasks.push_back(Task{starts[i], lengths[i], l_lo, s_lo, s_hi + l_hi - 1_i, {}});
+                tasks.push_back(Task{starts[i], lengths[i], state.lower_bound(lengths[i]), window.lo, window.hi, {}});
             }
             else if (tasks[found->second].length != lengths[i]) {
                 // Two resources disagreeing about a duration is not something

--- a/gcs/variable_id.hh
+++ b/gcs/variable_id.hh
@@ -7,6 +7,7 @@
 
 #include <functional>
 #include <variant>
+#include <vector>
 
 namespace gcs
 {
@@ -114,6 +115,23 @@ namespace gcs
     }
 
     /**
+     * \brief The value a constant IntegerVariableID stands for.
+     *
+     * Throws `std::bad_variant_access` when it is not a constant, so ask
+     * gcs::is_constant_variable() first --- or do not, where the caller already
+     * knows: a constraint that resolved its arguments once and kept the answer
+     * is entitled to say so, and a throw beats a wrong number.
+     *
+     * \sa IntegerVariableID
+     * \sa gcs::is_constant_variable()
+     * \ingroup Core
+     */
+    [[nodiscard]] constexpr inline auto constant_value_of(const IntegerVariableID & v) -> Integer
+    {
+        return std::get<ConstantIntegerVariableID>(v).const_value;
+    }
+
+    /**
      * \brief Create an IntegerVariableID for a constant value.
      *
      * \sa IntegerVariableID
@@ -123,6 +141,23 @@ namespace gcs
     [[nodiscard]] constexpr inline auto constant_variable(const Integer x) -> IntegerVariableID
     {
         return ConstantIntegerVariableID{x};
+    }
+
+    /**
+     * \brief gcs::constant_variable() over a whole vector, for a constraint
+     * whose variable-argument constructor is the one that does the work.
+     *
+     * \sa IntegerVariableID
+     * \sa gcs::constant_variable()
+     * \ingroup Core
+     */
+    [[nodiscard]] inline auto as_constant_variables(const std::vector<Integer> & values) -> std::vector<IntegerVariableID>
+    {
+        std::vector<IntegerVariableID> result;
+        result.reserve(values.size());
+        for (const auto & v : values)
+            result.push_back(constant_variable(v));
+        return result;
     }
 
     /**


### PR DESCRIPTION
Second of five follow-ups to the whole-design audit. This is the duplication group: four things the stack (and in two cases the tree before it) had written out several times, each with a comment on every copy saying it must agree with the others.

**The constant-argument unwrap.** Seven copies of a four-line `variant` unwrap, three added by this stack. It belongs next to `is_constant_variable` and `constant_variable` in `variable_id.hh`, which every one of these callers already includes. `as_constant_var_ids` came along --- three byte-identical copies in the same three anonymous namespaces --- as `as_constant_variables`.

**The windowing rule.** `[lb(start), ub(start) + ub(length) - 1]` in the posted constraint, the derived one, and all three presolvers. This is the highest-leverage one: `install_derived_cumulative` looks a donor's flags up by `(position, t)` and *declines* when they are not there, so a window that disagrees by one costs a presolver its inference and nothing says so. `cumulative_task_window` in `propagate.hh`, beside `prepare_cumulative_overload_check`, which exists for the eligibility half of the same question. Also: that function was called from two identical blocks in `derived_cumulative.cc`, the second guarded by `! spec.rules.overload`; `spec.rules.overload || spec.makespan` around one copy says it once.

**The proof-level idiom.** Two `give_back` lambdas, one `give_up` flag and three hand-written restore-and-forgets. `ProofScaffoldingScope` --- constructing enters `caller + 1`, destruction restores and forgets `caller + 2`, and `restore()` is for the three routines that pin at their caller's level. Beyond removing the copies: `inferred_cumulative`'s three early exits no longer carry a flag to the bottom of a hundred-line loop, and a `ProofError` from inside no longer leaves the logger a level deep.

**Evidence the scope guard changes nothing.** All 216 proof files the three presolver tests write are byte-identical across it, sweeps included at a pinned seed. The 84 relevant ctest entries pass with veripb on PATH.

Note for review: rebuilding the tree from `variable_id.hh` unmasked pre-existing warnings elsewhere (`global_cardinality`, `linear_equality`, `tabulation.hh`, `names_and_ids_tracker.cc`). None is this stack's and none is touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173hT2hFo3MyGRBon8SHt2p