### PR TITLE
Test the paths the review found nothing had ever run

### DIFF
--- a/examples/rcpsp/CMakeLists.txt
+++ b/examples/rcpsp/CMakeLists.txt
@@ -47,15 +47,28 @@ add_test(NAME rcpsp_sch COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_ver
 add_test(NAME rcpsp_dzn COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash --basename rcpsp_dzn
     $<TARGET_FILE:rcpsp> --dzn ${CMAKE_CURRENT_SOURCE_DIR}/sample.dzn)
 
-# The same instance with the InferredDisjunctive presolver, whose derived
-# capacity-one Cumulative is proved rather than asserted --- so this is the
-# end-to-end proof check for that certificate on a model read from a file, as
-# opposed to the presolver's own fixtures. sample.dzn is built so that each
-# conflicting pair is witnessed by a different resource, which is the case no
-# single posted Cumulative can reach; the presolver reports a capacity bound of
-# 6, and the optimum is 6.
+# The same instance with both inferring presolvers, whose derived Cumulatives
+# are proved rather than asserted --- so this is the end-to-end proof check for
+# those certificates on a model read from a file, as opposed to the presolvers'
+# own fixtures. sample.dzn is built so that each conflicting pair is witnessed
+# by a different resource, which is the case no single posted Cumulative can
+# reach; both presolvers report a capacity bound of 6, and the optimum is 6.
 add_test(NAME rcpsp_dzn_inferred COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash --basename rcpsp_dzn_inferred
-    $<TARGET_FILE:rcpsp> --dzn ${CMAKE_CURRENT_SOURCE_DIR}/sample.dzn --infer-disjunctive)
+    $<TARGET_FILE:rcpsp> --dzn ${CMAKE_CURRENT_SOURCE_DIR}/sample.dzn --infer-cumulative --infer-disjunctive)
+
+# The same, with each presolver's makespan bound corrupted by one. What this
+# covers that the presolvers' own mutation fixtures do not is the *forwarding*:
+# the spec field, the stats callback and the flag that reaches them all live
+# here rather than in a presolver, and a forward that bit-rotted would leave an
+# honest proof behind and nothing to say so --- the shape a no-op presolver
+# passing every check has, one layer out. Both lanes, because the two presolvers
+# forward it separately.
+add_test(NAME rcpsp_dzn_inferred_disjunctive_mutated COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_expect_verify_failure.bash
+    --basename rcpsp_dzn_inferred_disjunctive_mutated
+    $<TARGET_FILE:rcpsp> --dzn ${CMAKE_CURRENT_SOURCE_DIR}/sample.dzn --infer-disjunctive --mutate-makespan-bound)
+add_test(NAME rcpsp_dzn_inferred_cumulative_mutated COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_expect_verify_failure.bash
+    --basename rcpsp_dzn_inferred_cumulative_mutated
+    $<TARGET_FILE:rcpsp> --dzn ${CMAKE_CURRENT_SOURCE_DIR}/sample.dzn --infer-cumulative --mutate-makespan-bound)
 
 # Enumeration rather than optimisation, so this one reaches the COMPLETE
 # ENUMERATION conclusion, which none of the others do.

--- a/gcs/presolvers/cumulative_strengthening/cumulative_strengthening_test.cc
+++ b/gcs/presolvers/cumulative_strengthening/cumulative_strengthening_test.cc
@@ -991,6 +991,71 @@ auto main(int argc, char * argv[]) -> int
             fail("the donor alone refuted the all-variable-height instance at the root");
     }
 
