### PR TITLE
Dual licence under Apache-2.0 or MIT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -380,6 +380,14 @@ install(FILES
         ${CMAKE_CURRENT_BINARY_DIR}/GlasgowConstraintSolverConfigVersion.cmake
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/GlasgowConstraintSolver)
 
+# We are dual licensed under Apache-2.0 or MIT, and section 4(a) of the former
+# asks that redistributions carry a copy of it, so install both texts.
+install(FILES
+        ${CMAKE_CURRENT_SOURCE_DIR}/COPYRIGHT
+        ${CMAKE_CURRENT_SOURCE_DIR}/LICENCE-APACHE
+        ${CMAKE_CURRENT_SOURCE_DIR}/LICENCE-MIT
+        DESTINATION ${CMAKE_INSTALL_DOCDIR})
+
 if(GCS_ENABLE_EXECUTABLES)
     add_subdirectory(examples)
     add_subdirectory(benchmarks)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,20 @@ All contributions should pass both the `release` and `sanitize` build and tests
 before submission, including the full test suite (with VeriPB installed) in
 both modes. See `README.md` for details.
 
+Licensing
+=========
+
+The solver is dual licensed under the Apache License, Version 2.0 and the MIT
+License, at the user's option; see `COPYRIGHT` for the full statement. Unless
+you explicitly state otherwise, any contribution you intentionally submit for
+inclusion in this work, as defined in the Apache License, Version 2.0, shall be
+dual licensed as above, without any additional terms or conditions. There is no
+copyright assignment: you keep the copyright in what you write.
+
+If a contribution contains code you did not write yourself, say where it came
+from and under what terms in the pull request, so that we can check it can be
+released both ways before merging.
+
 Code Formatting
 ===============
 

