### PR TITLE
Make the .dzn reader refuse what it was quietly mis-reading

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -4,9 +4,12 @@
 # suite, not just pedagogy, and a program added here needs a fixed instance
 # whose proof verifies quickly.
 #
-# One exception: skeleton_puzzle is a genuine example, but has no add_test,
+# Two exceptions. skeleton_puzzle is a genuine example, but has no add_test,
 # because it does not finish in five minutes under --prove. Do not "fix" that by
-# registering it -- it needs a smaller instance first.
+# registering it -- it needs a smaller instance first. And dzn_test is a plain
+# unit test rather than an example, because dzn.hh's whole job is to fail rather
+# than silently mis-read an instance, and no proof would ever catch it doing
+# otherwise: a benchmark read wrong verifies perfectly and means nothing.
 #
 # Programs that only measure something live in ../benchmarks/ instead, and the
 # MiniCP comparison set in ../minicp_benchmarks/.
@@ -20,6 +23,9 @@
 # among them. They are kept for now because they still exercise a random
 # instance stream that the curated unit tests do not, but retiring them is now
 # a judgement call rather than a coverage regression.
+add_executable(dzn_test dzn_test.cc)
+add_test(NAME dzn_reader COMMAND $<TARGET_FILE:dzn_test>)
+
 add_subdirectory(auto_table)
 add_subdirectory(cake)
 add_subdirectory(colour)

--- a/examples/dzn.hh
+++ b/examples/dzn.hh
@@ -47,6 +47,49 @@ namespace dzn
             throw std::runtime_error{"'" + _path + "': " + name + " " + why};
         }
 