+    /* Raising a height against each of the three things a donor may now be,
+     * which every raising fixture above leaves untried: they are all constant
+     * and all mandatory, the optional fixtures' heights make no task full, and
+     * the sweeps draw neither presences nor variable lengths. The raise
+     * consumes recover_am1_from_row on the donor's row, so it meets a presence
+     * conjunct inside a flag, a converted height's `cc` bits and a
+     * two-variable `after` for the first time here.
+     *
+     * The analytical argument that each is fine is not the point --- it is that
+     * two individually-correct changes composing is a claim, and this stack's
+     * standard is that a firing path gets a fixture rather than an argument.
+     *
+     * One shape throughout: heights {6, 3, 3} under a capacity of eight. Six
+     * plus three overshoots, so the first task cannot run beside either other
+     * one and is raised; three plus three does not, so the other two are what
+     * kappa is the subset sum of, and eight comes down to six.
+     */
+    for (const auto & what : {string{"optional"}, string{"converted height"}, string{"variable length"}}) {
+        auto stats = make_shared<CumulativeStrengtheningStats>();
+
+        const vector<pair<int, int>> starts{{0, 2}, {0, 2}, {0, 2}};
+        auto lengths = vector<pair<int, int>>(3, {2, 2});
+        auto heights = vector<pair<int, int>>{{6, 6}, {3, 3}, {3, 3}};
+        vector<pair<int, int>> presences;
+
+        if (what == "optional")
+            presences.assign(3, {0, 1});
+        else if (what == "converted height")
+            // The raised task's own height, so that what the raise argues over
+            // is a term recover_constant_argument_row put there rather than one
+            // the donor posted. Its guaranteed demand is the six above, and the
+            // conversion is worth keeping: setting it aside would leave kappa
+            // over {3, 3} unchanged but lose the task, and a tie goes to the
+            // conversion.
+            heights[0] = {6, 7};
+        else
+            // The *raised* task again, so the pin that goes through the end
+            // proxy is the one on a flag the raise put a coefficient on. Its
+            // window widens with the upper bound, which is what makes the last
+            // time point one only this task can occupy --- the alone branch of
+            // the raise, which nothing else here reaches.
+            lengths[0] = {2, 3};
+
+        const GeneralInstance inst{starts, lengths, heights, presences, {8, 8}};
+        auto name = what;
+        std::replace(name.begin(), name.end(), ' ', '_');
+        auto outcome = solve_general(inst, stats, proofs ? make_optional("cumulative_strengthening_raise_" + name) : nullopt);
+
+        if (stats->donors_strengthened != 1)
+            fail("a donor was not strengthened, raising against " + what);
+        if (stats->tasks_raised != 1)
+            fail("raised " + std::to_string(stats->tasks_raised) + " heights, not the one, against " + what);
+        if (stats->capacity_units_removed != 2_i)
+            fail("took " + std::to_string(stats->capacity_units_removed.raw_value) + " units off the capacity, not two, against " + what);
+        if (proofs && stats->rows_with_a_raise == 0)
+            fail("no row raised anything in the proof, against " + what);
+        if (what == "converted height" && stats->converted_heights != 1)
+            fail("the raised task's variable height was not converted");
+        if (what != "converted height" && stats->donors_with_set_aside_tasks != 0)
+            fail("a task was set aside, against " + what);
+
+        check_solutions("raising against " + what, inst, outcome);
+        println(cerr, "raising against {}: {} pol steps over {} raised rows", what, stats->raise_lines_emitted, stats->rows_with_a_raise);
+    }
+
     // What is still declined outright: a capacity that is a *view*, whose bits
     // are not the ones the donor's rows mention, so there is no order literal
     // whose definition would cancel them and nothing to reduce the row against.

--- a/gcs/presolvers/inferred_cumulative/inferred_cumulative_test.cc
+++ b/gcs/presolvers/inferred_cumulative/inferred_cumulative_test.cc
@@ -423,7 +423,10 @@ auto main(int argc, char * argv[]) -> int
     // feasible makespan would be a bug, and this fixture knows its optimum. The
     // margin-of-one fixture that says the arithmetic is tight, and the
     // mutations that say so by being refused, are in
