### PR TITLE
Eliminate all 326 GCC 15.2.0 build warnings

### DIFF
--- a/gcs/constraints/global_cardinality/bounds_global_cardinality.cc
+++ b/gcs/constraints/global_cardinality/bounds_global_cardinality.cc
@@ -51,8 +51,8 @@ using fmt::print;
 
 auto gcs::innards::propagate_bounds_global_cardinality(const vector<IntegerVariableID> & vars, const ConstraintID & owner,
     const vector<Integer> & values, const vector<IntegerVariableID> & counts,
-    const vector<pair<optional<ProofLine>, optional<ProofLine>>> & count_lines, const vector<IntegerVariableID> & all_vars, const State & state,
-    auto & inference, ProofLogger * const logger) -> PropagatorState
+    const vector<pair<optional<ProofLine>, optional<ProofLine>>> & count_lines, const State & state, auto & inference, ProofLogger * const logger)
+    -> PropagatorState
 {
     auto m = values.size();
 
@@ -395,10 +395,10 @@ auto gcs::innards::propagate_bounds_global_cardinality(const vector<IntegerVaria
 
 template auto gcs::innards::propagate_bounds_global_cardinality(const std::vector<IntegerVariableID> & vars, const ConstraintID & owner,
     const std::vector<Integer> & values, const std::vector<IntegerVariableID> & counts,
-    const std::vector<std::pair<std::optional<ProofLine>, std::optional<ProofLine>>> & count_lines, const std::vector<IntegerVariableID> & all_vars,
-    const State & state, SimpleInferenceTracker & inference, ProofLogger * const logger) -> PropagatorState;
+    const std::vector<std::pair<std::optional<ProofLine>, std::optional<ProofLine>>> & count_lines, const State & state,
+    SimpleInferenceTracker & inference, ProofLogger * const logger) -> PropagatorState;
 
 template auto gcs::innards::propagate_bounds_global_cardinality(const std::vector<IntegerVariableID> & vars, const ConstraintID & owner,
     const std::vector<Integer> & values, const std::vector<IntegerVariableID> & counts,
-    const std::vector<std::pair<std::optional<ProofLine>, std::optional<ProofLine>>> & count_lines, const std::vector<IntegerVariableID> & all_vars,
-    const State & state, EagerProofLoggingInferenceTracker & inference, ProofLogger * const logger) -> PropagatorState;
+    const std::vector<std::pair<std::optional<ProofLine>, std::optional<ProofLine>>> & count_lines, const State & state,
+    EagerProofLoggingInferenceTracker & inference, ProofLogger * const logger) -> PropagatorState;

--- a/gcs/constraints/global_cardinality/bounds_global_cardinality.hh
+++ b/gcs/constraints/global_cardinality/bounds_global_cardinality.hh
@@ -22,8 +22,8 @@ namespace gcs
          */
         [[nodiscard]] auto propagate_bounds_global_cardinality(const std::vector<IntegerVariableID> & vars, const ConstraintID & owner,
             const std::vector<Integer> & values, const std::vector<IntegerVariableID> & counts,
-            const std::vector<std::pair<std::optional<ProofLine>, std::optional<ProofLine>>> & count_lines,
-            const std::vector<IntegerVariableID> & all_vars, const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState;
+            const std::vector<std::pair<std::optional<ProofLine>, std::optional<ProofLine>>> & count_lines, const State & state, auto & inference,
+            ProofLogger * const logger) -> PropagatorState;
     }
 
 }