+        /// What is between the outermost brackets, which is where an array's
+        /// contents are however it was written: a bare `[...]` and an
+        /// `array1d(1..5, [...])` wrapper both come back the same, the index
+        /// set having no brackets of its own.
+        [[nodiscard]] auto _bracketed(const std::string & name, const std::string & text) const -> std::string
+        {
+            auto open = text.find('[');
+            auto close = text.rfind(']');
+            if (open == std::string::npos || close == std::string::npos || close < open)
+                _bad(name, "is not an array: '" + text + "'");
+            return text.substr(open + 1, close - open - 1);
+        }
+
+        /// Every integer in a comma-separated list, with anything that is
+        /// neither an integer nor a separator an error rather than a place to
+        /// stop.
+        ///
+        /// Whitespace separates as well as commas do, which is what makes
+        /// integers() able to read a two-dimensional literal flat: with the row
+        /// bars turned into spaces, the `2 3` spanning a row boundary is two
+        /// entries. Splitting on commas alone made it one --- the 2 was read
+        /// and the 3 silently dropped, which is the failure this reader exists
+        /// to refuse.
+        [[nodiscard]] auto _integers_in(const std::string & name, const std::string & text, const std::string & what) const -> std::vector<long long>
+        {
+            auto separated = text;
+            for (auto & c : separated)
+                if (c == ',')
+                    c = ' ';
+
+            std::vector<long long> result;
+            std::istringstream in{separated};
+            long long value = 0;
+            while (in >> value)
+                result.push_back(value);
+            // Reading to the end sets eofbit as well as failbit; stopping on
+            // something else sets only failbit, and that something else is what
+            // has to be complained about rather than ignored.
+            if (! in.eof())
+                _bad(name, "has a non-integer " + what + ": '" + text + "'");
+            return result;
+        }
+
     public:
         Data(std::string path, std::map<std::string, std::string> values) : _path(std::move(path)), _values(std::move(values))
         {
@@ -83,32 +126,13 @@ namespace dzn
         [[nodiscard]] auto integers(const std::string & name) const -> std::vector<long long>
         {
             const auto & text = _raw(name);
-            auto open = text.find('[');
-            auto close = text.rfind(']');
-            if (open == std::string::npos || close == std::string::npos || close < open)
-                _bad(name, "is not an array: '" + text + "'");
-
-            auto body = text.substr(open + 1, close - open - 1);
+            auto body = _bracketed(name, text);
             // A 2-D literal is `[| a, b | c, d |]`; read flat, the row
             // separators are just more whitespace.
             for (auto & c : body)
                 if (c == '|')
                     c = ' ';
-
-            std::vector<long long> result;
-            std::istringstream in{body};
-            std::string item;
-            while (std::getline(in, item, ',')) {
-                std::istringstream one{item};
-                long long value = 0;
-                if (! (one >> value)) {
-                    if (item.find_first_not_of(" \t\r\n") == std::string::npos)
-                        continue;
-                    _bad(name, "has a non-integer entry: '" + item + "'");
-                }
-                result.push_back(value);
-            }
-            return result;
+            return _integers_in(name, body, "entry");
         }
 
         /// A two-dimensional integer array written `[| a, b | c, d |]`, as
@@ -118,12 +142,7 @@ namespace dzn
         [[nodiscard]] auto matrix(const std::string & name) const -> std::vector<std::vector<long long>>
         {
             const auto & text = _raw(name);
-            auto open = text.find('[');
-            auto close = text.rfind(']');
-            if (open == std::string::npos || close == std::string::npos || close < open)
-                _bad(name, "is not an array: '" + text + "'");
-
-            auto body = text.substr(open + 1, close - open - 1);
+            auto body = _bracketed(name, text);
             auto first = body.find_first_not_of(" \t\r\n");
             if (first == std::string::npos || body[first] != '|')
                 _bad(name, "is not a two-dimensional array literal: '" + text + "'");
@@ -136,20 +155,7 @@ namespace dzn
             while (std::getline(in, row, '|')) {
                 if (row.find_first_not_of(" \t\r\n") == std::string::npos)
                     continue;
-                std::vector<long long> entries;
-                std::istringstream cells{row};
-                std::string item;
-                while (std::getline(cells, item, ',')) {
-                    std::istringstream one{item};
-                    long long value = 0;
-                    if (! (one >> value)) {
-                        if (item.find_first_not_of(" \t\r\n") == std::string::npos)
-                            continue;
-                        _bad(name, "has a non-integer entry: '" + item + "'");
-                    }
-                    entries.push_back(value);
-                }
-                rows.push_back(std::move(entries));
+                rows.push_back(_integers_in(name, row, "entry"));
             }
 
             for (const auto & r : rows)
@@ -165,13 +171,9 @@ namespace dzn
         [[nodiscard]] auto sets(const std::string & name) const -> std::vector<std::vector<long long>>
         {
             const auto & text = _raw(name);
-            auto open = text.find('[');
-            auto close = text.rfind(']');
-            if (open == std::string::npos || close == std::string::npos || close < open)
-                _bad(name, "is not an array: '" + text + "'");
+            auto body = _bracketed(name, text);
 
             std::vector<std::vector<long long>> result;
-            auto body = text.substr(open + 1, close - open - 1);
             std::size_t at = 0;
             while (true) {
                 auto brace = body.find('{', at);
@@ -180,31 +182,26 @@ namespace dzn
                 auto end = body.find('}', brace);
                 if (end == std::string::npos)
                     _bad(name, "has a set that is never closed");
-
-                std::vector<long long> members;
-                std::istringstream in{body.substr(brace + 1, end - brace - 1)};
-                std::string item;
-                while (std::getline(in, item, ',')) {
-                    std::istringstream one{item};
-                    long long value = 0;
-                    if (! (one >> value)) {
-                        if (item.find_first_not_of(" \t\r\n") == std::string::npos)
-                            continue;
-                        _bad(name, "has a non-integer set member: '" + item + "'");
-                    }
-                    members.push_back(value);
-                }
-                result.push_back(std::move(members));
+                result.push_back(_integers_in(name, body.substr(brace + 1, end - brace - 1), "set member"));
                 at = end + 1;
             }
 
             // Anything outside the braces other than separators means this is
             // not an array of sets, and reading it as one would quietly drop it.
-            for (std::size_t i = 0, brace_depth = 0; i != body.size(); ++i) {
+            // A closing brace with nothing open is its own complaint, and has to
+            // be: with an unsigned counter it took the depth to SIZE_MAX, after
+            // which the outside-the-braces test never fired again and the rest
+            // of the string was accepted --- so the loop passed exactly the
+            // input it is here to catch.
+            long long brace_depth = 0;
+            for (std::size_t i = 0; i != body.size(); ++i) {
                 if (body[i] == '{')
                     ++brace_depth;
-                else if (body[i] == '}')
+                else if (body[i] == '}') {
+                    if (0 == brace_depth)
+                        _bad(name, "closes a set that was never opened: '" + text + "'");
                     --brace_depth;
+                }
                 else if (0 == brace_depth && ',' != body[i] && ! std::isspace(static_cast<unsigned char>(body[i])))
                     _bad(name, "is not an array of sets: '" + text + "'");
             }

--- a/examples/dzn_test.cc
+++ b/examples/dzn_test.cc
@@ -1,0 +1,153 @@
+// A unit test for dzn.hh, which the rest of examples/ is not: the programs
+// here are end-to-end proof checks, and this is the one exception, because the
+// reader's whole job is to fail rather than silently mis-read a benchmark
+// instance and there is no proof that would catch it doing otherwise.
+//
+// Every rejection case below is one the reader used to *accept*, with a number
+// in the answer and no complaint.
+
+#include "dzn.hh"
+
+#include <cstdlib>
+#include <exception>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <vector>
+
+using std::cerr;
+using std::string;
+using std::to_string;
+using std::vector;
+
+namespace
+{
+    auto failures = 0;
+
+    auto fail(const string & what) -> void
+    {
+        cerr << "dzn test failure: " << what << "\n";
+        ++failures;
+    }
+
+    auto as_text(const vector<long long> & v) -> string
+    {
+        string s{"{"};
+        for (const auto & x : v)
+            s += " " + to_string(x);
+        return s + " }";
+    }
+
+    auto expect(const string & what, const vector<long long> & got, const vector<long long> & want) -> void
+    {
+        if (got != want)
+            fail(what + ": got " + as_text(got) + " but wanted " + as_text(want));
+    }
+
+    auto expect_rejected(const string & what, const auto & read_it) -> void
+    {
+        try {
+            read_it();
+        }
+        catch (const std::exception &) {
+            return;
+        }
+        fail(what + ": accepted, so it would have been read as something it is not");
+    }
+}
+
+auto main(int, char *[]) -> int
+{
+    // In the working directory, like the proof files the other entries here
+    // write, and with a name no other test uses.
+    const string path = "dzn_test_data.dzn";
+    {
+        std::ofstream data{path};
+        data << "% a comment, which is not a statement\n";
+        data << "scalar = 7;\n";
+        data << "flat = [1, 2, 3, 4];\n";
+        data << "flat_wrapped = array1d(1..4, [5, 6, 7, 8]);\n";
+        data << "flat_2d = [| 1, 2 | 3, 4 |];\n";
+        data << "flat_empty = [];\n";
+        data << "flat_trailing_comma = [1, 2, ];\n";
+        data << "flat_negative = [-1, 2, -3];\n";
+        data << "flat_junk = [1, 2abc, 3];\n";
+        data << "grid = [| 1, 2, 3 | 4, 5, 6 |];\n";
+        data << "grid_ragged = [| 1, 2 | 3 |];\n";
+        data << "grid_junk = [| 1, 2x | 3, 4 |];\n";
+        data << "groups = [ {1, 2}, {}, {3} ];\n";
+        data << "groups_junk = [ {1, x} ];\n";
+        data << "groups_outside = [ {1} 7 ];\n";
+        data << "groups_stray_close = [ {1, 2} } 99 ];\n";
+        data << "groups_unclosed = [ {1, 2 ];\n";
+        if (! data)
+            fail("could not write the test data file");
+    }
+
+    try {
+        auto d = dzn::read(path);
+
+        if (d.integer("scalar") != 7)
+            fail("an integer scalar");
+        if (! d.contains("flat") || d.contains("nothing_of_the_sort"))
+            fail("contains()");
+
+        expect("a flat array", d.integers("flat"), {1, 2, 3, 4});
+        expect("an array1d wrapper, whose index set is not an entry", d.integers("flat_wrapped"), {5, 6, 7, 8});
+        expect("negative entries", d.integers("flat_negative"), {-1, 2, -3});
+        expect("an empty array", d.integers("flat_empty"), {});
+        expect("a trailing comma, which is a separator with nothing after it", d.integers("flat_trailing_comma"), {1, 2});
+
+        // The row bars become whitespace, so one entry can be separated from
+        // the next by a bar rather than by a comma. Splitting on commas alone
+        // made `2 | 3` a single entry, read the 2 out of it, and dropped the 3.
+        expect("a 2-D literal read flat, which keeps every entry", d.integers("flat_2d"), {1, 2, 3, 4});
+
+        auto grid = d.matrix("grid");
+        if (grid.size() != 2)
+            fail("a matrix's row count");
+        else {
+            expect("matrix row 0", grid[0], {1, 2, 3});
+            expect("matrix row 1", grid[1], {4, 5, 6});
+        }
+
+        auto groups = d.sets("groups");
+        if (groups.size() != 3)
+            fail("an array of sets' count");
+        else {
+            expect("set 0", groups[0], {1, 2});
+            expect("set 1, which is empty", groups[1], {});
+            expect("set 2", groups[2], {3});
+        }
+
+        expect_rejected("a non-integer entry", [&] { return d.integers("flat_junk"); });
+        expect_rejected("a non-integer matrix entry", [&] { return d.matrix("grid_junk"); });
+        expect_rejected("a non-integer set member", [&] { return d.sets("groups_junk"); });
+        expect_rejected("matrix rows of differing lengths", [&] { return d.matrix("grid_ragged"); });
+        expect_rejected("something outside the braces", [&] { return d.sets("groups_outside"); });
+        expect_rejected("a set that is never closed", [&] { return d.sets("groups_unclosed"); });
+
+        // A `}` with nothing open took an unsigned brace counter to SIZE_MAX,
+        // after which the outside-the-braces test never fired again and the
+        // rest of the string was accepted --- so the check was switched off by
+        // exactly the input it is there to catch.
+        expect_rejected("a closing brace with nothing open", [&] { return d.sets("groups_stray_close"); });
+
+        expect_rejected("a name the file does not define", [&] { return d.integer("absent"); });
+        expect_rejected("an integer scalar with trailing text", [&] { return d.integer("flat"); });
+    }
+    catch (const std::exception & e) {
+        fail(string{"unexpected exception: "} + e.what());
+    }
+
+    std::filesystem::remove(path);
+
+    if (0 != failures) {
+        cerr << "dzn test: " << failures << " failures\n";
+        return EXIT_FAILURE;
+    }
+
+    cerr << "dzn test: every check passed\n";
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Third of five follow-ups to the whole-design audit. The audit flagged `examples/dzn.hh` for triplicated parsing (finding 10), for accepting trailing junk in three of four readers (26), and for an unsigned underflow that disables a check (25). Writing the shared helper the first of those asks for turned up a fourth, which is the one worth reading this PR for.

**`integers()` on a 2-D literal dropped entries.** It split on commas, and a 2-D literal's row bar is not a comma, so the `2 | 3` spanning a row boundary arrived as one item; `one >> value` read the 2 and the 3 was gone. `[| 1, 2 | 3, 4 |]` read flat gave `{1, 2, 4}`. The doc comment has always said the row separators are just more whitespace; now they are.

**Trailing junk.** `integer()` checks that nothing follows the value. The other three did `if (! (one >> value))` and pushed on success, so `2abc` was a 2 and `[|1, 2x|3, 4|]` was a well-formed matrix.

**The brace-depth underflow.** A `}` with no `{` before it took the unsigned counter to `SIZE_MAX`, after which `0 == brace_depth` was never true again and everything to the end of the string was accepted --- so the loop was switched off by exactly the malformed input it is there to catch.

All three go away behind one `_integers_in` (commas *and* whitespace separate; anything else is an error, not a stopping point) and one `_bracketed` for the triplicated `[`/`]` preamble.

**A test.** `examples/` is documented as end-to-end proof checks rather than unit tests, and this is the second exception to that, recorded in the directory's own comment: the reader's job is to fail rather than mis-read, and no proof would ever catch it doing otherwise --- a benchmark read wrong verifies perfectly and means nothing. Against the reader as it was, `dzn_test` fails four of its cases; against this one it passes. `rcpsp --dzn sample.dzn` still reaches makespan 6, and all 19 dzn/rcpsp ctest entries pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173hT2hFo3MyGRBon8SHt2p