-    // derived_cumulative_test.cc.
+    // derived_cumulative_test.cc. What is left over is this presolver's
+    // *forwarding* of the mutation flag, which needs a tight bound to bite and
+    // so has no fixture here; the `rcpsp_dzn_inferred_cumulative_mutated` lane
+    // covers it end to end, on an instance whose bound is the optimum.
     {
         auto stats = make_shared<InferredCumulativeStats>();
         auto certified = solve_instance(

--- a/gcs/presolvers/inferred_disjunctive/inferred_disjunctive.cc
+++ b/gcs/presolvers/inferred_disjunctive/inferred_disjunctive.cc
@@ -650,13 +650,22 @@ auto InferredDisjunctive::run(Problem & problem, Propagators & propagators, Stat
                         // a clique's members share a witness, recovering their
                         // sub-clique in one step instead is what issue #666
                         // is about.
-                        // The bound it returns is not checked because it
-                        // cannot be anything else: two demands that overshoot
-                        // give a margin at most the larger of them, so the
-                        // divisor is that margin and |K| - ceil(Delta / d) is
-                        // one. build_am1_from_row's own paragraph is the
-                        // argument, and it is why a caller wanting the pairwise
-                        // case need not special-case anything.
+                        // The bound it returns is not checked, and the reason
+                        // is not quite the obvious one. Where the smaller
+                        // demand fits under the capacity the margin is at most
+                        // the larger of the two, so the divisor is the margin
+                        // and |K| - ceil(Delta / d) is one --- the at-most-one
+                        // this is named for. Where *both* demands exceed the
+                        // capacity the margin is bigger than either, so the
+                        // divisor is the larger demand instead and the bound
+                        // comes back as zero: neither task may run, which is
+                        // true (neither can) and is a strictly stronger line.
+                        // What carries that through is that the coefficients
+                        // are units either way, so the induction below still
+                        // advances --- with degree to spare rather than
+                        // exactly enough --- and the pin it ends on is an
+                        // implication check, which a stronger line passes.
+                        // `pair_both_over` in the test file is the fixture.
                         PolBuilder pair_amo;
                         build_am1_from_row(pair_amo, *reduced, {c.demand_u, c.demand_v}, weaken_out, c.capacity, tracker);
 

--- a/gcs/presolvers/inferred_disjunctive/inferred_disjunctive_test.cc
+++ b/gcs/presolvers/inferred_disjunctive/inferred_disjunctive_test.cc
@@ -126,6 +126,7 @@ namespace
         if (setup.presolve) {
             auto presolver = InferredDisjunctive{setup.stats};
             presolver.with_budgets(setup.max_candidates, setup.max_posted).with_minimum_clique_size(setup.min_clique_size);
+            presolver.with_proof_mutation(setup.mutation);
             if (setup.inferred_rules)
                 presolver.with_rules(*setup.inferred_rules);
             if (makespan)
@@ -284,6 +285,24 @@ auto main(int argc, char * argv[]) -> int
             fail("certified bound: the bound differs with proofs off");
 
         println(cerr, "certified makespan bound: derived {} over {} nodes", stats->certified_makespan_bound.raw_value, certified.recursions);
+
+        // And one more than the clique carries must be refused. The energy
+        // argument itself is mutation-tested where it lives, in
+        // makespan_energy; what this covers is *this* presolver's forwarding of
+        // it --- the spec field, the links it fills in and the flag that
+        // selects the corruption. A bound with slack in it verifies whatever it
+        // concludes, so an honest derivation reaching a number the geometry
+        // does not support would look exactly like this one. Six is the
+        // optimum, so seven is infeasible and the margin is the required one.
+        if (proofs) {
+            const string name = "inferred_disjunctive_makespan_mutation";
+            solve_family(3, 2, 8, Setup{.mutation = inferred_disjunctive_mutation::ClaimHigherMakespanBound{}, .minimise_makespan = true},
+                make_optional(name), false);
+            if (run_veripb(name + ".opb", name + ".pbp"))
+                fail("veripb accepted a makespan bound one above what the clique carries");
+            dispose_of_proof_files(name);
+            println(cerr, "veripb rejected the higher-makespan mutation, as expected");
+        }
     }
 
     // The sharp twin: one more unit of horizon and the three tasks fit exactly.
@@ -693,6 +712,56 @@ auto main(int argc, char * argv[]) -> int
         if (expected != solutions)
             fail("variable-duration solutions do not match brute force");
         println(cerr, "variable duration: a clique of {} tasks, {} solutions", stats->clique_members_posted, solutions.size());
+    }
+
+    /* A witnessing pair *both* of whose demands strictly exceed the capacity,
+     * which is the one case where recovering the at-most-one does not land on
+     * an at-most-one. The margin is then bigger than either demand, so the
+     * divisor is the larger demand rather than the margin, and the bound comes
+     * back as zero: a line saying neither task may run rather than that at most
+     * one may. Stronger, so the induction that folds the pairs still advances
+     * and the syntactic pin still accepts --- but for a different reason than
+     * the one written beside the call, which is why this is worth a fixture.
+     *
+     * It can only be an infeasible model, and that is not a fixture design
+     * choice: a task demanding more than a resource has can never be active at
+     * any time point, and a mandatory task of non-zero length must be active
+     * somewhere. So what this checks is the arithmetic and the pin --- `pol`
+     * steps are checked exactly whatever the model says, and an implication
+     * check is syntactic --- and *not* the enumeration, which an unsatisfiable
+     * model would agree with however the derivation had gone.
+     */
+    {
+        auto stats = make_shared<InferredDisjunctiveStats>();
+        Problem p;
+        vector<IntegerVariableID> starts;
+        for (int i = 0; i < 3; ++i)
+            starts.push_back(p.create_integer_variable(0_i, 3_i, "s" + to_string(i)));
+        const vector<Integer> lengths(3, 2_i);
+
+        // Three over two, so the margin is four and the larger demand is three.
+        p.post(Cumulative{starts, lengths, vector<Integer>{3_i, 3_i, 0_i}, 2_i});
+        // And the other two pairs witnessed ordinarily, so that the clique is
+        // of three and the fold has something to fold.
+        p.post(Cumulative{starts, lengths, vector<Integer>{1_i, 0_i, 1_i}, 1_i});
+        p.post(Cumulative{starts, lengths, vector<Integer>{0_i, 1_i, 1_i}, 1_i});
+        p.add_presolver(InferredDisjunctive{stats});
+
+        bool any_solution = false;
+        solve_with(p, SolveCallbacks{.solution = [&](const CurrentState &) -> bool {
+            any_solution = true;
+            return true;
+        }},
+            proofs ? make_optional<ProofOptions>(ProofFileNames{"inferred_disjunctive_pair_both_over"}) : nullopt);
+        if (proofs)
+            verify_proof_and_clean_up("inferred_disjunctive_pair_both_over");
+
+        if (any_solution)
+            fail("both demands over the capacity: a task that cannot run anywhere was scheduled");
+        if (stats->cliques_posted != 1 || stats->clique_members_posted != 3)
+            fail("both demands over the capacity: posted " + to_string(stats->cliques_posted) + " cliques over " +
+                to_string(stats->clique_members_posted) + " members, not the one clique of three");
+        println(cerr, "both demands over the capacity: the clique is still recovered and the pin still accepts");
     }
 
     if (! proofs) {


### PR DESCRIPTION
Part two of three answering the whole-stack review of #661–#694. Based on #697.

**The raise had never met an optional donor, a converted variable height or a
variable-length task.** Every raising fixture is constant and mandatory; the
optional fixtures' heights (all 3 under C = 8) make no task full; the random
sweeps draw no presences and constant lengths. So `recover_am1_from_row` had
never been handed a flag with a presence conjunct inside it, a row whose terms a
conversion put there, or a task whose `after` is reified on two variables. The
argument that each is fine is not the point: untested composition of two
individually-correct changes is exactly the shape #689 has. One shape covers all
three — heights {6, 3, 3} under a capacity of eight, with the six-height task the
one each fixture varies.

**The makespan-bound mutation was reachable from no ctest at all.** The energy
argument is mutation-tested in `derived_cumulative_test`, but each presolver
forwards the flag separately, and a bit-rotted forward is a mutation that
silently does nothing — a green lane meaning nothing, which is the "a no-op
passes every check" shape one layer out. `InferredDisjunctive` gets a fixture,
its bound being the optimum on that family. `InferredCumulative`'s is a
relaxation bound and cannot bite, so both get an `rcpsp` expect-verify-failure
lane instead — which also closes the other half of that finding: nothing ran
`--infer-cumulative` end to end anywhere, `rcpsp_dzn_inferred` being
disjunctive-only. That lane now runs both presolvers.

**And the case where recovering a pairwise at-most-one does not produce one.**
Two demands that both exceed the capacity give a margin bigger than either, so
the divisor is the larger demand and the bound comes back as zero. The comment
beside the call said the bound "cannot be anything else" than one. The conclusion
survives — unit coefficients, so the induction still advances, and a syntactic
pin accepts a stronger line — but for a subtler reason than stated. The comment
now says which; `pair_both_over` says it holds. It can only be an infeasible
model, which the fixture states rather than implies, along with what that means
for what it is and is not checking.

Verified: 635/635 ctest on GCC release, green on clang and Sanitize.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FiXjJTM4G1dMjbr45wGb12