### PR TITLE
Make five guards guard the thing they are documented to guard

### DIFF
--- a/gcs/constraints/cumulative/derived_cumulative.cc
+++ b/gcs/constraints/cumulative/derived_cumulative.cc
@@ -214,8 +214,26 @@ auto gcs::innards::install_derived_cumulative(
             "derived cumulative: " + to_string(rows_by_time.size()) + " capacity rows over " + to_string(spec.row_donors.size()) + " donors");
         for (const auto & [t, rows] : rows_by_time) {
             auto derived = spec.recipe(*logger, rows, t);
-            if (! derived)
+            if (! derived) {
+                // The rows for the earlier time points are already at Top, and
+                // nothing will ever cite them: this constraint is not being
+                // installed, so its propagator does not exist. Top is never
+                // forgotten, so leaving them there is #666 again --- live
+                // constraints for the rest of the proof, taxing every later
+                // unhinted RUP --- on the decline path this time rather than
+                // the success one. A recipe declining is not an error and not
+                // rare: a cut spanning several donors reaches time points one
+                // of them wrote no row for.
+                vector<ProofLine> orphans;
+                for (const auto & [_, line] : inputs->capacity_lines)
+                    orphans.push_back(line);
+                if (! orphans.empty()) {
+                    logger->emit_proof_comment("derived cumulative: declined at time " + to_string(t.raw_value) + ", dropping " +
+                        to_string(orphans.size()) + " rows already derived");
+                    logger->delete_proof_lines(orphans);
+                }
                 return false;
+            }
             inputs->capacity_lines.emplace(t, *derived);
         }
     }
