### PR TITLE
A diagnostic channel for solver decisions, instead of proof comments

### DIFF
--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -34,6 +34,7 @@ add_library(glasgow_constraint_solver
         constraints/count/count.cc
         constraints/cumulative/cumulative.cc
         constraints/cumulative/derived_cumulative.cc
+        constraints/cumulative/derived_cumulative_stats.cc
         constraints/cumulative/donor_view.cc
         constraints/difference/difference_constraints.cc
         constraints/difference/difference_graph.cc

--- a/gcs/constraints/cumulative/derived_cumulative.cc
+++ b/gcs/constraints/cumulative/derived_cumulative.cc
@@ -210,8 +210,6 @@ auto gcs::innards::install_derived_cumulative(
     // still the option of not installing a propagator whose inferences could
     // not be justified.
     if (logger) {
-        logger->emit_proof_comment(
-            "derived cumulative: " + to_string(rows_by_time.size()) + " capacity rows over " + to_string(spec.row_donors.size()) + " donors");
         for (const auto & [t, rows] : rows_by_time) {
             auto derived = spec.recipe(*logger, rows, t);
             if (! derived) {
@@ -286,7 +284,8 @@ auto gcs::innards::install_derived_cumulative(
 
         propagators.install_initialiser(
             [inputs, energy_tasks, energy_presences, makespan = *spec.makespan, capacity = spec.capacity, mutation = spec.makespan_mutation,
-                reached = spec.makespan_bound_reached](const State & state, auto & inference, ProofLogger * const logger) -> void {
+                reached = spec.makespan_bound_reached,
+                derived_stats = spec.stats](const State & state, auto & inference, ProofLogger * const logger) -> void {
                 // An optional task's length x height is guaranteed work only
                 // once it is known present, and at the root it usually is not.
                 // Counting one that is undecided would claim energy the
@@ -335,6 +334,9 @@ auto gcs::innards::install_derived_cumulative(
                 if (reached)
                     reached(bound->bound);
 
+                if (derived_stats)
+                    ++derived_stats->makespan_bounds_posted;
+
                 // Tests only: claiming one more than the argument reaches must
                 // be refused, since a derivation with slack in it verifies
                 // whatever it concludes.
@@ -378,6 +380,16 @@ auto gcs::innards::install_derived_cumulative(
             return propagate_cumulative(*inputs, state, inference, logger);
         },
         triggers);
+
+    // Only here, on the success path: every decline above returns without
+    // installing anything, and a block saying a constraint was derived when it
+    // was not is worse than one saying nothing. The caller's aggregate, not a
+    // component of this constraint's own --- see DerivedCumulativeSpec::stats.
+    if (spec.stats) {
+        ++spec.stats->constraints;
+        spec.stats->donors += spec.row_donors.size();
+        spec.stats->capacity_rows += inputs->capacity_lines.size();
+    }
 
     return true;
 }

--- a/gcs/constraints/cumulative/derived_cumulative.hh
+++ b/gcs/constraints/cumulative/derived_cumulative.hh
@@ -3,6 +3,7 @@
 
 #include <gcs/constraint_id.hh>
 #include <gcs/constraints/cumulative/cumulative.hh>
+#include <gcs/constraints/cumulative/derived_cumulative_stats.hh>
 #include <gcs/constraints/innards/makespan_energy.hh>
 #include <gcs/innards/proofs/proof_line.hh>
 #include <gcs/innards/proofs/proof_logger-fwd.hh>
@@ -14,6 +15,7 @@
 #include <cstddef>
 #include <functional>
 #include <map>
+#include <memory>
 #include <optional>
 #include <vector>
 
@@ -199,6 +201,19 @@ namespace gcs::innards
         /// all of them: it gets the same time-tabling and overload checking a
         /// posted Cumulative does, over the donors' flags.
         CumulativeRules rules;
+
+        /**
+         * \brief Where to add what this install came to, if the caller keeps a
+         * block.
+         *
+         * An out-param rather than a component of its own: the caller installs
+         * one of these per donor and reports one aggregate, so the natural
+         * owner is a DerivedCumulativeStats sitting inside the caller's own
+         * block. A shared_ptr rather than a raw one because
+         * makespan_bounds_posted is bumped from an initialiser, which runs
+         * after this call has returned.
+         */
+        std::shared_ptr<DerivedCumulativeStats> stats = nullptr;
     };
 
     /**

--- a/gcs/constraints/cumulative/derived_cumulative_stats.cc
+++ b/gcs/constraints/cumulative/derived_cumulative_stats.cc
@@ -1,0 +1,14 @@
+#include <gcs/constraints/cumulative/derived_cumulative_stats.hh>
+
+using namespace gcs;
+
+using std::string;
+using std::vector;
+
+auto DerivedCumulativeStats::add_entries_to(vector<StatsEntry> & entries, const string & prefix) const -> void
+{
+    entries.push_back(StatsEntry{prefix + "constraints", static_cast<long long>(constraints)});
+    entries.push_back(StatsEntry{prefix + "donors", static_cast<long long>(donors)});
+    entries.push_back(StatsEntry{prefix + "capacity_rows", static_cast<long long>(capacity_rows)});
+    entries.push_back(StatsEntry{prefix + "makespan_bounds_posted", static_cast<long long>(makespan_bounds_posted)});
+}

--- a/gcs/constraints/cumulative/derived_cumulative_stats.hh
+++ b/gcs/constraints/cumulative/derived_cumulative_stats.hh
@@ -1,0 +1,57 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_CUMULATIVE_DERIVED_CUMULATIVE_STATS_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_CUMULATIVE_DERIVED_CUMULATIVE_STATS_HH
+
+#include <gcs/stats.hh>
+
+#include <cstddef>
+#include <string>
+#include <vector>
+
+namespace gcs
+{
+    /**
+     * \brief What install_derived_cumulative() did, summed over every derived
+     * Cumulative a caller installed.
+     *
+     * Not a ComponentStats of its own, and deliberately: a derived Cumulative
+     * is installed once per donor, so one component entry per derived
+     * constraint would be noise where one aggregate is what a reader wants. A
+     * caller keeps one of these inside its own block --- see
+     * CumulativeStrengtheningStats::derived --- and hands
+     * DerivedCumulativeSpec::stats a share of it, so every install adds to the
+     * same figures.
+     *
+     * \ingroup Innards
+     */
+    struct DerivedCumulativeStats final
+    {
+        /// Derived constraints installed: one per successful call.
+        std::size_t constraints = 0;
+
+        /// Donors those constraints took their capacity rows from, summed. A
+        /// derived constraint over several resources names more than one.
+        std::size_t donors = 0;
+
+        /// Per-time capacity rows derived, summed. Zero with proofs off, there
+        /// being no rows to derive: it is a measure of what the certificate
+        /// cost, not of what the constraint says.
+        std::size_t capacity_rows = 0;
+
+        /// Makespan lower bounds actually pushed. Only a spec that asked for a
+        /// makespan can contribute, and only where the energy argument reached
+        /// a bound at all, so this is the count that says the argument fired
+        /// rather than that it was asked for.
+        std::size_t makespan_bounds_posted = 0;
+
+        /**
+         * \brief Append these figures to a flat view, under `prefix`.
+         *
+         * For the enclosing block's ComponentStats::entries(), which is where
+         * these reach a caller: they are part of that block's flat view rather
+         * than a view of their own.
+         */
+        auto add_entries_to(std::vector<StatsEntry> & entries, const std::string & prefix) const -> void;
+    };
+}
+
+#endif

--- a/gcs/innards/conflict_observer_test.cc
+++ b/gcs/innards/conflict_observer_test.cc
@@ -64,7 +64,9 @@ TEST_CASE("Conflict observer attributes a wipeout to the failing constraint, not
     auto x = state.allocate_integer_variable_with_state(0_i, 1_i);
     auto y = state.allocate_integer_variable_with_state(0_i, 1_i);
 
-    Propagators propagators;
+    Stats stats;
+
+    Propagators propagators{stats};
     // Constraint _1: innocent, triggers on x only. Dense constraint index 0.
     propagators.install(NumberedConstraint{1}, a_propagator_that_does_nothing(), Triggers{.on_change = {x}});
     // Constraint _2: explicitly contradicts, with a non-empty reason. It is
@@ -103,7 +105,9 @@ TEST_CASE("Conflict observer fires for an inference-driven wipeout")
     State state;
     auto x = state.allocate_integer_variable_with_state(0_i, 1_i);
 
-    Propagators propagators;
+    Stats stats;
+
+    Propagators propagators{stats};
     // The contradiction here comes not from an explicit contradiction() call but
     // from an inference that empties x's domain (the Contradiction case inside
     // the tracker), exercising the other reason-stash path.
@@ -145,7 +149,9 @@ TEST_CASE("Conflict observer fires for a non-throwing (_or_stop) wipeout")
     State state;
     auto x = state.allocate_integer_variable_with_state(0_i, 1_i);
 
-    Propagators propagators;
+    Stats stats;
+
+    Propagators propagators{stats};
     propagators.install(
         NumberedConstraint{9},
         [x](const State &, auto & inference, ProofLogger * const logger) -> PropagatorState {
@@ -179,7 +185,9 @@ TEST_CASE("Propagation without a conflict observer still detects the wipeout")
     State state;
     auto x = state.allocate_integer_variable_with_state(0_i, 1_i);
 
-    Propagators propagators;
+    Stats stats;
+
+    Propagators propagators{stats};
     propagators.install(
         NumberedConstraint{1},
         [](const State &, auto & inference, ProofLogger * const logger) -> PropagatorState {
@@ -198,7 +206,9 @@ TEST_CASE("Every attached conflict observer is notified of a wipeout")
     State state;
     auto x = state.allocate_integer_variable_with_state(0_i, 1_i);
 
-    Propagators propagators;
+    Stats stats;
+
+    Propagators propagators{stats};
     propagators.install(
         NumberedConstraint{3},
         [x](const State &, auto & inference, ProofLogger * const logger) -> PropagatorState {
@@ -227,7 +237,9 @@ TEST_CASE("Propagator scope and variable-to-constraint adjacency")
     auto y = state.allocate_integer_variable_with_state(0_i, 10_i);
     auto z = state.allocate_integer_variable_with_state(0_i, 10_i);
 
-    Propagators propagators;
+    Stats stats;
+
+    Propagators propagators{stats};
     // Constraint index 0, propagator 0: over x and y (with a duplicate and a
     // view of y to check deduplication / view resolution).
     propagators.install(NumberedConstraint{1}, a_propagator_that_does_nothing(), Triggers{.on_change = {x, y}, .on_bounds = {y, -y}});

--- a/gcs/innards/idempotent_claim_checker_test.cc
+++ b/gcs/innards/idempotent_claim_checker_test.cc
@@ -34,7 +34,8 @@ TEST_CASE("A lying idempotence claim is caught by the checker")
     enable_checker();
 
     State state;
-    Propagators propagators;
+    Stats stats;
+    Propagators propagators{stats};
     auto x = state.allocate_integer_variable_with_state(0_i, 10_i);
 
     // Shaves one value off x per run, so an immediate re-run always infers
@@ -58,7 +59,8 @@ TEST_CASE("An honest idempotence claim passes the checker")
     enable_checker();
 
     State state;
-    Propagators propagators;
+    Stats stats;
+    Propagators propagators{stats};
     auto x = state.allocate_integer_variable_with_state(0_i, 10_i);
 
     int runs = 0;
@@ -86,7 +88,8 @@ TEST_CASE("A downgraded claim is neither honoured nor checked")
     enable_checker();
 
     State state;
-    Propagators propagators;
+    Stats stats;
+    Propagators propagators{stats};
     auto x = state.allocate_integer_variable_with_state(0_i, 3_i);
 
     // The same liar as above, but with an aliased trigger scope: install()

--- a/gcs/innards/propagators.cc
+++ b/gcs/innards/propagators.cc
@@ -153,6 +153,11 @@ namespace
 
 struct Propagators::Imp : RefinedWatchSink
 {
+    // The search's Stats, which is where a component's decisions are reported
+    // as they happen. A pointer rather than a reference so that Propagators
+    // stays movable, which create_propagators returning one by value needs.
+    Stats * stats = nullptr;
+
     vector<PropagationFunction> propagation_functions;
     std::array<vector<InitialisationFunction>, number_of_initialiser_priorities> initialisation_functions_by_priority;
     // How many of each bucket initialise() has already run. A presolver can
@@ -353,8 +358,9 @@ struct Propagators::Imp : RefinedWatchSink
     }
 };
 
-Propagators::Propagators() : _imp(make_unique<Imp>())
+Propagators::Propagators(Stats & stats) : _imp(make_unique<Imp>())
 {
+    _imp->stats = &stats;
 }
 
 Propagators::~Propagators() = default;
@@ -926,6 +932,16 @@ auto Propagators::fill_in_constraint_stats(Stats & stats) const -> void
     stats.contradicting_propagations += _imp->contradicting_propagations;
     for (const auto & ignored : _imp->idempotence_claims_ignored)
         stats.idempotence_downgrades += ignored;
+}
+
+auto Propagators::add_component_stats(std::shared_ptr<const ComponentStats> component) -> void
+{
+    _imp->stats->add_component(move(component));
+}
+
+auto Propagators::report(StatsNote note) -> void
+{
+    _imp->stats->report(move(note));
 }
 
 auto Propagators::trigger_on_change(IntegerVariableID var, int t) -> void

--- a/gcs/innards/propagators.hh
+++ b/gcs/innards/propagators.hh
@@ -11,7 +11,9 @@
 #include <gcs/innards/propagators-fwd.hh>
 #include <gcs/innards/reason.hh>
 #include <gcs/innards/state.hh>
+#include <gcs/lifetime.hh>
 #include <gcs/problem.hh>
+#include <gcs/stats.hh>
 
 #include <atomic>
 #include <cstddef>
@@ -419,7 +421,16 @@ namespace gcs::innards
          * \name Constructors, destructors, etc.
          */
         ///@{
-        explicit Propagators();
+        /**
+         * \brief Construct over the Stats a search will fill in.
+         *
+         * The reference is the diagnostic bus: a component reports a decision
+         * through \ref report at the moment it makes it, rather than leaving
+         * something to be drained at teardown, which is what makes
+         * SolveCallbacks::stats_report worth having. The Stats must outlive
+         * this; gcs::solve_with() constructs it first for exactly that reason.
+         */
+        explicit Propagators(Stats & stats GCS_LIFETIME_BOUND);
         ~Propagators();
 
         Propagators(const Propagators &) = delete;
@@ -589,6 +600,23 @@ namespace gcs::innards
          * \sa Stats
          */
         auto fill_in_constraint_stats(Stats &) const -> void;
+
+        /**
+         * \brief Register a component's stats block with the search's Stats.
+         *
+         * For a Presolver, or a constraint installed by one, that keeps a block
+         * of its own: this is what puts it into Stats::components() so that it
+         * is reported. Registering the same block twice does nothing, so a
+         * constraint installed many times contributes one entry.
+         */
+        auto add_component_stats(std::shared_ptr<const ComponentStats>) -> void;
+
+        /**
+         * \brief Report one decision to the search's Stats, now.
+         *
+         * \sa StatsNote
+         */
+        auto report(StatsNote) -> void;
 
         ///@}
 

--- a/gcs/innards/propagators_test.cc
+++ b/gcs/innards/propagators_test.cc
@@ -36,7 +36,8 @@ namespace
 TEST_CASE("Claiming propagator is not re-woken by its own inference")
 {
     State state;
-    Propagators propagators;
+    Stats stats;
+    Propagators propagators{stats};
     auto x = state.allocate_integer_variable_with_state(0_i, 10_i);
 
     int runs = 0;
@@ -52,7 +53,8 @@ TEST_CASE("Claiming propagator is not re-woken by its own inference")
 TEST_CASE("Without a claim, a propagator is re-woken by its own inference")
 {
     State state;
-    Propagators propagators;
+    Stats stats;
+    Propagators propagators{stats};
     auto x = state.allocate_integer_variable_with_state(0_i, 10_i);
 
     int runs = 0;
@@ -68,7 +70,8 @@ TEST_CASE("Without a claim, a propagator is re-woken by its own inference")
 TEST_CASE("A claimant's inference wakes a sharing propagator, whose inference re-wakes the claimant")
 {
     State state;
-    Propagators propagators;
+    Stats stats;
+    Propagators propagators{stats};
     auto x = state.allocate_integer_variable_with_state(0_i, 10_i);
     auto y = state.allocate_integer_variable_with_state(0_i, 10_i);
 
@@ -120,7 +123,8 @@ TEST_CASE("A claimant's inference wakes a sharing propagator, whose inference re
 TEST_CASE("A claimant is not re-woken by a foreign inference it had already seen")
 {
     State state;
-    Propagators propagators;
+    Stats stats;
+    Propagators propagators{stats};
     auto x = state.allocate_integer_variable_with_state(0_i, 10_i);
     auto y = state.allocate_integer_variable_with_state(0_i, 10_i);
 
@@ -169,7 +173,8 @@ TEST_CASE("A claimant is not re-woken by a foreign inference it had already seen
 TEST_CASE("A claimant is re-woken by a foreign inference recorded after its run ended")
 {
     State state;
-    Propagators propagators;
+    Stats stats;
+    Propagators propagators{stats};
     auto x = state.allocate_integer_variable_with_state(0_i, 10_i);
     auto y = state.allocate_integer_variable_with_state(0_i, 10_i);
 
@@ -218,7 +223,8 @@ TEST_CASE("A claimant is re-woken by a foreign inference recorded after its run 
 TEST_CASE("A repeated trigger variable downgrades the claim")
 {
     State state;
-    Propagators propagators;
+    Stats stats;
+    Propagators propagators{stats};
     auto x = state.allocate_integer_variable_with_state(0_i, 10_i);
 
     int runs = 0;
@@ -236,7 +242,8 @@ TEST_CASE("A repeated trigger variable downgrades the claim")
 TEST_CASE("A view aliasing another trigger variable downgrades the claim")
 {
     State state;
-    Propagators propagators;
+    Stats stats;
+    Propagators propagators{stats};
     auto x = state.allocate_integer_variable_with_state(0_i, 10_i);
 
     int runs = 0;
@@ -252,7 +259,8 @@ TEST_CASE("A view aliasing another trigger variable downgrades the claim")
 TEST_CASE("A view of a distinct variable does not downgrade the claim")
 {
     State state;
-    Propagators propagators;
+    Stats stats;
+    Propagators propagators{stats};
     auto x = state.allocate_integer_variable_with_state(0_i, 10_i);
     auto y = state.allocate_integer_variable_with_state(0_i, 10_i);
 

--- a/gcs/presolvers/auto_table/auto_table.cc
+++ b/gcs/presolvers/auto_table/auto_table.cc
@@ -14,15 +14,24 @@
 using namespace gcs;
 using namespace gcs::innards;
 
+using std::make_shared;
 using std::make_unique;
 using std::move;
 using std::nullopt;
 using std::optional;
+using std::shared_ptr;
+using std::size_t;
+using std::string;
 using std::to_string;
 using std::unique_ptr;
 using std::vector;
 
-AutoTable::AutoTable(const vector<IntegerVariableID> & v) : _vars(v)
+AutoTable::AutoTable(const vector<IntegerVariableID> & v, shared_ptr<AutoTableStats> stats) :
+    _vars(v),
+    // Always a block: these numbers had no home outside a proof file, and the
+    // one that matters most is not in the proof file either when proofs are
+    // written with assertions on.
+    _stats(stats ? move(stats) : make_shared<AutoTableStats>())
 {
 }
 
@@ -30,8 +39,10 @@ namespace
 {
     auto solve_subproblem(unsigned depth, SimpleTuples & tuples, const vector<IntegerVariableID> & vars, Propagators & propagators, State & state,
         const optional<Literal> & this_branch_guess, const BranchCallback & branch_callback, ProofLogger * const logger,
-        SimpleIntegerVariableID selector_var_id) -> void
+        SimpleIntegerVariableID selector_var_id, size_t & search_nodes) -> void
     {
+        ++search_nodes;
+
         if (logger && logger->get_assertion_level() == AssertionLevel::Off)
             logger->enter_proof_level(depth + 1);
 
@@ -79,7 +90,7 @@ namespace
                     auto timestamp = state.new_epoch();
                     auto branch = *branch_iter;
                     state.guess(branch);
-                    solve_subproblem(depth + 1, tuples, vars, propagators, state, branch, branch_callback, logger, selector_var_id);
+                    solve_subproblem(depth + 1, tuples, vars, propagators, state, branch, branch_callback, logger, selector_var_id, search_nodes);
                     state.backtrack(timestamp);
                 }
             }
@@ -98,6 +109,12 @@ namespace
 
 auto AutoTable::run(Problem & problem, Propagators & propagators, State & initial_state, ProofLogger * const logger) -> bool
 {
+    // Before anything else, and unconditionally: a presolver that ran and found
+    // nothing is what this block exists to make visible.
+    propagators.add_component_stats(_stats);
+    _stats->ran = true;
+    _stats->variables = _vars.size();
+
     SimpleTuples tuples;
 
     // dom_then_deg is stateless, so its setup is a no-op; build the per-node
@@ -108,12 +125,9 @@ auto AutoTable::run(Problem & problem, Propagators & propagators, State & initia
     initial_state.guess(TrueLiteral{});
 
     auto selector_var_id = initial_state.what_variable_id_will_be_created_next();
-    if (logger && logger->get_assertion_level() == AssertionLevel::Off)
-        logger->emit_proof_comment("starting autotabulation");
-    solve_subproblem(0, tuples, _vars, propagators, initial_state, nullopt, branch_callback, logger, selector_var_id);
+    solve_subproblem(0, tuples, _vars, propagators, initial_state, nullopt, branch_callback, logger, selector_var_id, _stats->search_nodes);
 
-    if (logger && logger->get_assertion_level() == AssertionLevel::Off)
-        logger->emit_proof_comment("creating autotable with " + to_string(tuples.size()) + " entries");
+    _stats->tuples = tuples.size();
 
     initial_state.backtrack(timestamp);
 
@@ -125,8 +139,6 @@ auto AutoTable::run(Problem & problem, Propagators & propagators, State & initia
         throw UnexpectedException{"something went horribly wrong with variable IDs when autotabulating"};
 
     ExtensionalData data{selector, _vars, move(tuples)};
-    if (logger && logger->get_assertion_level() == AssertionLevel::Off)
-        logger->emit_proof_comment("finished autotabulation");
 
     Triggers triggers;
     triggers.on_change = {_vars.begin(), _vars.end()};
@@ -143,5 +155,27 @@ auto AutoTable::run(Problem & problem, Propagators & propagators, State & initia
 
 auto AutoTable::clone() const -> unique_ptr<Presolver>
 {
-    return make_unique<AutoTable>(_vars);
+    return make_unique<AutoTable>(_vars, _stats);
+}
+
+auto AutoTableStats::component_name() const -> string
+{
+    return "auto_table";
+}
+
+auto AutoTableStats::summary() const -> string
+{
+    if (! ran)
+        return "did not run";
+
+    if (0 == tuples)
+        return "found no satisfying assignment of " + to_string(variables) + " variables, in " + to_string(search_nodes) + " nodes";
+
+    return to_string(tuples) + " tuples over " + to_string(variables) + " variables, found in " + to_string(search_nodes) + " nodes";
+}
+
+auto AutoTableStats::entries() const -> vector<StatsEntry>
+{
+    return {StatsEntry{"ran", ran ? 1 : 0}, StatsEntry{"variables", static_cast<long long>(variables)},
+        StatsEntry{"tuples", static_cast<long long>(tuples)}, StatsEntry{"search_nodes", static_cast<long long>(search_nodes)}};
 }

--- a/gcs/presolvers/auto_table/auto_table.cc
+++ b/gcs/presolvers/auto_table/auto_table.cc
@@ -124,10 +124,15 @@ auto AutoTable::run(Problem & problem, Propagators & propagators, State & initia
     auto timestamp = initial_state.new_epoch(true);
     initial_state.guess(TrueLiteral{});
 
+    // A local rather than the block's field, so that a block shared across two
+    // solves reports this run's cost beside this run's tuples rather than one
+    // accumulated and the other overwritten.
+    size_t search_nodes = 0;
     auto selector_var_id = initial_state.what_variable_id_will_be_created_next();
-    solve_subproblem(0, tuples, _vars, propagators, initial_state, nullopt, branch_callback, logger, selector_var_id, _stats->search_nodes);
+    solve_subproblem(0, tuples, _vars, propagators, initial_state, nullopt, branch_callback, logger, selector_var_id, search_nodes);
 
     _stats->tuples = tuples.size();
+    _stats->search_nodes = search_nodes;
 
     initial_state.backtrack(timestamp);
 

--- a/gcs/presolvers/auto_table/auto_table.hh
+++ b/gcs/presolvers/auto_table/auto_table.hh
@@ -2,12 +2,61 @@
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_PRESOLVERS_AUTO_TABLE_AUTO_TABLE_HH
 
 #include <gcs/presolver.hh>
+#include <gcs/stats.hh>
 #include <gcs/variable_id.hh>
 
+#include <cstddef>
+#include <memory>
+#include <string>
 #include <vector>
 
 namespace gcs
 {
+    /**
+     * \brief What the autotabulating presolver did, filled in when it runs.
+     *
+     * Until #662 this presolver had no block at all, and the only record that
+     * it had run was a handful of proof comments --- so with proofs off, which
+     * is the configuration anyone measures in, `tuples` was unrecoverable:
+     * nothing said whether the table it installed had three entries or three
+     * million, and nothing said what finding out had cost. Since the presolver
+     * solves a subproblem to exhaustion before search even starts, that is a
+     * cost worth being able to see.
+     *
+     * The presolver allocates one of these whether or not a caller asked for
+     * one. \sa AutoTable
+     *
+     * \ingroup Presolvers
+     */
+    struct AutoTableStats final : ComponentStats
+    {
+        /// Whether run() was reached at all. Always true for a block that has
+        /// reached Stats::components(), which is registered from inside run();
+        /// it is for a caller holding its own handle, whose presolver may never
+        /// have been called --- an earlier presolver can refute the problem
+        /// first.
+        bool ran = false;
+
+        /// Variables tabulated over, which is what the caller asked for and so
+        /// the one figure here it already knew.
+        std::size_t variables = 0;
+
+        /// Entries in the table that was installed: the number that matters,
+        /// and the one that used to exist only inside a proof.
+        std::size_t tuples = 0;
+
+        /// Nodes the subproblem search visited to find them. The cost side of
+        /// the same trade: a tabulation that took a million nodes to find a
+        /// hundred tuples is one a caller would want to know about, and a
+        /// presolver that spent that before search started looks, from every
+        /// other measurement, exactly like a slow model.
+        std::size_t search_nodes = 0;
+
+        [[nodiscard]] virtual auto component_name() const -> std::string override;
+        [[nodiscard]] virtual auto summary() const -> std::string override;
+        [[nodiscard]] virtual auto entries() const -> std::vector<StatsEntry> override;
+    };
+
     /**
      * \brief Create a Table constraint over the specified variables.
      *
@@ -17,11 +66,25 @@ namespace gcs
     {
     private:
         const std::vector<IntegerVariableID> _vars;
+        std::shared_ptr<AutoTableStats> _stats;
 
     public:
-        explicit AutoTable(const std::vector<IntegerVariableID> & vars);
+        /**
+         * \brief Construct the presolver, optionally sharing a stats block that
+         * outlives the copy Problem takes.
+         *
+         * A caller that passes none still gets one, and it is still reported.
+         */
+        explicit AutoTable(const std::vector<IntegerVariableID> & vars, std::shared_ptr<AutoTableStats> stats = nullptr);
 
         virtual auto run(Problem &, innards::Propagators &, innards::State &, innards::ProofLogger * const) -> bool override;
+
+        /**
+         * Create a copy of the presolver, sharing its stats block rather than
+         * allocating a fresh one: Problem::add_presolver stores a clone and
+         * run() is called on that, so a fresh block here would leave the
+         * caller's handle reading zero for ever.
+         */
         virtual auto clone() const -> std::unique_ptr<Presolver> override;
     };
 }

--- a/gcs/presolvers/cumulative_strengthening/cumulative_strengthening.cc
+++ b/gcs/presolvers/cumulative_strengthening/cumulative_strengthening.cc
@@ -11,6 +11,7 @@
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/proofs/proof_scaffolding_scope.hh>
 #include <gcs/innards/proofs/subset_sum_strengthening.hh>
+#include <gcs/innards/propagators.hh>
 #include <gcs/innards/state.hh>
 #include <gcs/presolvers/cumulative_strengthening/cumulative_strengthening.hh>
 #include <gcs/problem.hh>
@@ -40,6 +41,7 @@ using std::optional;
 using std::pair;
 using std::shared_ptr;
 using std::size_t;
+using std::string;
 using std::to_string;
 using std::unique_ptr;
 using std::vector;
@@ -128,7 +130,11 @@ namespace
 }
 
 CumulativeStrengthening::CumulativeStrengthening(shared_ptr<CumulativeStrengtheningStats> stats) :
-    _stats(move(stats)), _max_dynamic_programming_states(20000), _max_raise_lines(5000), _max_subset_sum_capacity(1000000),
+    // Always a block, whether or not anyone asked for one: the default
+    // experience was silent because nothing was allocated, not because the
+    // channel was wrong.
+    _stats(stats ? move(stats) : std::make_shared<CumulativeStrengtheningStats>()), _max_dynamic_programming_states(20000), _max_raise_lines(5000),
+    _max_subset_sum_capacity(1000000),
     // Energy rules only: see with_rules(). A derived constraint's time-tabling
     // cannot infer anything its donor's has not, so running it is pure cost.
     _rules(CumulativeRules{.time_table = false, .overload = true, .profile_overload = true}), _mutation(cumulative_strengthening_mutation::None{})
@@ -167,12 +173,24 @@ auto CumulativeStrengthening::with_proof_mutation(CumulativeStrengtheningMutatio
 
 auto CumulativeStrengthening::run(Problem & problem, Propagators & propagators, State & state, ProofLogger * const logger) -> bool
 {
-    auto bump = [&](size_t CumulativeStrengtheningStats::* field) {
-        if (_stats)
-            ++((*_stats).*field);
+    // Before the loop, and unconditionally: a presolver that found nothing to
+    // look at is the case worth being able to see, and it is the one every
+    // other check passes without noticing.
+    propagators.add_component_stats(_stats);
+
+    auto bump = [&](size_t CumulativeStrengtheningStats::* field) { ++((*_stats).*field); };
+
+    auto note = [&](StatsLevel level, optional<ConstraintID> constraint, string text) {
+        propagators.report(StatsNote{.level = level, .component = _stats->component_name(), .constraint = move(constraint), .text = move(text)});
     };
 
+    // This run's own tally, rather than the block's: a block shared across two
+    // solves would otherwise have the first solve's declines counted into the
+    // second's summary note.
+    size_t donors_this_run = 0, limit_declines_this_run = 0;
+
     for (const auto & donor : problem.each_constraint_of_type<Cumulative>()) {
+        ++donors_this_run;
         bump(&CumulativeStrengtheningStats::donors_seen);
 
         // Everything below is an argument about the donor's per-time rows
@@ -188,8 +206,8 @@ auto CumulativeStrengthening::run(Problem & problem, Propagators & propagators, 
         auto view = cumulative_donor_view(donor, state, logger);
         if (! view) {
             bump(&CumulativeStrengtheningStats::declined_irreducible_capacity);
-            if (logger)
-                logger->emit_proof_comment("presolve cumulative: declining " + as_string(donor.constraint_id()) + ", capacity is not reducible");
+            note(StatsLevel::General, donor.constraint_id(),
+                "passed over: its capacity is a view, which cannot be reduced to a number to strengthen against");
             continue;
         }
         const auto & starts = donor.starts();
@@ -208,9 +226,10 @@ auto CumulativeStrengthening::run(Problem & problem, Propagators & propagators, 
         // count and the raise arithmetic below inside a `long long`.
         if (capacity > Integer{_max_subset_sum_capacity}) {
             bump(&CumulativeStrengtheningStats::declined_capacity_too_large);
-            if (logger)
-                logger->emit_proof_comment("presolve cumulative: declining " + as_string(donor.constraint_id()) + ", capacity " +
-                    to_string(capacity.raw_value) + " is beyond the subset-sum limit of " + to_string(_max_subset_sum_capacity));
+            ++limit_declines_this_run;
+            note(StatsLevel::General, donor.constraint_id(),
+                "passed over: its capacity of " + to_string(capacity.raw_value) + " is beyond the subset-sum limit of " +
+                    to_string(_max_subset_sum_capacity) + ", see with_subset_sum_capacity_limit");
             continue;
         }
 
@@ -225,9 +244,8 @@ auto CumulativeStrengthening::run(Problem & problem, Propagators & propagators, 
         // passes every other check.
         if (any_of(view->usable, [&](size_t i) { return view->heights[i] > capacity; })) {
             bump(&CumulativeStrengtheningStats::declined_infeasible_donor);
-            if (logger)
-                logger->emit_proof_comment(
-                    "presolve cumulative: declining " + as_string(donor.constraint_id()) + ", a task demands more than the capacity");
+            note(StatsLevel::General, donor.constraint_id(),
+                "passed over: a task's guaranteed demand is greater than the capacity, so the constraint is infeasible on its own");
             continue;
         }
 
@@ -390,6 +408,8 @@ auto CumulativeStrengthening::run(Problem & problem, Propagators & propagators, 
 
         if (! assessed) {
             bump(&CumulativeStrengtheningStats::declined_nothing_to_gain);
+            note(StatsLevel::Detailed, donor.constraint_id(),
+                "passed over: its capacity is already the largest load its tasks can reach, and no height moved either");
             continue;
         }
 
@@ -430,15 +450,19 @@ auto CumulativeStrengthening::run(Problem & problem, Propagators & propagators, 
 
             if (states > _max_dynamic_programming_states) {
                 bump(&CumulativeStrengtheningStats::declined_over_budget);
-                logger->emit_proof_comment("presolve cumulative: declining " + as_string(donor.constraint_id()) + ", derivation would need " +
-                    to_string(states) + " dynamic programming states against a budget of " + to_string(_max_dynamic_programming_states));
+                ++limit_declines_this_run;
+                note(StatsLevel::General, donor.constraint_id(),
+                    "passed over: the derivation would need " + to_string(states) + " dynamic programming states against a budget of " +
+                        to_string(_max_dynamic_programming_states) + ", see with_dynamic_programming_budget");
                 continue;
             }
 
             if (raise_lines > _max_raise_lines) {
                 bump(&CumulativeStrengtheningStats::declined_over_raise_budget);
-                logger->emit_proof_comment("presolve cumulative: declining " + as_string(donor.constraint_id()) + ", raising heights would need " +
-                    to_string(raise_lines) + " proof lines against a budget of " + to_string(_max_raise_lines));
+                ++limit_declines_this_run;
+                note(StatsLevel::General, donor.constraint_id(),
+                    "passed over: raising heights would need " + to_string(raise_lines) + " proof lines against a budget of " +
+                        to_string(_max_raise_lines) + ", see with_raise_budget");
                 continue;
             }
         }
@@ -547,12 +571,10 @@ auto CumulativeStrengthening::run(Problem & problem, Propagators & propagators, 
                         recipe_logger.emit_proof_comment("presolve cumulative kappa already reached");
                     else {
                         recipe_logger.emit_proof_comment(strengthened.by_division ? "presolve cumulative gcd" : "presolve cumulative kappa");
-                        if (stats) {
-                            if (strengthened.by_division)
-                                ++stats->rows_by_division;
-                            else
-                                ++stats->rows_by_dynamic_programming;
-                        }
+                        if (strengthened.by_division)
+                            ++stats->rows_by_division;
+                        else
+                            ++stats->rows_by_dynamic_programming;
                     }
                     return strengthened.line;
                 };
@@ -677,8 +699,7 @@ auto CumulativeStrengthening::run(Problem & problem, Propagators & propagators, 
                         WPBSum alone;
                         alone += kappa * flag_for(task);
                         row = recipe_logger.emit_rup_proof_line(move(alone) <= kappa, ProofLevel::Temporary);
-                        if (stats)
-                            ++stats->raise_lines_emitted;
+                        ++stats->raise_lines_emitted;
                     }
                     else if (total <= kappa) {
                         // Everything else fits alongside, so the at-most-ones
@@ -689,8 +710,7 @@ auto CumulativeStrengthening::run(Problem & problem, Propagators & propagators, 
                         for (const auto & [other, weight] : running)
                             summed.add(at_most_one_between(task, other), weight);
                         row = summed.emit(recipe_logger, ProofLevel::Temporary);
-                        if (stats)
-                            ++stats->raise_lines_emitted;
+                        ++stats->raise_lines_emitted;
 
                         if (total < kappa) {
                             WPBSum raised;
@@ -737,8 +757,7 @@ auto CumulativeStrengthening::run(Problem & problem, Propagators & propagators, 
                                 raise.add(at_most_one_between(task, other), e * weight);
                             raise.divide_by(lambda + e);
                             row = raise.emit(recipe_logger, ProofLevel::Temporary);
-                            if (stats)
-                                ++stats->raise_lines_emitted;
+                            ++stats->raise_lines_emitted;
 
                             raised_to += step;
                         }
@@ -747,19 +766,35 @@ auto CumulativeStrengthening::run(Problem & problem, Propagators & propagators, 
                     running.emplace(task, kappa);
                 }
 
-                if (stats)
-                    ++stats->rows_with_a_raise;
+                ++stats->rows_with_a_raise;
 
                 return recipe_logger.emit(ImpliesProofRule{*row}, move(load) <= kappa, ProofLevel::Top);
             },
-            .rules = _rules};
+            .rules = _rules,
+            // A share of this block's own sub-block, so that every donor's
+            // install adds to one aggregate rather than registering a component
+            // apiece.
+            .stats = shared_ptr<DerivedCumulativeStats>{_stats, &_stats->derived}};
 
         // After the install rather than before it: a decline writes nothing at
         // all, and a proof saying a constraint was strengthened when it was not
         // is worse than one saying nothing.
         if (! install_derived_cumulative(propagators, state, logger, move(spec))) {
-            bump(&CumulativeStrengtheningStats::declined_by_install);
-            continue;
+            // A state that cannot happen, so it throws rather than being
+            // counted: the rows here are derived over the donor's *own*
+            // windows, so the flags install_derived_cumulative goes looking for
+            // are ones the donor published. A note for a bug is a note nobody
+            // reads.
+            //
+            // With one exception, which is a restriction rather than a bug: a
+            // proof written with assertions on omits definitions, so a task
+            // with both a variable start and a variable length has no
+            // end-of-task line to pin `after` through and the install declines
+            // for a reason this presolver cannot do anything about.
+            if (logger && logger->get_assertion_level() != AssertionLevel::Off)
+                continue;
+            throw UnexpectedException{"cumulative strengthening: install_derived_cumulative declined " + as_string(donor_id) +
+                ", whose rows were derived over the donor's own windows"};
         }
 
         if (logger)
@@ -768,11 +803,20 @@ auto CumulativeStrengthening::run(Problem & problem, Propagators & propagators, 
                 " heights to the capacity");
 
         bump(&CumulativeStrengtheningStats::donors_strengthened);
-        if (_stats) {
-            _stats->capacity_units_removed += capacity - kappa;
-            _stats->tasks_raised += full_tasks.size();
-        }
+        _stats->capacity_units_removed += capacity - kappa;
+        _stats->tasks_raised += full_tasks.size();
     }
+
+    // The model-level consequence, for a reader who does not know what this
+    // presolver is: a limit stopped it doing what it was asked to do, so the
+    // configuration being run is not the one that was asked for. The figures
+    // and the constraint each decline is about are in the General notes above;
+    // this one names neither, because naming them is what makes a message
+    // unreadable to the person it is for.
+    if (0 != limit_declines_this_run)
+        note(StatsLevel::Important, nullopt,
+            "Cumulative strengthening was skipped on " + to_string(limit_declines_this_run) + " of " + to_string(donors_this_run) +
+                " constraints because a size limit was reached; answers are still correct, but search may be slower");
 
     return true;
 }
@@ -785,5 +829,49 @@ auto CumulativeStrengthening::clone() const -> unique_ptr<Presolver>
     result->with_subset_sum_capacity_limit(_max_subset_sum_capacity);
     result->with_rules(_rules);
     result->with_proof_mutation(_mutation);
+    return result;
+}
+
+auto CumulativeStrengtheningStats::component_name() const -> std::string
+{
+    return "cumulative_strengthening";
+}
+
+auto CumulativeStrengtheningStats::summary() const -> std::string
+{
+    if (0 == donors_seen)
+        return "no posted Cumulative to look at";
+
+    if (0 == donors_strengthened)
+        return "nothing strengthened, of " + to_string(donors_seen) + " posted Cumulative" + (1 == donors_seen ? "" : "s") + " looked at";
+
+    return to_string(donors_strengthened) + " of " + to_string(donors_seen) + " posted Cumulatives strengthened, taking " +
+        to_string(capacity_units_removed.raw_value) + " off their capacities and raising " + to_string(tasks_raised) + " heights";
+}
+
+auto CumulativeStrengtheningStats::entries() const -> vector<StatsEntry>
+{
+    vector<StatsEntry> result;
+    auto add = [&](const char * name, size_t value) { result.push_back(StatsEntry{name, static_cast<long long>(value)}); };
+
+    add("donors_seen", donors_seen);
+    add("donors_strengthened", donors_strengthened);
+    result.push_back(StatsEntry{"capacity_units_removed", capacity_units_removed.raw_value});
+    add("donors_with_set_aside_tasks", donors_with_set_aside_tasks);
+    add("donors_better_off_setting_heights_aside", donors_better_off_setting_heights_aside);
+    add("converted_heights", converted_heights);
+    add("tasks_raised", tasks_raised);
+    add("declined_irreducible_capacity", declined_irreducible_capacity);
+    add("declined_infeasible_donor", declined_infeasible_donor);
+    add("declined_capacity_too_large", declined_capacity_too_large);
+    add("declined_over_budget", declined_over_budget);
+    add("declined_over_raise_budget", declined_over_raise_budget);
+    add("declined_nothing_to_gain", declined_nothing_to_gain);
+    add("rows_by_division", rows_by_division);
+    add("rows_by_dynamic_programming", rows_by_dynamic_programming);
+    add("rows_with_a_raise", rows_with_a_raise);
+    add("raise_lines_emitted", raise_lines_emitted);
+    derived.add_entries_to(result, "derived_");
+
     return result;
 }

--- a/gcs/presolvers/cumulative_strengthening/cumulative_strengthening.cc
+++ b/gcs/presolvers/cumulative_strengthening/cumulative_strengthening.cc
@@ -31,6 +31,7 @@ using namespace gcs;
 using namespace gcs::innards;
 
 using std::make_optional;
+using std::make_shared;
 using std::make_unique;
 using std::map;
 using std::max;
@@ -133,7 +134,7 @@ CumulativeStrengthening::CumulativeStrengthening(shared_ptr<CumulativeStrengthen
     // Always a block, whether or not anyone asked for one: the default
     // experience was silent because nothing was allocated, not because the
     // channel was wrong.
-    _stats(stats ? move(stats) : std::make_shared<CumulativeStrengtheningStats>()), _max_dynamic_programming_states(20000), _max_raise_lines(5000),
+    _stats(stats ? move(stats) : make_shared<CumulativeStrengtheningStats>()), _max_dynamic_programming_states(20000), _max_raise_lines(5000),
     _max_subset_sum_capacity(1000000),
     // Energy rules only: see with_rules(). A derived constraint's time-tabling
     // cannot infer anything its donor's has not, so running it is pure cost.
@@ -187,10 +188,10 @@ auto CumulativeStrengthening::run(Problem & problem, Propagators & propagators, 
     // This run's own tally, rather than the block's: a block shared across two
     // solves would otherwise have the first solve's declines counted into the
     // second's summary note.
-    size_t donors_this_run = 0, limit_declines_this_run = 0;
+    auto donors_before = _stats->donors_seen;
+    size_t limit_declines_this_run = 0;
 
     for (const auto & donor : problem.each_constraint_of_type<Cumulative>()) {
-        ++donors_this_run;
         bump(&CumulativeStrengtheningStats::donors_seen);
 
         // Everything below is an argument about the donor's per-time rows
@@ -815,7 +816,8 @@ auto CumulativeStrengthening::run(Problem & problem, Propagators & propagators, 
     // unreadable to the person it is for.
     if (0 != limit_declines_this_run)
         note(StatsLevel::Important, nullopt,
-            "Cumulative strengthening was skipped on " + to_string(limit_declines_this_run) + " of " + to_string(donors_this_run) +
+            "Cumulative strengthening was skipped on " + to_string(limit_declines_this_run) + " of " +
+                to_string(_stats->donors_seen - donors_before) +
                 " constraints because a size limit was reached; answers are still correct, but search may be slower");
 
     return true;

--- a/gcs/presolvers/cumulative_strengthening/cumulative_strengthening.hh
+++ b/gcs/presolvers/cumulative_strengthening/cumulative_strengthening.hh
@@ -2,13 +2,17 @@
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_PRESOLVERS_CUMULATIVE_STRENGTHENING_CUMULATIVE_STRENGTHENING_HH
 
 #include <gcs/constraints/cumulative/cumulative.hh>
+#include <gcs/constraints/cumulative/derived_cumulative_stats.hh>
 #include <gcs/integer.hh>
 #include <gcs/presolver.hh>
 #include <gcs/presolvers/innards/cumulative_strengthening_mutations.hh>
+#include <gcs/stats.hh>
 
 #include <cstddef>
 #include <memory>
+#include <string>
 #include <variant>
+#include <vector>
 
 namespace gcs
 {
@@ -22,11 +26,17 @@ namespace gcs
      * unless energy reasoning is switched on. So every check that a presolver
      * normally has to pass is passed just as well by a presolver that did
      * nothing at all, and the counts below are how a test tells the two apart.
+     *
+     * The presolver allocates one of these whether or not a caller asked for
+     * one, so the block reaches Stats::components() and says what happened even
+     * when nobody was interested enough to pass a handle in --- which is the
+     * configuration in which "the presolver quietly stopped firing" used to be
+     * unobservable.
      * \sa CumulativeStrengthening
      *
      * \ingroup Presolvers
      */
-    struct CumulativeStrengtheningStats
+    struct CumulativeStrengtheningStats final : ComponentStats
     {
         /// Posted Cumulatives the presolver looked at.
         std::size_t donors_seen = 0;
@@ -112,10 +122,6 @@ namespace gcs
         /// The capacity was already the largest load the tasks can reach, and
         /// no height moved either, so there was nothing to strengthen.
         std::size_t declined_nothing_to_gain = 0;
-        /// Declined by install_derived_cumulative itself, which is a bug rather
-        /// than a restriction: the presolver derives its rows over the donor's
-        /// own windows, so the flags it asks for should always be there.
-        std::size_t declined_by_install = 0;
         ///@}
 
         /**
@@ -153,6 +159,16 @@ namespace gcs
         std::size_t rows_with_a_raise = 0;
         std::size_t raise_lines_emitted = 0;
         ///@}
+
+        /// What installing the strengthened constraints came to, summed over
+        /// every donor: one derived Cumulative is installed per strengthened
+        /// donor, and one component entry per derived constraint would be noise
+        /// where this is what a reader wants.
+        DerivedCumulativeStats derived;
+
+        [[nodiscard]] virtual auto component_name() const -> std::string override;
+        [[nodiscard]] virtual auto summary() const -> std::string override;
+        [[nodiscard]] virtual auto entries() const -> std::vector<StatsEntry> override;
     };
 
     /**
@@ -221,6 +237,11 @@ namespace gcs
         /**
          * \brief Construct the presolver, optionally sharing a stats block that
          * outlives the copy Problem takes.
+         *
+         * A caller that passes none still gets one: the block is allocated
+         * here, registered with the search's Stats when run() starts, and
+         * reported like any other. Silence used to be what a caller got for not
+         * asking, and silence is what #662 is about.
          */
         explicit CumulativeStrengthening(std::shared_ptr<CumulativeStrengtheningStats> stats = nullptr);
 
@@ -300,6 +321,15 @@ namespace gcs
         auto with_proof_mutation(innards::CumulativeStrengtheningMutation mutation) -> CumulativeStrengthening &;
 
         [[nodiscard]] virtual auto run(Problem &, innards::Propagators &, innards::State &, innards::ProofLogger * const) -> bool override;
+        /**
+         * Create a copy of the presolver, sharing its stats block rather than
+         * allocating a fresh one.
+         *
+         * Load-bearing, and easy to lose: Problem::add_presolver stores a
+         * clone, and run() is called on *that*, so a clone that allocated its
+         * own block would leave the caller's handle --- and the block anything
+         * else is holding --- reading zero for ever.
+         */
         [[nodiscard]] virtual auto clone() const -> std::unique_ptr<Presolver> override;
     };
 }

--- a/gcs/presolvers/cumulative_strengthening/cumulative_strengthening_test.cc
+++ b/gcs/presolvers/cumulative_strengthening/cumulative_strengthening_test.cc
@@ -1188,10 +1188,13 @@ auto main(int argc, char * argv[]) -> int
     }
 
     // Three: the level, asserted rather than the text. With proofs off, since
-    // that is the configuration the whole issue is about --- and the decline
-    // that reaches it is a view capacity, not a budget: both budget checks are
-    // estimates of *proof size* and are only made when there is a proof to
-    // size, so a proofs-off budget-decline fixture cannot exist.
+    // that is the configuration the whole issue is about. Two declines reach it
+    // there, and they sit on either side of the Important rung: a view
+    // capacity, which is not a limit and stays at General, and a capacity
+    // beyond the subset-sum limit, which is one. Neither *proof* budget can
+    // reach it --- both are estimates of proof size and are only made when
+    // there is a proof to size --- which is why the budget fixture below is
+    // proofs-on and this pair is not.
     {
         auto notes = make_shared<vector<StatsNote>>();
 
@@ -1224,6 +1227,43 @@ auto main(int argc, char * argv[]) -> int
         // everything is Important then nothing is.
         if (! notes_at(recorded, StatsLevel::Important).empty())
             fail("a view capacity raised an Important note");
+    }
+
+    // The other side of that rung, and the one path where an ordinary caller
+    // --- no proof, no stats_report --- has something written to `cerr`: a
+    // constant capacity beyond the subset-sum limit. It is reachable with
+    // proofs off because the check is deliberately made before any of the proof
+    // budgets, none of which runs without a proof; see the comment above it in
+    // cumulative_strengthening.cc. That makes this the fixture that pins the
+    // one behaviour visible to a caller who asked for none of this, so it
+    // asserts the *count* of Important notes rather than their presence: a
+    // second one here is a solver that has started talking over itself.
+    {
+        const Instance huge_capacity{{{0, 3}, {0, 3}, {0, 3}}, {2, 2, 2}, {3, 3, 3}, 2000000};
+        auto recorded = solve_recording(huge_capacity, Setup{}, nullopt);
+
+        auto general = notes_at(recorded, StatsLevel::General);
+        if (general.size() != 1)
+            fail("a capacity beyond the subset-sum limit reported " + to_string(general.size()) + " General notes with proofs off, not one");
+        if (! general[0].constraint)
+            fail("the note does not carry the constraint it is about, so nothing can filter on it");
+        if (general[0].component != "cumulative_strengthening")
+            fail("the note is not attributed to this presolver");
+        // The figures and the knob to turn, which is what separates this rung
+        // from the Important one saying the same thing to a different reader.
+        if (string::npos == general[0].text.find("subset-sum limit of 1000000") ||
+            string::npos == general[0].text.find("with_subset_sum_capacity_limit"))
+            fail("the note does not say which limit was reached, or which option raises it: " + general[0].text);
+
+        auto important = notes_at(recorded, StatsLevel::Important);
+        if (important.size() != 1)
+            fail("a capacity decline raised " + to_string(important.size()) + " Important notes with proofs off, not one");
+        if (important[0].constraint)
+            fail("the Important note names a constraint, which is not what it is for");
+        if (string::npos == important[0].text.find("1 of 1 constraints"))
+            fail("the Important note does not say how much was skipped: " + important[0].text);
+
+        println(cerr, "diagnostics: proofs-off Important note is `{}`", important[0].text);
     }
 
     // And the budget declines, which do carry a figure a caller would act on,

--- a/gcs/presolvers/cumulative_strengthening/cumulative_strengthening_test.cc
+++ b/gcs/presolvers/cumulative_strengthening/cumulative_strengthening_test.cc
@@ -68,6 +68,7 @@ using std::pair;
 using std::set;
 using std::shared_ptr;
 using std::string;
+using std::to_string;
 using std::vector;
 
 #if defined(__cpp_lib_print) && defined(__cpp_lib_format)
@@ -279,6 +280,69 @@ namespace
         if (proof_name && verify)
             verify_proof_and_clean_up(*proof_name);
         return outcome;
+    }
+
+    /// What a solve reported, alongside what it came to.
+    struct Recorded
+    {
+        Stats stats;
+        vector<StatsNote> notes;
+    };
+
+    [[nodiscard]] auto notes_at(const Recorded & recorded, StatsLevel level) -> vector<StatsNote>
+    {
+        vector<StatsNote> result;
+        for (const auto & note : recorded.notes)
+            if (note.level == level)
+                result.push_back(note);
+        return result;
+    }
+
+    [[nodiscard]] auto strengthening_component(const Stats & stats) -> shared_ptr<const ComponentStats>
+    {
+        for (const auto & component : stats.components())
+            if (component->component_name() == "cumulative_strengthening")
+                return component;
+        return nullptr;
+    }
+
+    /// The number of fields in a stats block, worked out from its size.
+    ///
+    /// Every field of this block is eight bytes wide --- a `std::size_t`, an
+    /// `Integer`, or the four-`std::size_t` sub-block --- and the only other
+    /// thing in the object is the vtable pointer ComponentStats brings. So
+    /// `sizeof` counts the fields, and a field added without a matching
+    /// `entries()` line moves one side of the comparison and not the other.
+    template <typename Block_>
+    [[nodiscard]] auto field_count() -> size_t
+    {
+        static_assert(0 == (sizeof(Block_) - sizeof(void *)) % sizeof(size_t),
+            "this block has a field that is not eight bytes wide, so counting "
+            "its fields needs doing another way");
+        return (sizeof(Block_) - sizeof(void *)) / sizeof(size_t);
+    }
+
+    /// Solve, recording every note the solver reported as it reported it.
+    ///
+    /// A recording callback rather than a parse of rendered output, because a
+    /// note's *level* is exactly what rendering throws away: a note drifting
+    /// from Important or General down to Detailed would still appear in a dump
+    /// and would still say the right words, and nothing but this would notice.
+    auto solve_recording(const Instance & inst, const Setup & setup, const optional<string> & proof_name) -> Recorded
+    {
+        Problem p;
+        post(p, inst, setup);
+
+        auto notes = make_shared<vector<StatsNote>>();
+        auto stats = solve_with(p,
+            SolveCallbacks{.solution = [](const CurrentState &) -> bool { return true; },
+                .stats_report = [notes](const StatsNote & note) -> void { notes->push_back(note); }},
+            proof_name ? make_optional<ProofOptions>(ProofFileNames{*proof_name}) : nullopt);
+
+        if (proof_name)
+            verify_proof_and_clean_up(*proof_name);
+
+        return Recorded{move(stats), move(*notes)};
     }
 
     /// Solve a general instance, collecting the same tuples brute force
@@ -1078,6 +1142,103 @@ auto main(int argc, char * argv[]) -> int
             fail("a view-capacity donor was not declined");
         if (stats->donors_strengthened != 0)
             fail("a view-capacity donor was strengthened anyway");
+    }
+
+    // #662's diagnostic channel. Three assertions, each of which is a way a
+    // feature like this gets added and then never fires again.
+    {
+        // One: a *default-constructed* presolver --- one nobody passed a block
+        // to --- reaches Stats::components() with something to say. That is the
+        // always-allocate path, which is the whole of the fix and the part with
+        // no other observable effect: every other check this presolver has to
+        // pass is passed just as well while its block is invisible.
+        auto recorded = solve_recording(pack, Setup{}, nullopt);
+        auto component = strengthening_component(recorded.stats);
+        if (! component)
+            fail("a default-constructed presolver did not register a stats block");
+        if (component->summary().empty())
+            fail("the registered block had nothing to say");
+
+        // And that it is the block the presolver filled in rather than a fresh
+        // one: Problem::add_presolver stores a *clone* and run() happens on
+        // that, so a clone allocating its own block would leave this reporting
+        // an idle presolver while the strengthening went ahead.
+        if (string::npos == component->summary().find("1 of 1 posted Cumulatives strengthened"))
+            fail("the registered block is not the one the presolver filled in: " + component->summary());
+
+        // Two: every field of the block reaches the flat view. A figure that is
+        // filled in and reaches nobody is what this design rots into, and
+        // nothing else would catch it.
+        if (component->entries().size() != field_count<CumulativeStrengtheningStats>())
+            fail("the flat view has " + to_string(component->entries().size()) + " entries for " +
+                to_string(field_count<CumulativeStrengtheningStats>()) + " fields");
+
+        println(cerr, "diagnostics: `{}`, {} entries", component->summary(), component->entries().size());
+    }
+
+    // Three: the level, asserted rather than the text. With proofs off, since
+    // that is the configuration the whole issue is about --- and the decline
+    // that reaches it is a view capacity, not a budget: both budget checks are
+    // estimates of *proof size* and are only made when there is a proof to
+    // size, so a proofs-off budget-decline fixture cannot exist.
+    {
+        auto notes = make_shared<vector<StatsNote>>();
+
+        Problem p;
+        vector<IntegerVariableID> starts;
+        for (int i = 0; i < 3; ++i)
+            starts.push_back(p.create_integer_variable(0_i, 3_i));
+        vector<IntegerVariableID> lengths{constant_variable(2_i), constant_variable(2_i), constant_variable(2_i)},
+            heights{constant_variable(3_i), constant_variable(3_i), constant_variable(3_i)};
+        p.post(Cumulative{starts, lengths, heights, p.create_integer_variable(4_i, 7_i) + 1_i});
+        p.add_presolver(CumulativeStrengthening{});
+        solve_with(p,
+            SolveCallbacks{.trace = [](const CurrentState &) -> bool { return false; },
+                .stats_report = [notes](const StatsNote & note) -> void { notes->push_back(note); }},
+            nullopt);
+
+        Recorded recorded{Stats{}, move(*notes)};
+        auto general = notes_at(recorded, StatsLevel::General);
+        if (general.size() != 1)
+            fail("a view-capacity decline reported " + to_string(general.size()) + " General notes with proofs off, not one");
+        if (! general[0].constraint)
+            fail("the note does not carry the constraint it is about, so nothing can filter on it");
+        if (general[0].component != "cumulative_strengthening")
+            fail("the note is not attributed to this presolver");
+        if (string::npos == general[0].text.find("view"))
+            fail("the note does not say what was wrong: " + general[0].text);
+
+        // Not Important: nothing was limited, and a capacity this presolver
+        // cannot argue about is not a configuration the caller can change. If
+        // everything is Important then nothing is.
+        if (! notes_at(recorded, StatsLevel::Important).empty())
+            fail("a view capacity raised an Important note");
+    }
+
+    // And the budget declines, which do carry a figure a caller would act on,
+    // reported at both levels: the figures at General, and what it means at
+    // Important. Proofs on, necessarily.
+    if (proofs) {
+        auto recorded = solve_recording(deep_gap, Setup{.budget = 0}, make_optional("cumulative_strengthening_note_budget"));
+
+        auto general = notes_at(recorded, StatsLevel::General);
+        auto has_figures = false;
+        for (const auto & note : general)
+            if (note.constraint && string::npos != note.text.find("dynamic programming states against a budget of 0") &&
+                string::npos == note.text.find("would need 0 dynamic"))
+                has_figures = true;
+        if (! has_figures)
+            fail("the budget decline's figures are not in any General note");
+
+        auto important = notes_at(recorded, StatsLevel::Important);
+        if (important.size() != 1)
+            fail("a budget decline raised " + to_string(important.size()) + " Important notes, not one");
+        if (important[0].constraint)
+            fail("the Important note names a constraint, which is not what it is for");
+        if (string::npos == important[0].text.find("1 of 1 constraints"))
+            fail("the Important note does not say how much was skipped: " + important[0].text);
+
+        println(cerr, "diagnostics: Important note is `{}`", important[0].text);
     }
 
     // The budget. Set to zero, the dynamic programming path is unaffordable and

--- a/gcs/presolvers/cumulative_strengthening/cumulative_strengthening_test.cc
+++ b/gcs/presolvers/cumulative_strengthening/cumulative_strengthening_test.cc
@@ -1159,12 +1159,23 @@ auto main(int argc, char * argv[]) -> int
         if (component->summary().empty())
             fail("the registered block had nothing to say");
 
-        // And that it is the block the presolver filled in rather than a fresh
-        // one: Problem::add_presolver stores a *clone* and run() happens on
-        // that, so a clone allocating its own block would leave this reporting
-        // an idle presolver while the strengthening went ahead.
+        // And that it has the figures in it, rather than being a block that was
+        // allocated and then left behind.
         if (string::npos == component->summary().find("1 of 1 posted Cumulatives strengthened"))
-            fail("the registered block is not the one the presolver filled in: " + component->summary());
+            fail("the registered block was not the one the presolver filled in: " + component->summary());
+
+        // Separately: a block the *caller* supplied is the block that gets
+        // registered, by identity. Problem::add_presolver stores a clone and
+        // run() happens on that, so a clone allocating its own would leave the
+        // caller's handle reading zero --- while everything above carried on
+        // passing, since what reaches Stats::components() is whatever the clone
+        // holds.
+        auto block = make_shared<CumulativeStrengtheningStats>();
+        auto shared = solve_recording(pack, Setup{.stats = block}, nullopt);
+        if (strengthening_component(shared.stats).get() != static_cast<const ComponentStats *>(block.get()))
+            fail("the caller's stats block is not the one that was registered");
+        if (block->donors_strengthened != 1)
+            fail("the caller's stats block was not the one that was filled in");
 
         // Two: every field of the block reaches the flat view. A figure that is
         // filled in and reaches nobody is what this design rots into, and

--- a/gcs/problem.cc
+++ b/gcs/problem.cc
@@ -200,9 +200,9 @@ auto Problem::add_presolver(const Presolver & p) -> void
     _imp->presolvers.push_back(p.clone());
 }
 
-auto Problem::create_propagators(State & state, ProofModel * const optional_proof_model) const -> Propagators
+auto Problem::create_propagators(State & state, Stats & stats, ProofModel * const optional_proof_model) const -> Propagators
 {
-    Propagators result;
+    Propagators result{stats};
     for (auto & c : _imp->constraints) {
         auto cc = c->clone();
         // clone() is deliberately id-agnostic; each post/install site sets the id.

--- a/gcs/problem.hh
+++ b/gcs/problem.hh
@@ -214,7 +214,8 @@ namespace gcs
          * \brief Create the propagators for a search over this Problem,
          * returned by value.
          */
-        [[nodiscard]] auto create_propagators(innards::State &, innards::ProofModel * const) const -> innards::Propagators;
+        [[nodiscard]] auto create_propagators(innards::State &, Stats & GCS_LIFETIME_BOUND, innards::ProofModel * const) const
+            -> innards::Propagators;
 
         /**
          * \warning The yielded references alias objects owned by this Problem,

--- a/gcs/problem.hh
+++ b/gcs/problem.hh
@@ -214,7 +214,7 @@ namespace gcs
          * \brief Create the propagators for a search over this Problem,
          * returned by value.
          */
-        [[nodiscard]] auto create_propagators(innards::State &, Stats & GCS_LIFETIME_BOUND, innards::ProofModel * const) const
+        [[nodiscard]] auto create_propagators(innards::State &, Stats & stats GCS_LIFETIME_BOUND, innards::ProofModel * const) const
             -> innards::Propagators;
 
         /**

--- a/gcs/search_heuristics_test.cc
+++ b/gcs/search_heuristics_test.cc
@@ -44,7 +44,9 @@ TEST_CASE("dom_wdeg orders by dom/W, with a zero-weight variable last")
     auto d = state.allocate_integer_variable_with_state(0_i, 3_i); // dom 4, in no constraint
     auto x = state.allocate_integer_variable_with_state(0_i, 3_i);
 
-    Propagators propagators;
+    Stats stats;
+
+    Propagators propagators{stats};
     // a is in one constraint, b in two, c in three (each paired with x); weights
     // are uniform at the root, so W(a)=1, W(b)=2, W(c)=3 and W(d)=0.
     propagators.install(NumberedConstraint{1}, a_propagator_that_does_nothing(), Triggers{.on_change = {a, x}});
@@ -79,7 +81,9 @@ TEST_CASE("dom_wdeg seeded weights change the choice")
     auto c = state.allocate_integer_variable_with_state(0_i, 3_i);
     auto x = state.allocate_integer_variable_with_state(0_i, 3_i);
 
-    Propagators propagators;
+    Stats stats;
+
+    Propagators propagators{stats};
     propagators.install(NumberedConstraint{1}, a_propagator_that_does_nothing(), Triggers{.on_change = {a, x}});
     propagators.install(NumberedConstraint{2}, a_propagator_that_does_nothing(), Triggers{.on_change = {b, x}});
     propagators.install(NumberedConstraint{3}, a_propagator_that_does_nothing(), Triggers{.on_change = {b, x}});
@@ -105,7 +109,9 @@ TEST_CASE("dom_wdeg tie-breaks on degree")
     auto a = state.allocate_integer_variable_with_state(0_i, 3_i);
     auto b = state.allocate_integer_variable_with_state(0_i, 3_i);
 
-    Propagators propagators;
+    Stats stats;
+
+    Propagators propagators{stats};
     // Both share the one binary constraint, so W(a)=W(b)=1 and dom/W ties. a is
     // also in a second, unary constraint: a unary constraint never has two
     // unassigned variables, so weighted_degree_of filters it out (W(a) stays 1),
@@ -132,7 +138,8 @@ TEST_CASE("split_random takes each half first sometimes")
 {
     State state;
     auto x = IntegerVariableID{state.allocate_integer_variable_with_state(1_i, 4_i)};
-    Propagators propagators;
+    Stats stats;
+    Propagators propagators{stats};
 
     // The split point does not depend on the coin flip: domain size 4 gives
     // mid = 2, and dropping mid - 1 = 1 value lands on 2 either way.

--- a/gcs/solve.cc
+++ b/gcs/solve.cc
@@ -282,6 +282,12 @@ auto gcs::solve_with(
     Problem & problem, SolveCallbacks callbacks, const optional<ProofOptions> & optional_proof_options, atomic<bool> * optional_abort_flag) -> Stats
 {
     Stats stats;
+
+    // Before anything can report: a presolver's decision is said as it is made,
+    // and the presolvers run inside this call. Unset does not mean silence
+    // here, deliberately --- see SolveCallbacks::stats_report.
+    stats.set_report_handler(callbacks.stats_report ? callbacks.stats_report : default_stats_report());
+
     auto start_time = steady_clock::now();
 
     optional<Proof> optional_proof;
@@ -303,7 +309,7 @@ auto gcs::solve_with(
         optional_proof->model()->write_preamble();
     }
 
-    auto propagators = problem.create_propagators(state, optional_proof ? optional_proof->model() : nullptr);
+    auto propagators = problem.create_propagators(state, stats, optional_proof ? optional_proof->model() : nullptr);
 
     // With restarts on, search learns nogoods from refuted regions. Install an
     // (initially empty) Nogoods over a store the restart loop grows, subscribed
@@ -459,6 +465,11 @@ auto gcs::solve_with(
     propagators.fill_in_constraint_stats(stats);
     if (nogood_store)
         stats.learned_nogoods = nogood_store->size();
+
+    // The search is over, so a caller holding the result should not be holding
+    // a live callback into it: the notes are all accumulated, and reporting a
+    // new one now would be reporting it about nothing.
+    stats.set_report_handler(StatsReportCallback{});
 
     return stats;
 }

--- a/gcs/solve.hh
+++ b/gcs/solve.hh
@@ -100,7 +100,8 @@ namespace gcs
     /**
      * \brief Callbacks for gcs::solve_with().
      *
-     * Every callback is optional.
+     * Every callback is optional, and unset means "do nothing" --- with the one
+     * documented exception of \ref stats_report.
      *
      * \ingroup SolveCallbacks
      */
@@ -111,6 +112,23 @@ namespace gcs
         BranchHeuristic branch = BranchHeuristic{};
         AfterProofStartedCallback after_proof_started = AfterProofStartedCallback{};
         CompletedCallback completed = CompletedCallback{};
+
+        /**
+         * \brief Where a component's decisions go, as they are decided.
+         *
+         * \warning The one callback whose unset behaviour is not silence: unset
+         * gets gcs::default_stats_report(), which writes StatsLevel::Important
+         * notes to `cerr`. A silent default is what this channel exists to fix,
+         * so silence is asked for with gcs::silent_stats_report() rather than
+         * by leaving this alone. Set it to route notes into a frontend's or a
+         * client library's own idiom instead of having `cerr` forced on it.
+         *
+         * Every note is accumulated on the returned Stats either way, so a
+         * caller that only wants them at the end can read Stats::notes().
+         *
+         * \sa StatsReportCallback
+         */
+        StatsReportCallback stats_report = StatsReportCallback{};
 
         /**
          * \brief If set, search restarts on a growing sequence of conflict

--- a/gcs/solve_test.cc
+++ b/gcs/solve_test.cc
@@ -725,3 +725,26 @@ TEST_CASE("AutoTable reports what it did, with no stats block asked for")
     CHECK(by_name["tuples"] == 4); // a + b == 3, over 0..3
     CHECK(by_name["search_nodes"] > 0);
 }
+
+TEST_CASE("A caller's AutoTable stats block is the one that gets filled in and reported")
+{
+    // Problem::add_presolver stores a *clone*, and run() is called on that, so
+    // a clone allocating a fresh block instead of sharing this one would leave
+    // the caller's handle reading zero for ever --- while everything visible
+    // through Stats::components() carried on looking exactly right, since what
+    // is registered there is whatever the clone happens to hold. Pointer
+    // identity is what says the two are the same block.
+    auto block = std::make_shared<AutoTableStats>();
+
+    Problem p;
+    auto a = p.create_integer_variable(0_i, 3_i);
+    auto b = p.create_integer_variable(0_i, 3_i);
+    p.post(WeightedSum{} + 1_i * a + 1_i * b == 3_i);
+    p.add_presolver(AutoTable{vector<IntegerVariableID>{a, b}, block});
+
+    auto stats = solve(p, [](const CurrentState &) -> bool { return true; });
+
+    CHECK(block->ran);
+    CHECK(block->tuples == 4);
+    CHECK(component_named(stats, "auto_table").get() == static_cast<const ComponentStats *>(block.get()));
+}

--- a/gcs/solve_test.cc
+++ b/gcs/solve_test.cc
@@ -13,9 +13,12 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include <cstdlib>
+#include <map>
 #include <memory>
 #include <optional>
 #include <set>
+#include <sstream>
+#include <string>
 #include <tuple>
 #include <vector>
 
@@ -568,4 +571,157 @@ TEST_CASE("A presolver's initialiser can report unsatisfiability")
     CHECK(*ran == 1);
     CHECK(! found_solution); // a contradiction there ends the solve, rather than being lost
     CHECK(verify_proof_and_dispose(proof_name));
+}
+
+namespace
+{
+    /// The number of fields in a stats block, worked out from its size.
+    ///
+    /// Every field of these blocks is eight bytes wide --- a `std::size_t`, an
+    /// `Integer`, a nested block of `std::size_t`s, or a `bool` that pads out to
+    /// the next one --- and the only other thing in the object is the vtable
+    /// pointer this design's base class brings. So `sizeof` counts the fields,
+    /// and a field added without a matching `entries()` line moves one side of
+    /// the comparison below and not the other. That is the rot this design can
+    /// grow: a figure that exists, is filled in, and reaches nobody.
+    template <typename Block_>
+    [[nodiscard]] auto field_count() -> std::size_t
+    {
+        static_assert(0 == (sizeof(Block_) - sizeof(void *)) % sizeof(std::size_t),
+            "this block has a field that is not eight bytes wide, so "
+            "counting its fields needs doing another way");
+        return (sizeof(Block_) - sizeof(void *)) / sizeof(std::size_t);
+    }
+
+    /// A recording StatsReportCallback. Tests assert on the notes rather than on
+    /// rendered output, because a note's *level* is what rendering throws away
+    /// and a level quietly drifting down to Detailed is what would undo this
+    /// channel with nothing else noticing.
+    struct Recorder
+    {
+        std::shared_ptr<std::vector<StatsNote>> notes = std::make_shared<std::vector<StatsNote>>();
+
+        [[nodiscard]] auto callback() const -> StatsReportCallback
+        {
+            return [notes = notes](const StatsNote & note) -> void { notes->push_back(note); };
+        }
+
+        [[nodiscard]] auto at_level(StatsLevel level) const -> std::vector<StatsNote>
+        {
+            std::vector<StatsNote> result;
+            for (const auto & note : *notes)
+                if (note.level == level)
+                    result.push_back(note);
+            return result;
+        }
+    };
+
+    [[nodiscard]] auto component_named(const Stats & stats, const std::string & name) -> std::shared_ptr<const ComponentStats>
+    {
+        for (const auto & component : stats.components())
+            if (component->component_name() == name)
+                return component;
+        return nullptr;
+    }
+}
+
+TEST_CASE("A note is rendered with its component label, except at Important")
+{
+    // The component label is for someone who knows what the component is, and
+    // an Important note is written for someone who does not.
+    CHECK(render(StatsNote{StatsLevel::General, "auto_table", nullopt, "did a thing"}) == "auto_table: did a thing");
+    CHECK(render(StatsNote{StatsLevel::Important, "auto_table", nullopt, "did a thing"}) == "did a thing");
+
+    // The ConstraintID is on the note rather than baked into the text, so that
+    // a caller can filter and a test can assert; putting it into words is the
+    // renderer's job.
+    CHECK(render(StatsNote{StatsLevel::General, "auto_table", ConstraintID{NumberedConstraint{7}}, "did a thing"}) == "auto_table: did a thing (_7)");
+}
+
+TEST_CASE("Stats accumulates notes and forwards them as they happen")
+{
+    Stats stats;
+
+    std::vector<StatsLevel> seen;
+    stats.set_report_handler([&](const StatsNote & note) -> void { seen.push_back(note.level); });
+
+    stats.report(StatsNote{StatsLevel::Debug, "a", nullopt, "one"});
+    stats.report(StatsNote{StatsLevel::Important, "a", nullopt, "two"});
+
+    // Forwarded at the moment of reporting, in order, and kept.
+    CHECK(seen == std::vector<StatsLevel>{StatsLevel::Debug, StatsLevel::Important});
+    CHECK(stats.notes().size() == 2);
+
+    // The default callback filters by level rather than reporting everything.
+    std::ostringstream captured;
+    auto old = std::cerr.rdbuf(captured.rdbuf());
+    auto reporter = default_stats_report();
+    reporter(StatsNote{StatsLevel::General, "a", nullopt, "quiet"});
+    reporter(StatsNote{StatsLevel::Important, "a", nullopt, "loud"});
+    std::cerr.rdbuf(old);
+    CHECK(captured.str() == "loud\n");
+}
+
+TEST_CASE("Registering the same component block twice reports it once")
+{
+    // A constraint installed many times, or a presolver whose block is shared
+    // with a caller who also registered it, should be one line and not N.
+    struct Block final : ComponentStats
+    {
+        [[nodiscard]] auto component_name() const -> std::string override
+        {
+            return "block";
+        }
+        [[nodiscard]] auto summary() const -> std::string override
+        {
+            return "nothing";
+        }
+        [[nodiscard]] auto entries() const -> std::vector<StatsEntry> override
+        {
+            return {};
+        }
+    };
+
+    Stats stats;
+    auto block = std::make_shared<Block>();
+    stats.add_component(block);
+    stats.add_component(block);
+    CHECK(stats.components().size() == 1);
+}
+
+TEST_CASE("AutoTable reports what it did, with no stats block asked for")
+{
+    // Default-constructed, deliberately: the always-allocate path is the whole
+    // of #662's fix for this presolver, and it is the part with no other
+    // observable effect. Before it, the only record that AutoTable ran at all
+    // was three proof comments, so with proofs off --- which is here --- a
+    // presolver that had quietly stopped firing looked exactly like one that
+    // had fired.
+    Problem p;
+    auto a = p.create_integer_variable(0_i, 3_i);
+    auto b = p.create_integer_variable(0_i, 3_i);
+    p.post(WeightedSum{} + 1_i * a + 1_i * b == 3_i);
+    p.add_presolver(AutoTable{vector<IntegerVariableID>{a, b}});
+
+    Recorder recorder;
+    auto stats = solve_with(p, SolveCallbacks{.solution = [](const CurrentState &) -> bool { return true; }, .stats_report = recorder.callback()});
+
+    auto component = component_named(stats, "auto_table");
+    REQUIRE(component);
+    CHECK(! component->summary().empty());
+
+    // And that it is the block the presolver actually filled in, rather than a
+    // fresh one: Problem::add_presolver stores a *clone*, and run() happens on
+    // that, so a clone allocating its own block would leave a summary saying
+    // nothing while the tabulation went ahead.
+    auto entries = component->entries();
+    CHECK(entries.size() == field_count<AutoTableStats>());
+
+    std::map<std::string, long long> by_name;
+    for (const auto & entry : entries)
+        by_name.emplace(entry.name, entry.value);
+    CHECK(by_name["ran"] == 1);
+    CHECK(by_name["variables"] == 2);
+    CHECK(by_name["tuples"] == 4); // a + b == 3, over 0..3
+    CHECK(by_name["search_nodes"] > 0);
 }

--- a/gcs/stats.cc
+++ b/gcs/stats.cc
@@ -1,11 +1,77 @@
 #include <gcs/stats.hh>
 
+#include <algorithm>
 #include <chrono>
+#include <iostream>
 #include <ostream>
+#include <utility>
 
 using namespace gcs;
 
+using std::move;
 using std::ostream;
+using std::shared_ptr;
+using std::string;
+using std::vector;
+
+ComponentStats::~ComponentStats() = default;
+
+auto gcs::render(const StatsNote & note) -> string
+{
+    string result;
+    if (note.level != StatsLevel::Important && ! note.component.empty())
+        result += note.component + ": ";
+    result += note.text;
+    if (note.constraint)
+        result += " (" + as_string(*note.constraint) + ")";
+    return result;
+}
+
+auto gcs::default_stats_report(StatsLevel level) -> StatsReportCallback
+{
+    return [level](const StatsNote & note) -> void {
+        if (note.level >= level)
+            std::cerr << render(note) << '\n';
+    };
+}
+
+auto gcs::silent_stats_report() -> StatsReportCallback
+{
+    return [](const StatsNote &) -> void {};
+}
+
+auto Stats::add_component(shared_ptr<const ComponentStats> component) -> void
+{
+    if (! component)
+        return;
+    // A constraint installed many times, or a presolver whose run() is reached
+    // more than once, reports one aggregate rather than one entry per install.
+    if (_components.end() != std::ranges::find(_components, component))
+        return;
+    _components.push_back(move(component));
+}
+
+auto Stats::report(StatsNote note) -> void
+{
+    if (_handler)
+        _handler(note);
+    _notes.push_back(move(note));
+}
+
+auto Stats::set_report_handler(StatsReportCallback handler) -> void
+{
+    _handler = move(handler);
+}
+
+auto Stats::components() const -> const vector<shared_ptr<const ComponentStats>> &
+{
+    return _components;
+}
+
+auto Stats::notes() const -> const vector<StatsNote> &
+{
+    return _notes;
+}
 
 auto gcs::operator<<(ostream & o, const Stats & s) -> ostream &
 {
@@ -20,5 +86,13 @@ auto gcs::operator<<(ostream & o, const Stats & s) -> ostream &
     o << "learned nogoods: " << s.learned_nogoods << '\n';
     o << "solutions: " << s.solutions << '\n';
     o << "solve time: " << (s.solve_time.count() / 1'000'000.0) << "s" << '\n';
+
+    for (const auto & component : s.components())
+        o << component->component_name() << ": " << component->summary() << '\n';
+
+    for (const auto & note : s.notes())
+        if (note.level >= StatsLevel::General)
+            o << render(note) << '\n';
+
     return o;
 }

--- a/gcs/stats.hh
+++ b/gcs/stats.hh
@@ -1,8 +1,16 @@
 #ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_STATS_HH
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_STATS_HH
 
+#include <gcs/constraint_id.hh>
+#include <gcs/lifetime.hh>
+
 #include <chrono>
+#include <functional>
 #include <iosfwd>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
 
 #include <version>
 
@@ -15,7 +23,207 @@
 namespace gcs
 {
     /**
+     * \brief How loudly a StatsNote is to be said.
+     *
+     * A rung is justified by a distinct *default behaviour*, not by a distinct
+     * shade of importance --- otherwise the ladder grows names faster than it
+     * grows meaning and nobody can tell where to put a new note. There are
+     * three behaviours and so, at most, four rungs:
+     *
+     * | Behaviour                                              | Rung        |
+     * |--------------------------------------------------------|-------------|
+     * | Goes to `cerr` live, unprompted, via the default callback | Important |
+     * | Appears in the default `operator<<`                     | General     |
+     * | Only when asked                                         | Detailed, Debug |
+     *
+     * Detailed and Debug share a behaviour and are a filter granularity; the
+     * split is kept because "meaningful only alongside a proof" is a stable
+     * distinction. A fifth rung should have to earn a fourth behaviour.
+     *
+     * \ref Important is defined by **audience**, not by provenance: things a
+     * user needs to know even if they are a non-expert arriving through
+     * MiniZinc. It does not mean "something went wrong" --- everything it
+     * reports is the solver working correctly --- which is why it is not called
+     * `Warning` or `Severe`. Two consequences follow, and are the rule for
+     * deciding where a note goes:
+     *
+     *   - An Important note is written for a different reader than a
+     *     ComponentStats::summary(). It names the model-level thing --- the
+     *     constraint, the option the caller passed --- and states the
+     *     consequence, without naming the component's internals. "Cumulative
+     *     strengthening was skipped on 2 of 12 constraints because a
+     *     proof-size limit was reached; answers are still correct, but search
+     *     may be slower" is Important. "2 donors passed over, largest needed
+     *     41000 states against a budget of 20000, see
+     *     with_dynamic_programming_budget" is the same fact at General. Both
+     *     exist.
+     *   - An Important note therefore renders *without* the component label:
+     *     `cumulative_strengthening:` means nothing to the reader it is for.
+     *     The label prefix applies at General and below.
+     *
+     * A state that cannot happen does not go on this ladder at all: it should
+     * throw. A note for a bug is a note nobody reads, and keeping such things
+     * here is what would let Important fill up with things to scroll past.
+     *
+     * \ingroup Core
+     */
+    enum class StatsLevel
+    {
+        /// Only means something to someone reading the emitted proof.
+        Debug,
+        /// The breakdown behind a summary.
+        Detailed,
+        /// An expert reading solver output wants it; the default.
+        General,
+        /// A non-expert would draw a false conclusion without it.
+        Important
+    };
+
+    /**
+     * \brief One leaf of a ComponentStats block, flattened for tabulating a
+     * sweep.
+     *
+     * A derived *view*, never a record: nothing reads an entry to decide
+     * anything, so its stringly-typed name costs nothing that matters, and a
+     * typo shows up in a dump rather than in a result.
+     *
+     * \ingroup Core
+     */
+    struct StatsEntry final
+    {
+        std::string name;
+        long long value;
+    };
+
+    /**
+     * \brief What one component of the solver did, as the component itself
+     * records it.
+     *
+     * The blocks are the source of truth --- the precise machine-readable
+     * record a test asserts on --- and this narrow base is what lets Stats
+     * render them without knowing their types. Deriving from it is how a
+     * component in its own directory joins the report without any Core header
+     * learning that the component exists.
+     *
+     * A component allocates its block whether or not a caller asked for one, so
+     * that a component which did nothing still says so: "nothing" is the answer
+     * worth being able to see, and it is the one every other check passes
+     * without noticing.
+     *
+     * \ingroup Core
+     */
+    class ComponentStats
+    {
+    public:
+        virtual ~ComponentStats() = 0;
+
+        /**
+         * \brief A stable identifier in the style of the header it lives in:
+         * `cumulative_strengthening`, `auto_table`, `difference_logic`.
+         */
+        [[nodiscard]] virtual auto component_name() const -> std::string = 0;
+
+        /**
+         * \brief One line, always shown, saying what the component did ---
+         * including when the answer is "nothing".
+         */
+        [[nodiscard]] virtual auto summary() const -> std::string = 0;
+
+        /**
+         * \brief The whole block, flattened. Not shown by default.
+         *
+         * Every field of the block belongs here: a field that never reaches the
+         * flat view is invisible to anything tabulating a sweep, and nothing
+         * else would notice.
+         */
+        [[nodiscard]] virtual auto entries() const -> std::vector<StatsEntry> = 0;
+    };
+
+    /**
+     * \brief One thing a component decided, reported when it decided it.
+     *
+     * Notes are not a second copy of the counters: a counter says *how many*,
+     * and the notes say *which ones, and with what figures*. That is the
+     * relationship a proof comment used to have to its counter, and it is the
+     * part of that arrangement worth keeping.
+     *
+     * \ingroup Core
+     */
+    struct StatsNote final
+    {
+        StatsLevel level;
+
+        /// Which component said it; the ComponentStats::component_name() of the
+        /// block this note goes with.
+        std::string component;
+
+        /// The constraint it is about, where there is one. Typed, so that a
+        /// caller can filter and a test can assert, rather than baked into
+        /// \ref text.
+        std::optional<ConstraintID> constraint;
+
+        /// What happened, in the component's own words, with the figures in it.
+        std::string text;
+    };
+
+    /**
+     * \brief Render a note as one line, as the default callback and the default
+     * `operator<<` both do it.
+     *
+     * The component label prefixes the text at General and below, and is
+     * omitted at Important; the constraint, if there is one, is named at the
+     * end. Phrasing a note is the renderer's job and not the reporting site's,
+     * which is why StatsNote carries the ConstraintID rather than a string with
+     * it already in.
+     *
+     * \ingroup Core
+     */
+    [[nodiscard]] auto render(const StatsNote &) -> std::string;
+
+    /**
+     * \brief Called by gcs::solve_with() as each StatsNote is reported, which
+     * is at the moment the component decided the thing it is about.
+     *
+     * \warning Unlike every other callback, leaving this unset does **not** mean
+     * "do nothing": unset gets default_stats_report(). A silent default is the
+     * thing this channel exists to fix, so silence has to be asked for, by
+     * setting a callback that does nothing.
+     *
+     * \warning May eventually be called from any search thread, once there is a
+     * parallel search. It is called during solving, not at teardown, which is
+     * the point of it: a presolver's decision is reported while it is being
+     * made.
+     *
+     * \ingroup SolveCallbacks
+     */
+    using StatsReportCallback = std::function<auto(const StatsNote &)->void>;
+
+    /**
+     * \brief The default StatsReportCallback: writes notes at `level` and above
+     * to `cerr`, rendered by render().
+     *
+     * \ingroup Core
+     */
+    [[nodiscard]] auto default_stats_report(StatsLevel level = StatsLevel::Important) -> StatsReportCallback;
+
+    /**
+     * \brief A StatsReportCallback that does nothing, for a caller that wants
+     * the notes accumulated on Stats but nothing written anywhere.
+     *
+     * Spelled out rather than left to `StatsReportCallback{}`, which means "use
+     * the default" instead.
+     *
+     * \ingroup Core
+     */
+    [[nodiscard]] auto silent_stats_report() -> StatsReportCallback;
+
+    /**
      * \brief Statistics from solving.
+     *
+     * Deliberately not an aggregate, despite the plain counters: what happens
+     * to a note at the moment it is reported has to stay a decision this class
+     * makes, rather than one every caller has already made by writing into a
+     * public vector.
      *
      * \sa gcs::solve()
      * \sa gcs::solve_with()
@@ -43,10 +251,54 @@ namespace gcs
         unsigned long long idempotence_downgrades = 0;
 
         std::chrono::microseconds solve_time;
+
+        /**
+         * \brief Register a component's block, so that its summary and entries
+         * are reported.
+         *
+         * Registering the same block twice does nothing: a component installed
+         * many times reports one aggregate rather than one entry per install.
+         * The block is registered *empty* --- the numbers arrive later, and are
+         * read when the report is rendered.
+         */
+        auto add_component(std::shared_ptr<const ComponentStats>) -> void;
+
+        /**
+         * \brief Report one decision, now.
+         *
+         * Forwards to the handler and then accumulates. The handler is what
+         * solve_with() installs from SolveCallbacks::stats_report, which is why
+         * this is a method and not a public vector.
+         */
+        auto report(StatsNote) -> void;
+
+        /**
+         * \brief Install the handler report() forwards to, or clear it.
+         *
+         * For gcs::solve_with(), which sets it before anything can report and
+         * clears it before returning, so that a caller holding the result is
+         * not holding a live callback into a finished search.
+         */
+        auto set_report_handler(StatsReportCallback) -> void;
+
+        [[nodiscard]] auto components() const GCS_LIFETIME_BOUND -> const std::vector<std::shared_ptr<const ComponentStats>> &;
+
+        [[nodiscard]] auto notes() const GCS_LIFETIME_BOUND -> const std::vector<StatsNote> &;
+
+    private:
+        std::vector<std::shared_ptr<const ComponentStats>> _components;
+        std::vector<StatsNote> _notes;
+        StatsReportCallback _handler;
     };
 
     /**
      * \brief Stats can be written to an ostream, for convenience.
+     *
+     * Writes the counters, then every registered component's summary, then
+     * every note at StatsLevel::General and above. The Important ones appear
+     * here as well as having gone to the handler when they happened, on
+     * purpose: a note reported during presolve has scrolled off the top of an
+     * hour-long run by the time anyone reads the counters.
      *
      * \sa Stats
      * \ingroup Core

--- a/gcs/variable_weighting_test.cc
+++ b/gcs/variable_weighting_test.cc
@@ -36,7 +36,9 @@ TEST_CASE("ClassicDomWDeg starts at the variable's degree")
     auto y = state.allocate_integer_variable_with_state(0_i, 10_i);
     auto z = state.allocate_integer_variable_with_state(0_i, 10_i);
 
-    Propagators propagators;
+    Stats stats;
+
+    Propagators propagators{stats};
     propagators.install(NumberedConstraint{1}, a_propagator_that_does_nothing(), Triggers{.on_change = {x, y}});
     propagators.install(NumberedConstraint{2}, a_propagator_that_does_nothing(), Triggers{.on_change = {y, z}});
     propagators.install(NumberedConstraint{3}, a_propagator_that_does_nothing(), Triggers{.on_change = {x, z}});
@@ -62,7 +64,9 @@ TEST_CASE("ClassicDomWDeg bumps the failing constraint's weight")
     auto y = state.allocate_integer_variable_with_state(0_i, 10_i);
     auto z = state.allocate_integer_variable_with_state(0_i, 10_i);
 
-    Propagators propagators;
+    Stats stats;
+
+    Propagators propagators{stats};
     propagators.install(NumberedConstraint{1}, a_propagator_that_does_nothing(), Triggers{.on_change = {x, y}});
     propagators.install(NumberedConstraint{2}, a_propagator_that_does_nothing(), Triggers{.on_change = {y, z}});
     propagators.install(NumberedConstraint{3}, a_propagator_that_does_nothing(), Triggers{.on_change = {x, z}});
@@ -89,7 +93,9 @@ TEST_CASE("ClassicDomWDeg counts only constraints with at least two unassigned v
     auto y = state.allocate_integer_variable_with_state(5_i, 5_i); // already fixed
     auto z = state.allocate_integer_variable_with_state(0_i, 10_i);
 
-    Propagators propagators;
+    Stats stats;
+
+    Propagators propagators{stats};
     // _1 over {x, y}: y is fixed, so only one unassigned variable -> excluded.
     propagators.install(NumberedConstraint{1}, a_propagator_that_does_nothing(), Triggers{.on_change = {x, y}});
     // _2 over {x, z}: two unassigned -> counted.
@@ -113,7 +119,9 @@ TEST_CASE("ClassicDomWDeg snapshot and load round-trip")
     auto y = state.allocate_integer_variable_with_state(0_i, 10_i);
     auto z = state.allocate_integer_variable_with_state(0_i, 10_i);
 
-    Propagators propagators;
+    Stats stats;
+
+    Propagators propagators{stats};
     propagators.install(NumberedConstraint{1}, a_propagator_that_does_nothing(), Triggers{.on_change = {x, y}});
     propagators.install(NumberedConstraint{2}, a_propagator_that_does_nothing(), Triggers{.on_change = {y, z}});
     propagators.install(NumberedConstraint{3}, a_propagator_that_does_nothing(), Triggers{.on_change = {x, z}});
@@ -184,7 +192,9 @@ TEST_CASE("ConflictHistorySearch builds a recency-weighted score")
     auto b = state.allocate_integer_variable_with_state(0_i, 10_i);
     auto x = state.allocate_integer_variable_with_state(0_i, 10_i);
 
-    Propagators propagators;
+    Stats stats;
+
+    Propagators propagators{stats};
     propagators.install(NumberedConstraint{1}, a_propagator_that_does_nothing(), Triggers{.on_change = {a, x}});
     propagators.install(NumberedConstraint{2}, a_propagator_that_does_nothing(), Triggers{.on_change = {b, x}});
 
@@ -214,7 +224,9 @@ TEST_CASE("ConflictHistorySearch snapshot and load round-trip the scores")
     auto a = state.allocate_integer_variable_with_state(0_i, 10_i);
     auto x = state.allocate_integer_variable_with_state(0_i, 10_i);
 
-    Propagators propagators;
+    Stats stats;
+
+    Propagators propagators{stats};
     propagators.install(NumberedConstraint{1}, a_propagator_that_does_nothing(), Triggers{.on_change = {a, x}});
 
     ConflictHistorySearch weighting{propagators};
@@ -235,7 +247,9 @@ TEST_CASE("RefinedWeighting ca.cd increments by 1 / (fut * (1 + dom))")
     auto a = state.allocate_integer_variable_with_state(0_i, 2_i); // dom 3
     auto b = state.allocate_integer_variable_with_state(0_i, 2_i); // dom 3
 
-    Propagators propagators;
+    Stats stats;
+
+    Propagators propagators{stats};
     propagators.install(NumberedConstraint{1}, a_propagator_that_does_nothing(), Triggers{.on_change = {a, b}});
 
     RefinedWeighting weighting{propagators, state, RefinedWeighting::Variant::CurrentArityCurrentDomain};
@@ -257,7 +271,9 @@ TEST_CASE("RefinedWeighting variants increment differently and round-trip")
     auto a = state.allocate_integer_variable_with_state(0_i, 2_i); // dom 3
     auto b = state.allocate_integer_variable_with_state(0_i, 2_i);
 
-    Propagators propagators;
+    Stats stats;
+
+    Propagators propagators{stats};
     propagators.install(NumberedConstraint{1}, a_propagator_that_does_nothing(), Triggers{.on_change = {a, b}});
 
     // The CurrentArity variant increments by 1 / fut = 1 / 2 = 0.5, not the ca.cd 0.125.


### PR DESCRIPTION
Closes #662.

## Read the comment, not the body

The issue's revision comment reverses several parts of the body, and this
implements the comment. A reviewer who remembers only the body should know that
the following were **deliberately not built**:

- **The central `std::variant`** (`using Diagnostic = std::variant<...>`) is
  gone. It is closed-world in an open-world tree: every new component would edit
  a Core header, and `stats.hh` would grow an include of every component's
  decline enum. Nothing here is a variant.
- **Severity levels are back in scope**, where the body put them out of it.
- **`SolveCallbacks::diagnostic` is back in scope**, where the body rejected it.
  What the body rejected was an *opt-in* callback defaulting to silence; this
  one defaults to `default_stats_report()`, which has the opposite property.
- **The "optional tasks or a variable height quietly stop being strengthened"
  premise is stale** and no fixture here relies on it. The capacity is the only
  argument that turns a whole donor away.
- **The two _proof-size_ budget declines are proofs-on only, but the `Important`
  note they raise is not.** `declined_over_budget` and
  `declined_over_raise_budget` do sit inside `if (logger)` at
  `cumulative_strengthening.cc:435`, because the figures are estimates of proof
  size. But they are two of *three* sites that increment
  `limit_declines_this_run`, and the third —
  `declined_capacity_too_large`, at `cumulative_strengthening.cc:228` — is
  deliberately outside that guard: the comment above it says it runs ahead of
  the proof budgets precisely because none of them runs with proofs off, and a
  donor with a capacity in the billions would otherwise spend hundreds of
  megabytes before anything decided there was nothing to strengthen.

  So **this PR does make the solver write to `cerr` in a default proofs-off
  run**: a `Cumulative` whose constant capacity exceeds
  `_max_subset_sum_capacity` (default 1000000) raises the aggregate `Important`
  note, and with no `stats_report` set that goes to `cerr` via
  `default_stats_report()`. That is the intended behaviour — a limit stopped the
  presolver doing what it was asked, which is what the rung is defined by, and
  it is the one limit decline reachable with proofs off — but it is a behaviour
  change for ordinary callers and is called out here rather than left to be
  discovered. See the discussion below on what that means for the three
  frontends.

  An earlier revision of this description said the budget declines were
  proofs-on only and stopped there, which was wrong in the direction that hid
  this; the coverage gap that let it stand is fixed too, in
  `cumulative_strengthening_test.cc`, which now asserts exactly one `Important`
  note on that path with proofs off.

## Typed notes, without a central variant

The open-world property comes from splitting what the body's variant conflated.

**Blocks stay the source of truth**, and derive from a narrow base so `Stats` can
render a block whose type it has never heard of:

```cpp
class ComponentStats
{
public:
    virtual ~ComponentStats() = 0;
    [[nodiscard]] virtual auto component_name() const -> std::string = 0;
    [[nodiscard]] virtual auto summary() const -> std::string = 0;
    [[nodiscard]] virtual auto entries() const -> std::vector<StatsEntry> = 0;
};
```

A component in its own directory joins the report by deriving from that and
calling `propagators.add_component_stats(_stats)`. No Core header learns that
the component exists. Every existing test on those blocks still passes
unchanged, which was the point of keeping them as the record.

**Decisions are pushed as events**, because a block is registered *empty* and
anything pulled from a finished block has lost the per-instance detail that made
the proof comments worth reading:

```cpp
struct StatsNote final
{
    StatsLevel level;
    std::string component;
    std::optional<ConstraintID> constraint;
    std::string text;
};
```

The `ConstraintID` is on the note rather than in the words, and `render()` is
the one thing that knows how to phrase it — same argument as `Reason` being
declarative and tuning going through `ArrayParam`. The typed part is the level,
the component and the constraint, which is what a caller filters on and what a
test asserts on; the figures are in `text` because the block already holds them
as numbers and a per-decline struct per component would be the closed world
again by another route.

`Propagators` is the bus, holding the `Stats &` `solve_with` constructs before
`create_propagators`, so a note fires while the presolver is running.
`SolveCallbacks::stats_report` is the handler, and is the one callback whose
unset behaviour is not silence: unset gets `default_stats_report()`, and silence
is asked for with `silent_stats_report()`. `solve_with` clears the handler before
returning, so a caller holding the result is not holding a live callback into a
finished search.

## The levels, and the name

`Debug < Detailed < General < Important`, filtered by comparison, with the
three-behaviours rule in the `StatsLevel` doc comment so it does not rot: a rung
is justified by a distinct default behaviour, not by a distinct shade of
importance.

I took the naming concern in the comment's *Deferred* section and picked
**`Important`** over `Severe` and over `Warning`. `Severe` asks for crashes.
`Warning` is the same mistake in a smaller font: in every logging framework it
means *provenance* — something went wrong — and everything at this rung is the
solver working correctly and getting the right answer. A user trained to read
`Warning: ...` as "a problem" will read "strengthening was skipped, answers are
still correct" as a problem, and a user trained the other way will start
ignoring the rung. `Important` says only "the reader needs this", which is
exactly what the rung is defined by, and it sorts naturally at the top of the
ladder.

## The proof comments

Deleted:

- the three `presolve cumulative: declining ...`;
- `starting autotabulation`, `creating autotable with N entries`, `finished
  autotabulation`;
- `derived cumulative: N capacity rows over M donors`.

Kept, being derivation annotation: `presolve cumulative gcd` / `kappa` / `amo`,
`presolve cumulative: strengthened <id> from capacity ...` — which is what keeps
the negative control at `cumulative_strengthening_test.cc` meaningful, since it
asserts the *absence* of the `presolve cumulative:` prefix for a donor that was
passed over — `new table entry found`, and `derived cumulative: declined at time
...`.

Checked by diffing real `.pbp` files against a build of `main`, since some test
lanes skip veripb:

- `auto_table --prove`: OPB byte-identical, and the `.pbp` diff is exactly the
  three deleted comment lines and nothing else.
- A two-donor Cumulative probe with `with_dynamic_programming_budget(0)`, so one
  donor is strengthened and one passed over: OPB byte-identical, `.pbp` diff is
  exactly the two deleted comment lines, `presolve cumulative: strengthened` and
  the three gcd/kappa markers still present, and VeriPB still verifies.

That probe's console output, which is the whole point of the issue:

```
solve time: 0.000802s
cumulative_strengthening: 1 of 2 posted Cumulatives strengthened, taking 2 off their capacities and raising 0 heights
cumulative_strengthening: passed over: the derivation would need 165 dynamic programming states against a budget of 0, see with_dynamic_programming_budget (_1)
Cumulative strengthening was skipped on 1 of 2 constraints because a size limit was reached; answers are still correct, but search may be slower
```

The last line also went to `cerr` live, when the presolver decided it.

## Components

- `CumulativeStrengtheningStats` becomes a `ComponentStats`, is always
  allocated, and carries a `DerivedCumulativeStats derived` sub-block.
- `AutoTableStats` is new: `ran`, `variables`, `tuples`, `search_nodes`. The
  worst case in the tree, since `tuples` was unrecoverable with proofs off.
  `search_nodes` is new information rather than a comment moved — the presolver
  solves a subproblem to exhaustion before search starts, and doing that
  expensively looked, from every other measurement, exactly like a slow model.
- `DerivedCumulativeStats` is an out-param on `DerivedCumulativeSpec`, folded
  into the caller's block, so a constraint installed once per donor contributes
  one aggregate rather than a component entry apiece. It has a fourth field the
  comment did not name, `constraints`, because `donors` alone conflates one
  constraint over three donors with three constraints over one.
- `declined_by_install` is **removed** rather than levelled, per the comment: it
  throws now. One guard the comment's reasoning does not cover — with assertions
  on the proof omits definitions, so a task with both a variable start and a
  variable length legitimately has no end-of-task line to pin through and the
  install declines for a reason the presolver cannot do anything about. That
  case `continue`s rather than throwing, with the reason in a comment.

## Testing

All three anti-never-fires tests from the comment, and each was **verified by
mutation** rather than assumed:

1. **A default-constructed presolver reaches `Stats::components()` with a
   non-empty summary.** As first written this did *not* catch a `clone()` that
   allocates a fresh block — what reaches `components()` is whatever the clone
   holds, so the summary looked right while the caller's handle read zero. It
   now also asserts, by pointer identity, that a caller-supplied block is the
   one registered. Mutating `clone()` to drop `_stats` fails both components.
2. **`entries().size()` equals the block's field count**, worked out from
   `sizeof` rather than written down, so adding a field moves one side of the
   comparison and not the other. Dropping one `entries()` line fails with "the
   flat view has 20 entries for 21 fields".
3. **The level is asserted, through a recording callback** rather than a parse of
   rendered output, which is exactly where a level gets thrown away. Dropping
   the view-capacity note from General to Detailed, and the aggregate from
   Important to Detailed, each fail on their own.

Three fixtures cover the level, one per reachable case, which is what the
corrected account of the decline sites above requires:

- **Proofs off, no `Important`**: a view capacity. Not a limit, so it stays at
  General — the negative control that stops `Important` becoming a rung
  everything reaches.
- **Proofs off, one `Important`**: a constant capacity beyond the subset-sum
  limit. This is the path an ordinary caller with no proof and no
  `stats_report` actually sees, so it asserts the *count* of `Important` notes
  rather than their presence: a second one is the solver talking over itself.
  Verified by mutation — dropping `++limit_declines_this_run` from the capacity
  site fails with "a capacity decline raised 0 Important notes with proofs off,
  not one".
- **Proofs on, one `Important`**: the dynamic-programming budget, asserting both
  the figures in the General note and the single Important note that names no
  constraint.

`ctest` is green on GCC (635/635) and on clang (639/639, Debug). Clang caught one
real defect GCC accepts silently: `GCS_LIFETIME_BOUND` on an unnamed parameter.

## Not done

- **`DifferenceLogicStats` is not migrated**, although the comment's level table
  sorts its fields and gives it an `Important` example (lifting zero edges from a
  non-zero number of donors). Deriving from `ComponentStats` makes it
  non-aggregate, which breaks seven designated-initialiser sites in
  `difference_logic_test.cc` — churn outside the comment's own survey of what
  moves. Mechanical follow-up, along with `InferredCumulativeStats`,
  `InferredDisjunctiveStats` and `DifferenceSimplificationStats`.
- **One judgement call to overrule if you disagree**: the comment's table names
  "either budget decline" for `Important`, and I also folded
  `declined_capacity_too_large` into the aggregate. It meets the stated test
  verbatim — a limit was reached, so the configuration being run is not the one
  that was asked for, and `with_subset_sum_capacity_limit` is a knob the caller
  can raise — and it is the only limit decline reachable with proofs off, so
  without it `Important` is a rung this presolver cannot reach in the
  configuration the issue is about. One `++limit_declines_this_run` to remove.
- **`python/gcspy.hh:61` is unchanged**, per the comment's *Deferred* section: it
  still returns `unordered_map<string, unsigned long long int>` and still works,
  since nothing existing moved.
- **The callback is not yet thread-safe**, but its contract now says it may
  eventually be called from any search thread, and `report()` being the only way
  in is what will make a `merge()` at the join easy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FiXjJTM4G1dMjbr45wGb12

