### PR TITLE
Delete logged solutions from proofs once something subsumes them

### DIFF
--- a/dev_docs/README.md
+++ b/dev_docs/README.md
@@ -98,6 +98,13 @@ library. For an introduction to *using* the solver, start with the top-level
   distinction that governs which linking clauses are load-bearing — with the
   W1–W5 witness suite as the regression defence against re-simplification.
   Read when touching range/interval reasons, branching, or `infer_not_in_range`.
+- [Deleting logged solutions from a proof](solution-constraint-deletion.md) — why
+  a solution's constraint can be deleted once it is superseded, and what has to
+  move into VeriPB's core set first for the checked deletion to discharge:
+  trivial for optimisation, and for enumeration the backtrack clause, every
+  clause on the path back to the root, and all of the lazily-introduced
+  encoding definitions. Read when touching `ProofLogger::solution`,
+  `ProofLogger::backtrack`, or proof levels.
 - [View proof logging](view-proof-logging.md) — how the proof layer handles
 - [arithmetic-proofs.md](arithmetic-proofs.md) — how Multiply/Divide/Modulus/Power propagate and justify against cake's encoding: the slot-keyed emitters, the ConditionalBound justification layer, the sign-case driver, and the hard-won RUP/pol rules.
 - [Decision-diagram proof strategies](decision-diagram-proof-strategies.md) — for

--- a/dev_docs/solution-constraint-deletion.md
+++ b/dev_docs/solution-constraint-deletion.md
@@ -184,28 +184,32 @@ become checked and fail. So the tracker marks its own lines, with
 lazily --- the first time a deletion actually needs them, and never at all in
 a proof that deletes nothing.
 
-It is *all* of them, and not just the ones the deletion goal reads. That is
-worth knowing because the narrower rule is the obvious one to try and it looks
-right on small proofs. The goal needs the definitional closure of the atoms in
-the discharging clause: an order atom's two halves, an eq atom's two halves
-plus the two order cuts it is stated over, a range literal's likewise --- and
-not the order chain linking neighbouring cuts, since the bits settle each cut
-on its own. Promoting exactly that closure and nothing else takes `abs_test`'s
-first batch from 26 lines to 10, and it verifies. It does not survive contact
-with a real instance: `skyscrapers 5` and `ortho_latin 5` then fail, not at a
-deletion but at the root `rup >= 1`, with no unchecked-deletion warning
-anywhere before it. `--unchecked-deletion` makes the failure go away, which
-places it in the checked-deletion path; and the two lines that turn out to be
-missing (`grid2_2`'s `eq5` reification, `w_how_many_hidden[3][2]`'s `eq0`) are
-definitions of atoms that appear in *no* backtrack clause in the proof, so no
-rule phrased in terms of what the goals read can reach them. VeriPB's
-propagation engine keeps a persistent root-level trail and disables the derived
-propagation sets for the duration of an `only_core` episode
-(`propagation_engine.rs`, `init_trail`); the shape of the failure is
-root-level propagation through *derived* constraints not surviving that. A
-minimal hand-written reproduction has so far resisted: a single checked
-deletion over a derived clause, or a derived general PB constraint, both
-re-propagate correctly. Until that is understood, promote the lot.
+It is *all* of them, and not just the ones the deletion goal reads --- but that
+is parked rather than settled, and the honest position is worth writing down.
+The narrower rule is the obvious one to try: promote only the definitional
+closure of the atoms in the discharging clause, being an order atom's two
+halves, an eq atom's two halves plus the two order cuts it is stated over, and
+a range literal's likewise --- but not the order chain linking neighbouring
+cuts, since the bits settle each cut on its own. That takes `abs_test`'s first
+batch from 26 lines to 10, and verifies. Whether it is *sufficient* we cannot
+currently say, because the two experiments that would answer it disagree, and
+at least one of them is measuring the checker rather than us:
+
+- Against a current checker, the narrow rule fails `skyscrapers 5` and
+  `ortho_latin 5` at a shallow `rup`, with no unchecked-deletion warning
+  anywhere before it. Both of those failures are VeriPB regressions, bisected
+  to two unrelated commits and reported upstream as `veripb-dev` issue #210. A
+  checker predating either commit verifies both proofs.
+- Against that older checker, however, the narrow rule fails 24 *other* tests
+  that the blanket promotion passes, mostly `linear_constraint_*`. Those are
+  not diagnosed. They are either a real gap in the closure that the newer
+  checker's propagation happens to paper over, or further checker bugs.
+
+Sufficiency that moves with checker version is not something to build on in
+either direction, so the blanket promotion stays until #210 is fixed and the
+comparison can be re-run against a checker worth trusting. Nothing else here
+depends on which way that lands: the blanket rule is a superset of the narrow
+one, so it is the safe end to sit at while the question is open.
 
 **2. Promotion cascades to the root.** Once a frame has promoted its clause,
 its parent's `forget_proof_level` will delete that clause, and *that* is a
@@ -237,6 +241,13 @@ need a VeriPB from 2026-06-22 or later. An older checker rejects them at the
 root with an error that reads like a missing constraint rather than a checker
 bug, and `--unchecked-deletion` makes it go away, which is misleading --- there
 is nothing wrong with the deletions.
+
+That is not the only checker caveat, and "new enough" is not the same as
+"correct": two later propagation regressions are reported as `veripb-dev` issue
+#210. Neither affects what is shipped here, which verifies 636/636, but both
+affect the narrow-promotion variant discussed above, and both are reasons to
+treat a lone deletion-related verification failure as a question about the
+checker until a second checker version agrees with it.
 
 Deleting through the level forget is kept, but on its own merits rather than to
 dodge anything: it puts the blocking constraint at the level that actually

--- a/dev_docs/solution-constraint-deletion.md
+++ b/dev_docs/solution-constraint-deletion.md
@@ -185,7 +185,7 @@ dodge anything: it puts the blocking constraint at the level that actually
 refutes it, and it costs one fewer `core id` step and one fewer checked
 deletion per solution than deleting next to the subsuming clause does.
 
-**Restarts cannot have this.** A restart unwinds through
+**The enumeration half cannot have restarts.** A restart unwinds through
 `SearchResult::RestartCutoffHit`, which forgets each level *without* emitting
 the frame's backtrack clause. There is then nothing to discharge the core
 deletions in that level with. `solve_with` calls
@@ -198,6 +198,20 @@ this ever matters.
 Assertion levels above `Definitions` are excluded for a related reason: at
 `Links` and above the atom definitions are omitted from the proof entirely, so
 (1) has nothing to promote.
+
+**The optimisation half is unaffected by both.** This is worth stating
+separately, because "nothing is deleted under restarts" is the obvious thing to
+say and it is wrong. `discard_superseded_objective_constraints` is reached from
+`solution` whenever there is an objective (`proof_logger.cc:371`) and carries
+neither gate; `deleting_solution_constraints` and the `assertion_level` test are
+read only on the enumeration path (`proof_logger.cc:336`, `486`, `880`). Nothing
+here needs a backtrack clause: what discharges the deletion is the improving
+constraint the *new* `soli` puts in core, and `objective_value` is declared
+outside the restart loop (`solve.cc:381`), so each `soli` is still strictly
+better than the last across passes. `colour --restarts 1 --prove` duly deletes
+the previous solution's pair and concludes `s VERIFIED BOUNDS 2 <= obj <= 2`,
+which is exactly what gets rejected if the guarantee has been dropped.
+`solve_test.cc` covers both halves under restarts.
 
 ## Measurements
 
@@ -212,13 +226,17 @@ Times are seconds, size is the `.pbp` in bytes, and the ratio uses medians.
 
 | instance | solutions | size before | size after | time before | time after | speedup |
 | --- | --- | --- | --- | --- | --- | --- |
-| `frequency_square --all --size 6 --lambda 2` | 53220 | 204569673 | 205546954 | 117.83 113.07 113.23 113.24 | 11.91 11.87 11.85 11.79 | 9.6x |
+| `frequency_square --all --size 6 --lambda 2` | 53220 | 204569673 | 205546954 | 117.83 113.07 113.23 113.24 | 11.91 11.87 11.85 11.79 | 9.5x |
 | `regular_random --all --seed=1` | 32985 | 14231970 | 13947925 | 21.54 21.46 21.42 21.41 21.25 | 1.99 1.97 1.98 1.98 1.98 | 10.8x |
 | `langford --all` | 52 | 964583 | 978761 | 0.23 0.23 0.23 0.23 0.23 | 0.26 0.25 0.26 0.26 0.25 | 0.88x |
 | `talent` (optimisation) | 23 | 6592428 | 6593004 | 1.11 1.10 1.11 1.11 1.11 | 1.10 1.10 1.10 1.10 1.11 | 1.01x |
 
-The first `frequency_square` "before" run is a cold-cache outlier; the median
-ignores it. Both sides verify in every case, and the solution counts agree
+The first `frequency_square` "before" run is a cold-cache outlier, which is
+why the ratios are medians rather than means: the median is 113.235 either way,
+so dropping the run by hand would change nothing. (Taking the mean instead, and
+keeping the outlier, is what gives 9.6 --- which is how a wrong figure got into
+an earlier version of this table.) Both sides verify in every case, and the
+solution counts agree
 (`ENUMERATION_COMPLETE` of 53220, 32985 and 52; `BOUNDS 6 <= obj <= 6` for
 `talent`).
 
@@ -247,6 +265,9 @@ conclusions stood up --- but they were not safe to quote at the time.
 
 - The `solx` lines themselves stay. They have to: `num_excluded_solutions`
   counts them, and that is what `ENUMERATION_COMPLETE` checks against.
-- Nothing is deleted under restarts, or above `AssertionLevel::Definitions`.
+- No *blocking* constraint is deleted under restarts, or above
+  `AssertionLevel::Definitions`. Both restrictions are specific to the
+  enumeration half; the optimisation half deletes under restarts and at every
+  assertion level, as above.
 - Nothing is deleted for a solution found at the root, since no frame above it
   ever refutes it.

--- a/dev_docs/solution-constraint-deletion.md
+++ b/dev_docs/solution-constraint-deletion.md
@@ -36,11 +36,12 @@ lives, not by whether the proof wrote `del` or `delc`. `delc` only *asserts*
 that the target is core (VeriPB errors if it is not); a plain `del` on a core
 constraint is still a checked deletion. So the range deletions
 `forget_proof_level` already emits become checked the moment anything in the
-range has been promoted.
+range is core --- which is exactly the mechanism this change uses.
 
 **Second, and this is the part that bites**: the re-derivation is attempted
-with `only_core` set. Derived constraints are invisible to it. That is fine
-for optimisation and fatal for enumeration, for reasons below.
+with `only_core` set (`DeletionChecker::compute` sets it for the duration).
+Derived constraints are invisible to it. That is free for optimisation and
+expensive for enumeration, for reasons below.
 
 The rejection is also reported a long way from its cause --- the warning names
 no line. A one-line patch to VeriPB's `DeletionChecker` to include the proof
@@ -76,9 +77,9 @@ Two ordering constraints, both load-bearing:
 ## Enumeration
 
 Here the constraint that subsumes a blocking constraint is not the next
-solution's --- it is the **backtrack clause** of whichever frame refutes the
-subtree the solution was found in. Any solution in that subtree satisfies all
-of the frame's guesses, so "at least one guess is false" excludes it. This is
+solution's --- it is the **backtrack clause** of a frame that refutes a
+subtree the solution lies in. Any solution in that subtree satisfies all of
+the frame's guesses, so "at least one guess is false" excludes it. This is
 example 3 of the paper:
 
 ```
@@ -88,27 +89,35 @@ example 3 of the paper:
          del id @sol1 ;
 ```
 
-`ProofLogger::solution` records each blocking constraint together with the
-proof level that was active when it was logged; `ProofLogger::backtrack`, once
-it has emitted its clause, deletes every recorded solution from a deeper
-level. Because `solve_with_state` emits the frame's backtrack clause *before*
-forgetting the level below it, the clause is always still in scope.
+We do not write the `del` ourselves. `ProofLogger::solution` records the
+blocking constraint at a **proof level** --- one shallower than the active
+level, which is the level the finding frame's own backtrack clause is tagged
+at --- and `forget_proof_level` deletes it as part of the range it already
+emits, at the point that subtree is torn down. So a solution found at depth
+*d* is deleted by the frame at depth *d-2*, discharged by that frame's
+clause. At depth 0 the level is Top and the constraint stays for the whole
+proof, which is right: nothing above ever refutes it.
 
-Note that the blocking constraint is load-bearing for the clause that replaces
-it: at a solution leaf the guesses fix every variable, so "at least one guess
-is false" is only RUP *because* the blocking constraint refutes the leaf. Emit
-first, delete second.
+Note that the blocking constraint is load-bearing for the clause that
+supersedes it: at a solution leaf the guesses fix every variable, so "at least
+one guess is false" is only RUP *because* the blocking constraint refutes the
+leaf. Emit first, delete later.
+
+`ProofLogger::backtrack` moves its clause into core exactly when the level it
+is about to forget holds core constraints. That is the whole promotion rule,
+and it covers both cases: a level holding solutions' blocking constraints, and
+a level holding a descendant's clause that was promoted for the same reason.
 
 ### The things that are not in the issue
 
 Three of them.
 
 **1. The lazily-introduced encoding definitions have to go to core.** This is