@@ -231,14 +249,24 @@ auto gcs::innards::install_derived_cumulative(
         vector<makespan_energy::EnergyTask> energy_tasks;
         vector<std::optional<IntegerVariableID>> energy_presences;
         for (auto i : inputs->overload_tasks) {
+            // A plain variable and a constant, and by construction:
+            // prepare_cumulative_overload_check keeps only such tasks, the
+            // window-energy lemma needing a task's energy to be a number before
+            // it can count it. So a variable-duration task takes part in the
+            // time-tabling and in the rows, and stays out of the energy
+            // argument.
+            //
+            // Checked rather than assumed, because the invariant lives in
+            // another file and loosening that filter is a thing somebody will
+            // want to do: what would arrive here otherwise is a
+            // std::bad_variant_access from inside an install initialiser, and
+            // what should arrive is nothing at all.
+            if (! std::holds_alternative<SimpleIntegerVariableID>(spec.tasks[i].start) || ! is_constant_variable(spec.tasks[i].length))
+                continue;
+
             energy_presences.push_back(inputs->presence[i]);
-            // A constant, and by construction: prepare_cumulative_overload_check
-            // keeps only tasks whose length and height are, the window-energy
-            // lemma needing a task's energy to be a number before it can count
-            // it. So a variable-duration task takes part in the time-tabling
-            // and in the rows, and stays out of the energy argument.
             energy_tasks.push_back(makespan_energy::EnergyTask{.start = std::get<SimpleIntegerVariableID>(spec.tasks[i].start),
-                .length = std::get<ConstantIntegerVariableID>(spec.tasks[i].length).const_value,
+                .length = constant_value_of(spec.tasks[i].length),
                 .height = spec.tasks[i].height,
                 .t_lo = inputs->per_task_t_lo[i],
                 .t_hi = per_task_t_hi[i],

--- a/gcs/constraints/cumulative/derived_cumulative_test.cc
+++ b/gcs/constraints/cumulative/derived_cumulative_test.cc
@@ -36,6 +36,7 @@
 
 using std::cerr;
 using std::flush;
+using std::getline;
 using std::ifstream;
 using std::make_optional;
 using std::make_unique;
@@ -47,6 +48,7 @@ using std::optional;
 using std::pair;
 using std::set;
 using std::string;
+using std::to_string;
 using std::tuple;
 using std::unique_ptr;
 using std::vector;
@@ -92,6 +94,12 @@ namespace
         /// asks about (task, time) pairs the donor never encoded. The install
         /// must decline.
         BeyondDonorWindow,
+        /// A recipe that derives the first time point's row and then declines,
+        /// which is what a cut spanning several donors does when it reaches a
+        /// time point one of them wrote no row for. The install must decline
+        /// --- and the rows it had already put at Top must be deleted, since
+        /// nothing will ever cite them and Top is never forgotten.
+        DeclineMidway,
         /// C'_t := C_t, plus a certified lower bound on the makespan from the
         /// tasks' energy.
         Makespan,
@@ -122,6 +130,9 @@ namespace
         std::shared_ptr<bool> installed = std::make_shared<bool>(false);
         // Set by the derived constraint's initialiser: the bound it reached.
         std::shared_ptr<optional<Integer>> bound_reached = std::make_shared<optional<Integer>>();
+        // How many rows the DeclineMidway recipe derived before giving up,
+        // which is how many deletions the proof owes.
+        std::shared_ptr<size_t> rows_before_declining = std::make_shared<size_t>(0);
 
         explicit DerivedDemoPresolver(Demo d, optional<IntegerVariableID> m = nullopt) : demo(d), makespan(m)
         {
@@ -257,6 +268,19 @@ namespace
                         return copy.emit(logger, ProofLevel::Top);
                     };
                     break;
+
+                case Demo::DeclineMidway:
+                    *rows_before_declining = 0;
+                    spec.recipe = [row_of, derived = rows_before_declining](
+                                      ProofLogger & logger, const DerivedCumulativeRows & rows, Integer) -> optional<ProofLine> {
+                        if (*derived > 0)
+                            return std::nullopt;
+                        PolBuilder copy;
+                        copy.add(row_of(rows));
+                        ++*derived;
+                        return copy.emit(logger, ProofLevel::Top);
+                    };
+                    break;
                 }
 
                 *installed = install_derived_cumulative(propagators, state, logger, move(spec));
@@ -269,6 +293,7 @@ namespace
             auto result = make_unique<DerivedDemoPresolver>(demo, makespan);
             result->installed = installed;
             result->bound_reached = bound_reached;
+            result->rows_before_declining = rows_before_declining;
             return result;
         }
     };
@@ -735,6 +760,59 @@ auto main(int argc, char * argv[]) -> int
             if (*installed)
                 fail("a derived constraint reaching past the donor's windows was installed anyway");
             dispose_of_proof_files("derived_cumulative_beyond_window");
+        }
+    }
+
+    // A recipe that declines part way through has already put rows at Top, and
+    // nothing will ever cite them: the constraint is not installed, so its
+    // propagator does not exist. Top is never forgotten, so those rows would
+    // otherwise stay live for the rest of the proof and tax every later
+    // unhinted RUP, which is issue #666 on the decline path.
+    //
+    // veripb verifying is not the check here --- it verified before this was
+    // fixed, and would verify if the deletions went missing again. What is
+    // asserted is that the proof says so: one deletion per row derived.
+    {
+        auto presolver = DerivedDemoPresolver{Demo::DeclineMidway};
+        auto installed = presolver.installed;
+        auto derived = presolver.rows_before_declining;
+        Problem p;
+        post(p, duplicate_instance, nullopt);
+        p.add_presolver(presolver);
+        solve_with(p, SolveCallbacks{.trace = [](const CurrentState &) -> bool { return false; }},
+            proofs ? make_optional<ProofOptions>(ProofFileNames{"derived_cumulative_decline_midway"}) : nullopt);
+        if (proofs) {
+            if (*installed)
+                fail("a derived constraint whose recipe declined was installed anyway");
+            if (0 == *derived)
+                fail("the declining recipe derived nothing, so there was no orphaned row to drop and this fixture proves nothing");
+
+            std::ifstream proof{"derived_cumulative_decline_midway.pbp"};
+            string line;
+            auto found_the_comment = false, counting = false;
+            size_t deletions = 0;
+            while (getline(proof, line)) {
+                if (line.contains("declined at time")) {
+                    found_the_comment = counting = true;
+                    continue;
+                }
+                if (counting) {
+                    if (line.contains("del id"))
+                        ++deletions;
+                    else
+                        counting = false;
+                }
+            }
+            if (! found_the_comment)
+                fail("the proof does not say the derived constraint declined, so nothing dropped its orphaned rows");
+            else if (deletions != *derived)
+                fail("the proof drops " + to_string(deletions) + " rows where the recipe derived " + to_string(*derived));
+            proof.close();
+
+            // And the deletions have to be legal, which is the other half: the
+            // rows go, nothing cites them afterwards, and the rest of the proof
+            // still checks.
+            verify_proof_and_clean_up("derived_cumulative_decline_midway");
         }
     }
 