--- a/gcs/constraints/global_cardinality/gac_global_cardinality.cc
+++ b/gcs/constraints/global_cardinality/gac_global_cardinality.cc
@@ -196,8 +196,8 @@ namespace gcs::innards
 
 auto gcs::innards::propagate_gac_global_cardinality(const vector<IntegerVariableID> & vars, const ConstraintID & owner,
     const vector<Integer> & values, const vector<IntegerVariableID> & counts, bool closed,
-    const vector<pair<optional<ProofLine>, optional<ProofLine>>> & count_lines, const vector<IntegerVariableID> & all_vars,
-    GacGlobalCardinalityScratch & scratch, const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState
+    const vector<pair<optional<ProofLine>, optional<ProofLine>>> & count_lines, GacGlobalCardinalityScratch & scratch, const State & state,
+    auto & inference, ProofLogger * const logger) -> PropagatorState
 {
     auto m = values.size();
     auto n = vars.size();
@@ -705,11 +705,10 @@ auto gcs::innards::propagate_gac_global_cardinality(const vector<IntegerVariable
 
 template auto gcs::innards::propagate_gac_global_cardinality(const std::vector<IntegerVariableID> & vars, const ConstraintID & owner,
     const std::vector<Integer> & values, const std::vector<IntegerVariableID> & counts, bool closed,
-    const std::vector<std::pair<std::optional<ProofLine>, std::optional<ProofLine>>> & count_lines, const std::vector<IntegerVariableID> & all_vars,
-    GacGlobalCardinalityScratch & scratch, const State & state, SimpleInferenceTracker & inference, ProofLogger * const logger) -> PropagatorState;
+    const std::vector<std::pair<std::optional<ProofLine>, std::optional<ProofLine>>> & count_lines, GacGlobalCardinalityScratch & scratch,
+    const State & state, SimpleInferenceTracker & inference, ProofLogger * const logger) -> PropagatorState;
 
 template auto gcs::innards::propagate_gac_global_cardinality(const std::vector<IntegerVariableID> & vars, const ConstraintID & owner,
     const std::vector<Integer> & values, const std::vector<IntegerVariableID> & counts, bool closed,
-    const std::vector<std::pair<std::optional<ProofLine>, std::optional<ProofLine>>> & count_lines, const std::vector<IntegerVariableID> & all_vars,
-    GacGlobalCardinalityScratch & scratch, const State & state, EagerProofLoggingInferenceTracker & inference, ProofLogger * const logger)
-    -> PropagatorState;
+    const std::vector<std::pair<std::optional<ProofLine>, std::optional<ProofLine>>> & count_lines, GacGlobalCardinalityScratch & scratch,
+    const State & state, EagerProofLoggingInferenceTracker & inference, ProofLogger * const logger) -> PropagatorState;

--- a/gcs/constraints/global_cardinality/gac_global_cardinality.hh
+++ b/gcs/constraints/global_cardinality/gac_global_cardinality.hh
@@ -39,9 +39,8 @@ namespace gcs
          */
         [[nodiscard]] auto propagate_gac_global_cardinality(const std::vector<IntegerVariableID> & vars, const ConstraintID & owner,
             const std::vector<Integer> & values, const std::vector<IntegerVariableID> & counts, bool closed,
-            const std::vector<std::pair<std::optional<ProofLine>, std::optional<ProofLine>>> & count_lines,
-            const std::vector<IntegerVariableID> & all_vars, GacGlobalCardinalityScratch & scratch, const State & state, auto & inference,
-            ProofLogger * const logger) -> PropagatorState;
+            const std::vector<std::pair<std::optional<ProofLine>, std::optional<ProofLine>>> & count_lines, GacGlobalCardinalityScratch & scratch,
+            const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState;
     }
 
 }

--- a/gcs/constraints/global_cardinality/global_cardinality.cc
+++ b/gcs/constraints/global_cardinality/global_cardinality.cc
@@ -111,15 +111,12 @@ auto GlobalCardinality::install_propagators(Propagators & propagators) -> void
     triggers.on_change.insert(triggers.on_change.end(), _vars.begin(), _vars.end());
     triggers.on_bounds.insert(triggers.on_bounds.end(), _counts.begin(), _counts.end());
 