--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,0 +1,19 @@
+The Glasgow Constraint Solver is copyright (c) 2021-26 Ciaran McCreesh.
+
+It is dual licensed under either of
+
+  * the Apache License, Version 2.0 (see LICENCE-APACHE, or
+    https://www.apache.org/licenses/LICENSE-2.0), or
+  * the MIT License (see LICENCE-MIT, or
+    https://opensource.org/licenses/MIT),
+
+at your option. You may use, modify and redistribute this software under the
+terms of whichever of the two you prefer; you do not have to satisfy both. In
+SPDX terms, the licence of this work is:
+
+    SPDX-License-Identifier: MIT OR Apache-2.0
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in this work by you, as defined in the Apache License, Version
+2.0, shall be dual licensed as above, without any additional terms or
+conditions.

--- a/LICENCE-APACHE
+++ b/LICENCE-APACHE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/LICENCE-MIT
+++ b/LICENCE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2021-25 Ciaran McCreesh
+Copyright (c) 2021-26 Ciaran McCreesh
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/README.md
+++ b/README.md
@@ -453,9 +453,9 @@ licensed as above, without any additional terms or conditions.
 Acknowledgements
 ================
 
-This work is supported by a Royal Academy of Engineering Research Fellowship. Part of this work was
-done while the author was participating in a program at the Simons Institute for the Theory of
-Computing.
+This work is supported by the Advanced Research + Invention Agency, and by a Royal Academy of
+Engineering Research Fellowship. Part of this work was done while the author was participating in a
+program at the Simons Institute for the Theory of Computing.
 
 <!-- vim: set tw=100 spell spelllang=en : -->
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Contents
 - [Navigating the Source Code](#navigating-the-source-code)
 - [Developer Documentation](#developer-documentation)
 - [How Do We Know It's Correct?](#how-do-we-know-its-correct)
+- [Licence](#licence)
 - [Acknowledgements](#acknowledgements)
 
 Getting Started
@@ -431,6 +432,23 @@ enough that you should probably be able to write your own proof checker if you p
 
 For how each constraint produces its OPB encoding and how we test that the encoding matches the
 constraint's semantics, see the [developer documentation](dev_docs/).
+
+Licence
+=======
+
+The Glasgow Constraint Solver is dual licensed under either of
+
+- the Apache License, Version 2.0 ([LICENCE-APACHE](LICENCE-APACHE), or
+  <https://www.apache.org/licenses/LICENSE-2.0>), or
+- the MIT License ([LICENCE-MIT](LICENCE-MIT), or <https://opensource.org/licenses/MIT>),
+
+at your option: you may use, modify and redistribute the solver under the terms of
+whichever of the two suits you, and you do not have to satisfy both. In SPDX terms, that
+is `MIT OR Apache-2.0`. See [COPYRIGHT](COPYRIGHT) for the full statement.
+
+Unless you explicitly state otherwise, any contribution you intentionally submit for
+inclusion in this work, as defined in the Apache License, Version 2.0, shall be dual
+licensed as above, without any additional terms or conditions.
 
 Acknowledgements
 ================

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -5,6 +5,7 @@ build-backend = "scikit_build_core.build"
 [project]
 name = "gcspy"
 version = "0.1.8"
+license = "MIT OR Apache-2.0"
 
 [tool.scikit-build]
 cmake.version = ">=3.18"


### PR DESCRIPTION
Funding conditions now require that software developed under them is released under both the Apache License, Version 2.0 and the MIT License. The usual arrangement for this pair (the one the Rust ecosystem popularised) is to offer the work under *either*, at the recipient's option, so that is what this does: in SPDX terms, `MIT OR Apache-2.0`.

What changes:

- `LICENCE` becomes `LICENCE-MIT` (a rename, so the history follows), with the copyright year rolled forward to 2026.
- `LICENCE-APACHE` holds the Apache License, Version 2.0. The text is byte-identical to <https://www.apache.org/licenses/LICENSE-2.0.txt> (sha256 `cfc7749b…`), appendix included, as the licence asks.
- `COPYRIGHT` states the "either of these, at your option; you do not have to satisfy both" position in one place, with the SPDX expression and the inbound-contribution paragraph. This is the file to point people at, and the reason for keeping it separate is that neither licence file can say it without ceasing to be a verbatim copy.
- `README.md` gains a Licence section, and `CONTRIBUTING.md` a Licensing section stating that contributions are dual licensed the same way unless the contributor says otherwise, that there is no copyright assignment, and that third-party code in a contribution must be declared so it can be checked against both licences.
- `install()` now puts `COPYRIGHT` and the two licence texts in `${CMAKE_INSTALL_DOCDIR}`. Section 4(a) of the Apache licence asks that redistributions carry a copy, and until now an installed copy of the library carried none.
- `python/pyproject.toml` declares `license = "MIT OR Apache-2.0"`, so the `gcspy` wheel stops shipping with no licence metadata at all.

Attribution is unchanged: both files still say Ciaran McCreesh, and I have not added an "and contributors" that was not there before.

Checks: the generated `cmake_install.cmake` puts the three files in `share/doc/Glasgow-Constraint-Solver`; the `pyproject.toml` change parses to `License-Expression: MIT OR Apache-2.0` under Metadata-Version 2.4 with the current scikit-build-core (1.0.3), which is what the unpinned build requirement resolves to. No C++ changed, so clang-format has nothing to say.

Two things deliberately not done, both easy to add if wanted:

- No `SPDX-License-Identifier` headers in the source files. The tree has never had per-file headers, and adding them would touch ~950 files; the two dual-licensing conventions (per-file SPDX tags vs. root licence files) are both fine, and this follows the one the repository already implies.
- The wheel declares the licence but does not embed the licence *texts*, because `pyproject.toml` lives in `python/` and PEP 639's `license-files` globs may not escape the project directory. Fixing it properly means either moving `pyproject.toml` to the root or duplicating the licence files under `python/`, neither of which belongs in this PR. The sdist is unaffected, since it is built from the repository root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

A second commit adds the Advanced Research + Invention Agency to the README's Acknowledgements, alongside the Royal Academy of Engineering fellowship. It rides along because it is the same funding whose conditions prompt the relicence, but it is a separate commit and can be split out if you would rather keep this PR to licensing alone.