--- a/gcs/innards/proofs/lifted_cover_cut.cc
+++ b/gcs/innards/proofs/lifted_cover_cut.cc
@@ -133,12 +133,23 @@ namespace
                     next.push_back(LiftedCoverCutState{move(weights), state.profit + coefficients[member]});
             }
 
-            reduce_to_frontier(next);
+            // Counted and checked *before* the frontier sweep, which is
+            // all-pairs over the layer: a layer large enough to blow the budget
+            // would otherwise pay the whole quadratic cost first and only then
+            // be turned away, which is the guard costing more than the thing it
+            // guards. So the budget counts the states the programme built
+            // rather than the ones that survived --- which is what the sweep
+            // actually costs, and is what the programme actually holds at the
+            // moment it holds the most. Nothing real comes near either count:
+            // the paper's own programmes are a few hundred states against a
+            // budget of a hundred thousand.
             states += next.size();
             if (states > state_budget) {
                 programme.over_budget = true;
                 return programme;
             }
+
+            reduce_to_frontier(next);
 
             programme.reached_ceiling = any_of(next, [&](const LiftedCoverCutState & state) { return state.profit >= profit_ceiling; });
             programme.layers.push_back(move(next));

--- a/gcs/innards/proofs/lifted_cover_cut.hh
+++ b/gcs/innards/proofs/lifted_cover_cut.hh
@@ -105,8 +105,8 @@ namespace gcs::innards
      * certificate.
      *
      * Returns no cut exactly when the cut is *false* --- when some 0/1 point
-     * the rows jointly allow breaks it --- or when its programme would be larger
-     * than `state_budget` states. Barring that budget there is no third answer:
+     * the rows jointly allow breaks it --- or when its programme would build
+     * more than `state_budget` states. Barring that budget there is no third answer:
      * every valid cut gets a dynamic programme and every dynamic programme
      * becomes a proof, which is the whole point of doing it this way. The
      * earlier design searched for a short cutting-planes derivation and refused

--- a/gcs/innards/proofs/proof_logger.cc
+++ b/gcs/innards/proofs/proof_logger.cc
@@ -986,6 +986,16 @@ auto ProofLogger::delete_range(ProofLine from, ProofLine up_to) -> void
                 << ";\n";
 }
 
