### PR TITLE
Move the last four examples onto the shared .dzn reader (#664)

### DIFF
--- a/examples/dzn.hh
+++ b/examples/dzn.hh
@@ -6,13 +6,16 @@
 //
 // This handles the fragment of dzn the examples' data files actually use: a
 // sequence of `name = value;` statements, `%` line comments, integer scalars,
-// integer arrays in one and two dimensions, and arrays of integer sets. It is
-// not a MiniZinc parser and does not try to be --- there are no expressions, no
-// floats, no strings, no enums and no output items.
+// integer and Boolean arrays in one and two dimensions, and arrays of integer
+// sets. It is not a MiniZinc parser and does not try to be --- there are no
+// expressions, no floats, no strings, no enums and no output items.
 //
-// Four examples (table_layout, seat_moving, nonogram, hitori) still carry their
-// own readers, written before this existed and diverged in what they accept.
-// Issue #664 tracks migrating them onto this; new examples should start here.
+// This is the only dzn reader in examples/. It used to be one of five: rcpsp,
+// table_layout, seat_moving, nonogram and hitori each had their own, and they
+// had diverged on what dzn they would accept, so which subset of the language
+// you got depended on which example you happened to be in. Issue #664 moved the
+// other four onto this one; new examples should start here rather than write a
+// sixth.
 
 #include <cctype>
 #include <cstddef>
@@ -135,6 +138,36 @@ namespace dzn
             return _integers_in(name, body, "entry");
         }
 
+        /// A one-dimensional array of Booleans, `[true, false, true]`.
+        ///
+        /// `1` and `0` are accepted as well as `true` and `false`. MiniZinc
+        /// itself writes only the words, and would reject the digits in a
+        /// `bool` array, but the reader this replaced in seat_moving took
+        /// both, and a migration that quietly stopped reading a file it used
+        /// to read would be a worse bargain than a reader that is one step
+        /// more generous than the language.
+        [[nodiscard]] auto bools(const std::string & name) const -> std::vector<bool>
+        {
+            const auto & text = _raw(name);
+            auto body = _bracketed(name, text);
+            for (auto & c : body)
+                if (c == ',')
+                    c = ' ';
+
+            std::vector<bool> result;
+            std::istringstream in{body};
+            std::string token;
+            while (in >> token) {
+                if ("true" == token || "1" == token)
+                    result.push_back(true);
+                else if ("false" == token || "0" == token)
+                    result.push_back(false);
+                else
+                    _bad(name, "has an entry that is not a Boolean: '" + text + "'");
+            }
+            return result;
+        }
+
         /// A two-dimensional integer array written `[| a, b | c, d |]`, as
         /// `rows` rows of equal length. The row count is taken from the `|`
         /// separators rather than supplied, so a ragged literal is an error
@@ -213,6 +246,12 @@ namespace dzn
     /// into `name = value;` statements. A statement without an `=` is ignored
     /// rather than rejected, so a data file carrying an `output` item or a
     /// bare `;` still reads.
