### PR TITLE
Tidy what the audit found reading the three presolvers

### DIFF
--- a/examples/rcpsp/rcpsp_instance.hh
+++ b/examples/rcpsp/rcpsp_instance.hh
@@ -163,16 +163,16 @@ namespace rcpsp
                 succ[static_cast<std::size_t>(i)].emplace_back(j, inst.durations[static_cast<std::size_t>(i)].raw_value);
 
             std::vector<std::vector<long long>> lp(n, std::vector<long long>(n, unreachable));
-            for (int i = inst.n_tasks - 1; i >= 0; --i) {
-                auto ui = static_cast<std::size_t>(i);
+            for (auto ui = n; ui-- > 0;) {
                 lp[ui][ui] = 0;
-                for (const auto & [j, w] : succ[ui])
-                    for (int t = j; t < inst.n_tasks; ++t) {
-                        auto ut = static_cast<std::size_t>(t);
-                        auto via = lp[static_cast<std::size_t>(j)][ut];
+                for (const auto & [j, w] : succ[ui]) {
+                    auto uj = static_cast<std::size_t>(j);
+                    for (auto ut = uj; ut < n; ++ut) {
+                        auto via = lp[uj][ut];
                         if (via != unreachable && w + via > lp[ui][ut])
                             lp[ui][ut] = w + via;
                     }
+                }
             }
             return lp;
         }
@@ -284,14 +284,14 @@ namespace rcpsp
     /// resources can only push a task later.
     [[nodiscard]] inline auto earliest_starts(const Instance & inst) -> std::vector<long long>
     {
-        std::vector<std::vector<int>> preds(inst.n_tasks);
+        std::vector<std::vector<int>> preds(static_cast<std::size_t>(inst.n_tasks));
         for (const auto & [i, j] : inst.precedences)
-            preds[j].push_back(i);
+            preds[static_cast<std::size_t>(j)].push_back(i);
 
-        std::vector<long long> est(inst.n_tasks, 0);
-        for (int j = 0; j < inst.n_tasks; ++j)
+        std::vector<long long> est(static_cast<std::size_t>(inst.n_tasks), 0);
+        for (std::size_t j = 0; j < est.size(); ++j)
             for (auto & i : preds[j])
-                est[j] = std::max(est[j], est[i] + inst.durations[i].raw_value);
+                est[j] = std::max(est[j], est[static_cast<std::size_t>(i)] + inst.durations[static_cast<std::size_t>(i)].raw_value);
         return est;
     }
 
@@ -300,14 +300,16 @@ namespace rcpsp
     /// any schedule of makespan H, task i cannot start after H - d_i - tail_i.
     [[nodiscard]] inline auto tails(const Instance & inst) -> std::vector<long long>
     {
-        std::vector<std::vector<int>> succs(inst.n_tasks);
+        std::vector<std::vector<int>> succs(static_cast<std::size_t>(inst.n_tasks));
         for (const auto & [i, j] : inst.precedences)
-            succs[i].push_back(j);
+            succs[static_cast<std::size_t>(i)].push_back(j);
 
-        std::vector<long long> tail(inst.n_tasks, 0);
-        for (int i = inst.n_tasks - 1; i >= 0; --i)
-            for (auto & j : succs[i])
-                tail[i] = std::max(tail[i], inst.durations[j].raw_value + tail[j]);
+        std::vector<long long> tail(static_cast<std::size_t>(inst.n_tasks), 0);
+        for (auto i = tail.size(); i-- > 0;)
+            for (auto & j : succs[i]) {
+                auto uj = static_cast<std::size_t>(j);
+                tail[i] = std::max(tail[i], inst.durations[uj].raw_value + tail[uj]);
+            }
         return tail;
     }
 
@@ -318,7 +320,7 @@ namespace rcpsp
         auto est = earliest_starts(inst);
         auto tail = tails(inst);
         long long cp = 0;
-        for (int i = 0; i < inst.n_tasks; ++i)
+        for (std::size_t i = 0; i < est.size(); ++i)
             cp = std::max(cp, est[i] + inst.durations[i].raw_value + tail[i]);
         return cp;
     }