+auto ProofLogger::delete_proof_lines(const vector<ProofLine> & lines) -> void
+{
+    // Every offset against the same `current`, deletions not advancing the line
+    // number, exactly as forget_proof_level does it.
+    for (const auto & line : lines) {
+        write_indent();
+        _imp->proof << "del id " << relative_proof_line(line, _imp->proof_line.number) << ";\n";
+    }
+}
+
 auto ProofLogger::write_indent() -> void
 {
     for (auto _ = _imp->current_indent; _--;) {

--- a/gcs/innards/proofs/proof_logger.hh
+++ b/gcs/innards/proofs/proof_logger.hh
@@ -17,6 +17,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <vector>
 
 namespace gcs::innards
 {
@@ -363,6 +364,22 @@ namespace gcs::innards
          * NB: This uses half-open range semantics, so "from" is included but "up_to" is excluded.
          */
         auto delete_range(ProofLine from, ProofLine up_to) -> void;
+
+        /**
+         * \brief Delete these lines, wherever they were recorded.
+         *
+         * For a caller that emitted something at ProofLevel::Top and then found
+         * it had nothing to cite it with. Top is never forgotten, so a line
+         * abandoned there stays live for the rest of the proof and taxes every
+         * later unhinted RUP --- which is what issue #666 was, and what
+         * \ref forget_proof_level does for every other level.
+         *
+         * One `del id` each rather than a range, the lines needing neither to be
+         * contiguous nor to be all of anything. So they must not already have
+         * been deleted: `del id` errors on a deleted id where `del range` skips
+         * it, which is why forget_proof_level uses ranges and this does not.
+         */
+        auto delete_proof_lines(const std::vector<ProofLine> &) -> void;
 
         /**
          * Write a number of spaces equal to current_indent.

--- a/gcs/presolvers/cumulative_strengthening/cumulative_strengthening.cc
+++ b/gcs/presolvers/cumulative_strengthening/cumulative_strengthening.cc
@@ -191,6 +191,23 @@ auto CumulativeStrengthening::run(Problem & problem, Propagators & propagators, 
         auto capacity = view->capacity;
         auto unentitled_raise = std::holds_alternative<cumulative_strengthening_mutation::RaiseUnentitled>(_mutation);
 
+        // A task whose *guaranteed* demand is above the capacity means the
+        // donor is infeasible on its own, which is the donor's business to
+        // detect and not something to build a subset sum over. Asked here
+        // rather than inside the assessment, and counted on its own: setting
+        // such a task aside takes its height to zero and hides the
+        // infeasibility, so an assessment of the set-aside candidate would go
+        // on to strengthen around it and report an ordinary decline --- and
+        // this stats block exists precisely because a presolver doing nothing
+        // passes every other check.
+        if (any_of(view->usable, [&](size_t i) { return view->heights[i] > capacity; })) {
+            bump(&CumulativeStrengtheningStats::declined_infeasible_donor);
+            if (logger)
+                logger->emit_proof_comment(
+                    "presolve cumulative: declining " + as_string(donor.constraint_id()) + ", a task demands more than the capacity");
+            continue;
+        }
+
         // Everything about a candidate view that decides whether it is worth
         // strengthening over, and what the strengthening would be. A candidate
         // rather than *the* view, because a donor with a variable height has
@@ -221,12 +238,6 @@ auto CumulativeStrengthening::run(Problem & problem, Propagators & propagators, 
                 t_lo[i] = window.lo;
                 t_hi[i] = window.hi;
             }
-
-            // A height above the capacity means the donor is infeasible on its
-            // own, which is the donor's business to detect and not something to
-            // build a subset sum over.
-            if (any_of(active_tasks, [&](size_t i) { return candidate.heights[i] > capacity; }))
-                return nullopt;
 
             // Schulz's coefficient raising, as the set of tasks it applies to.
             // A task that cannot run beside any *other* task that consumes

--- a/gcs/presolvers/cumulative_strengthening/cumulative_strengthening.hh
+++ b/gcs/presolvers/cumulative_strengthening/cumulative_strengthening.hh
@@ -91,6 +91,13 @@ namespace gcs
         /// row's. Named for the condition rather than for today's only instance
         /// of it --- see cumulative_donor_view.
         std::size_t declined_irreducible_capacity = 0;
+        /// Donors with a task whose guaranteed demand exceeds the capacity, so
+        /// the donor is infeasible on its own and its own propagator will say
+        /// so. Not a decline this presolver should be pleased about, and so not
+        /// counted with the ones it should --- a fixture that accidentally
+        /// builds an infeasible donor would otherwise read as a correct
+        /// "nothing to gain".
+        std::size_t declined_infeasible_donor = 0;
         std::size_t declined_over_budget = 0;
         std::size_t declined_over_raise_budget = 0;
         /// The capacity was already the largest load the tasks can reach, and

--- a/gcs/presolvers/inferred_cumulative/inferred_cumulative.cc
+++ b/gcs/presolvers/inferred_cumulative/inferred_cumulative.cc
@@ -540,7 +540,16 @@ auto InferredCumulative::run(Problem & problem, Propagators & propagators, State
                 vector<optional<size_t>>(donors.size(), std::nullopt), which};
             task.demands[which] = demand;
             task.positions[which] = i;
-            task_of.emplace(key, tasks.size());
+            // Only the first column with this key is findable, and that is the
+            // whole of what keeps a donor's duplicate tasks apart: the second
+            // one gets a column of its own, and the map goes on pointing at the
+            // first. What it costs is that a later donor's copy of that second
+            // task matches nothing and starts a third column, so cross-donor
+            // matching degrades where a donor has duplicates --- a weaker cut,
+            // never a wrong one. Written out because `emplace` doing nothing is
+            // load-bearing here, and `insert_or_assign` would quietly undo it.
+            if (found == task_of.end())
+                task_of.emplace(key, tasks.size());
             tasks.push_back(move(task));
         }
     }

--- a/gcs/presolvers/inferred_cumulative/inferred_cumulative.hh
+++ b/gcs/presolvers/inferred_cumulative/inferred_cumulative.hh
@@ -280,8 +280,13 @@ namespace gcs
         auto with_lifting_call_budget(std::size_t calls) -> InferredCumulative &;
 
         /**
-         * \brief How many states a cut's dynamic programme may hold before it
+         * \brief How many states a cut's dynamic programme may build before it
          * is dropped uncertified.
+         *
+         * Built rather than kept: the frontier sweep that reduces a layer to
+         * the states worth keeping is all-pairs over the layer, so a budget
+         * counting only survivors would be checked after the cost it is there
+         * to bound.
          *
          * Nothing the published procedure produces comes close, and on the
          * paper's own instances no programme exceeds a few hundred states, so


### PR DESCRIPTION
Last of five follow-ups to the whole-design audit: its "possible defects" group, findings 24 and 27-30. None is a soundness problem, and none changes a proof any existing test writes. What they have in common is a check that reads as covering something it does not.

**The lifted-cover state budget was checked after the quadratic step it bounds** (24). `reduce_to_frontier` is an all-pairs dominance sweep over the layer, and `states > state_budget` came after it, so a layer big enough to blow the budget paid the full sweep first. Now counted and checked before reducing, which makes the budget count states *built* rather than states *kept* --- what the sweep actually costs, and what the programme actually holds at its widest. It cannot bite where the old accounting did not: `inferred_cumulative`'s verified sweep asserts the budget is never reached at these sizes, and it still is not, against a default of 100 000 where the paper's own programmes are a few hundred states.

**A recipe declining part way left its earlier rows at Top** (28). Nothing ever cites them --- the constraint is not installed, so its propagator does not exist --- and Top is never forgotten, so they stayed live for the rest of the proof and taxed every later unhinted RUP. That is #666 on the decline path rather than the success one, and a decline is neither an error nor rare: a cut spanning several donors reaches time points one of them wrote no row for. `ProofLogger::delete_proof_lines` drops them.

`derived_cumulative_decline_midway` is a new fixture whose recipe declines on purpose. It asserts nothing was installed, that the proof says it declined, that the deletion count equals the rows derived, and that the result still verifies. Against the code as it was, it fails. **veripb verifying is not the check here** --- it verified before this fix and would verify if the deletions went missing again, which is exactly why the fixture counts them.

**Two `std::get`s whose safety lives in another file's filter** (29), and that filter is the one #689 is about loosening. Checked rather than assumed, so what arrives after that edit is nothing at all rather than a `bad_variant_access` from inside an install initialiser.

**A `map::emplace` doing nothing was load-bearing and did not say so** (27). It is the whole of what keeps a donor's duplicate tasks in separate columns; `insert_or_assign` would quietly undo it.

**An infeasible donor was counted as "nothing to gain"** (30). Its own counter now, and asked once per donor before the assessment rather than inside it --- setting such a task aside takes its height to zero and hides the infeasibility, so the set-aside candidate would go on to strengthen around an infeasible donor and report an ordinary decline. That is a behaviour change, small and deliberate; say so if you would rather have the old shape with only the counter split.

Full `ctest`: 633/633 pass with veripb on PATH.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173hT2hFo3MyGRBon8SHt2p