### PR TITLE
Fix what a whole-stack review found in the inference procedures

### DIFF
--- a/gcs/constraints/cumulative/derived_cumulative.cc
+++ b/gcs/constraints/cumulative/derived_cumulative.cc
@@ -348,9 +348,23 @@ auto gcs::innards::install_derived_cumulative(
             InitialiserPriority::Expensive);
     }
 
+    // The same trigger set a posted Cumulative installs, minus the two a
+    // derived one cannot have: its capacity is an Integer and its heights are
+    // Integers by the time a task is built, so neither can move. Lengths and
+    // presences can, and the arguments for waking on them are the posted
+    // constraint's verbatim --- a rise in a length's lower bound extends a
+    // mandatory part, and a presence fixed to 1 puts a task into the load
+    // profile. Missing them costs the derived constraint pruning it is entitled
+    // to, silently and with no test able to see it, since late is still sound.
     Triggers triggers;
     for (auto i : inputs->active_tasks)
         triggers.on_bounds.emplace_back(spec.tasks[i].start);
+    for (auto i : inputs->active_tasks)
+        if (! is_constant_variable(spec.tasks[i].length))
+            triggers.on_bounds.emplace_back(spec.tasks[i].length);
+    for (auto i : inputs->active_tasks)
+        if (inputs->presence[i] && ! is_constant_variable(*inputs->presence[i]))
+            triggers.on_instantiated.emplace_back(*inputs->presence[i]);
 
     propagators.install(
         inputs->owner,

--- a/gcs/constraints/cumulative/donor_view.cc
+++ b/gcs/constraints/cumulative/donor_view.cc
@@ -91,6 +91,19 @@ auto gcs::innards::cumulative_donor_view(const Cumulative & donor, const State &
             continue;
         }
 
+        // An *optional* task whose guaranteed demand alone exceeds the capacity
+        // is one the donor's own propagator will falsify the presence of; it is
+        // not a donor that cannot be satisfied. Set it aside, so that a caller
+        // asking "is any usable task over the capacity" gets the question it
+        // means to ask --- a donor that really is infeasible on its own ---
+        // rather than an optional task that has simply not been decided yet,
+        // and so that the rest of the donor keeps whatever it was going to get.
+        if (presence.literal && height_value > view.capacity) {
+            view.height_bounded_by[i] = nullopt;
+            view.set_aside.push_back(i);
+            continue;
+        }
+
         // A variable length is not a set-aside. It leaves the row untouched ---
         // no length appears in one --- and costs the *pins* instead: `after` is
         // then reified on the two-variable `start + length`, which no RUP
@@ -271,7 +284,12 @@ auto gcs::innards::recover_constant_argument_row(ProofLogger & logger, const Cum
         auto [shift, highest_bit, negative_bit] = get_bits_encoding_coeffs(lo, hi);
         if (0_i != negative_bit)
             return nullopt; // a signed capacity, which Cumulative rejects anyway
-        auto atom_coefficient = 2_i * highest_bit - 1_i - view.capacity;
+        // Written as two additions rather than as `2 * highest_bit - 1 -
+        // capacity`, which is the same number by a route that overflows: a
+        // capacity encoded up to bit 62 makes the doubling the first thing that
+        // does not fit, where the sum below reaches at most the largest value
+        // the encoding can express and so at most what a bit vector holds.
+        auto atom_coefficient = (highest_bit - 1_i - view.capacity) + highest_bit;
 
         // The definition, which is what brings the capacity's bits over to
         // cancel against the row's, and what leaves the atom behind.

--- a/gcs/constraints/cumulative/donor_view.hh
+++ b/gcs/constraints/cumulative/donor_view.hh
@@ -54,6 +54,13 @@ namespace gcs::innards
      * over its own bit vector, so the height's bound rows do not cancel against
      * it), or one whose lower bound is zero, which guarantees nothing.
      *
+     * One more task is set aside: an *optional* one whose guaranteed demand
+     * alone exceeds the capacity. Its presence is going to be falsified by the
+     * donor's own propagator, so there is nothing here to argue over --- and
+     * more to the point, it must not be mistaken for the mandatory version of
+     * the same shape, which says the donor cannot be satisfied at all and is
+     * something a caller wants to hear about rather than work around.
+     *
      * \ingroup Innards
      */
     struct CumulativeDonorView

--- a/gcs/presolvers/cumulative_strengthening/cumulative_strengthening.cc
+++ b/gcs/presolvers/cumulative_strengthening/cumulative_strengthening.cc
@@ -128,7 +128,7 @@ namespace
 }
 
 CumulativeStrengthening::CumulativeStrengthening(shared_ptr<CumulativeStrengtheningStats> stats) :