@@ -334,15 +336,17 @@ namespace rcpsp
             return false;
 
         long long horizon = 0;
-        for (int i = 0; i < inst.n_tasks; ++i) {
+        for (std::size_t i = 0; i < starts.size(); ++i) {
             if (starts[i] < 0)
                 return false;
             horizon = std::max(horizon, starts[i] + inst.durations[i].raw_value);
         }
 
-        for (const auto & [i, j] : inst.precedences)
-            if (starts[i] + inst.durations[i].raw_value > starts[j])
+        for (const auto & [i, j] : inst.precedences) {
+            auto ui = static_cast<std::size_t>(i);
+            if (starts[ui] + inst.durations[ui].raw_value > starts[static_cast<std::size_t>(j)])
                 return false;
+        }
 
         // The generalised lags too, minimum and maximum alike. This is what lets
         // the caller keep using a heuristic schedule's makespan as the horizon on
@@ -357,7 +361,7 @@ namespace rcpsp
 
         for (std::size_t r = 0; r < inst.capacities.size(); ++r) {
             std::vector<long long> load(horizon, 0);
-            for (int i = 0; i < inst.n_tasks; ++i)
+            for (std::size_t i = 0; i < starts.size(); ++i)
                 for (auto t = starts[i]; t < starts[i] + inst.durations[i].raw_value; ++t)
                     load[t] += inst.demands[r][i].raw_value;
             for (auto & l : load)
@@ -366,10 +370,12 @@ namespace rcpsp
         }
 
         std::vector<int> busy(horizon, 0);
-        for (auto & i : inst.machine_tasks)
+        for (auto & m : inst.machine_tasks) {
+            auto i = static_cast<std::size_t>(m);
             for (auto t = starts[i]; t < starts[i] + inst.durations[i].raw_value; ++t)
                 if (busy[t]++)
                     return false;
+        }
 
         return true;
     }
@@ -392,20 +398,22 @@ namespace rcpsp
 
         std::vector<std::vector<long long>> load(inst.capacities.size(), std::vector<long long>(total, 0));
         std::vector<int> busy(total, 0);
-        std::vector<char> needs_machine(inst.n_tasks, 0);
+        std::vector<char> needs_machine(static_cast<std::size_t>(inst.n_tasks), 0);
         for (auto & i : inst.machine_tasks)
-            needs_machine[i] = 1;
+            needs_machine[static_cast<std::size_t>(i)] = 1;
 
-        std::vector<std::vector<int>> preds(inst.n_tasks);
+        std::vector<std::vector<int>> preds(static_cast<std::size_t>(inst.n_tasks));
         for (const auto & [i, j] : inst.precedences)
-            preds[j].push_back(i);
+            preds[static_cast<std::size_t>(j)].push_back(i);
 