-    vector<IntegerVariableID> all_vars = _vars;
-    all_vars.insert(all_vars.end(), _counts.begin(), _counts.end());
-
     overloaded{[&](const consistency::BC &) {
                    propagators.install(
                        constraint_id(),
-                       [vars = _vars, owner = constraint_id(), values = _values, counts = _counts, count_lines = _count_lines, all_vars = all_vars](
+                       [vars = _vars, owner = constraint_id(), values = _values, counts = _counts, count_lines = _count_lines](
                            const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
-                           return propagate_bounds_global_cardinality(vars, owner, values, counts, count_lines, all_vars, state, inference, logger);
+                           return propagate_bounds_global_cardinality(vars, owner, values, counts, count_lines, state, inference, logger);
                        },
                        triggers);
                },
@@ -127,10 +124,9 @@ auto GlobalCardinality::install_propagators(Propagators & propagators) -> void
             propagators.install(
                 constraint_id(),
                 [vars = _vars, owner = constraint_id(), values = _values, counts = _counts, closed = _closed, count_lines = _count_lines,
-                    all_vars = all_vars, scratch = make_gac_global_cardinality_scratch()](
+                    scratch = make_gac_global_cardinality_scratch()](
                     const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
-                    return propagate_gac_global_cardinality(
-                        vars, owner, values, counts, closed, count_lines, all_vars, *scratch, state, inference, logger);
+                    return propagate_gac_global_cardinality(vars, owner, values, counts, closed, count_lines, *scratch, state, inference, logger);
                 },
                 triggers);
         }}

--- a/gcs/constraints/innards/cake_probe.hh
+++ b/gcs/constraints/innards/cake_probe.hh
@@ -42,6 +42,17 @@ namespace gcs::test_innards
     {
     }
 #else
+    // Every shell-out below is deliberately best effort: the probe recovers from
+    // a command that failed by inspecting what it did or did not write, and must
+    // never fail a test. std::system() is declared with glibc's warn_unused_result
+    // attribute, which -- unlike [[nodiscard]] -- a cast to void does not silence,
+    // so funnel the calls through one helper whose name records the decision
+    // rather than repeating an ignored return value at every site.
+    inline auto cake_run_ignoring_status(const std::string & cmd) -> void
+    {
+        [[maybe_unused]] auto status = std::system(cmd.c_str());
+    }
+
     inline auto cake_capture(const std::string & cmd) -> std::string
     {
         std::string out;
@@ -89,13 +100,9 @@ namespace gcs::test_innards
             line += "\n";
             std::fputs(line.c_str(), stderr);
         };
-        auto firstline = [](const std::string & s) {
-            auto n = s.find('\n');
-            return n == std::string::npos ? s : s.substr(0, n);
-        };
 
         // 1. cake_pb_cp re-derives its own OPB from the .scp.
-        std::system((cake + " " + scp + " > " + vopb + " 2>/dev/null").c_str());
+        cake_run_ignoring_status(cake + " " + scp + " > " + vopb + " 2>/dev/null");
         std::string opb = cake_capture("cat " + vopb);
         if (opb.find(">=") == std::string::npos && opb.find("<=") == std::string::npos) {
             log("SKIP_NO_OPB");
@@ -116,8 +123,8 @@ namespace gcs::test_innards
                 static int fail_seq = 0;
                 std::string dir{k}, sfx = std::to_string(++fail_seq);
                 for (auto ext : {".scp", ".pbp"})
-                    std::system(("mkdir -p " + dir + " && cp " + pn + ext + " " + dir + "/" + pn + "." + sfx + ext + " 2>/dev/null").c_str());
-                std::system(("cp " + vopb + " " + dir + "/" + pn + "." + sfx + ".cakeopb 2>/dev/null").c_str());
+                    cake_run_ignoring_status("mkdir -p " + dir + " && cp " + pn + ext + " " + dir + "/" + pn + "." + sfx + ext + " 2>/dev/null");
+                cake_run_ignoring_status("cp " + vopb + " " + dir + "/" + pn + "." + sfx + ".cakeopb 2>/dev/null");
             }
             std::remove(vopb.c_str());
             std::remove(core.c_str());

--- a/gcs/constraints/linear/linear_equality.cc
+++ b/gcs/constraints/linear/linear_equality.cc
@@ -266,8 +266,14 @@ auto ReifiedLinearEquality::install_propagators(Propagators & propagators) -> vo
         visit(
             [&, modifier = modifier](auto & sanitised_cv) {
                 TabulationVariables enum_vars;
+                // Registering each term variable in enum_vars is the point here;
+                // the position it comes back with is not wanted, because the
+                // sanitised terms have distinct variables, so nothing collapses
+                // and position always equals term index -- which is exactly what
+                // base_accept below assumes when it indexes current[] by term
+                // index.
                 for (auto & cv : sanitised_cv.terms)
-                    enum_vars.position_of(get_var(cv));
+                    (void)enum_vars.position_of(get_var(cv));
 
                 // the enumeration, in-proof selector introduction, and
                 // extensional wiring live in install_tabulation, and the

--- a/gcs/constraints/nogoods/nogoods_test.cc
+++ b/gcs/constraints/nogoods/nogoods_test.cc
@@ -69,6 +69,12 @@ namespace
         case NotEqual: return assignment[l.var] != l.value;
         case GreaterEqual: return assignment[l.var] >= l.value;
         case Less: return assignment[l.var] < l.value;
+        // A TestLit carries a single value rather than an interval, and random_op
+        // only ever picks the four scalar operators, so the range conditions
+        // cannot reach here; they fall through to the same never-taken default the
+        // switch already had.
+        case InRange:
+        case NotInRange: break;
         }
         return false;
     }
