### PR TITLE
Cancel CI runs a newer push to the same PR has superseded

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -7,6 +7,13 @@ on:
   # just onto main) are built and checked too.
   pull_request:
 
+# Cancel a run that a newer push to the same pull request has superseded: those
+# results are never read. Not on main, where every commit's build is wanted --
+# cancelling there would leave a gap over whichever commit broke something.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   format:
     name: clang-format

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -7,6 +7,13 @@ on:
   # just onto main) are built and checked too.
   pull_request:
 
+# Cancel a run that a newer push to the same pull request has superseded: those
+# results are never read. Not on main, where every commit's build is wanted --
+# cancelling there would leave a gap over whichever commit broke something.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   build:
     name: ${{ matrix.os }}${{ matrix.cxx && format(' ({0})', matrix.cxx) || '' }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -13,6 +13,13 @@ on:
     branches: [ "main" ]
   pull_request:
 
+# Cancel a run that a newer push to the same pull request has superseded: those
+# results are never read. Not on main, where every commit's build is wanted --
+# cancelling there would leave a gap over whichever commit broke something.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   msvc:
     name: windows-2022 / MSVC (library + ctest)


### PR DESCRIPTION
Suggested while reviewing #632, where three force-pushes each left ten jobs building commits that no longer existed.

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
```

Added to all three workflows (`cmake`, `clang-format`, `windows`), which had no `concurrency` key at all.

## Why the group is safe for stacked PRs

`github.ref` is `refs/pull/N/merge` on a `pull_request` event, so the group is per-PR, not per-branch. All three workflows deliberately have no base-branch filter so that PRs onto a feature branch get built — a push to a branch that is both PR A's head and PR B's base fires two `pull_request` events with different refs, so they land in different groups and neither cancels the other. Keying on `github.workflow` as well means the three workflows never contend.

## Why `cancel-in-progress` is an expression and not `true`

On a `push` to main, `github.ref` is `refs/heads/main` and every run shares one group. With a bare `true`, a merge landing while the previous merge is still building cancels it — and the cancelled one is exactly the build you want when something breaks, because it is the earlier commit that tells you which merge did it. Queued runs on main are cheap next to that.

The expression form is supported for `cancel-in-progress`; all three files parse, with `concurrency` before `jobs`.

## What this does not change

Nothing about what is built or how. The first push to a PR behaves identically; only a *superseded* run is affected, and only by being cancelled rather than finishing unread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FiXjJTM4G1dMjbr45wGb12