-    _stats(move(stats)), _max_dynamic_programming_states(20000), _max_raise_lines(5000),
+    _stats(move(stats)), _max_dynamic_programming_states(20000), _max_raise_lines(5000), _max_subset_sum_capacity(1000000),
     // Energy rules only: see with_rules(). A derived constraint's time-tabling
     // cannot infer anything its donor's has not, so running it is pure cost.
     _rules(CumulativeRules{.time_table = false, .overload = true, .profile_overload = true}), _mutation(cumulative_strengthening_mutation::None{})
@@ -144,6 +144,12 @@ auto CumulativeStrengthening::with_dynamic_programming_budget(long long states) 
 auto CumulativeStrengthening::with_raise_budget(long long lines) -> CumulativeStrengthening &
 {
     _max_raise_lines = lines;
+    return *this;
+}
+
+auto CumulativeStrengthening::with_subset_sum_capacity_limit(long long capacity) -> CumulativeStrengthening &
+{
+    _max_subset_sum_capacity = capacity;
     return *this;
 }
 
@@ -190,6 +196,23 @@ auto CumulativeStrengthening::run(Problem & problem, Propagators & propagators, 
         auto n = starts.size();
         auto capacity = view->capacity;
         auto unentitled_raise = std::holds_alternative<cumulative_strengthening_mutation::RaiseUnentitled>(_mutation);
+
+        // The assessment below subset-sums the heights at every time point, and
+        // that is a bitset of `capacity` bits built from scratch each time. It
+        // runs before any of the proof budgets, and with proofs off none of
+        // them ever runs at all --- so a donor posted in scaled units, with a
+        // capacity in the billions, spends hundreds of megabytes and a sweep of
+        // the whole horizon before anything has decided whether there was a
+        // strengthening to be had. Magnitude is the wrong thing to find that
+        // out with, so decline on it first. It is also what keeps the state
+        // count and the raise arithmetic below inside a `long long`.
+        if (capacity > Integer{_max_subset_sum_capacity}) {
+            bump(&CumulativeStrengtheningStats::declined_capacity_too_large);
+            if (logger)
+                logger->emit_proof_comment("presolve cumulative: declining " + as_string(donor.constraint_id()) + ", capacity " +
+                    to_string(capacity.raw_value) + " is beyond the subset-sum limit of " + to_string(_max_subset_sum_capacity));
+            continue;
+        }
 
         // A task whose *guaranteed* demand is above the capacity means the
         // donor is infeasible on its own, which is the donor's business to
@@ -497,14 +520,29 @@ auto CumulativeStrengthening::run(Problem & problem, Propagators & propagators, 
                 auto donor_row = *reduced_row;
 
                 auto strengthen_to_kappa = [&](ProofLine source) -> ProofLine {
-                    recipe_logger.emit_proof_comment(point->second.by_division ? "presolve cumulative gcd" : "presolve cumulative kappa");
                     auto strengthened =
                         derive_subset_sum_strengthening(recipe_logger, items, source, capacity, ProofLevel::Temporary, subset_sum_corruption);
-                    if (stats) {
-                        if (strengthened.by_division)
-                            ++stats->rows_by_division;
-                        else
-                            ++stats->rows_by_dynamic_programming;
+                    // After the call rather than before it, and off what came
+                    // back rather than off the assessment's prediction: the
+                    // marker and the counter then agree with each other and
+                    // with the line, where predicting has them disagree on
+                    // every point the arithmetic settles differently.
+                    //
+                    // A line that came back unchanged is neither derivation ---
+                    // the bound was already a reachable sum, so there was
+                    // nothing to derive --- and counting it as a dynamic
+                    // programme would say the expensive path ran when no line
+                    // was written at all.
+                    if (strengthened.line == source)
+                        recipe_logger.emit_proof_comment("presolve cumulative kappa already reached");
+                    else {
+                        recipe_logger.emit_proof_comment(strengthened.by_division ? "presolve cumulative gcd" : "presolve cumulative kappa");
+                        if (stats) {
+                            if (strengthened.by_division)
+                                ++stats->rows_by_division;
+                            else
+                                ++stats->rows_by_dynamic_programming;
+                        }
                     }
                     return strengthened.line;
                 };
@@ -558,6 +596,19 @@ auto CumulativeStrengthening::run(Problem & problem, Propagators & propagators, 
 
                     auto recovered =
                         recover_am1_from_row(recipe_logger, donor_row, {demand_a, heights[b]}, weaken_out, capacity, ProofLevel::Temporary);
+                    // An at-most-one is what the raise arithmetic below assumes
+                    // it has --- it weights these lines by the other task's
+                    // coefficient and divides --- and a cardinality bound of
+                    // anything else would make it argue about a line that says
+                    // something different. It cannot be anything else: the
+                    // pairwise case gives a bound of one whenever the smaller
+                    // demand fits under the capacity, and a donor with a task
+                    // over the capacity was declined 350 lines ago. Checked
+                    // rather than assumed, because that is a long way to have
+                    // to look for the reason.
+                    if (recovered.at_most != 1_i)
+                        throw ProofError{"cumulative strengthening: recovering the at-most-one between tasks " + to_string(a) + " and " +
+                            to_string(b) + " gave a bound of " + to_string(recovered.at_most.raw_value) + " rather than one"};
                     at_most_ones.emplace(key, recovered.line);
                     return recovered.line;
                 };
@@ -659,6 +710,13 @@ auto CumulativeStrengthening::run(Problem & problem, Propagators & propagators, 
                             // at-most-one weighted by its task's coefficient in
                             // that row, scaled so that the division comes out
                             // whole on every term but the degree.
+                            //
+                            // `e * weight` is a product of two quantities each
+                            // bounded by the capacity, so it is the capacity
+                            // limit at the top of run() that keeps this inside
+                            // a `long long` --- an unbounded capacity would
+                            // reach it a good deal sooner than anything here
+                            // looks like it could.
                             auto rest = total - raised_to - step;
                             auto common = Integer{std::gcd(step.raw_value, rest.raw_value)};
                             auto e = step / common, lambda = rest / common;
@@ -714,6 +772,7 @@ auto CumulativeStrengthening::clone() const -> unique_ptr<Presolver>
     auto result = make_unique<CumulativeStrengthening>(_stats);
     result->with_dynamic_programming_budget(_max_dynamic_programming_states);
     result->with_raise_budget(_max_raise_lines);
+    result->with_subset_sum_capacity_limit(_max_subset_sum_capacity);
     result->with_rules(_rules);
     result->with_proof_mutation(_mutation);
     return result;

--- a/gcs/presolvers/cumulative_strengthening/cumulative_strengthening.hh
+++ b/gcs/presolvers/cumulative_strengthening/cumulative_strengthening.hh
@@ -91,13 +91,22 @@ namespace gcs
         /// row's. Named for the condition rather than for today's only instance
         /// of it --- see cumulative_donor_view.
         std::size_t declined_irreducible_capacity = 0;
-        /// Donors with a task whose guaranteed demand exceeds the capacity, so
-        /// the donor is infeasible on its own and its own propagator will say
-        /// so. Not a decline this presolver should be pleased about, and so not
-        /// counted with the ones it should --- a fixture that accidentally
-        /// builds an infeasible donor would otherwise read as a correct
-        /// "nothing to gain".
+        /// Donors with a *mandatory* task whose guaranteed demand exceeds the
+        /// capacity, so the donor is infeasible on its own and its own
+        /// propagator will say so. Not a decline this presolver should be
+        /// pleased about, and so not counted with the ones it should --- a
+        /// fixture that accidentally builds an infeasible donor would otherwise
+        /// read as a correct "nothing to gain". An *optional* task of that
+        /// shape says only that its presence is false, and cumulative_donor_view
+        /// sets it aside instead, so the rest of the donor is still
+        /// strengthened.
         std::size_t declined_infeasible_donor = 0;
+        /// Donors whose capacity is too large to subset-sum over. Unlike the
+        /// two below it this one is not about proof size: the assessment itself
+        /// is a bitset of `capacity` bits rebuilt at every time point, so it
+        /// costs whether or not proofs are on, and the cost is the capacity's
+        /// magnitude rather than anything the model says about the tasks.
+        std::size_t declined_capacity_too_large = 0;
         std::size_t declined_over_budget = 0;
         std::size_t declined_over_raise_budget = 0;
         /// The capacity was already the largest load the tasks can reach, and
@@ -127,9 +136,12 @@ namespace gcs
         /**
          * \name What the raising cost, in the proof.
          *
-         * Zero when proofs are off. `rows_with_a_raise` counts time points
-         * whose row needed at-most-one reasoning at all; `raise_lines_emitted`
-         * counts the steps that took, which is not one per raised task --- how
+         * Zero when proofs are off. `rows_with_a_raise` counts time points at
+         * which some task's height was raised, whatever that took --- including
+         * the degenerate case where a raised task is the only one that can run
+         * then, and the row is a bare `active <= 1` with no at-most-one behind
+         * it. `raise_lines_emitted` counts the steps that took, which is not
+         * one per raised task --- how
          * many a raise takes depends on how far the rest of the row overshoots
          * the capacity, and is the sequence
          * CumulativeStrengthening::with_raise_budget caps. It does not count
@@ -201,6 +213,7 @@ namespace gcs
         std::shared_ptr<CumulativeStrengtheningStats> _stats;
         long long _max_dynamic_programming_states;
         long long _max_raise_lines;
+        long long _max_subset_sum_capacity;
         CumulativeRules _rules;
         innards::CumulativeStrengtheningMutation _mutation;
 
@@ -246,6 +259,25 @@ namespace gcs
          * only its own half disappear.
          */
         auto with_raise_budget(long long lines) -> CumulativeStrengthening &;
+
+        /**
+         * \brief Cap the capacity this presolver will subset-sum over, and so
+         * decline any donor posted with a larger one.
+         *
+         * Not a proof budget: the two above bound what a derivation costs, and
+         * this bounds what deciding whether to make one costs. `kappa` is found
+         * with a word-parallel bitset over the capacity's whole range, rebuilt
+         * at every time point of every donor, and that runs with proofs off
+         * too. A capacity in scaled units --- a resource measured in
+         * thousandths, say --- makes the assessment alone hundreds of megabytes
+         * of allocation and a horizon's worth of sweeps, for a strengthening
+         * nothing has yet said is worth having.
+         *
+         * The default is meant to be left alone; it exists as a knob so that a
+         * test can set it low and watch the decline appear. A donor over it is
+         * counted in CumulativeStrengtheningStats::declined_capacity_too_large.
+         */
+        auto with_subset_sum_capacity_limit(long long capacity) -> CumulativeStrengthening &;
 
         /**
          * \brief Select which propagation rules the derived constraints run.

--- a/gcs/presolvers/inferred_cumulative/inferred_cumulative.cc
+++ b/gcs/presolvers/inferred_cumulative/inferred_cumulative.cc
@@ -194,8 +194,20 @@ namespace
         if (cover_cardinality >= 3)
             for (size_t x = 0; x < n; ++x)
                 for (size_t y = x + 1; y < n; ++y) {
-                    if (demands[x] <= 0_i || demands[y] <= 0_i)
-                        continue;
+                    // A member that demands nothing of *this* row is one
+                    // Definition 6 admits and the reference implementation
+                    // enumerates --- its `A` matrix is dense, and a task with
+                    // no term in a row is a zero entry there exactly as it is a
+                    // task with no term here. The cover is a real one: its
+                    // demands still overshoot, so not all of it can run, and
+                    // the free member simply makes the inequality it starts
+                    // from one wider. What it changes is where lifting begins,
+                    // which is sequence-dependent, so it is not the same cut by
+                    // another route.
+                    //
+                    // `z` is the one member that cannot demand nothing, and
+                    // cannot: it has to exceed the room, which is never
+                    // negative.
                     auto room = capacity - demands[x] - demands[y];
                     if (room < 0_i)
                         continue;
@@ -326,9 +338,16 @@ namespace
         for (size_t i = 0; i < tasks.size(); ++i)
             if (std::find(cover.begin(), cover.end(), i) == cover.end())
                 remaining.push_back(i);
+        // By `least_length`, as every other ranking in this file is, and not by
+        // `length`: that is an IntegerVariableID, so comparing two of them
+        // orders by the variant's alternative before it looks at anything a
+        // scheduler would call a duration. All-constant lengths make the two
+        // agree, which is why the Pack corpus never noticed --- and a
+        // multi-mode instance, which is what variable lengths are here for, is
+        // exactly where the order below stops being the documented one.
         std::sort(remaining.begin(), remaining.end(), [&](size_t a, size_t b) {
-            if (tasks[a].length != tasks[b].length)
-                return tasks[a].length > tasks[b].length;
+            if (tasks[a].least_length != tasks[b].least_length)
+                return tasks[a].least_length > tasks[b].least_length;
             return a < b;
         });
 

--- a/gcs/presolvers/inferred_disjunctive/inferred_disjunctive.cc
+++ b/gcs/presolvers/inferred_disjunctive/inferred_disjunctive.cc
@@ -41,6 +41,8 @@ using std::size_t;
 using std::to_string;
 using std::unique_ptr;
 using std::vector;
+using std::ranges::all_of;
+using std::ranges::any_of;
 using std::ranges::find;
 using std::ranges::includes;
 using std::ranges::sort;
@@ -237,6 +239,24 @@ auto InferredDisjunctive::run(Problem & problem, Propagators & propagators, Stat
                 // and no bridge between them exists. The same variable is the
                 // same duration, whatever its bounds come to; two different
                 // ones are not, even where their bounds agree today.
+                bump(&InferredDisjunctiveStats::dropped_disagreeing_length);
+                continue;
+            }
+            else if (any_of(tasks[found->second].appearances, [&](const Appearance & a) { return a.donor == donor.constraint_id(); })) {
+                // A donor posting one (start, length) pair twice --- a height-2
+                // task split into two height-1 rows, say --- is a legal model,
+                // and the second row is a second appearance of the same node.
+                // Keeping it would break the invariant everything below rests
+                // on: a clique's flags are its members' *first* appearances, and
+                // a conflict witnessed by the donor those come from is assumed
+                // to be at the same position, so that no bridge is needed. The
+                // conflict scan would naturally record the later appearance, the
+                // at-most-one would land on its flags, the syntactic `ia` pin
+                // would sum the first one's, and VeriPB would refuse an
+                // otherwise honest proof. One appearance per (task, donor)
+                // restores the invariant; what it costs is a conflict this
+                // resource could have witnessed through the dropped row.
+                bump(&InferredDisjunctiveStats::dropped_duplicate_appearance);
                 continue;
             }
 
@@ -282,6 +302,22 @@ auto InferredDisjunctive::run(Problem & problem, Propagators & propagators, Stat
     if (candidate_pairs.empty())
         return true;
 
+    // Best first, by the same quantity a finished clique is ranked by: the
+    // durations its members are guaranteed to occupy. `_max_candidates` keeps a
+    // prefix of this list, so the order is what decides which pairs are grown
+    // at all, and (u, v) scan order would make that decision by variable
+    // creation order. The reference implementation's filter keeps the top ones
+    // by bound too; ours agreed with it on the cross-check targets because the
+    // pairs reaching the maximal clique there happen to come early, which is
+    // luck rather than a property.
+    sort(candidate_pairs, [&](const pair<size_t, size_t> & a, const pair<size_t, size_t> & b) {
+        auto la = tasks[a.first].least_length + tasks[a.second].least_length;
+        auto lb = tasks[b.first].least_length + tasks[b.second].least_length;
+        if (la != lb)
+            return la > lb;
+        return a < b;
+    });
+
     // Grow each candidate pair into a maximal clique, taking the longest task
     // first --- the unit-coefficient reading of Sidorov's lifting order, and
     // the one that maximises the energy the resulting constraint can argue
@@ -319,7 +355,7 @@ auto InferredDisjunctive::run(Problem & problem, Propagators & propagators, Stat
     size_t considered = 0;
     for (const auto & [u, v] : candidate_pairs) {
         if (considered >= _max_candidates) {
-            bump(&InferredDisjunctiveStats::dropped_over_budget, candidate_pairs.size() - considered);
+            bump(&InferredDisjunctiveStats::dropped_over_candidate_budget, candidate_pairs.size() - considered);
             if (logger)
                 logger->emit_proof_comment("presolve disjunctive: " + to_string(candidate_pairs.size() - considered) +
                     " candidate pairs left ungrown, against a budget of " + to_string(_max_candidates));
@@ -407,6 +443,34 @@ auto InferredDisjunctive::run(Problem & problem, Propagators & propagators, Stat
         return sum;
     };
 
+    // Dominance, which is Sidorov's L4 and the counterpart of the `pi <= d`
+    // test InferredCumulative runs: a clique every one of whose members
+    // consumes something from one posted capacity-one resource is that
+    // resource's own constraint, discovered again. Posting it costs a derived
+    // constraint that can prune nothing, and --- the reason it is here rather
+    // than in the "harmless" pile --- reporting its bound as
+    // `largest_capacity_bound` reports a number the model already contained as
+    // though this presolver had inferred it. Live on our own harness, where
+    // `rcpsp --machine-variant=cumulative` posts exactly such a resource.
+    // The test is the same one term by term: this constraint's right hand side
+    // is one and its coefficients are all one, so a row dominates it when its
+    // capacity is at most one and every member demands at least one of it.
+    // Only an exactly-dominated clique is declined --- `grow` returns maximal
+    // cliques, so one that reaches past the resource keeps a member the
+    // resource has no term for and is kept, which is the common case even on a
+    // model that does post such a resource.
+    //
+    // What a decline gives up is that clique's *makespan* bound, which the
+    // posted resource does not derive for itself; a posted Cumulative deriving
+    // its own is filed rather than done here.
+    auto already_posted = [&](const vector<size_t> & c) {
+        return any_of(resources, [&](const Resource & resource) {
+            return resource.capacity <= 1_i && all_of(c, [&](size_t i) {
+                return any_of(tasks[i].appearances, [&](const Appearance & a) { return a.donor == resource.id && a.height >= 1_i; });
+            });
+        });
+    };
+
     // Rank by that, and drop any clique contained in one already accepted.
     sort(found, [&](const vector<size_t> & a, const vector<size_t> & b) {
         auto ta = capacity_bound(a), tb = capacity_bound(b);
@@ -417,8 +481,13 @@ auto InferredDisjunctive::run(Problem & problem, Propagators & propagators, Stat
 
     vector<vector<size_t>> accepted;
     for (auto & clique : found) {
+        if (already_posted(clique)) {
+            bump(&InferredDisjunctiveStats::dropped_dominated);
+            continue;
+        }
+
         if (accepted.size() >= _max_posted) {
-            bump(&InferredDisjunctiveStats::dropped_over_budget);
+            bump(&InferredDisjunctiveStats::dropped_over_posting_budget);
             if (logger)
                 logger->emit_proof_comment("presolve disjunctive: a clique beyond the output budget of " + to_string(_max_posted) + " was dropped");
             continue;

--- a/gcs/presolvers/inferred_disjunctive/inferred_disjunctive.hh
+++ b/gcs/presolvers/inferred_disjunctive/inferred_disjunctive.hh
@@ -124,7 +124,34 @@ namespace gcs
         std::size_t declined_irreducible_capacity = 0;
         std::size_t dropped_too_small = 0;
         std::size_t dropped_subset = 0;
-        std::size_t dropped_over_budget = 0;
+        /// Cliques every member of which consumes something from one posted
+        /// capacity-one resource, so the constraint is that resource's own and
+        /// this presolver inferred nothing. Dropped rather than posted, which
+        /// is what keeps \ref largest_capacity_bound a number this presolver
+        /// derived rather than one the model already contained.
+        std::size_t dropped_dominated = 0;
+        /// Candidate pairs never grown into a clique, because the candidate
+        /// budget ran out first.
+        std::size_t dropped_over_candidate_budget = 0;
+        /// Grown cliques never posted, because the output budget was already
+        /// full. Separate from the pair budget: they are different units
+        /// bounding different costs, and one counter for both is one an
+        /// accounting identity cannot be written against.
+        std::size_t dropped_over_posting_budget = 0;
+        /// Appearances of an already-known task on a further resource that were
+        /// not merged into its node, because that resource gives the same start
+        /// variable a different duration variable. Sound --- the node keeps the
+        /// resources that agree --- but it is a resource silently not
+        /// witnessing conflicts, which is worth being able to see.
+        std::size_t dropped_disagreeing_length = 0;
+        /// Second and later appearances of a task on the *same* resource, which
+        /// a donor posting one (start, length) pair at two positions produces.
+        /// Only the first is kept; see the comment at the merge for why the
+        /// certificate needs that. InferredCumulative takes the opposite policy
+        /// on the same input, giving the duplicate a column of its own, and can
+        /// afford to: its members' flags and its rows come from the same
+        /// position by construction, so there is no bridge to get wrong.
+        std::size_t dropped_duplicate_appearance = 0;
         std::size_t declined_by_install = 0;
         ///@}
     };

--- a/gcs/presolvers/inferred_disjunctive/inferred_disjunctive_test.cc
+++ b/gcs/presolvers/inferred_disjunctive/inferred_disjunctive_test.cc
@@ -341,8 +341,10 @@ auto main(int argc, char * argv[]) -> int
         solve_family(3, 2, 6, Setup{.max_candidates = 0, .stats = stats}, nullopt);
         if (stats->cliques_posted != 0)
             fail("a zero candidate budget still posted a clique");
-        if (stats->dropped_over_budget == 0)
+        if (stats->dropped_over_candidate_budget == 0)
             fail("a zero candidate budget dropped candidates without counting them");
+        if (stats->dropped_over_posting_budget != 0)
+            fail("a zero candidate budget charged its drops to the posting budget");
         // Nothing posted has to mean no bound claimed: a stale capacity bound
         // would be a lower bound nobody derived.
         if (stats->largest_capacity_bound != 0_i)
@@ -608,10 +610,17 @@ auto main(int argc, char * argv[]) -> int
      * its place in the conflict graph now costs it nothing, provided its donor
      * published the line a pin of its `after` goes through.
      *
-     * Four tasks, pairwise conflicting on the four resources `(i + j) mod 4`
-     * covers between them, and the last one's duration a variable. The clique
-     * is a clique of *four*: three is what it would be with that task set
-     * aside, and the difference is the whole point.
+     * Four tasks, pairwise conflicting, one capacity-one resource per pair, and
+     * the last one's duration a variable. The clique is a clique of *four*:
+     * three is what it would be with that task set aside, and the difference is
+     * the whole point.
+     *
+     * A resource per pair rather than the four this used to share the six pairs
+     * out between, because any such sharing puts two disjoint pairs on one
+     * resource --- and a capacity-one resource holding every member of the
+     * clique *is* the clique, which the presolver now declines to infer again
+     * rather than reporting as its own. This fixture was measuring that decline
+     * without saying so.
      */
     {
         const int k = 4, length = 2, horizon = 9, latest = horizon - length;
@@ -628,16 +637,13 @@ auto main(int argc, char * argv[]) -> int
 
         vector<IntegerVariableID> lengths(static_cast<size_t>(k), constant_variable(Integer{length}));
         lengths.back() = varying;
-        for (int r = 0; r < k; ++r) {
-            vector<IntegerVariableID> heights(static_cast<size_t>(k), constant_variable(0_i));
-            for (int i = 0; i < k; ++i)
-                for (int j = i + 1; j < k; ++j)
-                    if ((i + j) % k == r) {
-                        heights[static_cast<size_t>(i)] = constant_variable(1_i);
-                        heights[static_cast<size_t>(j)] = constant_variable(1_i);
-                    }
-            p.post(Cumulative{starts, lengths, heights, constant_variable(1_i)});
-        }
+        for (int i = 0; i < k; ++i)
+            for (int j = i + 1; j < k; ++j) {
+                vector<IntegerVariableID> heights(static_cast<size_t>(k), constant_variable(0_i));
+                heights[static_cast<size_t>(i)] = constant_variable(1_i);
+                heights[static_cast<size_t>(j)] = constant_variable(1_i);
+                p.post(Cumulative{starts, lengths, heights, constant_variable(1_i)});
+            }
         p.add_presolver(InferredDisjunctive{stats});
 
         set<vector<int>> solutions;


### PR DESCRIPTION
Part one of three answering the whole-stack review of #661–#694
(`tmp/cumulative-stack-fable-review-2026-08-07.md`). This one is the code; #698
is the tests and #699 the docs.

Six defects, none of them soundness. Every one is a place where a capability
added late in the stack met a rule added early in it.

**Derived constraints never woke on length-bound or presence changes.**
`install_derived_cumulative` installed `on_bounds` for starts only, where the
posted constraint has four further trigger loops each with an argument that
applies verbatim to the derived form. Since optional donors (#682) and variable
lengths (#687) a derived constraint can carry both. Fixing a presence to one, or
tightening only a length's lower bound, left the overload check unrun — sound,
so no test could see it. Capacity and heights really are constants by
construction in a derived spec, so those two loops stay absent.

**The lifting order sorted variable IDs, not durations.** `lift_cover` compared
`tasks[a].length`, an `IntegerVariableID` — a `std::variant`, ordered by
alternative index first — where the struct carries `least_length` for exactly
this and every other ranking in the file uses it. All-constant lengths degrade
to comparing values, which is why the Pack corpus, the #665 cross-check and the
#672 artefact never noticed. With variable lengths, which is what #687/#688
exist for, the documented longest-first order became
constants-first-then-creation-order.

**The candidate cap kept the first 100 pairs by index, not the best 100.**
Sidorov's C2 filter retains the top ones by bound. Forty of the 110 Pack/Pack_d
instances have more than 100 conflicting pairs, including cross-check targets
pack004/009/011/016, so the 20/20 match went through the cap and succeeded by
the luck of those instances. Pairs are now ordered by their `least_length` sum
first. Still 20/20.

**A donor posting one (start, length) pair at two positions could make an honest
run write a proof VeriPB rejects.** A height-2 task split into two height-1 rows
is a legal model, and the merge kept both appearances. The clique's flags are its
members' *first* appearances; the conflict scan records whichever appearance
overshoots, naturally the later one; `bridge_to` short-circuits on same-donor and
emits nothing. The at-most-one lands on one position's flags, the syntactic `ia`
sums the other's, and the checker refuses. One appearance per (task, donor)
restores the invariant.

**Stage 1 could infer a constraint the model already posts, and report its L as
an inference.** Acceptance checked subsumption only against its own output;
Sidorov's L4 also discards constraints a model row dominates, which is the `pi
<= d` test `InferredCumulative` already runs, at unit coefficients. This is live
on our own harness — `rcpsp --machine-variant=cumulative` posts a capacity-one
machine — and it turned out to be live in-tree too: the variable-length fixture's
four-clique was one posted resource's own constraint, so that fixture was
measuring the gap. It now posts a resource per pair.

**Faithfulness in the other direction:** Algorithm 1's ternary covers turned away
a member demanding nothing of the row they are built from. Definition 6 and
`collect_row_cover_sets` both admit one — his `A` is dense, and a zero entry there
is a task with no term here.

**Hardening.** A capacity limit on the subset sum, which runs before any proof
budget and, with proofs off, under no budget at all: a legal donor with a
capacity in scaled units costs ~125 MB of allocation *per time point*. That limit
also closes the `e * weight` overflow in the raise. And the atom coefficient in
`recover_constant_argument_row` is reassociated so a capacity encoded up to bit
62 does not overflow on the way to a number that fits.

**Accounting.** An optional task whose guaranteed demand exceeds the capacity is
a presence to falsify, not an infeasible donor. The gcd/kappa marker is emitted
after the derivation decides rather than before, and a line that came back
underived is counted as neither derivation. The pair and clique budgets get a
counter each. The two silent appearance drops get one. The raise checks the bound
`recover_am1_from_row` hands it rather than resting on an invariant 350 lines
away.

Verified: 635/635 ctest on GCC release, green on clang and on Sanitize
(ASan+UBSan), and the Pack cross-check still matches 20 of 20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FiXjJTM4G1dMjbr45wGb12