### PR TITLE
Say what the using block actually does with std::ranges:: names

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,20 +127,30 @@ MSVC availability (CI is the backstop there).
 ### `using` declarations
 
 The `using` declarations block near the top of each `.cc` file is sorted **alphabetically
-by the full qualified name**. `std::ranges::` names sort under 'r', so they fall between
-`std::pair` and `std::string`. Example:
+by name**, with the `std::ranges::` names in a group of their own **after** all the plain
+`std::` ones, themselves alphabetical. Example:
 
 ```cpp
 using std::pair;
-using std::ranges::sort;   // 'r' < 's'
 using std::string;
+using std::vector;
+using std::ranges::any_of;
+using std::ranges::sort;
 ```
+
+Every one of the 48 files that names a `std::ranges::` algorithm does it this way, so
+follow it rather than sorting `std::ranges::sort` under 'r' between `std::pair` and
+`std::string` — which is what this section used to say and what nothing in the tree does.
+
+The `#if defined(__cpp_lib_print)` block that picks `std::print`/`fmt::print` is a
+separate block and stays where it is, below.
 
 ### Ranges algorithms
 
 When replacing a classic algorithm with its `std::ranges::` equivalent:
 - Remove `using std::foo;`
-- Add `using std::ranges::foo;` in the correct sorted position
+- Add `using std::ranges::foo;` to the `std::ranges::` group below the plain `std::` ones,
+  in alphabetical order within that group (see `using` declarations, above)
 - Leave the call site **unqualified** — do not write `std::ranges::sort(v)` at the call site
 
 ### `using enum`


### PR DESCRIPTION
CLAUDE.md's `using` declarations section said `std::ranges::` names sort under 'r', so they fall between `std::pair` and `std::string`, with an example to match. Nothing in the tree does that.

All 48 files that name a `std::ranges::` algorithm put them in a group *after* every plain `std::` name, alphabetical within the group --- `lifted_cover_cut.cc`, `names_and_ids_tracker.cc`, `cumulative.cc`, `element.cc`, `knapsack.cc` and the rest. There are no exceptions; the rule is uniform, it just was not the rule that was written down. (The two files whose *first* run of `using std::` lines is the `#if defined(__cpp_lib_print)` preamble follow it too, in their main block.)

So the doc now says what the tree does, and notes what it used to say so that a reader who remembers the old rule knows it changed rather than assuming they misread. The Ranges algorithms section, which said "in the correct sorted position", now points at it.

Found while following the documented order in the Cumulative stack (#693) and having to pick between the doc and every neighbouring file. Off `main` and independent of that stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173hT2hFo3MyGRBon8SHt2p