-the real obstacle, and it is a direct consequence of `only_core`. The deletion
-goal is `core /\ ~blocking(sigma) |- false`. Negating the blocking constraint
-fixes every *preserved bit* to its value in sigma. The backtrack clause is
-written in *atoms* --- `i[x][eq0]`, `i[x][ge3]`, `~i[x][ge3]`, range literals.
-Getting from one to the other needs the reifications that define those atoms:
+the real obstacle, and a direct consequence of `only_core`. The deletion goal
+is `core /\ ~blocking(sigma) |- false`. Negating the blocking constraint fixes
+every *preserved bit* to its value in sigma. The backtrack clause is written
+in *atoms* --- `i[x][eq0]`, `i[x][ge3]`, `~i[x][ge3]`, range literals. Getting
+from one to the other needs the reifications that define those atoms:
 
 ```
 red 1 i[z][b0] 2 i[z][b1] 2 ~i[z][ge2] >= 2 : i[z][ge2] -> 0 ;
@@ -119,9 +128,9 @@ red -1 i[z][ge1] -1 ~i[z][ge2] 1 i[z][eq1] >= -1 : i[z][eq1] -> 1 ;
 
 `NamesAndIDsTracker` emits these on first use, *in the proof*, so they are
 derived and the deletion check cannot see them --- and without them nothing
-propagates from the bits to the atoms and the goal fails. They have to be
-moved to core. There is no way round this: a witness or an explicit subproof
-does not help, because `check_checked_deletion` sets `only_core` regardless.
+propagates from the bits to the atoms and the goal fails. There is no way
+round it: a witness or an explicit subproof does not help, because
+`check_checked_deletion` sets `only_core` regardless.
 
 They are all emitted at `ProofLevel::Top` and never deleted, so promoting them
 is safe; the witnesses only ever touch the fresh atom, never a preserved
@@ -138,22 +147,55 @@ a proof that deletes nothing.
 its parent's `forget_proof_level` will delete that clause, and *that* is a
 checked deletion too. The constraint that discharges it is the parent's own
 backtrack clause, which is a prefix of the child's and so subsumes it --- but
-only if the parent promoted it as well. The parent may have no solutions of
-its own left to delete (the child already deleted them), so "promote when I
-have solutions to delete" is not enough. `ProofLogger` therefore keeps
-`core_lines_by_level` alongside `proof_lines_by_level`, and a frame promotes
-its clause if it has solutions to delete **or** if the level below it holds a
-promoted line. At the root the clause is the empty one, `rup >= 1`, and
+only if the parent promoted as well. `ProofLogger` therefore keeps
+`core_lines_by_level` alongside `proof_lines_by_level`, and the promotion rule
+above reads it. At the root the clause is the empty one, `rup >= 1`, and
 deleting anything against a contradictory core is trivial.
 
-**3. Restarts cannot have this.** A restart unwinds through
+**3. VeriPB loses a later conflict if a checked deletion lands in the wrong
+place.** This one is not about GCS at all, and it is why solution constraints
+are deleted by the *level forget* rather than next to the clause that subsumes
+them, which is what the first cut did and what the paper's example looks like.
+
+With the first cut, `scp_chain_multiply_square_sat` --- `--all` enumeration of
+`X * X = Z` over `X` in `-3..3`, seven solutions --- stopped verifying: the
+root's `rup >= 1` was rejected as not RUP. Moving the *single* deletion of the
+last solution's blocking constraint one rule later, from just before the
+parent frame's `rup 1 ~i[Z][eq9] >= 1` to just after it, makes the proof
+verify. Dumping VeriPB's live constraint database at the failing step in both
+variants (`-t`, replaying `ConstraintId` / `Deleting IDs` / `Checked deletion
+of ID` lines) gives **byte-identical sets of 226 constraints**, and the traces
+differ in exactly one place: which of the deletion and the addition comes
+first. So the checker reaches the same database and finds the conflict from
+one and not the other. Unit propagation to conflict is confluent, so this
+looks like state in the propagation engine that a checked deletion disturbs
+--- `Database::delete_constraint` detaches from the propagator, and
+`update_unique_index` merges and detaches duplicates, both inside the
+`only_core` window that `DeletionChecker::compute` opens. It deserves an
+upstream report; a minimal reproducer is a proof of the shape
+
+```
+solx ... ;      % a solution
+rup <leaf backtrack clause> ;
+core id -1 ;
+del id -2 ;     % <-- here fails, one rule later verifies
+rup <parent backtrack clause> ;
+...
+rup >= 1 ;      % rejected
+```
+
+Deleting through the level forget avoids it, because the blocking constraint
+then outlives every clause derivation it took part in. That is not a proof
+that the artefact cannot bite somewhere else, and it is the main reason to be
+careful when changing where these deletions are emitted.
+
+**Restarts cannot have this.** A restart unwinds through
 `SearchResult::RestartCutoffHit`, which forgets each level *without* emitting
-the frame's backtrack clause. There is then nothing to promote and nothing to
-discharge the descendants' clause deletions with, so the invariant in (2)
-cannot be maintained. `solve_with` calls
+the frame's backtrack clause. There is then nothing to discharge the core
+deletions in that level with. `solve_with` calls
 `ProofLogger::disable_solution_deletion` when restarts are enabled, and
-enumeration proofs under restarts keep every blocking constraint as before.
-Retaining the promoted clauses instead of deleting them (via
+enumeration proofs under restarts keep every blocking constraint at Top as
+before. Retaining the promoted lines instead of deleting them (via
 `IntervalSet::each_interval_minus`) would work and is the obvious extension if
 this ever matters.
 
@@ -161,11 +203,39 @@ Assertion levels above `Definitions` are excluded for a related reason: at
 `Links` and above the atom definitions are omitted from the proof entirely, so
 (1) has nothing to promote.
 
+## Measurements
+
+veripb 3.0.2, this VM, each pair timed back to back in one sitting; five runs
+each except `frequency_square`, which is four. Proof size is the `.pbp` in
+bytes. "before" is `d3c9e58b`.
+
+| instance | solutions | size before | size after | time before (s) | time after (s) | speedup |
+| --- | --- | --- | --- | --- | --- | --- |
+| `frequency_square --all --size 6 --lambda 2` | 53220 | 204569673 | 205546954 | 115.26 115.00 114.07 113.44 | 12.04 12.13 12.07 12.11 | 9.4x |
+| `regular_random --all --seed 1` | 32985 | 14231970 | 13947925 | 21.09 21.16 21.17 21.28 21.21 | 1.99 1.99 1.99 1.99 1.99 | 10.6x |
+| `langford --all` | 52 | 964583 | 978761 | 0.24 0.23 0.23 0.23 0.23 | 0.26 0.26 0.26 0.26 0.26 | 0.88x |
+| `nonogram --all` | 1 | 41287 | 42142 | 0.00 | 0.00 | --- |
+| `talent` (optimisation) | 3 | 6592428 | 6593004 | 1.11 1.12 1.11 1.13 1.11 | 1.11 1.10 1.11 1.11 1.10 | 1.00x |
+| `tour` (optimisation) | --- | 3280786 | 3280868 | 0.47 0.48 0.48 0.47 0.47 | 0.48 0.48 0.48 0.48 0.48 | 0.98x |
+| `table_layout` (optimisation) | --- | 5718477 | 5718529 | 0.24 0.25 0.24 0.24 0.25 | 0.25 0.24 0.25 0.24 0.24 | 1.00x |
+| `p_dispersion`, `colour`, `cumulative`, `circuit_random` | --- | --- | --- | 0.00 | 0.00 | --- |
+
+Peak RSS moves the wrong way on the big enumeration case: `frequency_square`
+goes from 564 MB to 645 MB, because the encoding definitions promoted to core
+are indexed differently there. `regular_random` is flat (48.6 MB to 48.4 MB).
+
+The shape to take from this: **the win is enumeration with many solutions, and
+it is an order of magnitude.** Optimisation is free but unmeasurable here ---
+these instances log two or three improving solutions, so there is almost
+nothing to delete; an instance with a long chain of improvements would be the
+one to look at. Small enumerations lose slightly (`langford`, 52 solutions, 12
+per cent slower and 1.5 per cent bigger) because the one-off promotion of the
+encoding to core is not paid back.
+
 ## What this does not do
 
 - The `solx` lines themselves stay. They have to: `num_excluded_solutions`
   counts them, and that is what `ENUMERATION_COMPLETE` checks against.
 - Nothing is deleted under restarts, or above `AssertionLevel::Definitions`.
-- The proof gets slightly *longer*, not shorter --- the `core id` and `del id`
-  steps are new text and the solution lines are unchanged. The win is in the
-  checker's working set and in checking time. See the measurements below.
+- Nothing is deleted for a solution found at the root, since no frame above it
+  ever refutes it.

--- a/dev_docs/solution-constraint-deletion.md
+++ b/dev_docs/solution-constraint-deletion.md
@@ -12,13 +12,15 @@ Counting?) Problems in VeriPB", first if you have not: examples 3 and 4 there
 are the enumeration recipe implemented here, and section 3's account of core
 versus derived is the reason a naive `del` does not work.
 
-**These proofs need a VeriPB containing `veripb-dev` MR !217** (2026-08-11,
-open at the time of writing, on branch `fix/reset-derived-constraints`). An
-older checker can reject them at a `rup` step, reported as if a constraint were
-missing rather than as a checker limitation, and `--unchecked-deletion` makes it
-go away --- which is misleading, since there is nothing wrong with the
-deletions. Every VeriPB build reports version 3.0.2 regardless of commit, so
-check the commit rather than `--version`.
+**These proofs need a VeriPB from 2026-06-22 or later**, i.e. one containing
+`veripb-dev` MR !193. An older checker rejects them at the root `rup >= 1`,
+reported as if a constraint were missing rather than as a checker limitation,
+and `--unchecked-deletion` makes it go away --- which is misleading, since there
+is nothing wrong with the deletions. Every VeriPB build reports version 3.0.2
+regardless of commit, so check the commit rather than `--version`.
+
+The narrow promotion discussed below needs a newer checker still, one containing
+MR !217; what ships here does not, and verifies against public VeriPB today.
 
 ## The obstacle: checked deletion only sees core
 
@@ -251,8 +253,10 @@ which is exactly what gets rejected if the guarantee has been dropped.
 
 ## Measurements
 
-Checker is `veripb-dev` at MR !217; quote the checker commit alongside any
-checking time, since the version string does not distinguish builds. "before"
+Checker is `veripb-dev` at MR !217 (chosen so the blanket and narrow tables
+below are comparable, not because these proofs need it); quote the checker
+commit alongside any checking time, since the version string does not
+distinguish builds. "before"
 is `d3c9e58b`; "after" is this branch. Each pair is timed *alternately* ---
 before, after, before, after --- so machine drift lands on both sides equally.
 Five runs each except `frequency_square`, which is four.

--- a/dev_docs/solution-constraint-deletion.md
+++ b/dev_docs/solution-constraint-deletion.md
@@ -12,10 +12,13 @@ Counting?) Problems in VeriPB", first if you have not: examples 3 and 4 there
 are the enumeration recipe implemented here, and section 3's account of core
 versus derived is the reason a naive `del` does not work.
 
-**These proofs need a VeriPB from 2026-06-22 or later**, i.e. one containing
-`veripb-dev` MR !193. An older checker rejects them at the root `rup >= 1`
-with what looks like a missing constraint. Finding 3 below has the details,
-including how to build a pre-fix checker and watch it happen.
+**These proofs need a VeriPB containing `veripb-dev` MR !217** (2026-08-11,
+open at the time of writing, on branch `fix/reset-derived-constraints`). An
+older checker can reject them at a `rup` step, reported as if a constraint were
+missing rather than as a checker limitation, and `--unchecked-deletion` makes it
+go away --- which is misleading, since there is nothing wrong with the
+deletions. Every VeriPB build reports version 3.0.2 regardless of commit, so
+check the commit rather than `--version`.
 
 ## The obstacle: checked deletion only sees core
 
@@ -149,7 +152,7 @@ a level holding a descendant's clause that was promoted for the same reason.
 
 ### The things that are not in the issue
 
-Three of them.
+Two of them.
 
 **1. The lazily-introduced encoding definitions have to go to core.** This is
 the real obstacle, and a direct consequence of `only_core`. The deletion goal
@@ -184,32 +187,26 @@ become checked and fail. So the tracker marks its own lines, with
 lazily --- the first time a deletion actually needs them, and never at all in
 a proof that deletes nothing.
 
-It is *all* of them, and not just the ones the deletion goal reads --- but that
-is parked rather than settled, and the honest position is worth writing down.
-The narrower rule is the obvious one to try: promote only the definitional
-closure of the atoms in the discharging clause, being an order atom's two
-halves, an eq atom's two halves plus the two order cuts it is stated over, and
-a range literal's likewise --- but not the order chain linking neighbouring
-cuts, since the bits settle each cut on its own. That takes `abs_test`'s first
-batch from 26 lines to 10, and verifies. Whether it is *sufficient* we cannot
-currently say, because the two experiments that would answer it disagree, and
-at least one of them is measuring the checker rather than us:
+What ships promotes *all* of them, and not just the ones the deletion goal
+reads --- but that is a decision about the checker we can rely on today, not a
+claim that the narrow rule is insufficient. It is not: promoting only the
+definitional closure of the atoms in the discharging clause --- an order atom's
+two halves, an eq atom's two halves plus the two order cuts it is stated over,
+and a range literal's likewise, but *not* the order chain linking neighbouring
+cuts, since the bits settle each cut on its own --- passes the whole suite,
+636/636. It is also a real reduction rather than a no-op: `abs_test`'s first
+batch goes from 26 promoted constraints to 10, and `langford --all` from 2604
+over 124 `core id` steps to 76 over 76. "The narrow closure, measured" below has
+what that buys, which is more than tidiness: it removes the one regression in
+the measurement table.
 
-- Against a current checker, the narrow rule fails `skyscrapers 5` and
-  `ortho_latin 5` at a shallow `rup`, with no unchecked-deletion warning
-  anywhere before it. Both of those failures are VeriPB regressions, bisected
-  to two unrelated commits and reported upstream as `veripb-dev` issue #210. A
-  checker predating either commit verifies both proofs.
-- Against that older checker, however, the narrow rule fails 24 *other* tests
-  that the blanket promotion passes, mostly `linear_constraint_*`. Those are
-  not diagnosed. They are either a real gap in the closure that the newer
-  checker's propagation happens to paper over, or further checker bugs.
-
-Sufficiency that moves with checker version is not something to build on in
-either direction, so the blanket promotion stays until #210 is fixed and the
-comparison can be re-run against a checker worth trusting. Nothing else here
-depends on which way that lands: the blanket rule is a superset of the narrow
-one, so it is the safe end to sit at while the question is open.
+The reason the blanket rule ships anyway is that the narrow one needs a checker
+containing MR !217, and the narrow rule's `skyscrapers 5` proof is one of the
+two cases that fail without it. CI installs the checker by cloning public
+`VeriPB.git` at HEAD, so until that contains !217, narrowing turns
+`skyscrapers-5` and `ortho_latin-5` red. Blanket is the superset, so it is the
+safe end to sit at meanwhile, and nothing else here depends on which is used.
+Switching over is a small change once the checker allows it.
 
 **2. Promotion cascades to the root.** Once a frame has promoted its clause,
 its parent's `forget_proof_level` will delete that clause, and *that* is a
@@ -220,39 +217,9 @@ only if the parent promoted as well. `ProofLogger` therefore keeps
 above reads it. At the root the clause is the empty one, `rup >= 1`, and
 deleting anything against a contradictory core is trivial.
 
-**3. The checker has to be new enough.** The first cut of this work appeared to
-show that VeriPB lost a conflict when a checked deletion landed between a
-constraint's last use and a later `rup`: `scp_chain_multiply_square_sat` ---
-`--all` enumeration of `X * X = Z` over `X` in `-3..3`, seven solutions ---
-stopped verifying, with the root's `rup >= 1` rejected as not RUP.
-
-That diagnosis was wrong, and an earlier version of this section proposed an
-upstream report that should not be filed. The failure is `veripb-dev` issue
-#192, fixed by MR !193 ("never reset trailhead to higher position than
-current", merged 2026-06-22); the checker installed on the machine at the time
-predated the fix while still reporting version 3.0.2. Deletion position has
-nothing to do with it. The *shipped* proof, with the deletion where this branch
-puts it, fails at the root `rup >= 1` on a pre-fix checker and verifies on a
-fixed one --- and so does every variant with the deletion moved earlier or
-later. Build `veripb-dev` at `dbc46fe0^` to see it for yourself.
-
-What survives is a requirement rather than a design constraint: these proofs
-need a VeriPB from 2026-06-22 or later. An older checker rejects them at the
-root with an error that reads like a missing constraint rather than a checker
-bug, and `--unchecked-deletion` makes it go away, which is misleading --- there
-is nothing wrong with the deletions.
-
-That is not the only checker caveat, and "new enough" is not the same as
-"correct": two later propagation regressions are reported as `veripb-dev` issue
-#210. Neither affects what is shipped here, which verifies 636/636, but both
-affect the narrow-promotion variant discussed above, and both are reasons to
-treat a lone deletion-related verification failure as a question about the
-checker until a second checker version agrees with it.
-
-Deleting through the level forget is kept, but on its own merits rather than to
-dodge anything: it puts the blocking constraint at the level that actually
-refutes it, and it costs one fewer `core id` step and one fewer checked
-deletion per solution than deleting next to the subsuming clause does.
+Deleting through the level forget, rather than next to the subsuming clause,
+puts the blocking constraint at the level that actually refutes it, and costs
+one fewer `core id` step and one fewer checked deletion per solution.
 
 **The enumeration half cannot have restarts.** A restart unwinds through
 `SearchResult::RestartCutoffHit`, which forgets each level *without* emitting
@@ -284,38 +251,34 @@ which is exactly what gets rejected if the guarantee has been dropped.
 
 ## Measurements
 
-Checker **pinned** to `veripb-dev` f8c29244, built at
-`~/claude/tmp/veripb-pinned`, because `~/.cargo/bin/veripb` was replaced
-part-way through this work and both binaries report 3.0.2 (see finding 3).
-Anything timed against an unpinned `veripb` on this machine is not comparable.
-"before" is `d3c9e58b`; "after" is this branch. Each pair is timed
-*alternately* --- before, after, before, after --- so machine drift lands on
-both sides equally. Five runs each except `frequency_square`, which is four.
+Checker is `veripb-dev` at MR !217; quote the checker commit alongside any
+checking time, since the version string does not distinguish builds. "before"
+is `d3c9e58b`; "after" is this branch. Each pair is timed *alternately* ---
+before, after, before, after --- so machine drift lands on both sides equally.
+Five runs each except `frequency_square`, which is four.
 Times are seconds, size is the `.pbp` in bytes, and the ratio uses medians.
 
 | instance | solutions | size before | size after | time before | time after | speedup |
 | --- | --- | --- | --- | --- | --- | --- |
-| `frequency_square --all --size 6 --lambda 2` | 53220 | 204569673 | 224919034 | 117.83 113.07 113.23 113.24 | 12.64 12.62 12.70 | 9.0x |
-| `regular_random --all --seed=1` | 32985 | 14231970 | 18870069 | 21.54 21.46 21.42 21.41 21.25 | 2.09 2.11 2.11 2.12 2.17 | 10.1x |
-| `langford --all` | 52 | 964583 | 1024105 | 0.23 0.23 0.23 0.23 0.23 | 0.26 0.26 0.27 0.27 0.27 | 0.85x |
-| `talent` (optimisation) | 23 | 6592428 | 6669941 | 1.11 1.10 1.11 1.11 1.11 | 1.13 1.13 1.13 1.12 1.12 | 0.98x |
+| `frequency_square --all --size 6 --lambda 2` | 53220 | 204569673 | 224919034 | 117.19 114.45 125.08 116.78 | 12.52 12.34 12.69 12.38 | 9.4x |
+| `regular_random --all --seed=1` | 32985 | 14231970 | 18870069 | 21.62 21.63 21.54 21.48 21.91 | 2.07 2.08 2.07 2.10 2.11 | 10.4x |
+| `langford --all` | 52 | 964583 | 1024105 | 0.24 0.24 0.24 0.24 0.24 | 0.27 0.27 0.26 0.27 0.26 | 0.89x |
+| `talent` (optimisation) | 23 | 6592428 | 6669941 | 1.13 1.18 1.14 1.12 1.12 | 1.15 1.14 1.13 1.11 1.12 | 1.00x |
 
 The "after" side includes stating solutions in bits, which is what the size
 column mostly moved on; the section above separates the two changes.
 
-The first `frequency_square` "before" run is a cold-cache outlier, which is
-why the ratios are medians rather than means: the median is 113.235 either way,
-so dropping the run by hand would change nothing. (Taking the mean instead, and
-keeping the outlier, is what gives 9.6 --- which is how a wrong figure got into
-an earlier version of this table.) Both sides verify in every case, and the
-solution counts agree
-(`ENUMERATION_COMPLETE` of 53220, 32985 and 52; `BOUNDS 6 <= obj <= 6` for
-`talent`).
+Ratios are medians because the `frequency_square` "before" side has a spread of
+about ten per cent run to run --- 114.45 to 125.08, with the high run third, so
+it is variance on a 200 MB proof rather than a cold cache. The other three
+instances are stable to a few per cent. Both sides verify in every case and the
+solution counts agree (`ENUMERATION_COMPLETE` of 53220, 32985 and 52;
+`BOUNDS 6 <= obj <= 6` for `talent`).
 
 Peak RSS moves the wrong way on the big enumeration case: `frequency_square`
-goes from 564580 KB to 644752 KB, because the encoding definitions promoted to
-core are indexed differently there. `regular_random` is flat (48608 KB to
-48352 KB) and `langford` is near enough (13804 KB to 14072 KB).
+goes from 564780 KB to 644768 KB, because the encoding definitions promoted to
+core are indexed differently there. `regular_random` is flat (48724 KB to
+48680 KB) and `langford` is near enough (14072 KB to 14312 KB).
 
 The shape to take from this: **the win is enumeration with many solutions, and
 it is an order of magnitude.** Optimisation is free but not a speedup on
@@ -326,13 +289,35 @@ objective terms, so it is not what the checker's time goes on; the 77 kB it
 gains is the bit-form `soli` lines, not the deletions. Take the optimisation
 half as tidiness (and as the thing that stops a long-running branch and bound
 accumulating rows without limit) rather than as a number. Small enumerations
-lose slightly (`langford`, 52 solutions, 15 per cent slower and 6 per cent
+lose slightly (`langford`, 52 solutions, 12 per cent slower and 6 per cent
 bigger) because the one-off promotion of the encoding to core is not paid back
 at that scale.
 
-These figures replace an earlier set taken while the checker was being swapped
-underneath them. They came out the same to within noise, so the earlier
-conclusions stood up --- but they were not safe to quote at the time.
+### The narrow closure, measured
+
+Both sides are this branch; the only difference is which encoding definitions
+get promoted. Same checker and the same alternating method, blanket → narrow:
+
+| instance | promoted ids | `.pbp` bytes | median time |
+| --- | --- | --- | --- |
+| `frequency_square` | 52786 → 52652 | 224919034 → 224918889 | 12.65 → 12.80 |
+| `regular_random` | 7717 → 7679 | 18870069 → 18869929 | 2.08 → 2.03 |
+| `langford` | 2604 → 76 | 1024105 → 1011205 | 0.26 → 0.24 |
+| `talent` | 0 → 0 | 6669941 → 6669941 | 1.14 → 1.14 |
+
+The saving is concentrated where the enumeration is *small*, which is exactly
+where the blanket rule costs us. On `langford` promotion drops by a factor of 34
+and the 12 per cent loss in the table above disappears completely --- 0.24 s is
+what the no-deletion baseline takes, so narrowing makes the small case free
+rather than merely cheaper. On the two big enumerations there is almost nothing
+to save, because with tens of thousands of solutions nearly every definition is
+needed by some deletion goal anyway; `frequency_square` comes out about one per
+cent slower, which is the closest thing to a cost here.
+
+`talent` promotes nothing under either rule, which is worth stating: the
+optimisation half never needs a definition in core at all, since what discharges
+its deletion is the new `soli`'s own improving constraint, over the objective
+terms. The closure question is entirely about the enumeration half.
 
 ## What this does not do
 

--- a/dev_docs/solution-constraint-deletion.md
+++ b/dev_docs/solution-constraint-deletion.md
@@ -93,10 +93,11 @@ We do not write the `del` ourselves. `ProofLogger::solution` records the
 blocking constraint at a **proof level** --- one shallower than the active
 level, which is the level the finding frame's own backtrack clause is tagged
 at --- and `forget_proof_level` deletes it as part of the range it already
-emits, at the point that subtree is torn down. So a solution found at depth
-*d* is deleted by the frame at depth *d-2*, discharged by that frame's
-clause. At depth 0 the level is Top and the constraint stays for the whole
-proof, which is right: nothing above ever refutes it.
+emits, at the point that subtree is torn down. A frame at depth *d* forgets
+level *d+1*, so a solution found at depth *d* --- recorded at level *d* --- is
+deleted by its parent, at depth *d-1*, and discharged by that frame's clause.
+A solution found at depth 0 lands at Top and stays for the whole proof, which
+is right: there is no frame above it to refute it.
 
 Note that the blocking constraint is load-bearing for the clause that
 supersedes it: at a solution leaf the guesses fix every variable, so "at least

--- a/dev_docs/solution-constraint-deletion.md
+++ b/dev_docs/solution-constraint-deletion.md
@@ -12,6 +12,11 @@ Counting?) Problems in VeriPB", first if you have not: examples 3 and 4 there
 are the enumeration recipe implemented here, and section 3's account of core
 versus derived is the reason a naive `del` does not work.
 
+**These proofs need a VeriPB from 2026-06-22 or later**, i.e. one containing
+`veripb-dev` MR !193. An older checker rejects them at the root `rup >= 1`
+with what looks like a missing constraint. Finding 3 below has the details,
+including how to build a pre-fix checker and watch it happen.
+
 ## The obstacle: checked deletion only sees core
 
 VeriPB keeps two constraint sets, *core* and *derived*. The input formula is
@@ -153,42 +158,32 @@ only if the parent promoted as well. `ProofLogger` therefore keeps
 above reads it. At the root the clause is the empty one, `rup >= 1`, and
 deleting anything against a contradictory core is trivial.
 
-**3. VeriPB loses a later conflict if a checked deletion lands in the wrong
-place.** This one is not about GCS at all, and it is why solution constraints
-are deleted by the *level forget* rather than next to the clause that subsumes
-them, which is what the first cut did and what the paper's example looks like.
+**3. The checker has to be new enough.** The first cut of this work appeared to
+show that VeriPB lost a conflict when a checked deletion landed between a
+constraint's last use and a later `rup`: `scp_chain_multiply_square_sat` ---
+`--all` enumeration of `X * X = Z` over `X` in `-3..3`, seven solutions ---
+stopped verifying, with the root's `rup >= 1` rejected as not RUP.
 
-With the first cut, `scp_chain_multiply_square_sat` --- `--all` enumeration of
-`X * X = Z` over `X` in `-3..3`, seven solutions --- stopped verifying: the
-root's `rup >= 1` was rejected as not RUP. Moving the *single* deletion of the
-last solution's blocking constraint one rule later, from just before the
-parent frame's `rup 1 ~i[Z][eq9] >= 1` to just after it, makes the proof
-verify. Dumping VeriPB's live constraint database at the failing step in both
-variants (`-t`, replaying `ConstraintId` / `Deleting IDs` / `Checked deletion
-of ID` lines) gives **byte-identical sets of 226 constraints**, and the traces
-differ in exactly one place: which of the deletion and the addition comes
-first. So the checker reaches the same database and finds the conflict from
-one and not the other. Unit propagation to conflict is confluent, so this
-looks like state in the propagation engine that a checked deletion disturbs
---- `Database::delete_constraint` detaches from the propagator, and
-`update_unique_index` merges and detaches duplicates, both inside the
-`only_core` window that `DeletionChecker::compute` opens. It deserves an
-upstream report; a minimal reproducer is a proof of the shape
+That diagnosis was wrong, and an earlier version of this section proposed an
+upstream report that should not be filed. The failure is `veripb-dev` issue
+#192, fixed by MR !193 ("never reset trailhead to higher position than
+current", merged 2026-06-22); the checker installed on the machine at the time
+predated the fix while still reporting version 3.0.2. Deletion position has
+nothing to do with it. The *shipped* proof, with the deletion where this branch
+puts it, fails at the root `rup >= 1` on a pre-fix checker and verifies on a
+fixed one --- and so does every variant with the deletion moved earlier or
+later. Build `veripb-dev` at `dbc46fe0^` to see it for yourself.
 
-```
-solx ... ;      % a solution
-rup <leaf backtrack clause> ;
-core id -1 ;
-del id -2 ;     % <-- here fails, one rule later verifies
-rup <parent backtrack clause> ;
-...
-rup >= 1 ;      % rejected
-```
+What survives is a requirement rather than a design constraint: these proofs
+need a VeriPB from 2026-06-22 or later. An older checker rejects them at the
+root with an error that reads like a missing constraint rather than a checker
+bug, and `--unchecked-deletion` makes it go away, which is misleading --- there
+is nothing wrong with the deletions.
 
-Deleting through the level forget avoids it, because the blocking constraint
-then outlives every clause derivation it took part in. That is not a proof
-that the artefact cannot bite somewhere else, and it is the main reason to be
-careful when changing where these deletions are emitted.
+Deleting through the level forget is kept, but on its own merits rather than to
+dodge anything: it puts the blocking constraint at the level that actually
+refutes it, and it costs one fewer `core id` step and one fewer checked
+deletion per solution than deleting next to the subsuming clause does.
 
 **Restarts cannot have this.** A restart unwinds through
 `SearchResult::RestartCutoffHit`, which forgets each level *without* emitting
@@ -206,24 +201,31 @@ Assertion levels above `Definitions` are excluded for a related reason: at
 
 ## Measurements
 
-veripb 3.0.2, this VM, each pair timed back to back in one sitting; five runs
-each except `frequency_square`, which is four. Proof size is the `.pbp` in
-bytes. "before" is `d3c9e58b`.
+Checker **pinned** to `veripb-dev` f8c29244, built at
+`~/claude/tmp/veripb-pinned`, because `~/.cargo/bin/veripb` was replaced
+part-way through this work and both binaries report 3.0.2 (see finding 3).
+Anything timed against an unpinned `veripb` on this machine is not comparable.
+"before" is `d3c9e58b`; "after" is this branch. Each pair is timed
+*alternately* --- before, after, before, after --- so machine drift lands on
+both sides equally. Five runs each except `frequency_square`, which is four.
+Times are seconds, size is the `.pbp` in bytes, and the ratio uses medians.
 
-| instance | solutions | size before | size after | time before (s) | time after (s) | speedup |
+| instance | solutions | size before | size after | time before | time after | speedup |
 | --- | --- | --- | --- | --- | --- | --- |
-| `frequency_square --all --size 6 --lambda 2` | 53220 | 204569673 | 205546954 | 115.26 115.00 114.07 113.44 | 12.04 12.13 12.07 12.11 | 9.4x |
-| `regular_random --all --seed 1` | 32985 | 14231970 | 13947925 | 21.09 21.16 21.17 21.28 21.21 | 1.99 1.99 1.99 1.99 1.99 | 10.6x |
-| `langford --all` | 52 | 964583 | 978761 | 0.24 0.23 0.23 0.23 0.23 | 0.26 0.26 0.26 0.26 0.26 | 0.88x |
-| `nonogram --all` | 1 | 41287 | 42142 | 0.00 | 0.00 | --- |
-| `talent` (optimisation) | 23 | 6592428 | 6593004 | 1.11 1.12 1.11 1.13 1.11 | 1.11 1.10 1.11 1.11 1.10 | 1.00x |
-| `tour` (optimisation) | 4 | 3280786 | 3280868 | 0.47 0.48 0.48 0.47 0.47 | 0.48 0.48 0.48 0.48 0.48 | 0.98x |
-| `table_layout` (optimisation) | 3 | 5718477 | 5718529 | 0.24 0.25 0.24 0.24 0.25 | 0.25 0.24 0.25 0.24 0.24 | 1.00x |
-| `p_dispersion`, `colour`, `cumulative`, `circuit_random` | --- | --- | --- | 0.00 | 0.00 | --- |
+| `frequency_square --all --size 6 --lambda 2` | 53220 | 204569673 | 205546954 | 117.83 113.07 113.23 113.24 | 11.91 11.87 11.85 11.79 | 9.6x |
+| `regular_random --all --seed=1` | 32985 | 14231970 | 13947925 | 21.54 21.46 21.42 21.41 21.25 | 1.99 1.97 1.98 1.98 1.98 | 10.8x |
+| `langford --all` | 52 | 964583 | 978761 | 0.23 0.23 0.23 0.23 0.23 | 0.26 0.25 0.26 0.26 0.25 | 0.88x |
+| `talent` (optimisation) | 23 | 6592428 | 6593004 | 1.11 1.10 1.11 1.11 1.11 | 1.10 1.10 1.10 1.10 1.11 | 1.01x |
+
+The first `frequency_square` "before" run is a cold-cache outlier; the median
+ignores it. Both sides verify in every case, and the solution counts agree
+(`ENUMERATION_COMPLETE` of 53220, 32985 and 52; `BOUNDS 6 <= obj <= 6` for
+`talent`).
 
 Peak RSS moves the wrong way on the big enumeration case: `frequency_square`
-goes from 564 MB to 645 MB, because the encoding definitions promoted to core
-are indexed differently there. `regular_random` is flat (48.6 MB to 48.4 MB).
+goes from 564580 KB to 644752 KB, because the encoding definitions promoted to
+core are indexed differently there. `regular_random` is flat (48608 KB to
+48352 KB) and `langford` is near enough (13804 KB to 14072 KB).
 
 The shape to take from this: **the win is enumeration with many solutions, and
 it is an order of magnitude.** Optimisation is free but not a speedup on
@@ -234,8 +236,12 @@ is one short PB row over the objective terms, so it is not what the checker's
 time goes on. Take the optimisation half as tidiness (and as the thing that
 stops a long-running branch and bound accumulating rows without limit) rather
 than as a number. Small enumerations lose slightly (`langford`, 52 solutions,
-12 per cent slower and 1.5 per cent bigger) because the one-off promotion of
+13 per cent slower and 1.5 per cent bigger) because the one-off promotion of
 the encoding to core is not paid back.
+
+These figures replace an earlier set taken while the checker was being swapped
+underneath them. They came out the same to within noise, so the earlier
+conclusions stood up --- but they were not safe to quote at the time.
 
 ## What this does not do
 

--- a/dev_docs/solution-constraint-deletion.md
+++ b/dev_docs/solution-constraint-deletion.md
@@ -1,0 +1,171 @@
+# Deleting logged solutions from a proof
+
+Every solution we log costs the checker a constraint that lives for the rest
+of the proof. For optimisation that is the objective-improving constraint
+`soli` creates; for enumeration it is the blocking constraint `solx` creates,
+which is a clause with one literal per preserved bit. We used to keep all of
+them, forever, at `ProofLevel::Top`. Both are superseded long before the proof
+ends, and this document is about deleting them when they are.
+
+Read the CP 2026 paper, "Proof Logging for Projected Enumeration (and
+Counting?) Problems in VeriPB", first if you have not: examples 3 and 4 there
+are the enumeration recipe implemented here, and section 3's account of core
+versus derived is the reason a naive `del` does not work.
+
+## The obstacle: checked deletion only sees core
+
+VeriPB keeps two constraint sets, *core* and *derived*. The input formula is
+core; everything a proof derives is derived unless an explicit `core id` step
+moves it. Deleting a derived constraint is free. Deleting a *core* constraint
+is a **checked deletion**: the checker must re-derive the deleted constraint
+from what is left. If it cannot, it does not fail --- it warns ("switching
+from stronger to weaker guarantee using unchecked deletion"), drops
+`strong_solution_guarantees`, and carries on. Everything downstream that
+depended on the guarantee then silently stops working:
+
+- `num_excluded_solutions` stops incrementing, so an `ENUMERATION_COMPLETE n`
+  conclusion is rejected for having the wrong `n`;
+- `best_valid_objective_value` stops updating, so a `BOUNDS` conclusion is
+  rejected;
+- `output EQUIOPTIMAL` / `EQUISATISFIABLE` / `EQUIENUMERABLE` is rejected.
+
+Two things follow, and they are the whole design.
+
+**First**, which set a constraint is deleted *from* is decided by where it
+lives, not by whether the proof wrote `del` or `delc`. `delc` only *asserts*
+that the target is core (VeriPB errors if it is not); a plain `del` on a core
+constraint is still a checked deletion. So the range deletions
+`forget_proof_level` already emits become checked the moment anything in the
+range has been promoted.
+
+**Second, and this is the part that bites**: the re-derivation is attempted
+with `only_core` set. Derived constraints are invisible to it. That is fine
+for optimisation and fatal for enumeration, for reasons below.
+
+The rejection is also reported a long way from its cause --- the warning names
+no line. A one-line patch to VeriPB's `DeletionChecker` to include the proof
+line, the constraint ID and the proof goal is on the branch
+`claude/deletion-message-line-numbers` in the local VeriPB checkout; it is
+worth upstreaming.
+
+## Optimisation
+
+Branch and bound only ever logs a strictly better solution than the last, so
+when a `soli` goes out, everything the previous one left behind is subsumed.
+There are two constraints per solution:
+
+- the objective-improving constraint VeriPB creates for the `soli` rule.
+  `SolutionChecker::add_constraints_to_core` returns `true`, so this is
+  **core**, and deleting it is checked;
+- our own order-literal restatement `[obj < v] >= 1` that follows the `e`
+  line, which is a plain `rup` and so derived, and free to delete.
+
+The checked deletion needs no scaffolding at all. The goal is
+`core \ {obj <= v_old - 1} /\ obj >= v_old |- false`, and the constraint that
+discharges it --- `obj <= v_new - 1`, with `v_new < v_old` --- was put into
+core by the `soli` we have just written. Both are over the same objective
+terms, in the same vocabulary, so unit propagation closes it immediately.
+
+Two ordering constraints, both load-bearing:
+
+- the deletions go **after** the `e` line, which addresses the just-created
+  constraint as `-1` and would otherwise be misdirected;
+- they go **after** the new `soli`, so the discharging constraint is already
+  in core when the goal is posed.
+
+## Enumeration
+
+Here the constraint that subsumes a blocking constraint is not the next
+solution's --- it is the **backtrack clause** of whichever frame refutes the
+subtree the solution was found in. Any solution in that subtree satisfies all
+of the frame's guesses, so "at least one guess is false" excludes it. This is
+example 3 of the paper:
+
+```
+@sol1    solx x1 -x2 ~x3 ;
+@x1false rup 1 -x1 >= 1 ;
+         core id @x1false ;
+         del id @sol1 ;
+```
+
+`ProofLogger::solution` records each blocking constraint together with the
+proof level that was active when it was logged; `ProofLogger::backtrack`, once
+it has emitted its clause, deletes every recorded solution from a deeper
+level. Because `solve_with_state` emits the frame's backtrack clause *before*
+forgetting the level below it, the clause is always still in scope.
+
+Note that the blocking constraint is load-bearing for the clause that replaces
+it: at a solution leaf the guesses fix every variable, so "at least one guess
+is false" is only RUP *because* the blocking constraint refutes the leaf. Emit
+first, delete second.
+
+### The things that are not in the issue
+
+Three of them.
+
+**1. The lazily-introduced encoding definitions have to go to core.** This is
+the real obstacle, and it is a direct consequence of `only_core`. The deletion
+goal is `core /\ ~blocking(sigma) |- false`. Negating the blocking constraint
+fixes every *preserved bit* to its value in sigma. The backtrack clause is
+written in *atoms* --- `i[x][eq0]`, `i[x][ge3]`, `~i[x][ge3]`, range literals.
+Getting from one to the other needs the reifications that define those atoms:
+
+```
+red 1 i[z][b0] 2 i[z][b1] 2 ~i[z][ge2] >= 2 : i[z][ge2] -> 0 ;
+red -1 i[z][b0] -2 i[z][b1] 2 i[z][ge2] >= -1 : i[z][ge2] -> 1 ;
+red 1 i[z][ge1] 1 ~i[z][ge2] 2 ~i[z][eq1] >= 2 : i[z][eq1] -> 0 ;
+red -1 i[z][ge1] -1 ~i[z][ge2] 1 i[z][eq1] >= -1 : i[z][eq1] -> 1 ;
+```
+
+`NamesAndIDsTracker` emits these on first use, *in the proof*, so they are
+derived and the deletion check cannot see them --- and without them nothing
+propagates from the bits to the atoms and the goal fails. They have to be
+moved to core. There is no way round this: a witness or an explicit subproof
+does not help, because `check_checked_deletion` sets `only_core` regardless.
+
+They are all emitted at `ProofLevel::Top` and never deleted, so promoting them
+is safe; the witnesses only ever touch the fresh atom, never a preserved
+variable, so Proposition 6 of the paper applies and the projected solution set
+is unchanged. Promoting *every* Top line would be simpler but is wrong:
+`DerivedCumulative` deletes abandoned Top lines through
+`ProofLogger::delete_proof_lines` (issue #666), and those deletions would
+become checked and fail. So the tracker marks its own lines, with
+`DefinitionRecordingScope`, and they are batched into `core id` steps issued
+lazily --- the first time a deletion actually needs them, and never at all in
+a proof that deletes nothing.
+
+**2. Promotion cascades to the root.** Once a frame has promoted its clause,
+its parent's `forget_proof_level` will delete that clause, and *that* is a
+checked deletion too. The constraint that discharges it is the parent's own
+backtrack clause, which is a prefix of the child's and so subsumes it --- but
+only if the parent promoted it as well. The parent may have no solutions of
+its own left to delete (the child already deleted them), so "promote when I
+have solutions to delete" is not enough. `ProofLogger` therefore keeps
+`core_lines_by_level` alongside `proof_lines_by_level`, and a frame promotes
+its clause if it has solutions to delete **or** if the level below it holds a
+promoted line. At the root the clause is the empty one, `rup >= 1`, and
+deleting anything against a contradictory core is trivial.
+
+**3. Restarts cannot have this.** A restart unwinds through
+`SearchResult::RestartCutoffHit`, which forgets each level *without* emitting
+the frame's backtrack clause. There is then nothing to promote and nothing to
+discharge the descendants' clause deletions with, so the invariant in (2)
+cannot be maintained. `solve_with` calls
+`ProofLogger::disable_solution_deletion` when restarts are enabled, and
+enumeration proofs under restarts keep every blocking constraint as before.
+Retaining the promoted clauses instead of deleting them (via
+`IntervalSet::each_interval_minus`) would work and is the obvious extension if
+this ever matters.
+
+Assertion levels above `Definitions` are excluded for a related reason: at
+`Links` and above the atom definitions are omitted from the proof entirely, so
+(1) has nothing to promote.
+
+## What this does not do
+
+- The `solx` lines themselves stay. They have to: `num_excluded_solutions`
+  counts them, and that is what `ENUMERATION_COMPLETE` checks against.
+- Nothing is deleted under restarts, or above `AssertionLevel::Definitions`.
+- The proof gets slightly *longer*, not shorter --- the `core id` and `del id`
+  steps are new text and the solution lines are unchanged. The win is in the
+  checker's working set and in checking time. See the measurements below.

--- a/dev_docs/solution-constraint-deletion.md
+++ b/dev_docs/solution-constraint-deletion.md
@@ -216,9 +216,9 @@ bytes. "before" is `d3c9e58b`.
 | `regular_random --all --seed 1` | 32985 | 14231970 | 13947925 | 21.09 21.16 21.17 21.28 21.21 | 1.99 1.99 1.99 1.99 1.99 | 10.6x |
 | `langford --all` | 52 | 964583 | 978761 | 0.24 0.23 0.23 0.23 0.23 | 0.26 0.26 0.26 0.26 0.26 | 0.88x |
 | `nonogram --all` | 1 | 41287 | 42142 | 0.00 | 0.00 | --- |
-| `talent` (optimisation) | 3 | 6592428 | 6593004 | 1.11 1.12 1.11 1.13 1.11 | 1.11 1.10 1.11 1.11 1.10 | 1.00x |
-| `tour` (optimisation) | --- | 3280786 | 3280868 | 0.47 0.48 0.48 0.47 0.47 | 0.48 0.48 0.48 0.48 0.48 | 0.98x |
-| `table_layout` (optimisation) | --- | 5718477 | 5718529 | 0.24 0.25 0.24 0.24 0.25 | 0.25 0.24 0.25 0.24 0.24 | 1.00x |
+| `talent` (optimisation) | 23 | 6592428 | 6593004 | 1.11 1.12 1.11 1.13 1.11 | 1.11 1.10 1.11 1.11 1.10 | 1.00x |
+| `tour` (optimisation) | 4 | 3280786 | 3280868 | 0.47 0.48 0.48 0.47 0.47 | 0.48 0.48 0.48 0.48 0.48 | 0.98x |
+| `table_layout` (optimisation) | 3 | 5718477 | 5718529 | 0.24 0.25 0.24 0.24 0.25 | 0.25 0.24 0.25 0.24 0.24 | 1.00x |
 | `p_dispersion`, `colour`, `cumulative`, `circuit_random` | --- | --- | --- | 0.00 | 0.00 | --- |
 
 Peak RSS moves the wrong way on the big enumeration case: `frequency_square`
@@ -226,12 +226,16 @@ goes from 564 MB to 645 MB, because the encoding definitions promoted to core
 are indexed differently there. `regular_random` is flat (48.6 MB to 48.4 MB).
 
 The shape to take from this: **the win is enumeration with many solutions, and
-it is an order of magnitude.** Optimisation is free but unmeasurable here ---
-these instances log two or three improving solutions, so there is almost
-nothing to delete; an instance with a long chain of improvements would be the
-one to look at. Small enumerations lose slightly (`langford`, 52 solutions, 12
-per cent slower and 1.5 per cent bigger) because the one-off promotion of the
-encoding to core is not paid back.
+it is an order of magnitude.** Optimisation is free but not a speedup on
+anything we have. `talent` is the longest improvement chain in the examples, at
+23 logged solutions, and deleting 22 of them changes the proof by 576 bytes and
+the checking time by nothing measurable --- an objective-improving constraint
+is one short PB row over the objective terms, so it is not what the checker's
+time goes on. Take the optimisation half as tidiness (and as the thing that
+stops a long-running branch and bound accumulating rows without limit) rather
+than as a number. Small enumerations lose slightly (`langford`, 52 solutions,
+12 per cent slower and 1.5 per cent bigger) because the one-off promotion of
+the encoding to core is not paid back.
 
 ## What this does not do
 

--- a/dev_docs/solution-constraint-deletion.md
+++ b/dev_docs/solution-constraint-deletion.md
@@ -54,6 +54,39 @@ line, the constraint ID and the proof goal is on the branch
 `claude/deletion-message-line-numbers` in the local VeriPB checkout; it is
 worth upstreaming.
 
+## Why the solution is stated in bits
+
+`ProofLogger::solution` writes the assignment handed to `solx` / `soli` as bit
+literals --- `i[x][b0] ~i[x][b1] i[x][b2]` --- rather than as the direct
+encoding's `i[x][eq5]`. Both work: the rule propagates whatever it is given to
+a full assignment before doing anything with it, and unit propagation crosses
+between the two vocabularies through the same reifications either way. The
+reason to prefer the bits is that they are the variables the OPB is written
+over. That makes the logged solution a solution to the *formula*, in the
+formula's own terms, and it makes the preserved set --- and so the projection
+the `ENUMERATION_COMPLETE` conclusion is about --- the model's variables rather
+than a set of atoms the proof introduced along the way. A trimmer then has to
+keep the model alive to make sense of a solution line, which it must do
+regardless, instead of the encoding definitions for whichever atoms the search
+happened to create.
+
+It costs proof size, because a variable is one eq atom but several bits.
+Measured against `d3c9e58b`, on the enumeration instances where solution lines
+are a real share of the file:
+
+| instance | solutions | size before | size after | check before | check after |
+| --- | --- | --- | --- | --- | --- |
+| `frequency_square --all --size 6 --lambda 2` | 53220 | 205546954 | 224919034 | 12.37 12.37 12.50 | 12.64 12.62 12.70 |
+| `regular_random --all --seed=1` | 32985 | 13947925 | 18870069 | 2.03 2.03 2.03 | 2.09 2.11 2.11 |
+| `langford --all` | 52 | 978761 | 1024105 | 0.26 0.26 0.26 | 0.26 0.26 0.27 |
+
+So 9%, 35% and 5% on size and 2--4% on checking time; peak RSS is unmoved on
+`frequency_square` (644.8 MB against 644.7 MB). `regular_random` is the shape
+that pays most, and it shows what the cost actually is: six variables, so a
+solution line goes from six literals to eighteen, against a proof that is
+otherwise small per solution. All three verify to the same conclusion before
+and after.
+
 ## Optimisation
 
 Branch and bound only ever logs a strictly better solution than the last, so
@@ -121,7 +154,9 @@ Three of them.
 **1. The lazily-introduced encoding definitions have to go to core.** This is
 the real obstacle, and a direct consequence of `only_core`. The deletion goal
 is `core /\ ~blocking(sigma) |- false`. Negating the blocking constraint fixes
-every *preserved bit* to its value in sigma. The backtrack clause is written
+every *preserved variable* to its value in sigma --- the bits, since those are
+what the OPB is written over and what `solution` now states a solution in (see
+"Why the solution is stated in bits" below). The backtrack clause is written
 in *atoms* --- `i[x][eq0]`, `i[x][ge3]`, `~i[x][ge3]`, range literals. Getting
 from one to the other needs the reifications that define those atoms:
 
@@ -148,6 +183,29 @@ become checked and fail. So the tracker marks its own lines, with
 `DefinitionRecordingScope`, and they are batched into `core id` steps issued
 lazily --- the first time a deletion actually needs them, and never at all in
 a proof that deletes nothing.
+
+It is *all* of them, and not just the ones the deletion goal reads. That is
+worth knowing because the narrower rule is the obvious one to try and it looks
+right on small proofs. The goal needs the definitional closure of the atoms in
+the discharging clause: an order atom's two halves, an eq atom's two halves
+plus the two order cuts it is stated over, a range literal's likewise --- and
+not the order chain linking neighbouring cuts, since the bits settle each cut
+on its own. Promoting exactly that closure and nothing else takes `abs_test`'s
+first batch from 26 lines to 10, and it verifies. It does not survive contact
+with a real instance: `skyscrapers 5` and `ortho_latin 5` then fail, not at a
+deletion but at the root `rup >= 1`, with no unchecked-deletion warning
+anywhere before it. `--unchecked-deletion` makes the failure go away, which
+places it in the checked-deletion path; and the two lines that turn out to be
+missing (`grid2_2`'s `eq5` reification, `w_how_many_hidden[3][2]`'s `eq0`) are
+definitions of atoms that appear in *no* backtrack clause in the proof, so no
+rule phrased in terms of what the goals read can reach them. VeriPB's
+propagation engine keeps a persistent root-level trail and disables the derived
+propagation sets for the duration of an `only_core` episode
+(`propagation_engine.rs`, `init_trail`); the shape of the failure is
+root-level propagation through *derived* constraints not surviving that. A
+minimal hand-written reproduction has so far resisted: a single checked
+deletion over a derived clause, or a derived general PB constraint, both
+re-propagate correctly. Until that is understood, promote the lot.
 
 **2. Promotion cascades to the root.** Once a frame has promoted its clause,
 its parent's `forget_proof_level` will delete that clause, and *that* is a
@@ -226,10 +284,13 @@ Times are seconds, size is the `.pbp` in bytes, and the ratio uses medians.
 
 | instance | solutions | size before | size after | time before | time after | speedup |
 | --- | --- | --- | --- | --- | --- | --- |
-| `frequency_square --all --size 6 --lambda 2` | 53220 | 204569673 | 205546954 | 117.83 113.07 113.23 113.24 | 11.91 11.87 11.85 11.79 | 9.5x |
-| `regular_random --all --seed=1` | 32985 | 14231970 | 13947925 | 21.54 21.46 21.42 21.41 21.25 | 1.99 1.97 1.98 1.98 1.98 | 10.8x |
-| `langford --all` | 52 | 964583 | 978761 | 0.23 0.23 0.23 0.23 0.23 | 0.26 0.25 0.26 0.26 0.25 | 0.88x |
-| `talent` (optimisation) | 23 | 6592428 | 6593004 | 1.11 1.10 1.11 1.11 1.11 | 1.10 1.10 1.10 1.10 1.11 | 1.01x |
+| `frequency_square --all --size 6 --lambda 2` | 53220 | 204569673 | 224919034 | 117.83 113.07 113.23 113.24 | 12.64 12.62 12.70 | 9.0x |
+| `regular_random --all --seed=1` | 32985 | 14231970 | 18870069 | 21.54 21.46 21.42 21.41 21.25 | 2.09 2.11 2.11 2.12 2.17 | 10.1x |
+| `langford --all` | 52 | 964583 | 1024105 | 0.23 0.23 0.23 0.23 0.23 | 0.26 0.26 0.27 0.27 0.27 | 0.85x |
+| `talent` (optimisation) | 23 | 6592428 | 6669941 | 1.11 1.10 1.11 1.11 1.11 | 1.13 1.13 1.13 1.12 1.12 | 0.98x |
+
+The "after" side includes stating solutions in bits, which is what the size
+column mostly moved on; the section above separates the two changes.
 
 The first `frequency_square` "before" run is a cold-cache outlier, which is
 why the ratios are medians rather than means: the median is 113.235 either way,
@@ -248,14 +309,15 @@ core are indexed differently there. `regular_random` is flat (48608 KB to
 The shape to take from this: **the win is enumeration with many solutions, and
 it is an order of magnitude.** Optimisation is free but not a speedup on
 anything we have. `talent` is the longest improvement chain in the examples, at
-23 logged solutions, and deleting 22 of them changes the proof by 576 bytes and
-the checking time by nothing measurable --- an objective-improving constraint
-is one short PB row over the objective terms, so it is not what the checker's
-time goes on. Take the optimisation half as tidiness (and as the thing that
-stops a long-running branch and bound accumulating rows without limit) rather
-than as a number. Small enumerations lose slightly (`langford`, 52 solutions,
-13 per cent slower and 1.5 per cent bigger) because the one-off promotion of
-the encoding to core is not paid back.
+23 logged solutions, and deleting 22 of them moves the checking time by nothing
+measurable --- an objective-improving constraint is one short PB row over the
+objective terms, so it is not what the checker's time goes on; the 77 kB it
+gains is the bit-form `soli` lines, not the deletions. Take the optimisation
+half as tidiness (and as the thing that stops a long-running branch and bound
+accumulating rows without limit) rather than as a number. Small enumerations
+lose slightly (`langford`, 52 solutions, 15 per cent slower and 6 per cent
+bigger) because the one-off promotion of the encoding to core is not paid back
+at that scale.
 
 These figures replace an earlier set taken while the checker was being swapped
 underneath them. They came out the same to within noise, so the earlier

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -640,6 +640,10 @@ if(GCS_BUILD_TESTS)
     target_link_libraries(invar_test PRIVATE glasgow_constraint_solver)
     add_test(NAME invar_test COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_verify.bash $<TARGET_FILE:invar_test>)
 
+    add_executable(solution_deletion_test innards/proofs/solution_deletion_test.cc)
+    target_link_libraries(solution_deletion_test PRIVATE glasgow_constraint_solver)
+    add_test(NAME solution_deletion_test COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_verify.bash $<TARGET_FILE:solution_deletion_test>)
+
     add_executable(range_branch_test innards/proofs/range_branch_test.cc)
     target_link_libraries(range_branch_test PRIVATE glasgow_constraint_solver)
     add_test(NAME range_branch_test COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_verify.bash $<TARGET_FILE:range_branch_test>)

--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -424,6 +424,7 @@ auto NamesAndIDsTracker::switch_from_model_to_proof(ProofLogger * const logger) 
 
 auto NamesAndIDsTracker::emit_delayed_proof_steps() -> void
 {
+    DefinitionRecordingScope definitions{_imp->logger};
     for (const auto & step : _imp->delayed_proof_steps)
         step(_imp->logger);
     _imp->delayed_proof_steps.clear();
@@ -447,6 +448,7 @@ auto NamesAndIDsTracker::track_variable_takes_at_least_one_value(const SimpleOrP
 
 auto NamesAndIDsTracker::need_constraint_saying_variable_takes_at_least_one_value(IntegerVariableID var) -> ProofLine
 {
+    DefinitionRecordingScope definitions{_imp->logger};
     return overloaded{
         [&](const ConstantIntegerVariableID &) -> ProofLine { throw UnimplementedException{}; }, //
         [&](const SimpleIntegerVariableID & var) -> ProofLine {
@@ -716,6 +718,8 @@ auto NamesAndIDsTracker::need_direct_encoding_for(SimpleOrProofOnlyIntegerVariab
     if (_imp->find_condition(id == v))
         return;
 
+    DefinitionRecordingScope definitions{_imp->logger};
+
     auto eqvar = allocate_xliteral_meaning(id, EqualsOrGreaterEqual::Equals, v);
     _imp->store_condition(id == v, eqvar);
 
@@ -901,6 +905,8 @@ auto NamesAndIDsTracker::need_gevar(SimpleOrProofOnlyIntegerVariableID id, Integ
 {
     if (_imp->find_condition(id >= v))
         return;
+
+    DefinitionRecordingScope definitions{_imp->logger};
 
     auto gevar = allocate_xliteral_meaning(id, EqualsOrGreaterEqual::GreaterEqual, v);
     _imp->store_condition(id >= v, gevar);
@@ -1365,6 +1371,8 @@ auto NamesAndIDsTracker::need_invar(SimpleOrProofOnlyIntegerVariableID id, Integ
 {
     if (lo > hi)
         return FalseLiteral{};
+
+    DefinitionRecordingScope definitions{_imp->logger};
 
     if (lo == hi) {
         need_direct_encoding_for(id, lo);

--- a/gcs/innards/proofs/proof_logger.cc
+++ b/gcs/innards/proofs/proof_logger.cc
@@ -43,7 +43,6 @@ using fmt::format;
 using std::cmp_less;
 using std::cmp_less_equal;
 using std::deque;
-using std::erase_if;
 using std::flush;
 using std::fstream;
 using std::ios;
@@ -60,7 +59,6 @@ using std::tuple;
 using std::variant;
 using std::vector;
 using std::visit;
-using std::ranges::any_of;
 
 using namespace gcs;
 using namespace gcs::innards;
@@ -205,16 +203,14 @@ struct ProofLogger::Imp
     //
     // deleting_solution_constraints gates the whole thing;
     // definitions_awaiting_core collects the encoding definitions a checked
-    // deletion will need to see in core (see begin_recording_definitions);
-    // solution_constraints pairs each blocking constraint with the proof level
-    // that was active when it was logged, so a backtrack knows which ones its
-    // clause covers; and core_lines_by_level mirrors proof_lines_by_level for
-    // just the lines we promoted, so a backtrack can tell whether a descendant
-    // already promoted something and its own clause has to follow.
+    // deletion will need to see in core (see begin_recording_definitions); and
+    // core_lines_by_level mirrors proof_lines_by_level for just the lines that
+    // are in core, so a backtrack can tell whether the level it is about to
+    // forget holds any, and its own clause therefore has to go to core to
+    // discharge their deletion.
     bool deleting_solution_constraints = true;
     unsigned long long recording_definitions = 0;
     vector<long long> definitions_awaiting_core;
-    vector<pair<ProofLine, int>> solution_constraints;
     deque<IntervalSet<long long>> core_lines_by_level;
 
     string proof_file;
@@ -335,7 +331,14 @@ auto ProofLogger::solution(const vector<pair<IntegerVariableID, Integer>> & all_
     }
 
     _imp->proof << ";\n";
-    ProofLine solution_constraint = record_proof_line(advance_proof_line_number(), ProofLevel::Top);
+    auto solution_line = advance_proof_line_number();
+    auto delete_when_backtracking =
+        ! optional_minimise_variable_and_value && _imp->deleting_solution_constraints && _imp->assertion_level <= AssertionLevel::Definitions;
+    if (delete_when_backtracking)
+        record_solution_constraint(solution_line);
+    else
+        record_proof_line(solution_line, ProofLevel::Top);
+    ProofLine solution_constraint = solution_line;
 
     optional<ProofLine> objective_bound;
 
@@ -376,16 +379,6 @@ auto ProofLogger::solution(const vector<pair<IntegerVariableID, Integer>> & all_
         _imp->previous_soli_constraint = solution_constraint;
         _imp->previous_objective_bound = objective_bound;
     }
-    else if (_imp->deleting_solution_constraints && _imp->assertion_level <= AssertionLevel::Definitions) {
-        // Enumeration: the blocking constraint solx creates is subsumed by the
-        // backtrack clause of whichever frame eventually refutes the subtree
-        // this solution was found in, so hand it to backtrack() to delete, along
-        // with the level that says which frames those are. Above
-        // AssertionLevel::Definitions there is nothing to hand over: the atom
-        // definitions a checked deletion needs to see are asserted or omitted
-        // rather than derived, so the deletion goal could not be discharged.
-        _imp->solution_constraints.emplace_back(solution_constraint, _imp->active_proof_level);
-    }
 }
 
 auto ProofLogger::discard_superseded_objective_constraints() -> void
@@ -422,7 +415,6 @@ auto ProofLogger::disable_solution_deletion() -> void
 {
     _imp->deleting_solution_constraints = false;
     _imp->definitions_awaiting_core.clear();
-    _imp->solution_constraints.clear();
 }
 
 auto ProofLogger::begin_recording_definitions() -> void
@@ -462,26 +454,46 @@ auto ProofLogger::promote_definitions_to_core() -> void
     _imp->definitions_awaiting_core.clear();
 }
 
+auto ProofLogger::record_solution_constraint(ProofLineNumber line) -> void
+{
+    // A solution found under this frame's guesses is excluded by the backtrack
+    // clause of the frame *above* it, so its blocking constraint belongs to the
+    // level that frame forgets --- one shallower than the active level, which is
+    // the level this frame's own clause will be tagged at. At depth 0 that is
+    // Top, and the constraint simply stays for the whole proof, which is what we
+    // want: nothing above ever refutes it.
+    //
+    // Doing it this way rather than deleting the constraint next to the clause
+    // that subsumes it also means the constraint outlives the clause derivation
+    // it took part in. VeriPB's unit propagation loses the conflict for a later
+    // rup if a checked deletion lands between the constraint's last use and that
+    // rup, even though the resulting database is identical either way; see
+    // dev_docs/solution-constraint-deletion.md.
+    auto level = std::max(_imp->active_proof_level - 1, 0);
+    if (cmp_less_equal(_imp->proof_lines_by_level.size(), level))
+        _imp->proof_lines_by_level.resize(level + 1);
+    _imp->proof_lines_by_level.at(level).insert_at_end(line.number);
+
+    // Solution rules put what they create into core, so the forget that
+    // eventually deletes this is a checked deletion, and the frame doing the
+    // forgetting has to have moved its clause to core first.
+    if (cmp_less_equal(_imp->core_lines_by_level.size(), level))
+        _imp->core_lines_by_level.resize(level + 1);
+    _imp->core_lines_by_level.at(level).insert_at_end(line.number);
+}
+
 auto ProofLogger::discharge_solution_constraints(const ProofLine & backtrack_clause) -> void
 {
     if (! _imp->deleting_solution_constraints)
         return;
 
+    // The forget that follows this backtrack will delete the level below, and if
+    // anything down there is core --- a solution's blocking constraint, or a
+    // descendant's clause that had to be promoted for the same reason --- those
+    // are checked deletions, and this clause is what discharges them.
     auto level = _imp->active_proof_level;
-
-    // Everything logged deeper than this frame is inside the subtree the clause
-    // has just refuted.
-    auto covered = [&](const pair<ProofLine, int> & s) { return s.second > level; };
-    auto any_solutions = any_of(_imp->solution_constraints, covered);
-
-    // Even with no solutions of our own left to delete, a descendant that
-    // deleted some had to put its own clause into core, and the forget that
-    // follows this backtrack will delete that clause. That is a checked
-    // deletion too, and ours is the constraint that discharges it.
     auto below = core_lines_at(_imp->core_lines_by_level, level + 1);
-    auto any_core_below = below && ! below->empty();
-
-    if (! any_solutions && ! any_core_below)
+    if (! below || below->empty())
         return;
 
     promote_definitions_to_core();
@@ -489,15 +501,6 @@ auto ProofLogger::discharge_solution_constraints(const ProofLine & backtrack_cla
     if (cmp_less_equal(_imp->core_lines_by_level.size(), level))
         _imp->core_lines_by_level.resize(level + 1);
     _imp->core_lines_by_level.at(level).insert_at_end(std::get<ProofLineNumber>(backtrack_clause).number);
-
-    if (any_solutions) {
-        vector<ProofLine> to_delete;
-        for (const auto & s : _imp->solution_constraints)
-            if (covered(s))
-                to_delete.push_back(s.first);
-        erase_if(_imp->solution_constraints, covered);
-        delete_proof_lines(to_delete);
-    }
 }
 
 auto ProofLogger::emit_learned_nogood(const vector<Literal> & decisions) -> ProofLine

--- a/gcs/innards/proofs/proof_logger.cc
+++ b/gcs/innards/proofs/proof_logger.cc
@@ -47,6 +47,7 @@ using std::ios;
 using std::ios_base;
 using std::make_unique;
 using std::map;
+using std::nullopt;
 using std::optional;
 using std::ostream;
 using std::pair;
@@ -177,6 +178,15 @@ struct ProofLogger::Imp
     int active_proof_level = 0;
     deque<IntervalSet<long long>> proof_lines_by_level;
 
+    // The constraints the previous `soli` left behind: the objective-improving
+    // constraint VeriPB itself creates for the rule (which lands in the *core*
+    // set), and the order-literal restatement of the same bound that we RUP
+    // afterwards (which is derived, at Top). Both are superseded the moment a
+    // strictly better solution is logged, so solution() deletes them then. See
+    // discard_superseded_objective_constraints.
+    optional<ProofLine> previous_soli_constraint;
+    optional<ProofLine> previous_objective_bound;
+
     string proof_file;
     fstream proof;
     // A proof is many short lines; the default stream buffer makes for a
@@ -295,14 +305,16 @@ auto ProofLogger::solution(const vector<pair<IntegerVariableID, Integer>> & all_
     }
 
     _imp->proof << ";\n";
-    record_proof_line(advance_proof_line_number(), ProofLevel::Top);
+    ProofLine solution_constraint = record_proof_line(advance_proof_line_number(), ProofLevel::Top);
+
+    optional<ProofLine> objective_bound;
 
     if (optional_minimise_variable_and_value && _imp->assertion_level > AssertionLevel::Definitions)
         // soli and no links => have to assert the objective improving constraint
         visit(
             [&](const auto & id) {
-                emit(AssertProofRule{}, WPBSum{} + 1_i * (id < optional_minimise_variable_and_value->second) >= 1_i, ProofLevel::Top,
-                    AssertionAnnotation{.hint_name = hints::SoliImprove::hint_name});
+                objective_bound = emit(AssertProofRule{}, WPBSum{} + 1_i * (id < optional_minimise_variable_and_value->second) >= 1_i,
+                    ProofLevel::Top, AssertionAnnotation{.hint_name = hints::SoliImprove::hint_name});
             },
             optional_minimise_variable_and_value->first);
     else if (optional_minimise_variable_and_value)
@@ -313,7 +325,7 @@ auto ProofLogger::solution(const vector<pair<IntegerVariableID, Integer>> & all_
                 emit_inequality_to(names_and_ids_tracker(), WPBSum{} + 1_i * id <= optional_minimise_variable_and_value->second - 1_i, _imp->proof);
                 _imp->proof << ":" << relative_proof_line(_imp->proof_line, _imp->proof_line.number) << ";\n";
 
-                emit_rup_proof_line(WPBSum{} + 1_i * (id < optional_minimise_variable_and_value->second) >= 1_i, ProofLevel::Top);
+                objective_bound = emit_rup_proof_line(WPBSum{} + 1_i * (id < optional_minimise_variable_and_value->second) >= 1_i, ProofLevel::Top);
             },
             optional_minimise_variable_and_value->first);
     else if (_imp->assertion_level > AssertionLevel::Definitions) {
@@ -321,6 +333,32 @@ auto ProofLogger::solution(const vector<pair<IntegerVariableID, Integer>> & all_
         emit(AssertProofRule{}, blocking_sum >= 1_i, ProofLevel::Top, AssertionAnnotation{.hint_name = hints::SolxBlock::hint_name});
     }
     // nothing needs done for solx below AssertionLevel::Links
+
+    if (optional_minimise_variable_and_value) {
+        // Branch and bound only ever logs a strictly better solution than the
+        // last, so everything the previous soli left behind is now subsumed and
+        // can go. The objective-improving constraint that VeriPB creates for the
+        // rule lives in the *core* set, so its deletion is a checked one: the
+        // goal is discharged by RUP against the improving constraint the soli we
+        // have just written put there, which is strictly stronger. The
+        // order-literal restatement is derived, and deleting it is free.
+        discard_superseded_objective_constraints();
+        _imp->previous_soli_constraint = solution_constraint;
+        _imp->previous_objective_bound = objective_bound;
+    }
+}
+
+auto ProofLogger::discard_superseded_objective_constraints() -> void
+{
+    vector<ProofLine> to_delete;
+    if (_imp->previous_soli_constraint)
+        to_delete.emplace_back(*_imp->previous_soli_constraint);
+    if (_imp->previous_objective_bound)
+        to_delete.emplace_back(*_imp->previous_objective_bound);
+    _imp->previous_soli_constraint = nullopt;
+    _imp->previous_objective_bound = nullopt;
+    if (! to_delete.empty())
+        delete_proof_lines(to_delete);
 }
 
 auto ProofLogger::backtrack(const vector<Literal> & guesses) -> void

--- a/gcs/innards/proofs/proof_logger.cc
+++ b/gcs/innards/proofs/proof_logger.cc
@@ -16,6 +16,7 @@
 #include <gcs/interval_set.hh>
 #include <gcs/proof.hh>
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdlib>
 #include <deque>
@@ -39,8 +40,10 @@ using fmt::format;
 
 #include <util/overloaded.hh>
 
+using std::cmp_less;
 using std::cmp_less_equal;
 using std::deque;
+using std::erase_if;
 using std::flush;
 using std::fstream;
 using std::ios;
@@ -57,6 +60,7 @@ using std::tuple;
 using std::variant;
 using std::vector;
 using std::visit;
+using std::ranges::any_of;
 
 using namespace gcs;
 using namespace gcs::innards;
@@ -168,6 +172,14 @@ namespace
         }
             .visit(lit);
     }
+
+    // The lines a level holds that we promoted to core, if any. Levels only get
+    // an entry once something is promoted at them, so most proofs never grow
+    // this at all.
+    [[nodiscard]] auto core_lines_at(deque<IntervalSet<long long>> & levels, int depth) -> IntervalSet<long long> *
+    {
+        return cmp_less(depth, levels.size()) ? &levels.at(depth) : nullptr;
+    }
 }
 
 struct ProofLogger::Imp
@@ -186,6 +198,24 @@ struct ProofLogger::Imp
     // discard_superseded_objective_constraints.
     optional<ProofLine> previous_soli_constraint;
     optional<ProofLine> previous_objective_bound;
+
+    // Enumeration's half of the same idea, which is more involved because a
+    // blocking constraint is subsumed not by the next solution's but by the
+    // backtrack clause refuting the subtree it was found in.
+    //
+    // deleting_solution_constraints gates the whole thing;
+    // definitions_awaiting_core collects the encoding definitions a checked
+    // deletion will need to see in core (see begin_recording_definitions);
+    // solution_constraints pairs each blocking constraint with the proof level
+    // that was active when it was logged, so a backtrack knows which ones its
+    // clause covers; and core_lines_by_level mirrors proof_lines_by_level for
+    // just the lines we promoted, so a backtrack can tell whether a descendant
+    // already promoted something and its own clause has to follow.
+    bool deleting_solution_constraints = true;
+    unsigned long long recording_definitions = 0;
+    vector<long long> definitions_awaiting_core;
+    vector<pair<ProofLine, int>> solution_constraints;
+    deque<IntervalSet<long long>> core_lines_by_level;
 
     string proof_file;
     fstream proof;
@@ -346,6 +376,16 @@ auto ProofLogger::solution(const vector<pair<IntegerVariableID, Integer>> & all_
         _imp->previous_soli_constraint = solution_constraint;
         _imp->previous_objective_bound = objective_bound;
     }
+    else if (_imp->deleting_solution_constraints && _imp->assertion_level <= AssertionLevel::Definitions) {
+        // Enumeration: the blocking constraint solx creates is subsumed by the
+        // backtrack clause of whichever frame eventually refutes the subtree
+        // this solution was found in, so hand it to backtrack() to delete, along
+        // with the level that says which frames those are. Above
+        // AssertionLevel::Definitions there is nothing to hand over: the atom
+        // definitions a checked deletion needs to see are asserted or omitted
+        // rather than derived, so the deletion goal could not be discharged.
+        _imp->solution_constraints.emplace_back(solution_constraint, _imp->active_proof_level);
+    }
 }
 
 auto ProofLogger::discard_superseded_objective_constraints() -> void
@@ -373,8 +413,91 @@ auto ProofLogger::backtrack(const vector<Literal> & guesses) -> void
     for (const auto & guess : guesses)
         guesses_as_reason.emplace_back(ProofLiteral{guess});
     auto assert_or_rup = (_imp->assertion_level >= AssertionLevel::Inferences) ? ProofRule(AssertProofRule{}) : ProofRule(RUPProofRule{});
-    emit_under_reason(
+    auto clause = emit_under_reason(
         assert_or_rup, WPBSum{} >= 1_i, ProofLevel::Current, guesses_as_reason, AssertionAnnotation{.hint_name = hints::Backtrack::hint_name});
+    discharge_solution_constraints(clause);
+}
+
+auto ProofLogger::disable_solution_deletion() -> void
+{
+    _imp->deleting_solution_constraints = false;
+    _imp->definitions_awaiting_core.clear();
+    _imp->solution_constraints.clear();
+}
+
+auto ProofLogger::begin_recording_definitions() -> void
+{
+    ++_imp->recording_definitions;
+}
+
+auto ProofLogger::end_recording_definitions() -> void
+{
+    --_imp->recording_definitions;
+}
+
+auto ProofLogger::move_to_core(const vector<ProofLine> & lines) -> void
+{
+    if (lines.empty())
+        return;
+
+    write_indent();
+    _imp->proof << "core id";
+    for (const auto & line : lines)
+        _imp->proof << " " << relative_proof_line(line, _imp->proof_line.number);
+    _imp->proof << ";\n";
+}
+
+auto ProofLogger::promote_definitions_to_core() -> void
+{
+    // One `core id` step can take a list, and the first batch can be most of the
+    // encoding, so chunk it rather than writing a line megabytes wide.
+    const std::size_t per_line = 128;
+    for (std::size_t start = 0; start < _imp->definitions_awaiting_core.size(); start += per_line) {
+        write_indent();
+        _imp->proof << "core id";
+        for (auto n = start; n != std::min(start + per_line, _imp->definitions_awaiting_core.size()); ++n)
+            _imp->proof << " " << (_imp->definitions_awaiting_core[n] - _imp->proof_line.number - 1);
+        _imp->proof << ";\n";
+    }
+    _imp->definitions_awaiting_core.clear();
+}
+
+auto ProofLogger::discharge_solution_constraints(const ProofLine & backtrack_clause) -> void
+{
+    if (! _imp->deleting_solution_constraints)
+        return;
+
+    auto level = _imp->active_proof_level;
+
+    // Everything logged deeper than this frame is inside the subtree the clause
+    // has just refuted.
+    auto covered = [&](const pair<ProofLine, int> & s) { return s.second > level; };
+    auto any_solutions = any_of(_imp->solution_constraints, covered);
+
+    // Even with no solutions of our own left to delete, a descendant that
+    // deleted some had to put its own clause into core, and the forget that
+    // follows this backtrack will delete that clause. That is a checked
+    // deletion too, and ours is the constraint that discharges it.
+    auto below = core_lines_at(_imp->core_lines_by_level, level + 1);
+    auto any_core_below = below && ! below->empty();
+
+    if (! any_solutions && ! any_core_below)
+        return;
+
+    promote_definitions_to_core();
+    move_to_core({backtrack_clause});
+    if (cmp_less_equal(_imp->core_lines_by_level.size(), level))
+        _imp->core_lines_by_level.resize(level + 1);
+    _imp->core_lines_by_level.at(level).insert_at_end(std::get<ProofLineNumber>(backtrack_clause).number);
+
+    if (any_solutions) {
+        vector<ProofLine> to_delete;
+        for (const auto & s : _imp->solution_constraints)
+            if (covered(s))
+                to_delete.push_back(s.first);
+        erase_if(_imp->solution_constraints, covered);
+        delete_proof_lines(to_delete);
+    }
 }
 
 auto ProofLogger::emit_learned_nogood(const vector<Literal> & decisions) -> ProofLine
@@ -684,6 +807,12 @@ auto ProofLogger::enter_proof_level(int depth) -> void
 
 auto ProofLogger::forget_proof_level(int depth) -> void
 {
+    // Any clause we promoted at this level goes with it: it is a core deletion,
+    // discharged by the backtrack clause of the frame doing the forgetting,
+    // which discharge_solution_constraints has just put into core.
+    if (auto promoted = core_lines_at(_imp->core_lines_by_level, depth))
+        promoted->clear();
+
     auto & lines = _imp->proof_lines_by_level.at(depth);
     // Emit deletions as *relative* (negative) ids so a constraint-count
     // difference between the solver's OPB and cake_pb_cp's re-derived OPB
@@ -744,7 +873,11 @@ auto ProofLogger::start_proof(const ProofModel & model) -> void
 auto ProofLogger::record_proof_line(ProofLineNumber line, ProofLevel level) -> ProofLineNumber
 {
     switch (level) {
-    case ProofLevel::Top: _imp->proof_lines_by_level.at(0).insert_at_end(line.number); break;
+    case ProofLevel::Top:
+        _imp->proof_lines_by_level.at(0).insert_at_end(line.number);
+        if (_imp->recording_definitions && _imp->deleting_solution_constraints)
+            _imp->definitions_awaiting_core.push_back(line.number);
+        break;
     case ProofLevel::Current: _imp->proof_lines_by_level.at(_imp->active_proof_level).insert_at_end(line.number); break;
     case ProofLevel::Temporary: _imp->proof_lines_by_level.at(_imp->active_proof_level + 1).insert_at_end(line.number); break;
     }

--- a/gcs/innards/proofs/proof_logger.cc
+++ b/gcs/innards/proofs/proof_logger.cc
@@ -338,7 +338,6 @@ auto ProofLogger::solution(const vector<pair<IntegerVariableID, Integer>> & all_
         record_solution_constraint(solution_line);
     else
         record_proof_line(solution_line, ProofLevel::Top);
-    ProofLine solution_constraint = solution_line;
 
     optional<ProofLine> objective_bound;
 
@@ -376,7 +375,7 @@ auto ProofLogger::solution(const vector<pair<IntegerVariableID, Integer>> & all_
         // have just written put there, which is strictly stronger. The
         // order-literal restatement is derived, and deleting it is free.
         discard_superseded_objective_constraints();
-        _imp->previous_soli_constraint = solution_constraint;
+        _imp->previous_soli_constraint = ProofLine{solution_line};
         _imp->previous_objective_bound = objective_bound;
     }
 }

--- a/gcs/innards/proofs/proof_logger.cc
+++ b/gcs/innards/proofs/proof_logger.cc
@@ -299,32 +299,31 @@ auto ProofLogger::solution(const vector<pair<IntegerVariableID, Integer>> & all_
 
     WPBSum blocking_sum{};
 
+    // The assignment handed to the rule is stated in bits, at every assertion
+    // level. The bits are the variables the OPB is written over, so this is a
+    // solution to the formula in the formula's own terms: what VeriPB then
+    // preserves, and what the trimmer has to keep alive to make sense of the
+    // line, is the model rather than a set of atoms the proof introduced along
+    // the way. Stating it in eq atoms also works --- unit propagation gets from
+    // one to the other either way, through the same reifications -- but it
+    // leaves the enumeration projected onto extension variables.
     for (const auto & [var, val] : all_variables_and_values) {
         if (! optional_minimise_variable_and_value && _imp->assertion_level > AssertionLevel::Definitions)
             blocking_sum += 1_i * (var != val);
 
         overloaded{
-            [&](const ConstantIntegerVariableID &) {}, //
-            [&](const SimpleIntegerVariableID & var) {
-                if (_imp->assertion_level > AssertionLevel::Definitions)
-                    _imp->proof << " " << names_and_ids_tracker().bit_assignment_string_for(var, val);
-                else
-                    _imp->proof << " " << names_and_ids_tracker().pb_file_string_for(var == val);
-            }, //
+            [&](const ConstantIntegerVariableID &) {},                                                                                       //
+            [&](const SimpleIntegerVariableID & var) { _imp->proof << " " << names_and_ids_tracker().bit_assignment_string_for(var, val); }, //
             [&](const ViewOfIntegerVariableID & var) {
-                if (_imp->assertion_level > AssertionLevel::Definitions) {
-                    // An unregistered view (e.g. an objective too wide to
-                    // host its own bit vector) is witnessed through the
-                    // underlying's bits at the deviewed value instead.
-                    if (auto v_id = names_and_ids_tracker().find_view(var))
-                        _imp->proof << " " << names_and_ids_tracker().bit_assignment_string_for(*v_id, val);
-                    else
-                        _imp->proof << " "
-                                    << names_and_ids_tracker().bit_assignment_string_for(
-                                           var.actual_variable, var.negate_first ? var.then_add - val : val - var.then_add);
-                }
+                // An unregistered view (e.g. an objective too wide to host its
+                // own bit vector) is witnessed through the underlying's bits at
+                // the deviewed value instead.
+                if (auto v_id = names_and_ids_tracker().find_view(var))
+                    _imp->proof << " " << names_and_ids_tracker().bit_assignment_string_for(*v_id, val);
                 else
-                    _imp->proof << " " << names_and_ids_tracker().pb_file_string_for(deview(var == val));
+                    _imp->proof << " "
+                                << names_and_ids_tracker().bit_assignment_string_for(
+                                       var.actual_variable, var.negate_first ? var.then_add - val : val - var.then_add);
             } //
         }
             .visit(var);
@@ -463,11 +462,9 @@ auto ProofLogger::record_solution_constraint(ProofLineNumber line) -> void
     // want: nothing above ever refutes it.
     //
     // Doing it this way rather than deleting the constraint next to the clause
-    // that subsumes it also means the constraint outlives the clause derivation
-    // it took part in. VeriPB's unit propagation loses the conflict for a later
-    // rup if a checked deletion lands between the constraint's last use and that
-    // rup, even though the resulting database is identical either way; see
-    // dev_docs/solution-constraint-deletion.md.
+    // that subsumes it costs one fewer `core id` step and one fewer checked
+    // deletion per solution, the range that forget_proof_level already emits
+    // doing the work; see dev_docs/solution-constraint-deletion.md.
     auto level = std::max(_imp->active_proof_level - 1, 0);
     if (cmp_less_equal(_imp->proof_lines_by_level.size(), level))
         _imp->proof_lines_by_level.resize(level + 1);

--- a/gcs/innards/proofs/proof_logger.hh
+++ b/gcs/innards/proofs/proof_logger.hh
@@ -60,6 +60,14 @@ namespace gcs::innards
 
         auto log_stacktrace() -> void;
 
+        /**
+         * Delete what the previous \c soli left behind, if anything: the
+         * objective-improving constraint VeriPB creates for the rule, and our
+         * own order-literal restatement of the same bound. Called from
+         * \ref solution when a strictly better solution supersedes them.
+         */
+        auto discard_superseded_objective_constraints() -> void;
+
     public:
         /**
          * \name Constructors, destructors, and the like.

--- a/gcs/innards/proofs/proof_logger.hh
+++ b/gcs/innards/proofs/proof_logger.hh
@@ -68,6 +68,19 @@ namespace gcs::innards
          */
         auto discard_superseded_objective_constraints() -> void;
 
+        /**
+         * Move every definition recorded since the last call into the core set,
+         * as one `core id` step per batch. See \ref begin_recording_definitions.
+         */
+        auto promote_definitions_to_core() -> void;
+
+        /**
+         * Having just emitted the given backtrack clause, delete the blocking
+         * constraints of every solution found in the subtree it refutes. See
+         * \ref backtrack.
+         */
+        auto discharge_solution_constraints(const ProofLine & backtrack_clause) -> void;
+
     public:
         /**
          * \name Constructors, destructors, and the like.
@@ -100,8 +113,57 @@ namespace gcs::innards
 
         /**
          * Log that we are backtracking.
+         *
+         * When solution deletion is on (see \ref disable_solution_deletion) and
+         * the refuted subtree contained solutions, this also moves the
+         * backtrack clause into the core set and deletes those solutions'
+         * blocking constraints, which the clause subsumes.
          */
         auto backtrack(const std::vector<Literal> & guesses) -> void;
+
+        /**
+         * \brief Stop deleting solution-blocking constraints as search
+         * backtracks past them.
+         *
+         * Deleting a blocking constraint means moving the backtrack clause that
+         * subsumes it into the core set, and, once any clause is in core, every
+         * clause on the path back to the root must go there too --- otherwise
+         * the ancestor frame's \ref forget_proof_level deletes a core constraint
+         * with nothing left to derive it from. A restart unwinds without
+         * emitting the ancestors' backtrack clauses at all, so there is nothing
+         * to promote and the invariant cannot be maintained. Search calls this
+         * when restarts are enabled.
+         */
+        auto disable_solution_deletion() -> void;
+
+        /**
+         * \brief Start recording the proof lines emitted at \c ProofLevel::Top
+         * as *definitional* --- part of what a variable's proof atoms mean,
+         * rather than something inferred about the problem.
+         *
+         * VeriPB checks a deletion from the core set by asking for the deleted
+         * constraint to be re-derivable from the rest of core *alone*: derived
+         * constraints are invisible to that check. Deleting a solution's
+         * blocking constraint, which is over the preserved bits, therefore needs
+         * everything linking those bits to the order and direct encoding atoms
+         * the backtrack clause is written in --- and those definitions are
+         * introduced lazily, in the proof, so they are derived. Lines recorded
+         * inside this scope are batched up and moved to core the first time a
+         * deletion needs them.
+         *
+         * Prefer \ref DefinitionRecordingScope to calling this directly. Nests.
+         */
+        auto begin_recording_definitions() -> void;
+
+        /**
+         * Counterpart to \ref begin_recording_definitions.
+         */
+        auto end_recording_definitions() -> void;
+
+        /**
+         * Move the given already-emitted lines into the core set.
+         */
+        auto move_to_core(const std::vector<ProofLine> &) -> void;
 
         /**
          * Derive a learned nogood --- the clause forbidding the given conjunction
@@ -399,6 +461,32 @@ namespace gcs::innards
          * instead of fully justified.
          */
         auto get_assertion_level() -> AssertionLevel;
+    };
+
+    /**
+     * Scoped form of ProofLogger::begin_recording_definitions, tolerating a null
+     * logger so a caller that also runs without proofs need not test first.
+     */
+    class DefinitionRecordingScope
+    {
+    private:
+        ProofLogger * _logger;
+
+    public:
+        explicit DefinitionRecordingScope(ProofLogger * const logger) : _logger(logger)
+        {
+            if (_logger)
+                _logger->begin_recording_definitions();
+        }
+
+        ~DefinitionRecordingScope()
+        {
+            if (_logger)
+                _logger->end_recording_definitions();
+        }
+
+        DefinitionRecordingScope(const DefinitionRecordingScope &) = delete;
+        auto operator=(const DefinitionRecordingScope &) -> DefinitionRecordingScope & = delete;
     };
 }
 

--- a/gcs/innards/proofs/proof_logger.hh
+++ b/gcs/innards/proofs/proof_logger.hh
@@ -75,9 +75,15 @@ namespace gcs::innards
         auto promote_definitions_to_core() -> void;
 
         /**
-         * Having just emitted the given backtrack clause, delete the blocking
-         * constraints of every solution found in the subtree it refutes. See
-         * \ref backtrack.
+         * Record a solution's blocking constraint at the proof level of the
+         * frame above the one that found it, so that frame's forget deletes it.
+         */
+        auto record_solution_constraint(ProofLineNumber line) -> void;
+
+        /**
+         * Having just emitted the given backtrack clause, move it to core if the
+         * level this frame is about to forget holds any core constraints, whose
+         * deletion is then checked against it. See \ref backtrack.
          */
         auto discharge_solution_constraints(const ProofLine & backtrack_clause) -> void;
 
@@ -114,10 +120,11 @@ namespace gcs::innards
         /**
          * Log that we are backtracking.
          *
-         * When solution deletion is on (see \ref disable_solution_deletion) and
-         * the refuted subtree contained solutions, this also moves the
-         * backtrack clause into the core set and deletes those solutions'
-         * blocking constraints, which the clause subsumes.
+         * When solution deletion is on (see \ref disable_solution_deletion),
+         * this also moves the backtrack clause into the core set if the level
+         * about to be forgotten holds solution blocking constraints (or a
+         * descendant's clause promoted for the same reason), since deleting
+         * those is checked and this clause is what subsumes them.
          */
         auto backtrack(const std::vector<Literal> & guesses) -> void;
 

--- a/gcs/innards/proofs/proof_logger.hh
+++ b/gcs/innards/proofs/proof_logger.hh
@@ -69,6 +69,11 @@ namespace gcs::innards
         auto discard_superseded_objective_constraints() -> void;
 
         /**
+         * Move the given already-emitted lines into the core set.
+         */
+        auto move_to_core(const std::vector<ProofLine> &) -> void;
+
+        /**
          * Move every definition recorded since the last call into the core set,
          * as one `core id` step per batch. See \ref begin_recording_definitions.
          */
@@ -166,11 +171,6 @@ namespace gcs::innards
          * Counterpart to \ref begin_recording_definitions.
          */
         auto end_recording_definitions() -> void;
-
-        /**
-         * Move the given already-emitted lines into the core set.
-         */
-        auto move_to_core(const std::vector<ProofLine> &) -> void;
 
         /**
          * Derive a learned nogood --- the clause forbidding the given conjunction

--- a/gcs/innards/proofs/solution_deletion_test.cc
+++ b/gcs/innards/proofs/solution_deletion_test.cc
@@ -1,0 +1,219 @@
+#include <gcs/constraints/comparison.hh>
+#include <gcs/constraints/equals.hh>
+#include <gcs/current_state.hh>
+#include <gcs/problem.hh>
+#include <gcs/solve.hh>
+
+#include <cstdlib>
+#include <fstream>
+#include <set>
+#include <string>
+#include <vector>
+#include <version>
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+#include <print>
+#else
+#include <fmt/core.h>
+#endif
+
+using namespace gcs;
+
+using std::getline;
+using std::ifstream;
+using std::set;
+using std::size_t;
+using std::stoll;
+using std::string;
+using std::vector;
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+using std::print;
+#else
+using fmt::print;
+#endif
+
+// A solution's constraint is deleted once something subsumes it, which is a
+// checked deletion because VeriPB's solution rules put what they create into
+// the core set. Verification on its own cannot tell that apart from deleting
+// nothing: a proof that keeps every solution for ever verifies perfectly well,
+// and is exactly what we used to write. So this replays the proof's own
+// addressing and asserts the constraints really are deleted.
+//
+// Both halves are covered, because they work differently: an enumeration,
+// whose solx blocking constraints go when the frame above the one that found
+// them forgets its level, and an optimisation, whose soli objective-improving
+// constraint goes as soon as a strictly better solution supersedes it. The
+// optimisation proof is written first and then overwritten by the enumeration
+// one, so that exactly one set of proof files is left for
+// run_test_and_verify.bash to check and dispose of; the optimisation half's
+// deletions are veripb-checked by every optimisation example in the suite.
+namespace
+{
+    // Every rule that introduces a constraint advances VeriPB's id counter;
+    // deletions, `core` steps, `e` and comments do not. All of our references
+    // are relative to that counter (see relative_proof_line), so replaying it
+    // from any starting point resolves them: a constant offset from not knowing
+    // how many rows the OPB had cancels on both sides.
+    struct ProofAddressing
+    {
+        long long counter = 0;
+        vector<long long> solution_constraints;
+        set<long long> deleted;
+        long long core_steps = 0;
+        bool understood = true;
+
+        [[nodiscard]] auto resolve(long long relative) const -> long long
+        {
+            return counter + relative + 1;
+        }
+    };
+
+    [[nodiscard]] auto tokens_of(const string & line) -> vector<string>
+    {
+        vector<string> result;
+        string current;
+        for (auto c : line) {
+            if (c == ' ' || c == '\t' || c == ';') {
+                if (! current.empty()) {
+                    result.push_back(current);
+                    current.clear();
+                }
+            }
+            else
+                current += c;
+        }
+        if (! current.empty())
+            result.push_back(current);
+        return result;
+    }
+
+    [[nodiscard]] auto replay(const string & proof_file) -> ProofAddressing
+    {
+        ProofAddressing state;
+        ifstream proof{proof_file};
+
+        for (string line; getline(proof, line);) {
+            auto words = tokens_of(line);
+            if (words.empty())
+                continue;
+
+            const auto & rule = words[0];
+            if (rule.starts_with("%") || rule.starts_with("*") || rule == "pseudo-Boolean" || rule == "output" || rule == "conclusion" ||
+                rule == "end" || rule == "e")
+                continue;
+
+            if (rule == "begin" || rule == "proofgoal" || rule == "qed") {
+                // Nested contexts have their own id space, which this does not
+                // model. Fail loudly rather than measure the wrong thing.
+                print(stderr, "replay does not model subproofs, and `{}` appeared\n", rule);
+                state.understood = false;
+                return state;
+            }
+
+            if (rule == "core")
+                ++state.core_steps;
+            else if (rule == "del") {
+                if (words.at(1) == "id")
+                    for (auto n = words.begin() + 2; n != words.end(); ++n)
+                        state.deleted.insert(state.resolve(stoll(*n)));
+                else if (words.at(1) == "range")
+                    for (auto id = state.resolve(stoll(words.at(2))); id != state.resolve(stoll(words.at(3))); ++id)
+                        state.deleted.insert(id);
+            }
+            else {
+                ++state.counter;
+                if (rule == "solx" || rule == "soli")
+                    state.solution_constraints.push_back(state.counter);
+            }
+        }
+
+        return state;
+    }
+
+    // The enumeration half has to move the backtrack clause and the encoding
+    // definitions into core before it can delete anything; the optimisation
+    // half needs nothing moved, because the constraint that discharges its
+    // deletion goal is the one the new soli itself put into core.
+    enum class NeedsCoreSteps
+    {
+        Yes,
+        No
+    };
+
+    [[nodiscard]] auto check(const string & what, const ProofAddressing & state, size_t expected_solutions, size_t expected_deleted,
+        NeedsCoreSteps needs_core_steps) -> bool
+    {
+        auto ok = state.understood;
+
+        if (state.solution_constraints.size() != expected_solutions) {
+            print(stderr, "{}: proof logs {} solutions, solving found {}\n", what, state.solution_constraints.size(), expected_solutions);
+            ok = false;
+        }
+
+        size_t deleted = 0;
+        for (auto id : state.solution_constraints)
+            if (state.deleted.contains(id))
+                ++deleted;
+
+        if (deleted != expected_deleted) {
+            print(stderr, "{}: {} of {} solution constraints deleted, expected {}\n", what, deleted, state.solution_constraints.size(),
+                expected_deleted);
+            ok = false;
+        }
+
+        if (NeedsCoreSteps::Yes == needs_core_steps && 0 == state.core_steps) {
+            print(stderr, "{}: nothing was moved to core, so nothing could have been checked-deleted\n", what);
+            ok = false;
+        }
+
+        return ok;
+    }
+}
+
+auto main() -> int
+{
+    auto ok = true;
+
+    {
+        // Maximising, so that the default smallest-value-first branching meets
+        // the objective from the wrong end and branch and bound logs a chain of
+        // improving solutions rather than hitting the optimum first. Every one
+        // but the last is superseded and deleted.
+        Problem p;
+        auto x = p.create_integer_variable(0_i, 5_i, "x");
+        auto y = p.create_integer_variable(0_i, 5_i, "y");
+        p.post(LessThan{y, x});
+        p.maximise(y);
+
+        auto stats = solve_with(p, SolveCallbacks{}, ProofOptions{"solution_deletion_test"});
+
+        auto state = replay("solution_deletion_test.pbp");
+        if (stats.solutions < 2) {
+            print(stderr, "optimisation: only {} solutions logged, so nothing could be superseded\n", stats.solutions);
+            ok = false;
+        }
+        else
+            ok = check("optimisation", state, stats.solutions, stats.solutions - 1, NeedsCoreSteps::No) && ok;
+    }
+
+    {
+        // An enumeration deep enough that every solution is found below a frame
+        // whose parent forgets the level it lives at. A solution reached at
+        // depth 1 would land at Top and stay, which is correct but would make
+        // the count below wrong, so there are three variables to branch on.
+        Problem p;
+        auto x = p.create_integer_variable(0_i, 2_i, "x");
+        auto y = p.create_integer_variable(0_i, 2_i, "y");
+        auto z = p.create_integer_variable(0_i, 2_i, "z");
+        p.post(NotEquals{x, y});
+        p.post(NotEquals{y, z});
+
+        auto stats =
+            solve_with(p, SolveCallbacks{.solution = [](const CurrentState &) -> bool { return true; }}, ProofOptions{"solution_deletion_test"});
+
+        ok = check("enumeration", replay("solution_deletion_test.pbp"), stats.solutions, stats.solutions, NeedsCoreSteps::Yes) && ok;
+    }
+
+    return ok ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/gcs/innards/proofs/solution_deletion_test.cc
+++ b/gcs/innards/proofs/solution_deletion_test.cc
@@ -198,10 +198,10 @@ auto main() -> int
     }
 
     {
-        // An enumeration deep enough that every solution is found below a frame
-        // whose parent forgets the level it lives at. A solution reached at
-        // depth 1 would land at Top and stay, which is correct but would make
-        // the count below wrong, so there are three variables to branch on.
+        // An enumeration with enough to branch on that no solution is reached
+        // at depth 0, where the blocking constraint would land at Top and stay
+        // --- correct, since there is no frame above it to refute it, but it
+        // would make the count below wrong.
         Problem p;
         auto x = p.create_integer_variable(0_i, 2_i, "x");
         auto y = p.create_integer_variable(0_i, 2_i, "y");

--- a/gcs/solve.cc
+++ b/gcs/solve.cc
@@ -314,6 +314,12 @@ auto gcs::solve_with(
     // adds land after the preamble, like every other constraint's.
     shared_ptr<NogoodStore> nogood_store;
     if (callbacks.restarts) {
+        // A restart unwinds without emitting the ancestor frames' backtrack
+        // clauses, so once a descendant has promoted its clause to core there is
+        // nothing to discharge that clause's own deletion with. See
+        // ProofLogger::disable_solution_deletion.
+        if (optional_proof)
+            optional_proof->logger()->disable_solution_deletion();
         nogood_store = make_shared<NogoodStore>();
         // Use refined per-literal watches for the learned-nogood store (issue #335,
         // stage C-2): the propagator wakes only when a learned clause loses a


### PR DESCRIPTION
We log every solution at `ProofLevel::Top` and keep it for the whole proof.
Nothing needs that: for optimisation the previous solution's constraint is
superseded the moment a better one is found, and for enumeration a solution's
blocking constraint is subsumed by the backtrack clause of the frame that
refutes the subtree it was found in. This deletes them. It also states the
solution itself in bits rather than in direct-encoding atoms.

**These proofs need a VeriPB from 2026-06-22 or later**, i.e. one containing
`veripb-dev` MR !193. An older checker rejects them at the root `rup >= 1`,
reported as if a constraint were missing, and `--unchecked-deletion` makes it go
away --- which is misleading, since there is nothing wrong with the deletions.
Every VeriPB build reports version 3.0.2 regardless of commit, so check the
commit rather than `--version`. What ships here verifies against public VeriPB
today; only the narrow promotion discussed below needs a newer checker.

The measurements are in `dev_docs/solution-constraint-deletion.md`; the
headline is that **enumeration checking gets an order of magnitude faster**,
and that optimisation is free but is not a speedup on anything we have.

| instance | solutions | size before | size after | time before (s) | time after (s) | speedup |
| --- | --- | --- | --- | --- | --- | --- |
| `frequency_square --all --size 6 --lambda 2` | 53220 | 204569673 | 224919034 | 117.19 114.45 125.08 116.78 | 12.52 12.34 12.69 12.38 | 9.4x |
| `regular_random --all --seed=1` | 32985 | 14231970 | 18870069 | 21.62 21.63 21.54 21.48 21.91 | 2.07 2.08 2.07 2.10 2.11 | 10.4x |
| `langford --all` | 52 | 964583 | 1024105 | 0.24 0.24 0.24 0.24 0.24 | 0.27 0.27 0.26 0.27 0.26 | 0.89x |
| `talent` (optimisation) | 23 | 6592428 | 6669941 | 1.13 1.18 1.14 1.12 1.12 | 1.15 1.14 1.13 1.11 1.12 | 1.00x |

Checker is `veripb-dev` at MR !217. Each pair is timed *alternately* so machine
drift lands on both sides; ratios use medians, because the `frequency_square`
before side has about ten per cent spread run to run.

Two things in that table are not good news and should not be glossed over.
`langford` is 12% slower and 6% bigger: 52 solutions is too few to pay back
the one-off promotion of the encoding to core --- and this is the one number the
narrow closure below would fix outright. And `talent` is the longest
improvement chain in the examples --- deleting 22 objective-improving
constraints moves the checking time by nothing, because such a constraint is
one short PB row over the objective terms and is not where the checker's time
goes. Take the optimisation half as tidiness, and as what stops a long-running
branch and bound accumulating rows without limit, not as a number. Peak RSS
moves the wrong way on the big enumeration case (`frequency_square`, 564 MB to
645 MB) while `regular_random` is flat.

## Solutions are stated in bits

`solx` / `soli` now get the assignment as bit literals at every assertion
level, where below `AssertionLevel::Definitions` they used to get eq atoms.
Both work --- the rule propagates whatever it is handed to a full assignment,
and unit propagation crosses between the two vocabularies through the same
reifications either way --- but the bits are the variables the OPB is written
over. The logged solution is then a solution to the *formula*, in the
formula's own terms, and the preserved set (so the projection the
`ENUMERATION_COMPLETE` conclusion is about) is the model's variables rather
than a set of atoms the proof introduced along the way. A trimmer has to keep
the model alive regardless; this way it does not also have to keep the
encoding definitions for whichever atoms the search happened to create.

It costs size, since a variable is one eq literal but several bit literals:
9% on `frequency_square`, 35% on `regular_random` (six variables, so a
solution line goes from six literals to eighteen against an otherwise small
per-solution proof), 5% on `langford`, and 2--4% of checking time. That is
separated from the deletion change in the dev doc.

## Optimisation

Two constraints per `soli`: the objective-improving constraint VeriPB creates
for the rule, which is **core**, so deleting it is a checked deletion; and our
own order-literal restatement, which is derived and free. The checked deletion
needs no scaffolding at all --- the constraint that discharges it is the
improving constraint the new `soli` has just put into core, over the same
terms. The only subtlety is ordering: the deletions have to follow the `e`
line, which addresses the new constraint as `-1`, and the new `soli`, which
supplies the discharging constraint.

## Enumeration, and the two things the issue did not anticipate

The issue expected the backtrack (and restart) constraints to need moving to
core. They do. Two more things came out of it.

**The lazily-introduced encoding definitions have to go to core too.**
`check_checked_deletion` sets `only_core`, so derived constraints are invisible
to it. Negating a blocking constraint fixes the preserved *bits*; the backtrack
clause is written in *atoms*; and the reifications joining the two are emitted
by `NamesAndIDsTracker` on first use, in the proof, so they are derived.
Without them nothing propagates and the goal fails. A witness or an explicit
subproof does not help. Promoting *every* Top line would be simpler and wrong,
because `DerivedCumulative` deletes abandoned Top lines (#666) and those
deletions would become checked and fail --- so the tracker marks its own, and
they are batched into `core id` steps issued lazily, the first time a deletion
needs them and never at all in a proof that deletes nothing.

What ships promotes all of the tracker's definitions, not just the ones a
deletion goal reads --- but that is a decision about the checker we can rely on
today, not a claim that the narrow rule is insufficient. It is not. Promoting
only the definitional closure of the atoms in the discharging clause (an eq
atom's two halves plus its two order cuts, and not the chain linking
neighbouring cuts) passes the whole suite, 636/636, and is a real reduction
rather than a no-op: `abs_test`'s first batch goes from 26 promoted constraints
to 10, and `langford --all` from 2604 over 124 `core id` steps to 76 over 76.
What it buys is better than tidiness. Measured blanket → narrow, same branch
both sides:

| instance | promoted ids | `.pbp` bytes | median time |
| --- | --- | --- | --- |
| `frequency_square` | 52786 → 52652 | 224919034 → 224918889 | 12.65 → 12.80 |
| `regular_random` | 7717 → 7679 | 18870069 → 18869929 | 2.08 → 2.03 |
| `langford` | 2604 → 76 | 1024105 → 1011205 | 0.26 → 0.24 |
| `talent` | 0 → 0 | 6669941 → 6669941 | 1.14 → 1.14 |

The saving lands where the enumeration is small, which is exactly where the
blanket rule costs us: `langford`'s 12% loss disappears completely, 0.24 s being
what the no-deletion baseline takes. On the big enumerations nearly every
definition is needed by some goal anyway, so there is almost nothing to save and
`frequency_square` is about 1% slower. `talent` promotes nothing either way ---
the optimisation half never needs a definition in core, so this is entirely an
enumeration question.

Blanket ships anyway because narrowing needs a checker containing MR !217 --- the
narrow rule's `skyscrapers 5` proof is one of the cases that fails without it,
and CI installs the checker by cloning public `VeriPB.git` at HEAD. Until that
contains !217, narrowing turns `skyscrapers-5` and `ortho_latin-5` red. Blanket
is the superset, so it is the safe end to sit at meanwhile, and nothing else in
the PR depends on which is used.

**Promotion cascades to the root.** Once a frame promotes its clause, the
parent's `forget_proof_level` deletes that clause, which is checked in turn,
discharged by the parent's own clause --- but only if the parent promoted as
well, which it has no local reason to. `ProofLogger` keeps
`core_lines_by_level` next to `proof_lines_by_level` so a frame can see that
the level it is about to forget holds core constraints.

Deletion goes through the level forget rather than next to the subsuming
clause: solution constraints are recorded at the proof *level* the subsuming
frame forgets, so `forget_proof_level` deletes them as part of the range it
already emits, which costs one fewer `core id` step and one fewer checked
deletion per solution.

## Deliberately not done

- The `solx` lines themselves stay --- `num_excluded_solutions` counts them,
  and that is what `ENUMERATION_COMPLETE` checks against.
- No *blocking* constraint is deleted under restarts. `RestartCutoffHit`
  forgets a level without emitting the frame's backtrack clause, so there is
  nothing to discharge the core deletions with. `solve_with` calls
  `ProofLogger::disable_solution_deletion` when restarts are on. This is
  specific to the enumeration half: the optimisation half deletes under
  restarts and at every assertion level, since what discharges it is the new
  `soli`'s improving constraint rather than a backtrack clause. Lifting it
  needs two things: the nld-nogood `solve.cc` already emits at Top for each
  refuted sibling promoted to core (it is a subset of the guesses, so it still
  subsumes the blocking constraints below it, and being at Top it survives the
  restart's forget), and `forget_proof_level` retaining rather than deleting
  the core lines of the abandoned spine, which nothing refutes
  (`IntervalSet::each_interval_minus`).
- Nothing is deleted above `AssertionLevel::Definitions`, which omits the atom
  definitions the deletion goals need.
- Nothing is deleted for a solution found at depth 0: there is no frame above
  it to refute it.

## Testing

`ctest` is 636/636 with GCC 15.2, including the lanes that actually invoke
veripb. `solution_deletion_test` is the guard against this quietly becoming a
no-op: it replays the proof's own relative addressing and asserts the `solx`
and `soli` constraints land in a later deletion, for both halves.
Mutation-checked --- defaulting `deleting_solution_constraints` to false gives
"0 of 12 solution constraints deleted", dropping the
`discard_superseded_objective_constraints` call gives "0 of 5".

## Related, not in this PR

VeriPB's "switching from stronger to weaker guarantee using unchecked
deletion" warning names no line, which makes a dropped guarantee very hard to
localise --- the symptom only shows up much later, as a rejected conclusion. A
minimal patch adding the proof line, the constraint ID and the proof goal is
sitting on the branch `claude/deletion-message-line-numbers` in the local
VeriPB checkout. It is worth upstreaming on its own merits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wnubze1Z1SqBQxFyHg1PyY