-        std::vector<long long> start(inst.n_tasks, 0);
-        for (int i = 0; i < inst.n_tasks; ++i) {
+        std::vector<long long> start(static_cast<std::size_t>(inst.n_tasks), 0);
+        for (std::size_t i = 0; i < start.size(); ++i) {
             auto len = inst.durations[i].raw_value;
             long long t = 0;
-            for (auto & p : preds[i])
-                t = std::max(t, start[p] + inst.durations[p].raw_value);
+            for (auto & p : preds[i]) {
+                auto up = static_cast<std::size_t>(p);
+                t = std::max(t, start[up] + inst.durations[up].raw_value);
+            }
 
             for (;; ++t) {
                 if (t + len > total)
@@ -443,7 +451,7 @@ namespace rcpsp
     [[nodiscard]] inline auto makespan_of(const Instance & inst, const std::vector<long long> & starts) -> long long
     {
         long long m = 0;
-        for (int i = 0; i < inst.n_tasks; ++i)
+        for (std::size_t i = 0; i < starts.size(); ++i)
             m = std::max(m, starts[i] + inst.durations[i].raw_value);
         return m;
     }
@@ -465,8 +473,8 @@ namespace rcpsp
     [[nodiscard]] inline auto default_horizon(const Instance & inst) -> long long
     {
         std::vector<long long> per_task(static_cast<std::size_t>(inst.n_tasks), 0);
-        for (int i = 0; i < inst.n_tasks; ++i)
-            per_task[static_cast<std::size_t>(i)] = inst.durations[static_cast<std::size_t>(i)].raw_value;
+        for (std::size_t i = 0; i < per_task.size(); ++i)
+            per_task[i] = inst.durations[i].raw_value;
 
         // A precedence's own weight is the tail's duration, so it never raises
         // the term above; only a generalised minimum lag can.
@@ -681,10 +689,10 @@ namespace rcpsp
             if (static_cast<int>(rr[r].size()) != inst.n_tasks)
                 throw std::runtime_error{"'" + path + "' gives " + std::to_string(rr[r].size()) + " demands for resource " + std::to_string(r) +
                     ", not " + std::to_string(inst.n_tasks)};
-            for (int i = 0; i != inst.n_tasks; ++i) {
-                if (rr[r][static_cast<std::size_t>(i)] < 0)
+            for (std::size_t i = 0; i != rr[r].size(); ++i) {
+                if (rr[r][i] < 0)
                     throw std::runtime_error{"'" + path + "' has a negative demand"};
-                inst.demands[r][static_cast<std::size_t>(i)] = gcs::Integer{rr[r][static_cast<std::size_t>(i)]};
+                inst.demands[r][i] = gcs::Integer{rr[r][i]};
             }
         }
 
@@ -697,8 +705,9 @@ namespace rcpsp
         if (static_cast<int>(suc.size()) != inst.n_tasks)
             throw std::runtime_error{
                 "'" + path + "' gives successors for " + std::to_string(suc.size()) + " tasks, not " + std::to_string(inst.n_tasks)};
-        for (int i = 0; i != inst.n_tasks; ++i)
-            for (auto & one_based : suc[static_cast<std::size_t>(i)]) {
+        for (std::size_t at = 0; at != suc.size(); ++at) {
+            auto i = static_cast<int>(at);
+            for (auto & one_based : suc[at]) {
                 auto j = static_cast<int>(one_based) - 1;
                 if (j < 0 || j >= inst.n_tasks)
                     throw std::runtime_error{"'" + path + "' has a precedence to a nonexistent task"};
@@ -707,6 +716,7 @@ namespace rcpsp
                         std::to_string(i + 1) + ", so the tasks are not in topological order; this reader needs them to be"};
                 inst.precedences.emplace_back(i, j);
             }
+        }
 
         inst.description = "dzn " + path + " n=" + std::to_string(inst.n_tasks) + " resources=" + std::to_string(n_res) +
             " precedences=" + std::to_string(inst.precedences.size());

--- a/gcs/constraints/cumulative/donor_view.cc
+++ b/gcs/constraints/cumulative/donor_view.cc
@@ -253,8 +253,8 @@ auto gcs::innards::recover_constant_argument_row(ProofLogger & logger, const Cum
             hints = vector<ProofLine>{ProofLine{*contribution_row}, *line, *holds};
 
         WPBSum guaranteed;
-        for (Integer k = 0_i; k.raw_value < static_cast<long long>(cc.size()); ++k)
-            guaranteed += power2(k) * cc[k.raw_value];
+        for (size_t k = 0; k < cc.size(); ++k)
+            guaranteed += power2(Integer(static_cast<long long>(k))) * cc[k];
         guaranteed += view.heights[i] * ! *active;
         reduced.add(logger.emit(RUPProofRule{hints}, move(guaranteed) >= view.heights[i], ProofLevel::Temporary));
     }

--- a/gcs/constraints/innards/makespan_energy.cc
+++ b/gcs/constraints/innards/makespan_energy.cc
@@ -79,8 +79,10 @@ auto gcs::innards::makespan_energy::makespan_energy_bound(const vector<EnergyTas
 
         auto supply = capacity * slots_within(time_slot_prefix, lo, lo, mu);
         if (energy > supply)
-            best = MakespanBound{
-                mu + 1_i, lo, mu, energy, supply, slots_within(time_slot_prefix, lo, lo, mu + 1_i) > slots_within(time_slot_prefix, lo, lo, mu)};
+            best = MakespanBound{.bound = mu + 1_i,
+                .lo = lo,
+                .hi = mu,
+                .wider_supplies_more = slots_within(time_slot_prefix, lo, lo, mu + 1_i) > slots_within(time_slot_prefix, lo, lo, mu)};
     }
 
     return best;

--- a/gcs/constraints/innards/makespan_energy.hh
+++ b/gcs/constraints/innards/makespan_energy.hh
@@ -168,9 +168,6 @@ namespace gcs::innards::makespan_energy
         /// `bound - 1`: the largest makespan the argument refutes.
         Integer lo, hi;
 
-        /// What the tasks need inside it, and what it supplies.
-        Integer energy, supply;
-
         /// Whether a window one time point wider would have a capacity row to
         /// go with it. False when the window already reaches the last row ---
         /// which is only of interest to \ref makespan_energy_mutation::ClaimHigherBound,

--- a/gcs/presolvers/cumulative_strengthening/cumulative_strengthening.cc
+++ b/gcs/presolvers/cumulative_strengthening/cumulative_strengthening.cc
@@ -43,6 +43,10 @@ using std::size_t;
 using std::to_string;
 using std::unique_ptr;
 using std::vector;
+using std::ranges::all_of;
+using std::ranges::any_of;
+using std::ranges::max_element;
+using std::ranges::sort;
 
 namespace
 {
@@ -80,26 +84,46 @@ namespace
     /// the capacity raises in a single step; one that overshoots by half gets
     /// steps of one and pays a `pol` per unit of `kappa`, which is why the
     /// caller budgets this. Predicting it is arithmetic and needs no proof, so
-    /// the budget and the derivation call the same function --- a prediction
-    /// that disagreed would decline the wrong donors.
-    [[nodiscard]] auto raise_steps(Integer total, Integer kappa) -> vector<Integer>
+    /// the budget and the derivation walk the same steps --- a prediction that
+    /// disagreed would decline the wrong donors.
+    template <typename Step_>
+    auto for_each_raise_step(Integer total, Integer kappa, Step_ && each_step) -> void
     {
         // Everything else fits alongside, so the at-most-ones alone say it:
         // summed, they give the whole row in one `pol`, and there is no
         // division to survive.
-        if (total <= kappa)
-            return {kappa};
+        if (total <= kappa) {
+            each_step(kappa);
+            return;
+        }
 
         auto overshoot = total - kappa;
-        vector<Integer> steps;
         for (auto c = 0_i; c < kappa;) {
             // ceil((total - c) / overshoot) - 1, which is at least one while
             // `c < kappa`, so this terminates.
             auto step = min(kappa - c, (total - c + overshoot - 1_i) / overshoot - 1_i);
-            steps.push_back(step);
+            each_step(step);
             c += step;
         }
+    }
+
+    /// \ref for_each_raise_step, as the steps themselves.
+    [[nodiscard]] auto raise_steps(Integer total, Integer kappa) -> vector<Integer>
+    {
+        vector<Integer> steps;
+        for_each_raise_step(total, kappa, [&](Integer step) { steps.push_back(step); });
         return steps;
+    }
+
+    /// \ref for_each_raise_step, as how many there are --- which is all the
+    /// budget wants, and it wants it once per raised task per time point, on
+    /// the path whose whole purpose is to decide cheaply whether the expensive
+    /// one is affordable.
+    [[nodiscard]] auto raise_step_count(Integer total, Integer kappa) -> long long
+    {
+        long long count = 0;
+        for_each_raise_step(total, kappa, [&](Integer) { ++count; });
+        return count;
     }
 }
 
@@ -201,7 +225,7 @@ auto CumulativeStrengthening::run(Problem & problem, Propagators & propagators, 
             // A height above the capacity means the donor is infeasible on its
             // own, which is the donor's business to detect and not something to
             // build a subset sum over.
-            if (std::any_of(active_tasks.begin(), active_tasks.end(), [&](size_t i) { return candidate.heights[i] > capacity; }))
+            if (any_of(active_tasks, [&](size_t i) { return candidate.heights[i] > capacity; }))
                 return nullopt;
 
             // Schulz's coefficient raising, as the set of tasks it applies to.
@@ -226,7 +250,7 @@ auto CumulativeStrengthening::run(Problem & problem, Propagators & propagators, 
             auto & full_tasks = assessment.full_tasks;
             vector<size_t> other_tasks;
             for (auto i : active_tasks) {
-                auto conflicts_with_everything = std::all_of(active_tasks.begin(), active_tasks.end(), [&](size_t j) {
+                auto conflicts_with_everything = all_of(active_tasks, [&](size_t j) {
                     return i == j || t_hi[i] < t_lo[j] || t_hi[j] < t_lo[i] || candidate.heights[i] + candidate.heights[j] > capacity;
                 });
                 (conflicts_with_everything ? full_tasks : other_tasks).push_back(i);
@@ -237,11 +261,10 @@ auto CumulativeStrengthening::run(Problem & problem, Propagators & propagators, 
             // anyway. Everything downstream then runs honestly on a set that is
             // wrong, and the row it lands on is a row the donor does not imply.
             if (unentitled_raise && ! other_tasks.empty()) {
-                auto tallest = std::max_element(
-                    other_tasks.begin(), other_tasks.end(), [&](size_t a, size_t b) { return candidate.heights[a] < candidate.heights[b]; });
+                auto tallest = max_element(other_tasks, [&](size_t a, size_t b) { return candidate.heights[a] < candidate.heights[b]; });
                 full_tasks.push_back(*tallest);
                 other_tasks.erase(tallest);
-                std::sort(full_tasks.begin(), full_tasks.end());
+                sort(full_tasks);
             }
 
             auto global_lo = t_lo[active_tasks.front()], global_hi = t_hi[active_tasks.front()];
@@ -290,8 +313,7 @@ auto CumulativeStrengthening::run(Problem & problem, Propagators & propagators, 
             // capacity really is. If that is the capacity already, and no
             // task's height changes either, the donor was posted with the
             // numbers it deserved and there is nothing here.
-            auto raises_a_height =
-                std::any_of(full_tasks.begin(), full_tasks.end(), [&](size_t i) { return candidate.heights[i] != assessment.kappa; });
+            auto raises_a_height = any_of(full_tasks, [&](size_t i) { return candidate.heights[i] != assessment.kappa; });
             if (assessment.kappa >= capacity && ! raises_a_height)
                 return nullopt;
 
@@ -313,7 +335,7 @@ auto CumulativeStrengthening::run(Problem & problem, Propagators & propagators, 
         // Neither direction dominates and both are arithmetic, so work out both
         // and keep the bigger reduction rather than assuming. A tie goes to the
         // converted one, which says the same about the capacity over more tasks.
-        if (std::any_of(view->height_bounded_by.begin(), view->height_bounded_by.end(), [](const auto & h) { return h.has_value(); })) {
+        if (any_of(view->height_bounded_by, [](const auto & h) { return h.has_value(); })) {
             auto without = view->with_converted_heights_set_aside();
             if (auto set_aside_instead = assess(without); set_aside_instead && (! assessed || set_aside_instead->kappa < assessed->kappa)) {
                 bump(&CumulativeStrengtheningStats::donors_better_off_setting_heights_aside);
@@ -351,9 +373,13 @@ auto CumulativeStrengthening::run(Problem & problem, Propagators & propagators, 
                 if (! point.by_division)
                     states += static_cast<long long>(point.heights.size()) * (capacity.raw_value + 1);
 
+                // A repeat count rather than an index: each raised task is
+                // raised out of the row the one before it left behind, which is
+                // a kappa heavier, so what varies between the rounds is `total`
+                // and not which task it is.
                 auto total = std::accumulate(point.heights.begin(), point.heights.end(), 0_i);
-                for (size_t taken = 0; taken < point.full_tasks.size(); ++taken) {
-                    raise_lines += static_cast<long long>(raise_steps(total, kappa).size());
+                for (size_t rounds = point.full_tasks.size(); rounds > 0; --rounds) {
+                    raise_lines += raise_step_count(total, kappa);
                     total += kappa;
                 }
             }
@@ -394,12 +420,12 @@ auto CumulativeStrengthening::run(Problem & problem, Propagators & propagators, 
             derived_heights[i] = kappa;
 
         // Fixed for the whole donor, so worked out once rather than per row.
-        SubsetSumMutation subset_sum_corruption = std::visit(
-            overloaded{//
-                [](const cumulative_strengthening_mutation::ClaimOneBetter &) -> SubsetSumMutation { return subset_sum_mutation::ClaimOneBetter{}; },
-                [](const cumulative_strengthening_mutation::BogusDivisor &) -> SubsetSumMutation { return subset_sum_mutation::BogusDivisor{}; },
-                [](const auto &) -> SubsetSumMutation { return subset_sum_mutation::None{}; }},
-            _mutation);
+        SubsetSumMutation subset_sum_corruption = overloaded{//
+            [](const cumulative_strengthening_mutation::ClaimOneBetter &) -> SubsetSumMutation { return subset_sum_mutation::ClaimOneBetter{}; },
+            [](const cumulative_strengthening_mutation::BogusDivisor &) -> SubsetSumMutation { return subset_sum_mutation::BogusDivisor{}; },
+            [](const auto &) -> SubsetSumMutation {
+                return subset_sum_mutation::None{};
+            }}.visit(_mutation);
         auto raise_too_fast = std::holds_alternative<cumulative_strengthening_mutation::RaiseTooFast>(_mutation);
 
         DerivedCumulativeSpec spec{.tasks = derived_cumulative_tasks_from(donor_id, starts, view->lengths, derived_heights, view->presences),

--- a/gcs/presolvers/inferred_cumulative/inferred_cumulative.cc
+++ b/gcs/presolvers/inferred_cumulative/inferred_cumulative.cc
@@ -723,8 +723,11 @@ auto InferredCumulative::run(Problem & problem, Propagators & propagators, State
             const auto & task = tasks[cut.support[k]];
             auto link = makespan_links.find(task.start);
             links.push_back(link == makespan_links.end() ? std::nullopt : optional<makespan_energy::MakespanLink>{link->second});
-            derived_tasks.push_back(DerivedCumulativeTask{
-                donors[task.canonical_donor].id, *task.positions[task.canonical_donor], task.start, task.length, cut.coefficients[k]});
+            derived_tasks.push_back(DerivedCumulativeTask{.donor = donors[task.canonical_donor].id,
+                .position = *task.positions[task.canonical_donor],
+                .start = task.start,
+                .length = task.length,
+                .height = cut.coefficients[k]});
             recipe.members.push_back(RecipeMember{task.canonical_donor, *task.positions[task.canonical_donor], task.demands, task.positions,
                 cut.coefficients[k], task.t_lo, task.t_hi});
         }

--- a/gcs/presolvers/inferred_disjunctive/inferred_disjunctive.cc
+++ b/gcs/presolvers/inferred_disjunctive/inferred_disjunctive.cc
@@ -41,6 +41,9 @@ using std::size_t;
 using std::to_string;
 using std::unique_ptr;
 using std::vector;
+using std::ranges::find;
+using std::ranges::includes;
+using std::ranges::sort;
 
 namespace
 {
@@ -290,7 +293,7 @@ auto InferredDisjunctive::run(Problem & problem, Propagators & propagators, Stat
             if (w != u && w != v && conflict[u][w] && conflict[v][w])
                 candidates.push_back(w);
 
-        std::sort(candidates.begin(), candidates.end(), [&](size_t a, size_t b) {
+        sort(candidates, [&](size_t a, size_t b) {
             if (tasks[a].least_length != tasks[b].least_length)
                 return tasks[a].least_length > tasks[b].least_length;
             return a < b;
@@ -307,7 +310,7 @@ auto InferredDisjunctive::run(Problem & problem, Propagators & propagators, Stat
                 clique.push_back(w);
         }
 
-        std::sort(clique.begin(), clique.end());
+        sort(clique);
         return clique;
     };
 
@@ -342,7 +345,7 @@ auto InferredDisjunctive::run(Problem & problem, Propagators & propagators, Stat
     if (include_non_conflicting && ! found.empty()) {
         auto & clique = found.front();
         for (size_t w = 0; w < tasks.size(); ++w) {
-            if (std::find(clique.begin(), clique.end(), w) != clique.end())
+            if (find(clique, w) != clique.end())
                 continue;
 
             // Every member has to at least share a resource with it, or there
@@ -355,15 +358,20 @@ auto InferredDisjunctive::run(Problem & problem, Propagators & propagators, Stat
                     continue;
                 }
                 optional<Conflict> shared;
-                for (const auto & aw : tasks[w].appearances)
+                for (const auto & aw : tasks[w].appearances) {
                     for (const auto & am : tasks[member].appearances)
-                        if (aw.donor == am.donor && ! shared)
+                        if (aw.donor == am.donor) {
                             // Demands that overshoot by exactly one: a lie,
                             // and the same lie the mutation is about, since
                             // what it fabricates is a conflict that is not
                             // there. Recovering the at-most-one then runs
                             // honestly on numbers that are wrong.
                             shared = Conflict{aw.donor, am.position, aw.position, capacity_of.at(aw.donor), 1_i, capacity_of.at(aw.donor)};
+                            break;
+                        }
+                    if (shared)
+                        break;
+                }
                 if (! shared) {
                     usable = false;
                     break;
@@ -379,7 +387,7 @@ auto InferredDisjunctive::run(Problem & problem, Propagators & propagators, Stat
                     conflict[w][member] = Conflict{c.witness, c.witness_position_v, c.witness_position_u, c.demand_v, c.demand_u, c.capacity};
                 }
             clique.push_back(w);
-            std::sort(clique.begin(), clique.end());
+            sort(clique);
             break;
         }
     }
@@ -400,7 +408,7 @@ auto InferredDisjunctive::run(Problem & problem, Propagators & propagators, Stat
     };
 
     // Rank by that, and drop any clique contained in one already accepted.
-    std::sort(found.begin(), found.end(), [&](const vector<size_t> & a, const vector<size_t> & b) {
+    sort(found, [&](const vector<size_t> & a, const vector<size_t> & b) {
         auto ta = capacity_bound(a), tb = capacity_bound(b);
         if (ta != tb)
             return ta > tb;
@@ -418,7 +426,7 @@ auto InferredDisjunctive::run(Problem & problem, Propagators & propagators, Stat
 
         bool subsumed = false;
         for (const auto & already : accepted)
-            if (std::includes(already.begin(), already.end(), clique.begin(), clique.end())) {
+            if (includes(already, clique)) {
                 subsumed = true;
                 break;
             }
@@ -440,7 +448,8 @@ auto InferredDisjunctive::run(Problem & problem, Propagators & propagators, Stat
             const auto & home = tasks[i].appearances.front();
             auto link = makespan_links.find(tasks[i].start);
             links.push_back(link == makespan_links.end() ? std::nullopt : optional<makespan_energy::MakespanLink>{link->second});
-            derived_tasks.push_back(DerivedCumulativeTask{home.donor, home.position, tasks[i].start, tasks[i].length, 1_i});
+            derived_tasks.push_back(DerivedCumulativeTask{
+                .donor = home.donor, .position = home.position, .start = tasks[i].start, .length = tasks[i].length, .height = 1_i});
         }
         for (size_t a = 0; a < clique.size(); ++a)
             for (size_t b = a + 1; b < clique.size(); ++b)
@@ -572,9 +581,15 @@ auto InferredDisjunctive::run(Problem & problem, Propagators & propagators, Stat
                         // a clique's members share a witness, recovering their
                         // sub-clique in one step instead is what issue #666
                         // is about.
+                        // The bound it returns is not checked because it
+                        // cannot be anything else: two demands that overshoot
+                        // give a margin at most the larger of them, so the
+                        // divisor is that margin and |K| - ceil(Delta / d) is
+                        // one. build_am1_from_row's own paragraph is the
+                        // argument, and it is why a caller wanting the pairwise
+                        // case need not special-case anything.
                         PolBuilder pair_amo;
-                        [[maybe_unused]] auto at_most =
-                            build_am1_from_row(pair_amo, *reduced, {c.demand_u, c.demand_v}, weaken_out, c.capacity, tracker);
+                        build_am1_from_row(pair_amo, *reduced, {c.demand_u, c.demand_v}, weaken_out, c.capacity, tracker);
 
                         // Bridging a task onto the *other* task's flags leaves
                         // its own term uncancelled, so what is merged is not the


### PR DESCRIPTION
Fourth of five follow-ups to the whole-design audit: the craft group, findings 13-19 and 22. None is behavioural --- the 216 proof files the three presolver tests write are byte-identical across the whole PR, sweeps included at a pinned seed.

- **A discarded return value with a `[[maybe_unused]]` where an argument belonged.** `build_am1_from_row` is not `[[nodiscard]]`, so the binding and the attribute were both noise; what was missing was the reason it is safe not to check, which is that at two members the divisor is the margin and the bound is always one.
- **Designated initialisers** for `DerivedCumulativeTask` at the two positional sites --- five of six members deep, relying on the default for `presence`, on the struct whose own doc warns a wrong `start` "would silently mean something else".
- **Idioms**, so the three sibling presolvers agree: `overloaded{...}.visit(x)` rather than `std::visit(overloaded{...}, x)`, which is what CLAUDE.md and the rest of the stack use, and `std::ranges::` algorithms rather than iterator pairs.
- **An `Integer` as a bit position** into a `vector<ProofFlag>`, with two round trips through `.raw_value`.
- **The raise budget** allocated a `vector<Integer>` per raised task per time point just to take its `.size()`, on the path whose purpose is to decide *cheaply* whether the expensive path is affordable. `for_each_raise_step` now walks the steps; `raise_steps` collects and `raise_step_count` counts, so the budget and the derivation still cannot disagree --- which is the property the comment above it argues for.
- **An inner search** that runs both loops to completion after it has found, correct only through a `&& ! shared` guard.
- **`MakespanBound::energy` and `::supply`** are written and never read anywhere in the tree. `derive_makespan_bound` deliberately recomputes the energy at the window it argues over, with a comment saying why.
- **`rcpsp_instance.hh`** cast every subscript in half the file and none in the other half. It now counts loops in the type the subscript wants and casts where an index arrives as data, which needs fewer casts than either half had.

Note for review: the tree's actual `using`-block convention puts `std::ranges::` names *after* all plain `std::` ones (lifted_cover_cut.cc, names_and_ids_tracker.cc, cumulative.cc all do), which is not what CLAUDE.md says --- it claims they sort under 'r', between `std::pair` and `std::string`. I followed the tree. The doc is worth correcting one way or the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173hT2hFo3MyGRBon8SHt2p