@@ -114,6 +120,9 @@ namespace
             if (s.lower_bound(v) >= val)
                 return Holds::False;
             return Holds::Undecided;
+        // Unreachable for the same reason as in literal_true_on, above.
+        case InRange:
+        case NotInRange: break;
         }
         return Holds::Undecided;
     }

--- a/gcs/constraints/plus_minus/hints.hh
+++ b/gcs/constraints/plus_minus/hints.hh
@@ -28,7 +28,10 @@ namespace gcs::innards::hints
     struct Plus
     {
         ConstraintID originator;
-        std::optional<ProofLine> pol_line;
+        // Defaulted so that a caller which has no sum line to offer -- the
+        // tabulated path builds its hints as Plus{owner} -- is not a
+        // -Wmissing-field-initializers site.
+        std::optional<ProofLine> pol_line = std::nullopt;
         static constexpr std::string_view hint_name = "plus";
     };
 
@@ -47,7 +50,8 @@ namespace gcs::innards::hints
     struct Minus
     {
         ConstraintID originator;
-        std::optional<ProofLine> pol_line;
+        // Defaulted for the same reason as Plus::pol_line, above.
+        std::optional<ProofLine> pol_line = std::nullopt;
         static constexpr std::string_view hint_name = "minus";
     };
 

--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -223,11 +223,30 @@ struct NamesAndIDsTracker::Imp
 
     [[nodiscard]] auto find_atoms(const SimpleOrProofOnlyIntegerVariableID & id) const -> const VariableAtoms *
     {
+        // GCC 15's -Wdangling-reference sees a call returning a reference whose
+        // argument list contains a temporary (the overloaded{...} visitor) and
+        // assumes the reference might point into that temporary. It does not:
+        // both lambdas return a reference to a member of *this, which outlives
+        // the visitor by a long way. atoms_for() a few lines up is the same
+        // construct and is not warned about -- only the const-qualified,
+        // const-reference-returning copy trips the heuristic -- which is itself
+        // a sign the diagnostic is guessing rather than analysing. Clang, whose
+        // lifetime analysis is stricter in general, is silent here.
+        // Cf. https://gcc.gnu.org/bugzilla/show_bug.cgi?id=107532 for the same
+        // shape: a reference into the parent object, reported as dangling
+        // because a temporary happened to be an argument.
+#if defined(__GNUC__) && ! defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdangling-reference"
+#endif
         const auto & table =
             visit(overloaded{//
                       [&](const SimpleIntegerVariableID &) -> const vector<VariableAtoms> & { return simple_variable_atoms; },
                       [&](const ProofOnlySimpleIntegerVariableID &) -> const vector<VariableAtoms> & { return proof_only_variable_atoms; }},
                 id);
+#if defined(__GNUC__) && ! defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
         auto idx = visit([&](const auto & i) { return static_cast<vector<VariableAtoms>::size_type>(i.index); }, id);
         return idx < table.size() ? &table[idx] : nullptr;
     }

--- a/gcs/innards/propagators.cc
+++ b/gcs/innards/propagators.cc
@@ -143,6 +143,13 @@ namespace
                 case NotEqual: return on_change;
                 case GreaterEqual:
                 case Less: return on_bounds;
+                // State::test_literal calls `x in [lo, hi]` true exactly when both
+                // bounds have moved inside the interval, so only a bound move can
+                // newly entail it. `x not in [lo, hi]` becomes true when the domain
+                // stops intersecting the interval, which a removal from the interior
+                // can do, so that one needs the full on_change mask.
+                case InRange: return on_bounds;
+                case NotInRange: return on_change;
                 }
                 return on_change; // unreachable; conservative default
             },