+    ///
+    /// The last statement in the file need not be terminated. MiniZinc accepts
+    /// that, and the Challenge's `2025/hitori/h20-2.dzn` needs it: its `clue`
+    /// matrix simply runs off the end of the file. Requiring the semicolon
+    /// dropped the statement silently, which then read as "the file does not
+    /// define clue" --- true of the map, and nonsense about the file.
     [[nodiscard]] inline auto read(const std::string & path) -> Data
     {
         std::ifstream infile{path};
@@ -235,12 +274,10 @@ namespace dzn
 
         std::map<std::string, std::string> values;
         std::size_t pos = 0;
-        while (true) {
+        while (pos != text.size()) {
             auto end = text.find(';', pos);
-            if (end == std::string::npos)
-                break;
-            auto statement = text.substr(pos, end - pos);
-            pos = end + 1;
+            auto statement = text.substr(pos, end == std::string::npos ? std::string::npos : end - pos);
+            pos = (end == std::string::npos ? text.size() : end + 1);
 
             auto eq = statement.find('=');
             if (eq == std::string::npos)

--- a/examples/dzn_test.cc
+++ b/examples/dzn_test.cc
@@ -53,12 +53,19 @@ namespace
             fail(what + ": got " + as_text(got) + " but wanted " + as_text(want));
     }
 
-    auto expect_rejected(const string & what, const auto & read_it) -> void
+    /// Rejected, and rejected with a message that names what was being read.
+    /// The naming is half the point: #664 asks for one diagnostic style across
+    /// the examples, and "stoi" --- which is what table_layout's reader used to
+    /// say, being std::stol's own exception --- tells a reader of a
+    /// thousand-line data file nothing about where to look.
+    auto expect_rejected(const string & what, const string & naming, const auto & read_it) -> void
     {
         try {
             read_it();
         }
-        catch (const std::exception &) {
+        catch (const std::exception & e) {
+            if (string{e.what()}.find(naming) == string::npos)
+                fail(what + ": rejected, but the message '" + e.what() + "' does not name '" + naming + "'");
             return;
         }
         fail(what + ": accepted, so it would have been read as something it is not");
@@ -76,6 +83,7 @@ auto main(int, char *[]) -> int
         data << "scalar = 7;\n";
         data << "flat = [1, 2, 3, 4];\n";
         data << "flat_wrapped = array1d(1..4, [5, 6, 7, 8]);\n";
+        data << "flat_wrapped_3d = array3d(ROWS, COLS, CONFIGS, [1, 2, 3, 4, 5, 6, 7, 8]);\n";
         data << "flat_2d = [| 1, 2 | 3, 4 |];\n";
         data << "flat_empty = [];\n";
         data << "flat_trailing_comma = [1, 2, ];\n";
@@ -108,6 +116,12 @@ auto main(int, char *[]) -> int
 
         expect("a flat array", d.integers("flat"), {1, 2, 3, 4});
         expect("an array1d wrapper, whose index set is not an entry", d.integers("flat_wrapped"), {5, 6, 7, 8});
+
+        // The wrapper the Challenge's TableLayout.mzn data files use for their
+        // width and height arrays, and the one feature only table_layout's own
+        // reader used to have. Its index sets are named rather than ranges, so
+        // they carry no digits and no brackets of their own.
+        expect("an array3d wrapper, read flat", d.integers("flat_wrapped_3d"), {1, 2, 3, 4, 5, 6, 7, 8});
         expect("negative entries", d.integers("flat_negative"), {-1, 2, -3});
         expect("an empty array", d.integers("flat_empty"), {});
         expect("a trailing comma, which is a separator with nothing after it", d.integers("flat_trailing_comma"), {1, 2});
@@ -142,27 +156,47 @@ auto main(int, char *[]) -> int
             expect("set 2", groups[2], {3});
         }
 
-        expect_rejected("a non-integer entry", [&] { return d.integers("flat_junk"); });
-        expect_rejected("a non-integer matrix entry", [&] { return d.matrix("grid_junk"); });
-        expect_rejected("a non-Boolean entry", [&] { return d.bools("flags_junk"); });
-        expect_rejected("a non-integer set member", [&] { return d.sets("groups_junk"); });
-        expect_rejected("matrix rows of differing lengths", [&] { return d.matrix("grid_ragged"); });
-        expect_rejected("something outside the braces", [&] { return d.sets("groups_outside"); });
-        expect_rejected("a set that is never closed", [&] { return d.sets("groups_unclosed"); });
+        expect_rejected("a non-integer entry", "flat_junk", [&] { return d.integers("flat_junk"); });
+        expect_rejected("a non-integer matrix entry", "grid_junk", [&] { return d.matrix("grid_junk"); });
+        expect_rejected("a non-Boolean entry", "flags_junk", [&] { return d.bools("flags_junk"); });
+        expect_rejected("a non-integer set member", "groups_junk", [&] { return d.sets("groups_junk"); });
+        expect_rejected("matrix rows of differing lengths", "grid_ragged", [&] { return d.matrix("grid_ragged"); });
+        expect_rejected("something outside the braces", "groups_outside", [&] { return d.sets("groups_outside"); });
+        expect_rejected("a set that is never closed", "groups_unclosed", [&] { return d.sets("groups_unclosed"); });
+
+        // hitori and nonogram read their clue grids with matrix() precisely so
+        // that a file whose array does not have the shape the scalars promise is
+        // a complaint. Reading a flat array as a matrix would otherwise be one
+        // row of everything, which is a shape no data file means.
+        expect_rejected("a flat array read as a matrix", "flat", [&] { return d.matrix("flat"); });
 
         // A `}` with nothing open took an unsigned brace counter to SIZE_MAX,
         // after which the outside-the-braces test never fired again and the
         // rest of the string was accepted --- so the check was switched off by
         // exactly the input it is there to catch.
-        expect_rejected("a closing brace with nothing open", [&] { return d.sets("groups_stray_close"); });
+        expect_rejected("a closing brace with nothing open", "groups_stray_close", [&] { return d.sets("groups_stray_close"); });
 
-        expect_rejected("a name the file does not define", [&] { return d.integer("absent"); });
-        expect_rejected("an integer scalar with trailing text", [&] { return d.integer("flat"); });
+        expect_rejected("a name the file does not define", "absent", [&] { return d.integer("absent"); });
+        expect_rejected("an integer scalar with trailing text", "flat", [&] { return d.integer("flat"); });
     }
     catch (const std::exception & e) {
         fail(string{"unexpected exception: "} + e.what());
     }
 
+    // A name defined twice, in a file of its own because it is the whole file
+    // that is refused rather than the one accessor. Three of the four readers
+    // #664 replaced took the first definition and said nothing, so a data file
+    // with a stale line left above a corrected one solved the wrong instance.
+    const string duplicate_path = "dzn_test_duplicate.dzn";
+    {
+        std::ofstream data{duplicate_path};
+        data << "twice = 1;\ntwice = 2;\n";
+        if (! data)
+            fail("could not write the duplicate-definition test data file");
+    }
+    expect_rejected("a name defined twice", "twice", [&] { return dzn::read(duplicate_path); });
+
+    std::filesystem::remove(duplicate_path);
     std::filesystem::remove(path);
 
     if (0 != failures) {

--- a/examples/dzn_test.cc
+++ b/examples/dzn_test.cc
@@ -39,6 +39,14 @@ namespace
         return s + " }";
     }
 
+    /// So that a Boolean array can be checked by the same expect() as an
+    /// integer one, rather than growing a second one that prints `{ 1 0 1 }`
+    /// anyway.
+    auto as_integers(const vector<bool> & v) -> vector<long long>
+    {
+        return {v.begin(), v.end()};
+    }
+
     auto expect(const string & what, const vector<long long> & got, const vector<long long> & want) -> void
     {
         if (got != want)
@@ -76,11 +84,16 @@ auto main(int, char *[]) -> int
         data << "grid = [| 1, 2, 3 | 4, 5, 6 |];\n";
         data << "grid_ragged = [| 1, 2 | 3 |];\n";
         data << "grid_junk = [| 1, 2x | 3, 4 |];\n";
+        data << "flags = [true, false, true];\n";
+        data << "flags_as_digits = [1, 0, 1];\n";
+        data << "flags_junk = [true, maybe];\n";
         data << "groups = [ {1, 2}, {}, {3} ];\n";
         data << "groups_junk = [ {1, x} ];\n";
         data << "groups_outside = [ {1} 7 ];\n";
         data << "groups_stray_close = [ {1, 2} } 99 ];\n";
         data << "groups_unclosed = [ {1, 2 ];\n";
+        // Last, because it is deliberately not terminated.
+        data << "unterminated = [9, 8, 7]\n";
         if (! data)
             fail("could not write the test data file");
     }
@@ -112,6 +125,14 @@ auto main(int, char *[]) -> int
             expect("matrix row 1", grid[1], {4, 5, 6});
         }
 
+        // MiniZinc lets the last statement in a file go unterminated, and the
+        // Challenge's 2025/hitori/h20-2.dzn does exactly that with its clue
+        // matrix. Requiring the semicolon dropped the statement without a word.
+        expect("a last statement with no terminating semicolon", d.integers("unterminated"), {9, 8, 7});
+
+        expect("a Boolean array", as_integers(d.bools("flags")), {1, 0, 1});
+        expect("a Boolean array written with digits", as_integers(d.bools("flags_as_digits")), {1, 0, 1});
+
         auto groups = d.sets("groups");
         if (groups.size() != 3)
             fail("an array of sets' count");
@@ -123,6 +144,7 @@ auto main(int, char *[]) -> int
 
         expect_rejected("a non-integer entry", [&] { return d.integers("flat_junk"); });
         expect_rejected("a non-integer matrix entry", [&] { return d.matrix("grid_junk"); });
+        expect_rejected("a non-Boolean entry", [&] { return d.bools("flags_junk"); });
         expect_rejected("a non-integer set member", [&] { return d.sets("groups_junk"); });
         expect_rejected("matrix rows of differing lengths", [&] { return d.matrix("grid_ragged"); });
         expect_rejected("something outside the braces", [&] { return d.sets("groups_outside"); });

--- a/examples/hitori/CMakeLists.txt
+++ b/examples/hitori/CMakeLists.txt
@@ -4,3 +4,17 @@ target_link_libraries(hitori PRIVATE cxxopts)
 
 add_test(NAME hitori COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash --basename hitori $<TARGET_FILE:hitori>)
 add_test(NAME hitori-no-connectivity COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash --basename hitori-no-connectivity $<TARGET_FILE:hitori> --connectivity none)
+
+# The .dzn reader, on the same grid `--size 4 --seed 0` generates, so this lane
+# and the generator must agree on the optimum. Nothing else in examples/ runs
+# this reader: before issue #664 moved it onto the shared examples/dzn.hh it was
+# reachable only by hand, with a Challenge data file that is not in the tree.
+add_test(NAME hitori-dzn COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash --basename hitori-dzn
+    $<TARGET_FILE:hitori> --dzn ${CMAKE_CURRENT_SOURCE_DIR}/sample.dzn)
+
+# The proof lane above says the reader produced a model that solves and whose
+# proof checks out; it cannot say the reader read the right numbers, because a
+# proof of a differently-parsed instance verifies just as happily. So a second,
+# proofless lane pins the answer, which is what a misparse changes.
+add_test(NAME hitori-dzn-answer COMMAND $<TARGET_FILE:hitori> --dzn ${CMAKE_CURRENT_SOURCE_DIR}/sample.dzn)
+set_tests_properties(hitori-dzn-answer PROPERTIES PASS_REGULAR_EXPRESSION "obj = 13")

--- a/examples/hitori/hitori.cc
+++ b/examples/hitori/hitori.cc
@@ -8,17 +8,16 @@
 #include <gcs/solve.hh>
 
 #include <examples/benchmark_cli.hh>
+#include <examples/dzn.hh>
 
 #include <algorithm>
-#include <cctype>
 #include <cstddef>
 #include <cstdlib>
-#include <fstream>
+#include <exception>
 #include <iostream>
 #include <memory>
 #include <optional>
 #include <random>
-#include <sstream>
 #include <string>
 #include <utility>
 #include <vector>
@@ -43,7 +42,6 @@ using gcs::innards::TrueLiteral;
 using std::cerr;
 using std::cout;
 using std::endl;
-using std::ifstream;
 using std::make_optional;
 using std::make_shared;
 using std::mt19937;
@@ -53,7 +51,6 @@ using std::pair;
 using std::random_device;
 using std::size_t;
 using std::string;
-using std::stringstream;
 using std::swap;
 using std::uniform_int_distribution;
 using std::vector;
@@ -294,77 +291,41 @@ namespace
     // written in dzn's `[| a, b | c, d |]` form.
     auto read_dzn(const string & path) -> optional<Instance>
     {
-        ifstream in(path);
-        if (! in) {
-            cerr << "Could not open dzn file: " << path << endl;
-            return nullopt;
-        }
+        try {
+            auto data = dzn::read(path);
 
-        stringstream buffer;
-        buffer << in.rdbuf();
-        auto text = buffer.str();
-
-        // Strip MiniZinc line comments so stray '%' text can't confuse the scan.
-        for (size_t i = 0; i < text.size(); ++i)
-            if (text[i] == '%')
-                while (i < text.size() && text[i] != '\n')
-                    text[i++] = ' ';
-
-        // Find `key = `, taking `key` as a whole identifier so that looking for
-        // `n` does not stop at the n of some other parameter's name.
-        auto assignment_to = [&](const string & key) -> size_t {
-            auto is_name_char = [](char ch) { return std::isalnum(static_cast<unsigned char>(ch)) || ch == '_'; };
-            for (auto at = text.find(key); at != string::npos; at = text.find(key, at + 1)) {
-                if (at > 0 && is_name_char(text[at - 1]))
-                    continue;
-                auto after = at + key.size();
-                if (after < text.size() && is_name_char(text[after]))
-                    continue;
-                while (after < text.size() && std::isspace(static_cast<unsigned char>(text[after])))
-                    ++after;
-                if (after < text.size() && text[after] == '=')
-                    return after;
+            auto n = static_cast<int>(data.integer("n"));
+            if (n <= 0) {
+                cerr << "dzn file gives n = " << n << ", which is not a grid size: " << path << endl;
+                return nullopt;
             }
-            return string::npos;
-        };
 
-        // Pull every integer out of the assignment to a named parameter, i.e.
-        // out of the text between `key = ` and the next ';'.
-        auto integers = [&](const string & key) -> vector<int> {
-            vector<int> values;
-            auto at = assignment_to(key);
-            if (at == string::npos)
-                return values;
-            auto end = text.find(';', at);
-            auto body = text.substr(at + 1, end - at - 1);
-            for (char & ch : body)
-                if (! std::isdigit(static_cast<unsigned char>(ch)))
-                    ch = ' ';
-            stringstream tokens(body);
-            int value;
-            while (tokens >> value)
-                values.push_back(value);
-            return values;
-        };
+            // Reading the matrix as a matrix rather than flat is what makes the
+            // shape check below possible: a clue array of the wrong size used
+            // to be taken n * n entries at a time regardless.
+            auto rows = data.matrix("clue");
+            if (static_cast<int>(rows.size()) != n) {
+                cerr << "dzn file gives a clue grid of " << rows.size() << " rows for n = " << n << ": " << path << endl;
+                return nullopt;
+            }
 
-        auto sizes = integers("n");
-        auto values = integers("clue");
-        if (sizes.empty()) {
-            cerr << "dzn file does not give n: " << path << endl;
+            // One width check covers every row, because matrix() has already
+            // refused a literal whose rows are not all the same length.
+            if (static_cast<int>(rows.front().size()) != n) {
+                cerr << "dzn file gives " << rows.front().size() << " clues per row for n = " << n << ": " << path << endl;
+                return nullopt;
+            }
+
+            vector<vector<int>> clue(n, vector<int>(n, 0));
+            for (int r = 0; r < n; ++r)
+                for (int c = 0; c < n; ++c)
+                    clue[r][c] = static_cast<int>(rows[r][c]);
+            return Instance{path, n, clue};
+        }
+        catch (const std::exception & e) {
+            cerr << "Error reading the instance: " << e.what() << endl;
             return nullopt;
         }
-
-        auto n = sizes.front();
-        if (n <= 0 || static_cast<int>(values.size()) < n * n) {
-            cerr << "dzn file has too few clue entries: " << path << endl;
-            return nullopt;
-        }
-
-        vector<vector<int>> clue(n, vector<int>(n, 0));
-        for (int r = 0; r < n; ++r)
-            for (int c = 0; c < n; ++c)
-                clue[r][c] = values[r * n + c];
-        return Instance{path, n, clue};
     }
 
     // The model's implied and symmetry-breaking constraints. Every one of them

--- a/examples/hitori/sample.dzn
+++ b/examples/hitori/sample.dzn
@@ -1,0 +1,15 @@
+% A small hitori instance in the format of the MiniZinc Challenge 2025 data
+% files, for the --dzn reader. Written here rather than taken from the Challenge
+% set, so it is small enough to prove quickly and there is no licence question
+% about redistributing it.
+%
+% This is exactly the grid `--size 4 --seed 0` generates, so the --dzn lane and
+% the built-in generator must reach the same optimum of 13. That is the point of
+% the file: it makes the reader's answer checkable against something other than
+% itself.
+
+n = 4;
+clue = [| 1, 1, 4, 4
+        | 4, 3, 1, 2
+        | 1, 4, 4, 1
+        | 1, 2, 4, 3 |];

--- a/examples/nonogram/CMakeLists.txt
+++ b/examples/nonogram/CMakeLists.txt
@@ -7,3 +7,18 @@ add_test(NAME nonogram-all COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_
 add_test(NAME nonogram-bacchus COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash --basename nonogram-bacchus $<TARGET_FILE:nonogram> --bacchus)
 add_test(NAME nonogram-legacy COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash --basename nonogram-legacy $<TARGET_FILE:nonogram> --legacy)
 add_test(NAME nonogram-heart COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash --basename nonogram-heart $<TARGET_FILE:nonogram> --puzzle heart)
+
+# The .dzn reader, on the built-in `plus` puzzle written in the Challenge 2013
+# padded-cons format, so this lane and `--puzzle plus` must draw the same
+# picture. Nothing else in examples/ runs this reader: before issue #664 moved
+# it onto the shared examples/dzn.hh it was reachable only by hand, with a
+# Challenge data file that is not in the tree.
+add_test(NAME nonogram-dzn COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash --basename nonogram-dzn
+    $<TARGET_FILE:nonogram> --dzn ${CMAKE_CURRENT_SOURCE_DIR}/sample.dzn)
+
+# The proof lane above says the reader produced a model that solves and whose
+# proof checks out; it cannot say the reader read the right numbers, because a
+# proof of a differently-parsed instance verifies just as happily. So a second,
+# proofless lane pins the answer, which is what a misparse changes.
+add_test(NAME nonogram-dzn-answer COMMAND $<TARGET_FILE:nonogram> --dzn ${CMAKE_CURRENT_SOURCE_DIR}/sample.dzn)
+set_tests_properties(nonogram-dzn-answer PROPERTIES PASS_REGULAR_EXPRESSION "#####")

--- a/examples/nonogram/nonogram.cc
+++ b/examples/nonogram/nonogram.cc
@@ -2,15 +2,16 @@
 #include <gcs/problem.hh>
 #include <gcs/solve.hh>
 
-#include <cctype>
+#include <examples/dzn.hh>
+
 #include <cstdlib>
-#include <fstream>
+#include <exception>
 #include <iostream>
 #include <map>
 #include <optional>
 #include <random>
-#include <sstream>
 #include <string>
+#include <tuple>
 #include <utility>
 #include <vector>
 
@@ -31,7 +32,6 @@ using namespace gcs;
 using std::cerr;
 using std::cout;
 using std::endl;
-using std::ifstream;
 using std::make_optional;
 using std::map;
 using std::mt19937;
@@ -39,7 +39,7 @@ using std::nullopt;
 using std::optional;
 using std::random_device;
 using std::string;
-using std::stringstream;
+using std::tuple;
 using std::uniform_int_distribution;
 using std::vector;
 
@@ -257,89 +257,15 @@ namespace
     // resulting cons strings drive `dfa_of_cons` directly.
     auto read_dzn(const string & path) -> optional<Puzzle>
     {
-        ifstream in(path);
-        if (! in) {
-            cerr << "Could not open dzn file: " << path << endl;
-            return nullopt;
-        }
-
-        stringstream buffer;
-        buffer << in.rdbuf();
-        auto text = buffer.str();
-
-        // Strip MiniZinc line comments so stray '%' text can't confuse the scan.
-        for (size_t i = 0; i < text.size(); ++i)
-            if (text[i] == '%')
-                while (i < text.size() && text[i] != '\n')
-                    text[i++] = ' ';
-
-        auto scalar = [&](const string & key) -> optional<int> {
-            auto at = text.find(key);
-            if (at == string::npos)
-                return nullopt;
-            at = text.find('=', at);
-            if (at == string::npos)
-                return nullopt;
-            auto end = text.find(';', at);
-            return std::stoi(text.substr(at + 1, end - at - 1));
-        };
-
-        // Pull every integer (including negatives) out of the assignment for a
-        // named array, i.e. the text between `key` and the next ';'.
-        auto integers = [&](const string & key) -> vector<int> {
-            vector<int> values;
-            auto at = text.find(key);
-            if (at == string::npos)
-                return values;
-            at = text.find('=', at);
-            auto end = text.find(';', at);
-            auto body = text.substr(at + 1, end - at - 1);
-            stringstream tokens(body);
-            string token;
-            auto is_int = [](const string & s) {
-                if (s.empty())
-                    return false;
-                size_t k = (s[0] == '-' || s[0] == '+') ? 1 : 0;
-                if (k == s.size())
-                    return false;
-                for (; k < s.size(); ++k)
-                    if (! std::isdigit(static_cast<unsigned char>(s[k])))
-                        return false;
-                return true;
-            };
-            // Split on the bracketing/separator characters MiniZinc matrices use.
-            for (char & c : body)
-                if (c == '[' || c == ']' || c == '|' || c == ',')
-                    c = ' ';
-            stringstream clean(body);
-            while (clean >> token)
-                if (is_int(token))
-                    values.push_back(std::stoi(token));
-            return values;
-        };
-
-        auto x = scalar("X"), y = scalar("Y"), maxlen = scalar("maxlen");
-        if (! x || ! y || ! maxlen) {
-            cerr << "dzn file missing X, Y or maxlen: " << path << endl;
-            return nullopt;
-        }
-
-        auto rows = integers("rows"), cols = integers("cols");
-        if (static_cast<int>(rows.size()) < *y * *maxlen || static_cast<int>(cols.size()) < *x * *maxlen) {
-            cerr << "dzn file has too few clue entries: " << path << endl;
-            return nullopt;
-        }
-
         // The .dzn already stores cons strings, but built-in puzzles carry run
         // lengths; keep the Puzzle uniform by recovering run lengths from each
         // cons string (a maximal run of 1s), which cons_of_clue re-expands.
-        auto clues_of = [&](const vector<int> & flat, int count, int stride) {
+        auto clues_of = [](const vector<vector<long long>> & lines) {
             vector<vector<int>> clues;
-            for (int i = 0; i < count; ++i) {
+            for (const auto & line : lines) {
                 vector<int> clue;
                 int run = 0;
-                for (int j = 0; j < stride; ++j) {
-                    auto v = flat[i * stride + j];
+                for (auto v : line) {
                     if (v < 0)
                         continue; // padding sentinel
                     if (v == 1) {
@@ -358,8 +284,33 @@ namespace
             return clues;
         };
 
-        Puzzle puzzle{path, clues_of(rows, *y, *maxlen), clues_of(cols, *x, *maxlen)};
-        return puzzle;
+        try {
+            auto data = dzn::read(path);
+            auto x = static_cast<int>(data.integer("X")), y = static_cast<int>(data.integer("Y"));
+            auto maxlen = static_cast<int>(data.integer("maxlen"));
+
+            // Reading the two clue arrays as matrices rather than flat is what
+            // makes these checks possible: a file whose arrays disagreed with X,
+            // Y and maxlen used to be chopped into *maxlen-wide lines anyway, so
+            // long as there were enough entries to go round.
+            auto rows = data.matrix("rows"), cols = data.matrix("cols");
+            for (const auto & [what, lines, count] : {tuple{"rows", &rows, y}, tuple{"cols", &cols, x}}) {
+                if (static_cast<int>(lines->size()) != count) {
+                    println(cerr, "dzn file gives {} lines of {}, expected {}: {}", lines->size(), what, count, path);
+                    return nullopt;
+                }
+                if (! lines->empty() && static_cast<int>(lines->front().size()) != maxlen) {
+                    println(cerr, "dzn file gives {} of width {}, not maxlen = {}: {}", what, lines->front().size(), maxlen, path);
+                    return nullopt;
+                }
+            }
+
+            return Puzzle{path, clues_of(rows), clues_of(cols)};
+        }
+        catch (const std::exception & e) {
+            println(cerr, "Error reading the instance: {}", e.what());
+            return nullopt;
+        }
     }
 
     auto solve_puzzle(const Puzzle & puzzle, bool all_solutions, bool legacy, bool bacchus, bool short_reasons, bool print_grid,

--- a/examples/nonogram/sample.dzn
+++ b/examples/nonogram/sample.dzn
@@ -1,0 +1,30 @@
+% A small nonogram in the format of the MiniZinc Challenge 2013 data files
+% (2013/nonogram/non.mzn), for the --dzn reader. Written here rather than taken
+% from the Challenge set, so it is small enough to prove quickly and there is no
+% licence question about redistributing it.
+%
+% Those files do not store run lengths: each line is already the "cons" string
+% the model's automaton runs over -- a 1 per filled cell of a run, a single 0
+% between runs -- right-padded to maxlen with -1. So a clue of [1] is
+% `1, -1, -1, -1, -1` and a clue of [5] is `1, 1, 1, 1, 1`, and reading the
+% padding as clue data is what a reader that ignored the sentinels would do.
+%
+% This is the built-in `plus` puzzle, so the --dzn lane and `--puzzle plus` must
+% draw the same picture. That is the point of the file: it makes the reader's
+% answer checkable against something other than itself.
+
+X = 5;
+Y = 5;
+maxlen = 5;
+
+rows = [| 1, -1, -1, -1, -1
+        | 1, -1, -1, -1, -1
+        | 1,  1,  1,  1,  1
+        | 1, -1, -1, -1, -1
+        | 1, -1, -1, -1, -1 |];
+
+cols = [| 1, -1, -1, -1, -1
+        | 1, -1, -1, -1, -1
+        | 1,  1,  1,  1,  1
+        | 1, -1, -1, -1, -1
+        | 1, -1, -1, -1, -1 |];

--- a/examples/seat_moving/CMakeLists.txt
+++ b/examples/seat_moving/CMakeLists.txt
@@ -9,3 +9,19 @@ add_test(NAME seat_moving COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_v
 add_test(NAME seat_moving-not-equals COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash --basename seat_moving-not-equals $<TARGET_FILE:seat_moving> --all-different not-equals)
 add_test(NAME seat_moving-vc COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash --basename seat_moving-vc $<TARGET_FILE:seat_moving> --all-different vc)
 add_test(NAME seat_moving-random COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash --basename seat_moving-random $<TARGET_FILE:seat_moving> --seats 7 --people 4 --seed 1)
+
+# The .dzn reader, on the built-in `small` instance written out as data, so this
+# lane and `--instance small` must reach the same answer. It is also the only
+# lane anywhere that reads a Boolean array, which is what Can_swap is. Nothing
+# else in examples/ runs this reader: before issue #664 moved it onto the shared
+# examples/dzn.hh it was reachable only by hand, with a Challenge data file that
+# is not in the tree.
+add_test(NAME seat_moving-dzn COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash --basename seat_moving-dzn
+    $<TARGET_FILE:seat_moving> --dzn ${CMAKE_CURRENT_SOURCE_DIR}/sample.dzn)
+
+# The proof lane above says the reader produced a model that solves and whose
+# proof checks out; it cannot say the reader read the right numbers, because a
+# proof of a differently-parsed instance verifies just as happily. So a second,
+# proofless lane pins the answer, which is what a misparse changes.
+add_test(NAME seat_moving-dzn-answer COMMAND $<TARGET_FILE:seat_moving> --dzn ${CMAKE_CURRENT_SOURCE_DIR}/sample.dzn)
+set_tests_properties(seat_moving-dzn-answer PROPERTIES PASS_REGULAR_EXPRESSION "objective = 40")

--- a/examples/seat_moving/sample.dzn
+++ b/examples/seat_moving/sample.dzn
@@ -1,0 +1,16 @@
+% A small seat-moving instance in the format of the MiniZinc Challenge 2018 data
+% files, for the --dzn reader. Written here rather than taken from the Challenge
+% set, so it is small enough to prove quickly and there is no licence question
+% about redistributing it.
+%
+% This is the built-in `small` instance, so the --dzn lane and `--instance small`
+% must reach the same answer. That is the point of the file: it makes the
+% reader's answer checkable against something other than itself. It is also the
+% only data file in examples/ with a Boolean array in it, which is what
+% Can_swap is and what dzn.hh's bools() is for.
+
+S = 5;
+P = 3;
+Start = [1, 0, 2, 0, 3];
+Goal = [3, 2, 0, 1, 0];
+Can_swap = [true, false, true];

--- a/examples/seat_moving/seat_moving.cc
+++ b/examples/seat_moving/seat_moving.cc
@@ -10,15 +10,13 @@
 #include <gcs/solve.hh>
 
 #include <algorithm>
-#include <cctype>
 #include <cstdlib>
-#include <fstream>
+#include <exception>
 #include <iostream>
 #include <map>
 #include <numeric>
 #include <optional>
 #include <random>
-#include <sstream>
 #include <string>
 #include <utility>
 #include <vector>
@@ -26,6 +24,7 @@
 #include <cxxopts.hpp>
 
 #include <examples/benchmark_cli.hh>
+#include <examples/dzn.hh>
 
 #include <version>
 
@@ -42,7 +41,6 @@ using namespace gcs;
 using std::cerr;
 using std::cout;
 using std::endl;
-using std::ifstream;
 using std::make_optional;
 using std::map;
 using std::mt19937;
@@ -50,7 +48,6 @@ using std::nullopt;
 using std::optional;
 using std::pair;
 using std::string;
-using std::stringstream;
 using std::vector;
 using std::ranges::shuffle;
 
@@ -210,118 +207,31 @@ namespace
     }
 
     // Read a MiniZinc Challenge 2018 seat-moving data file, which assigns S, P,
-    // Start, Goal and Can_swap. Deliberately forgiving about layout, like the
-    // nonogram example's reader.
+    // Start, Goal and Can_swap. Everything the file says about sizes is checked
+    // by validate(), not here, so a short Start is a complaint about the
+    // instance rather than about the file.
     [[nodiscard]] auto read_dzn(const string & path) -> optional<Instance>
     {
-        ifstream in(path);
-        if (! in) {
-            println(cerr, "Could not open dzn file: {}", path);
+        try {
+            auto data = dzn::read(path);
+
+            Instance instance{path, 0, 0, {}, {}, {}};
+            instance.seats = static_cast<int>(data.integer("S"));
+            instance.people = static_cast<int>(data.integer("P"));
+
+            for (const auto & [name, into] : {pair{"Start", &instance.start}, pair{"Goal", &instance.goal}})
+                for (auto seat : data.integers(name))
+                    into->push_back(static_cast<int>(seat));
+
+            for (auto swaps : data.bools("Can_swap"))
+                instance.can_swap.push_back(swaps ? 1 : 0);
+
+            return instance;
+        }
+        catch (const std::exception & e) {
+            println(cerr, "Error reading the instance: {}", e.what());
             return nullopt;
         }
-
-        stringstream buffer;
-        buffer << in.rdbuf();
-        auto text = buffer.str();
-
-        // Blank out MiniZinc line comments so stray text cannot confuse the scan.
-        for (size_t i = 0; i < text.size(); ++i)
-            if (text[i] == '%')
-                while (i < text.size() && text[i] != '\n')
-                    text[i++] = ' ';
-
-        auto is_ident_char = [](char c) { return std::isalnum(static_cast<unsigned char>(c)) || c == '_'; };
-
-        // The text between `name =` and the next ';', for `name` appearing as a
-        // whole identifier (so looking for "S" does not match "Start").
-        auto body_of = [&](const string & name) -> optional<string> {
-            for (auto at = text.find(name); at != string::npos; at = text.find(name, at + 1)) {
-                if (at > 0 && is_ident_char(text[at - 1]))
-                    continue;
-                auto after = at + name.size();
-                if (after < text.size() && is_ident_char(text[after]))
-                    continue;
-                auto eq = text.find_first_not_of(" \t\r\n", after);
-                if (eq == string::npos || text[eq] != '=')
-                    continue;
-                auto end = text.find(';', eq);
-                return text.substr(eq + 1, end == string::npos ? string::npos : end - eq - 1);
-            }
-            return nullopt;
-        };
-
-        // Split a body on MiniZinc's array punctuation and hand back the tokens.
-        auto tokens_of = [](string body) -> vector<string> {
-            for (auto & c : body)
-                if (c == '[' || c == ']' || c == '|' || c == ',')
-                    c = ' ';
-            vector<string> tokens;
-            stringstream stream(body);
-            string token;
-            while (stream >> token)
-                tokens.push_back(token);
-            return tokens;
-        };
-
-        Instance instance{path, 0, 0, {}, {}, {}};
-
-        auto scalar = [&](const string & name) -> optional<int> {
-            auto body = body_of(name);
-            if (! body)
-                return nullopt;
-            auto tokens = tokens_of(*body);
-            if (1 != tokens.size())
-                return nullopt;
-            try {
-                return std::stoi(tokens[0]);
-            }
-            catch (const std::exception &) {
-                return nullopt;
-            }
-        };
-
-        auto seats = scalar("S"), people = scalar("P");
-        if (! seats || ! people) {
-            println(cerr, "dzn file is missing S or P: {}", path);
-            return nullopt;
-        }
-        instance.seats = *seats;
-        instance.people = *people;
-
-        for (const auto & [name, into] : {pair{"Start", &instance.start}, pair{"Goal", &instance.goal}}) {
-            auto body = body_of(name);
-            if (! body) {
-                println(cerr, "dzn file is missing {}: {}", name, path);
-                return nullopt;
-            }
-            for (const auto & token : tokens_of(*body)) {
-                try {
-                    into->push_back(std::stoi(token));
-                }
-                catch (const std::exception &) {
-                    println(cerr, "could not read '{}' as an integer in {}: {}", token, name, path);
-                    return nullopt;
-                }
-            }
-        }
-
-        auto can_swap = body_of("Can_swap");
-        if (! can_swap) {
-            println(cerr, "dzn file is missing Can_swap: {}", path);
-            return nullopt;
-        }
-        for (const auto & token : tokens_of(*can_swap)) {
-            if (token == "true" || token == "1")
-                instance.can_swap.push_back(1);
-            else if (token == "false" || token == "0")
-                instance.can_swap.push_back(0);
-            else {
-                println(cerr, "could not read '{}' as a bool in Can_swap: {}", token, path);
-                return nullopt;
-            }
-        }
-
-        return instance;
     }
 
     // A random instance: seat the people in a random subset of the seats, twice

--- a/examples/table_layout/CMakeLists.txt
+++ b/examples/table_layout/CMakeLists.txt
@@ -7,3 +7,19 @@ target_link_libraries(table_layout PRIVATE cxxopts)
 add_test(NAME table_layout-table COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash --basename table_layout-table $<TARGET_FILE:table_layout> --variant table)
 add_test(NAME table_layout-auto-table COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash --basename table_layout-auto-table $<TARGET_FILE:table_layout> --variant auto-table)
 add_test(NAME table_layout-element COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash --basename table_layout-element $<TARGET_FILE:table_layout> --variant element)
+
+# The .dzn reader, on a hand-written instance carrying both the things a
+# generated one does not: the array3d(...) wrapper the Challenge data uses, and
+# cells with fewer configurations than maxconfig, so the negative padding is
+# there to be mistaken for a configuration. Nothing else in examples/ runs this
+# reader: before issue #664 moved it onto the shared examples/dzn.hh it was
+# reachable only by hand, with a Challenge data file that is not in the tree.
+add_test(NAME table_layout-dzn COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash --basename table_layout-dzn
+    $<TARGET_FILE:table_layout> --dzn ${CMAKE_CURRENT_SOURCE_DIR}/sample.dzn)
+
+# The proof lane above says the reader produced a model that solves and whose
+# proof checks out; it cannot say the reader read the right numbers, because a
+# proof of a differently-parsed instance verifies just as happily. So a second,
+# proofless lane pins the answer, which is what a misparse changes.
+add_test(NAME table_layout-dzn-answer COMMAND $<TARGET_FILE:table_layout> --dzn ${CMAKE_CURRENT_SOURCE_DIR}/sample.dzn)
+set_tests_properties(table_layout-dzn-answer PROPERTIES PASS_REGULAR_EXPRESSION "totalheight: 7")

--- a/examples/table_layout/sample.dzn
+++ b/examples/table_layout/sample.dzn
@@ -1,0 +1,31 @@
+% A small table-layout instance in the format of the MiniZinc Challenge
+% TableLayout.mzn data files, for the --dzn reader. Written here rather than
+% taken from the Challenge set, so it is small enough to prove quickly and there
+% is no licence question about redistributing it.
+%
+% Two things it exercises that a generated instance does not. The arrays come
+% through the `array3d(ROWS, COLS, CONFIGS, [...])` wrapper the Challenge data
+% uses, whose index-set arguments are not entries; and cells (1,2), (2,1) and
+% (2,2) have fewer than maxconfig configurations, so their surplus entries are
+% the negative padding, and reading that padding as a configuration is what a
+% reader that did not know about the convention would do.
+%
+% Cell (r,c) configuration l is (width[r,c,l], height[r,c,l]):
+%
+%   (1,1)  (10,1) (5,2) (2,4)      (1,2)  (8,1) (4,3)
+%   (2,1)  (6,2)  (3,5)            (2,2)  (9,1)
+%
+% Column 2 is 9 wide whatever happens, because (2,2) has only the one
+% configuration, so the pixelwidth budget of 14 leaves column 1 at most 5. That
+% rules out (1,1)'s 10-wide configuration and (2,1)'s 6-wide one, which forces
+% (2,1) to (3,5) and makes row 2 five high; row 1 is then 2, from (1,1) at (5,2)
+% and (1,2) at (8,1). The optimum is a total height of 7. The budget is what
+% makes that interesting: raise pixelwidth and the answer is 3.
+
+pixelwidth = 14;
+maxconfig = 3;
+rows = 2;
+cols = 2;
+
+width = array3d(ROWS, COLS, CONFIGS, [10, 5, 2, 8, 4, -1, 6, 3, -1, 9, -1, -1]);
+height = array3d(ROWS, COLS, CONFIGS, [1, 2, 4, 1, 3, -1, 2, 5, -1, 1, -1, -1]);

--- a/examples/table_layout/table_layout_instance.hh
+++ b/examples/table_layout/table_layout_instance.hh
@@ -16,15 +16,17 @@
 // explicitly, in legal_configurations() below, which is the single place that
 // knows about it.
 
+#include <examples/dzn.hh>
+
 #include <gcs/integer.hh>
 
 #include <algorithm>
+#include <cstddef>
 #include <cstdint>
-#include <fstream>
 #include <random>
-#include <sstream>
 #include <stdexcept>
 #include <string>
+#include <tuple>
 #include <vector>
 
 namespace table_layout
@@ -141,86 +143,25 @@ namespace table_layout
         return inst;
     }
 
-    namespace detail
-    {
-        /// Everything between the first '[' and the last ']' of a .dzn
-        /// right-hand side, split on commas. Handles both a bare array literal
-        /// and the array3d(ROWS, COLS, CONFIGS, [...]) wrapper the Challenge
-        /// data uses, because the index-set arguments contain no brackets.
-        [[nodiscard]] inline auto parse_int_array(const std::string & rhs) -> std::vector<long>
-        {
-            auto open = rhs.find('[');
-            auto close = rhs.rfind(']');
-            if (open == std::string::npos || close == std::string::npos || close < open)
-                throw std::runtime_error{"expected an array literal in .dzn value '" + rhs + "'"};
-
-            std::vector<long> result;
-            std::stringstream body{rhs.substr(open + 1, close - open - 1)};
-            std::string item;
-            while (std::getline(body, item, ',')) {
-                auto first = item.find_first_not_of(" \t\r\n");
-                if (first == std::string::npos)
-                    continue;
-                result.push_back(std::stol(item.substr(first)));
-            }
-            return result;
-        }
-    }
-
     /// Read a TableLayout.mzn .dzn data file: the scalars pixelwidth, maxconfig,
     /// rows and cols, and the width and height arrays in row-major
-    /// (ROWS, COLS, CONFIGS) order. Percent comments are stripped; everything
-    /// else is parsed as `name = value;` statements, and any statement whose
-    /// name is not one of the six the model needs is ignored.
+    /// (ROWS, COLS, CONFIGS) order. The Challenge data writes the two arrays
+    /// through an `array3d(ROWS, COLS, CONFIGS, [...])` wrapper, which the
+    /// reader drops: the shape is given by the scalars, so it is checked
+    /// against them below rather than taken from the literal.
     [[nodiscard]] inline auto read_dzn(const std::string & path) -> Instance
     {
-        std::ifstream infile{path};
-        if (! infile)
-            throw std::runtime_error{"cannot read '" + path + "'"};
-
-        std::string text, line;
-        while (std::getline(infile, line)) {
-            auto comment = line.find('%');
-            text += (comment == std::string::npos ? line : line.substr(0, comment));
-            text += '\n';
-        }
+        auto data = dzn::read(path);
 
         Instance inst;
-        std::vector<long> flat_width, flat_height;
-        std::size_t pos = 0;
-        while (true) {
-            auto end = text.find(';', pos);
-            if (end == std::string::npos)
-                break;
-            auto statement = text.substr(pos, end - pos);
-            pos = end + 1;
-
-            auto eq = statement.find('=');
-            if (eq == std::string::npos)
-                continue;
-            auto name_first = statement.find_first_not_of(" \t\r\n");
-            auto name_last = statement.find_last_not_of(" \t\r\n", eq - 1);
-            if (name_first == std::string::npos || name_last == std::string::npos || name_last < name_first)
-                continue;
-            auto name = statement.substr(name_first, name_last - name_first + 1);
-            auto value = statement.substr(eq + 1);
-
-            if (name == "pixelwidth")
-                inst.pixelwidth = std::stol(value);
-            else if (name == "maxconfig")
-                inst.maxconfig = std::stoi(value);
-            else if (name == "rows")
-                inst.rows = std::stoi(value);
-            else if (name == "cols")
-                inst.cols = std::stoi(value);
-            else if (name == "width")
-                flat_width = detail::parse_int_array(value);
-            else if (name == "height")
-                flat_height = detail::parse_int_array(value);
-        }
+        inst.pixelwidth = static_cast<long>(data.integer("pixelwidth"));
+        inst.maxconfig = static_cast<int>(data.integer("maxconfig"));
+        inst.rows = static_cast<int>(data.integer("rows"));
+        inst.cols = static_cast<int>(data.integer("cols"));
+        auto flat_width = data.integers("width"), flat_height = data.integers("height");
 
         if (inst.rows < 1 || inst.cols < 1 || inst.maxconfig < 1)
-            throw std::runtime_error{"'" + path + "' does not define positive rows, cols and maxconfig"};
+            throw std::runtime_error{"'" + path + "' does not give positive rows, cols and maxconfig"};
         auto expected = static_cast<std::size_t>(inst.rows) * inst.cols * inst.maxconfig;
         if (flat_width.size() != expected || flat_height.size() != expected)
             throw std::runtime_error{"'" + path + "' has width/height arrays of size " + std::to_string(flat_width.size()) + "/" +
@@ -232,8 +173,8 @@ namespace table_layout
         for (int r = 0; r < inst.rows; ++r)
             for (int c = 0; c < inst.cols; ++c)
                 for (int l = 0; l < inst.maxconfig; ++l, ++at) {
-                    inst.width[r][c][l] = flat_width[at];
-                    inst.height[r][c][l] = flat_height[at];
+                    inst.width[r][c][l] = static_cast<long>(flat_width[at]);
+                    inst.height[r][c][l] = static_cast<long>(flat_height[at]);
                 }
 
         inst.description = "dzn " + path + " rows=" + std::to_string(inst.rows) + " cols=" + std::to_string(inst.cols) +


### PR DESCRIPTION
Closes #664.

`examples/dzn.hh` landed with #548 and was used for RCPSP only; this is the
follow-up that moves the other four readers onto it. `table_layout`,
`seat_moving`, `nonogram` and `hitori` each carried their own, and between them
they reimplemented the same three things — strip `%` comments, split into
`name = value;` statements, pull an integer array out of a right-hand side —
with the comment stripper byte-identical in three of the four. That duplication
is gone, and `examples/dzn.hh` is now the only dzn reader in `examples/`.

Net **239 lines lighter** across the four examples (97 in, 336 out); +59 in the
shared header for the two features the migration needed. Each example keeps its
own `Instance`-building code and its own size checks; only the lexing moved.

## What the shared header gained

Two things, both because an example needs them, and nothing else:

- **`bools()`** — `seat_moving`'s `Can_swap` is an array of Booleans and nothing
  else in `examples/` has ever needed one. `1`/`0` are taken as well as
  `true`/`false`, because seat_moving's own reader took both and a migration
  that quietly stopped reading a file it used to read is a worse bargain than a
  reader one step more generous than the language.
- **An unterminated last statement.** The Challenge's `2025/hitori/h20-2.dzn`
  ends its `clue` matrix at the end of the file with no semicolon, and MiniZinc
  reads it happily. Requiring the semicolon dropped the statement silently and
  then reported "does not define 'clue'" — true of the map it had built, and
  nonsense about the file. hitori's own reader took everything up to the next
  `;` or the end of the text, so this was one of the divergences #664 is about,
  hiding in the reader that was meant to settle them.

`array3d(...)`, the 2-D `[| … |]` literal, set literals and the
report-the-statement diagnostics were already in the header; what changes is
that all five examples now get them, rather than one each.

## Behaviour preserved: the evidence

Nothing in the tree ran these four readers before this PR, so the check was run
against the Challenge data. A dump of the parsed instance was patched into each
example's `main`, binaries were built either side of the change, and the outputs
were diffed. **All 50 Challenge instances the four can be pointed at parse
byte-identically:**

| example | instances | result |
|---|---|---|
| `hitori` | 2025/hitori, 5 files (`h5-1`, `h11-1`, `h14-1`, `h15-1`, `h20-2`) | 5/5 identical |
| `nonogram` | 2009 (10), 2011 (5), 2012 (5), 2013 (5) nonogram | 25/25 identical |
| `seat_moving` | 2018 (5) and 2021 (5) seat-moving | 10/10 identical |
| `table_layout` | 2011 (5) and 2023 (5) table-layout | 10/10 identical |

The dumps compared everything the reader produces: hitori's `n` and clue grid,
nonogram's row and column clue lists, seat_moving's `S`, `P`, `Start`, `Goal`
and `Can_swap`, and table_layout's scalars, full `width`/`height` arrays and
derived extents. The instrumentation is not in the branch.

Also cross-checked: `hitori --dzn sample.dzn` matches `--size 4 --seed 0`,
`nonogram --dzn sample.dzn` matches `--puzzle plus`, and `seat_moving --dzn
sample.dzn` matches `--instance small`, output for output.

## Intended behaviour changes

Three, all on input the old readers got wrong or reported badly. Each example
was also run on a deliberately malformed file and an empty file; those 12 runs
are the only differences anywhere in the sweep.

1. **`table_layout` reads a 2-D literal instead of mis-parsing it.** Its reader
   split on commas alone, so `2 | 3` spanning a row boundary was one item;
   `std::stol` read the 2 out of it and discarded the 3, with no complaint. It
   now reads flat and correctly, like the others.
2. **`hitori` and `nonogram` read their clue arrays as matrices, not flat.** An
   array that disagrees with the size scalars is now a complaint, rather than
   being chopped into rows of the declared width regardless of what the file
   actually contained.
3. **A malformed file names the statement it went wrong on.** `table_layout`
   used to answer one with `Error building instance: stoi` — `std::stol`'s own
   exception, which tells someone holding a thousand-line data file nothing.
   It now says
   `'…/bad.dzn': rows is not an integer: '[| 1, x | 0, 1 |]'`. All four examples
   report through one style: `Error reading the instance: <what dzn.hh said>`.

## Tests

Nothing in the tree ran these four readers — every registered lane went through
a built-in instance or the generator, and `--dzn` was reachable only by hand
with a Challenge file that is not in the repository. That is how they came to
diverge with the suite green throughout. So each example gets a small
hand-written `sample.dzn` (following `examples/rcpsp/sample.dzn`) and two lanes:

- a `run_test_and_verify.bash` proof lane, and
- a proofless answer lane pinned with `PASS_REGULAR_EXPRESSION`, because the
  proof lane cannot say the reader read the *right* numbers — a proof of a
  differently-parsed instance verifies just as happily.

All four answer lanes were checked by corrupting the data file — a clue, a cons
string, the `Can_swap` array, the `pixelwidth` budget — and confirming the
answer lane fails while the proof lane does not, which is the point of having
both.

`examples/dzn_test.cc` gains the `array3d(...)` wrapper, Booleans (words and
digits), an unterminated final statement, a flat array read as a matrix, a name
defined twice, and — for every rejection case, old and new — a check that the
message *names* the statement, which a throw/no-throw test cannot see.

## Prior art

Three commits on the unmerged, never-PR'd branch `cumulative-30-dzn-migration`
did most of this before the #541 cumulative stack was cut down. They rebase onto
current `main` unchanged, so they are reused rather than rewritten: reproducing
them worse would have been the only alternative. Reviewed and changed on top:
the four examples now share one diagnostic prefix rather than each repeating the
path the header had already printed; hitori's per-row width check was one
`matrix()` already guarantees, so it is now a single check that can actually
fire; two diagnostics were reworded; and `dzn_test.cc` grew the coverage above.
The "net 191 lines" figure in the original commit message was wrong and is now
the measured 239.

## Checks

- GCC 15 release build clean; `ctest --parallel 32` **643/643 green**.
- clang 21 release build clean; `ctest --parallel 32` 647/647 green there too.
- `clang-format` 21 clean on everything touched; nothing renamed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FiXjJTM4G1dMjbr45wGb12