--- a/gcs/innards/propagators.cc
+++ b/gcs/innards/propagators.cc
@@ -590,7 +590,22 @@ auto Propagators::propagate(const Literals & guesses, State & state, ProofLogger
     // every honoured claim immediately and abort if it infers anything or
     // contradicts. Read once: the constraint test harness sets this before the
     // first solve in the process.
+    // GCC 15 false positive: this is read below, but only from inside the
+    // generic lambda `run`. A static local is not captured, so the read is not
+    // a capture; and the read that is there lives in a lambda body that is
+    // still an uninstantiated template when the enclosing function's scope
+    // pops, which is where -Wunused-but-set-variable is decided. Making the
+    // variable non-static, or making `run` non-generic, silences it either way
+    // -- neither of which is a change worth making for a diagnostic.
+    // Cf. https://gcc.gnu.org/bugzilla/show_bug.cgi?id=96400. Clang does not warn.
+#if defined(__GNUC__) && ! defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
+#endif
     static const bool check_idempotent_claims = nullptr != std::getenv("GCS_CHECK_IDEMPOTENT_CLAIMS");
+#if defined(__GNUC__) && ! defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 
     auto enqueue_if_idle = [&](const int p) {
         if (_imp->lookup[p] >= _imp->enqueued_end && _imp->lookup[p] < _imp->idle_end) {

--- a/xcsp/CMakeLists.txt
+++ b/xcsp/CMakeLists.txt
@@ -6,6 +6,24 @@ FetchContent_Declare(xcsp3_cpp_parser
     EXCLUDE_FROM_ALL)
 FetchContent_MakeAvailable(xcsp3_cpp_parser)
 
+# The top-level add_compile_options(-W -Wall) applies to every target in the
+# build, including this fetched one, so the parser's sources are compiled with
+# a warning set they were never written against: eleven warnings
+# (-Wsign-compare, -Wunused-parameter, -Wdeprecated-copy, and a deprecated
+# libxml2 entity call) that are not ours to fix and that we do not want between
+# us and our own. Turn warnings off for the parser's own compilation only;
+# nothing else in the build is affected, and headers it exposes to us are still
+# compiled with our warnings when we include them.
+foreach(_gcs_xcsp_target xcsp3parser xcsp3parser_dynamic)
+    if(TARGET ${_gcs_xcsp_target})
+        if(MSVC)
+            target_compile_options(${_gcs_xcsp_target} PRIVATE /w)
+        else()
+            target_compile_options(${_gcs_xcsp_target} PRIVATE -w)
+        endif()
+    endif()
+endforeach()
+
 find_package(LibXml2 REQUIRED)
 
 add_executable(xcsp_glasgow_constraint_solver xcsp_glasgow_constraint_solver.cc)


### PR DESCRIPTION
A full GCC 15.2.0 build of the tree (Release preset, all 410 translation
units: library, examples, tests, XCSP and MiniZinc frontends) emitted
**326 warnings**. It now emits **0**.

```
$ cmake --preset release && make -C build -j32 -k -Otarget
```

| warning | before | after | whose |
|---|---:|---:|---|
| `-Wunused-result` | 219 | 0 | ours |
| `-Wunused-but-set-variable` | 73 | 0 | ours |
| `-Wmissing-field-initializers` | 12 | 0 | ours |
| `-Wswitch` | 6 | 0 | ours |
| `-Wunused-parameter` | 7 | 0 | 4 ours, 3 XCSP3 parser |
| `-Wsign-compare` | 5 | 0 | XCSP3 parser |
| `-Wdeprecated-copy` | 2 | 0 | XCSP3 parser |
| `-Wdeprecated-declarations` | 1 | 0 | XCSP3 parser (libxml2) |
| `-Wdangling-reference` | 1 | 0 | ours |
| **total** | **326** | **0** | 315 ours, 11 third-party |

The "after" number is from a from-scratch rebuild (`rm -rf build`,
reconfigure, 410/410 TUs compiled), not an incremental one.

326 warnings is only 30 distinct source locations — 288 of them are four
sites in one header that 72 translation units include.

## What was actually wrong

**`cake_probe.hh` — 288 warnings, four sites.** The measurement-only
cake chain probe is a header included by every constraint test.
`firstline` was a lambda nothing ever called, so it goes; GCC 15 reports
an uncalled local lambda under `-Wunused-but-set-variable`. The other
three are `std::system()` calls discarding their return value. glibc
declares `system()` with `warn_unused_result`, which — unlike
`[[nodiscard]]` — a cast to void does *not* silence, so the three go
through one `cake_run_ignoring_status()` helper whose name records that
the exit status is deliberately unexamined. It genuinely is: the probe
recovers from a failed command by inspecting what it did or did not
write, and must never fail a test.

**`GlobalCardinality` was carrying a dead argument — 4 warnings.**
`install_propagators` built `all_vars` (the variables concatenated with
the counts), captured a copy of it into each of the BC and GAC
propagator lambdas, and threaded it through to
`propagate_bounds_global_cardinality` / `propagate_gac_global_cardinality`,
neither of which ever read it. That is not just an unused parameter, it
is a live `vector<IntegerVariableID>` copy held for the lifetime of
every GlobalCardinality propagator for nothing, so the parameter is
removed rather than annotated.

**Two switches predate `InRange`/`NotInRange` — 6 warnings.**
`refined_watch_trigger_mask()` in `propagators.cc` was falling into its
conservative "wake on anything" default for both range operators. Not
wrong, but not free either, and now spelled out: `State::test_literal`
entails `x in [lo, hi]` exactly when both bounds have moved inside the
interval, so `InRange` only needs the bounds mask, while
`x not in [lo, hi]` becomes true when the domain stops intersecting the
interval — which a removal from the *interior* can do — so `NotInRange`
keeps the full `on_change` mask. The two oracles in `nogoods_test.cc`
cannot see a range condition at all (a `TestLit` holds a single value,
not an interval, and the random operator picker only produces the four
scalar ones), so those cases now fall explicitly into the never-taken
default the switches already had.

**`hints::Plus` / `hints::Minus` — 12 warnings.** The tabulated path
builds these as `Hint_{owner}`, correctly — it has no `pol` line to cite
— but `install_tabulation` is generic over the hint type and so cannot
name the remaining field. A default member initialiser on `pol_line`
fixes it at the definition instead.

**`LinearEquality` — 3 warnings.** Its tabulated path calls
`TabulationVariables::position_of` purely to register each term
variable, and `position_of` is `[[nodiscard]]`. The discard is now
explicit, with a note that the position is uninteresting precisely
because the sanitised terms are distinct, so position always equals term
index — which is what the acceptance test relies on when it indexes by
term index.

**Nothing here was a real defect.** No uninitialised read, no dangling
reference, no sign-compare that could go wrong: the `-Wsign-compare`
warnings are all in the fetched parser. The nearest thing to a bug found
is the dead `all_vars` plumbing above, which cost memory rather than
correctness.

## The suspected compiler bugs — there are two

Both are GCC being wrong about correct code, and both are handled the
way `element.cc:236` already handles a `-Wmaybe-uninitialized` false
positive: a narrow `#pragma GCC diagnostic push/ignored/pop` around the
single offending construct, guarded `#if defined(__GNUC__) && !
defined(__clang__)`. That guard is load-bearing — clang understands
`#pragma GCC diagnostic` but knows neither warning name, and answers
with `-Wunknown-warning-option` (verified). **One site each**, so a
pragma is far narrower than the tree-wide `-Wno-` the CMakeLists carries
for `-Wrestrict` and `-Wstringop-overread`; a tree-wide flag would also
disable the diagnostic for the ~150 other `visit(overloaded{...})` calls
in the tree, where it might one day be right.

### 1. `-Wdangling-reference`, `names_and_ids_tracker.cc:226`

`NamesAndIDsTracker::Imp::find_atoms` binds `const auto & table` to
`visit(overloaded{...}, id)`, where both lambdas return a reference to a
member of `*this`. GCC sees a reference-returning call with a temporary
(the `overloaded{...}` visitor) among its arguments and assumes the
result might point into that temporary. It cannot — it points at
`simple_variable_atoms` or `proof_only_variable_atoms`, which outlive
the visitor by the whole solve.

The tell that this is a heuristic and not an analysis: `atoms_for()`,
ten lines above, is the *same construct* — same `visit`, same
`overloaded`, same two members — and is not warned about. Only the
`const`-qualified copy returning a `const` reference trips it. A 30-line
reduction reproduces exactly that asymmetry:

```cpp
struct Holder {
    std::vector<int> xs, ys;
    auto find_nonconst(const V & id) -> int * {           // no warning
        auto & table = std::visit(overloaded{
            [&](const A &) -> std::vector<int> & { return xs; },
            [&](const B &) -> std::vector<int> & { return ys; }}, id);
        return table.empty() ? nullptr : &table[0];
    }
    auto find_const(const V & id) const -> const int * {  // warns
        const auto & table = std::visit(overloaded{
            [&](const A &) -> const std::vector<int> & { return xs; },
            [&](const B &) -> const std::vector<int> & { return ys; }}, id);
        return table.empty() ? nullptr : &table[0];
    }
};
```

Clang 21, whose lifetime analysis is stricter in general, is silent on
both. This is the long-running `-Wdangling-reference` false-positive
family; the closest documented shape is
<https://gcc.gnu.org/bugzilla/show_bug.cgi?id=107532> — a reference into
the parent object, reported as dangling because a temporary happened to
be one of the arguments.

### 2. `-Wunused-but-set-variable`, `propagators.cc:586`

This one is the more interesting of the two, because the variable is
plainly read. `check_idempotent_claims` is read ~280 lines below, in the
`PropagatorState::EnableButIdempotent` arm. GCC still calls it set but
not used, at every optimisation level including `-O0`, so it is a
front-end decision, not an optimiser one.

Two things conspire. The read is inside `run`, which is a **generic**
lambda (`[&](auto & tracker)`). A `static` local is not captured, so
there is no capture to mark it read — and the only read that exists sits
in a lambda body that is still an uninstantiated template at the point
the enclosing function's scope pops, which is where the front end
decides this warning. Reduced to seven lines:

```cpp
#include <cstdlib>
extern void sink();
struct A { int a; };
auto f() -> bool {
    static const bool flag = nullptr != std::getenv("X");   // "set but not used"
    auto run = [&](auto & t) -> bool { if (flag) sink(); return t.a == 0; };
    A a{};
    return run(a);
}
```

Change `auto & t` to `A & t`, or drop the `static`, and the warning
disappears in either case — which pins both ingredients. Neither is a
change worth making to the propagation loop to appease a diagnostic
(`run` is generic because it is instantiated for both tracker types, and
the flag is `static` so the `getenv` happens once per process rather
than once per `propagate()` call). Closest bugzilla entry:
<https://gcc.gnu.org/bugzilla/show_bug.cgi?id=96400>. Clang does not
warn.

## Third-party warnings (11)

The last 11 are in `build/_deps/xcsp3_cpp_parser-src` and are not ours
to fix — that tree is fetched at a pinned commit. They are only there
because `add_compile_options(-W -Wall)` at the top level applies to
every target in the build, so a third-party library gets compiled
against a warning set it was never written for. The last commit turns
warnings off for the parser's own two library targets, which is the
narrowest place to do it: nothing else changes, and the parser headers
we include are still compiled with our flags in our own translation
units. **That commit is separable — drop it if you would rather keep the
upstream noise visible.**

## Checks

- **GCC 15.2.0**, from-scratch Release build, 410/410 TUs: 326 → **0**
  warnings, 0 errors.
- **clang 21.1.8**, full Release build, 410/410 TUs: 153 warnings, 0
  errors — all pre-existing kinds (115 `-Winconsistent-missing-override`
  from `proof.hh` and `variable_weighting.hh`, 37
  `-Wunused-lambda-capture`, 1 `-Wdeprecated-copy`) at 4 distinct
  locations. **None of them is in any file this branch touches**, so
  this branch introduces no clang warnings and fixes none; clang's
  situation is untouched and out of scope here.
- **`ctest --parallel 32`**: 635/635 tests passed, 0 failed, on the GCC 15 Release build (`Total Test time (real) = 46.37 sec`).
- `clang-format` 21 clean on every touched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FiXjJTM4G1dMjbr45wGb12
