### PR TITLE
Read back every constraint the .scp writer can write, and keep it that way

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -386,6 +386,16 @@ if(GCS_ENABLE_EXECUTABLES)
     add_subdirectory(verified_encodings)
     add_subdirectory(scp)
     add_subdirectory(minicp_benchmarks)
+
+    # run_test_and_verify.bash reads a written .scp back with glasgow_scp_solver
+    # --parse-only, so an example that posts a constraint gcs::read_scp cannot
+    # rebuild fails there rather than much later in the chain harness. The path
+    # goes in a generated file beside the binaries rather than an ENVIRONMENT
+    # property on each test: the script already knows the build directory (it is
+    # the directory of the program it was handed), so this needs no change to
+    # any of the ~200 add_test registrations.
+    file(GENERATE OUTPUT ${CMAKE_BINARY_DIR}/scp_solver_path
+        CONTENT "$<TARGET_FILE:glasgow_scp_solver>")
 endif()
 
 if(GCS_ENABLE_DOXYGEN)

--- a/dev_docs/constraints.md
+++ b/dev_docs/constraints.md
@@ -212,6 +212,16 @@ strategies). `s_expr` returns the constraint's `.scp` entry as a structured
 s-expression term `(name op args...)` (built with `innards::SExpr::list`/`atom`
 and `NamesAndIDsTracker::s_expr_term_of`); `innards::write_scp` serialises it.
 
+Whatever keyword `constraint_type` returns, **`gcs::read_scp` must have a case
+for it**: the writer and the reader are meant to be inverses, and the
+workflow-2 chain harness re-solves the `.scp` as its first step, so a keyword
+the reader does not know fails the chain before `cake_pb_cp` is reached. Your
+constraint's own test enforces this — `verify_proof_and_dispose` reads the
+`.scp` back and fails on an unknown keyword. See
+`dev_docs/workflow2_testing.md`. The keyword names the *constraint*, not the
+propagator: an alternative propagator for an existing constraint writes the
+existing keyword (all three `Regular` variants write `regular`).
+
 ## The three install phases
 
 `Constraint::install` is not virtual and is not yours to write. It is
@@ -901,7 +911,11 @@ that is a finding about the honest derivation.
 4. Add the `.cc` to the library and the test target to
    `gcs/CMakeLists.txt` (alphabetically), plus an `add_test` entry.
 5. Add the header to `gcs/gcs.hh` (alphabetically).
-6. Decide explicitly how the constraint behaves when the caller passes
+6. Add a `read_scp` case for the keyword `constraint_type` returns, in
+   `gcs/scp_reader.cc`, plus an `enumerate` and a write -> read -> write
+   test in `gcs/scp_reader_test.cc`. The writer and the reader are
+   inverses; the constraint tests fail if the keyword has no case.
+7. Decide explicitly how the constraint behaves when the caller passes
    the same `IntegerVariableID` (or a view that resolves to the same
    underlying variable) in two argument slots, or twice within an
    array argument. Pick one of three patterns and cover it with a test

--- a/dev_docs/workflow2_testing.md
+++ b/dev_docs/workflow2_testing.md
@@ -46,6 +46,84 @@ for the format lives outside this repo (cake's `SEXP_FORMAT.md`); the reader is
 the authority for what we accept, and `cake_pb_cp` for what the verified encoder
 accepts.
 
+## Writer/reader symmetry is a requirement, not a nicety
+
+`gcs::read_scp` must have a case for **every** keyword `Constraint::s_expr()`
+can write. The chain runner's first step re-solves the `.scp` with
+`glasgow_scp_solver`, so a keyword the reader has never heard of fails the chain
+before `cake_pb_cp` is even invoked — and the failure looks like a solver bug,
+not a coverage gap. This is not automatic: `s_expr()` is a per-constraint
+override, so a new constraint can introduce a keyword and nothing notices.
+
+Two checks enforce it, between them covering everything that writes a `.scp`:
+
+- **Constraint tests, in process.** `verify_proof_and_dispose` calls
+  `test_innards::check_scp_writer_reader_symmetry`, which reads the test's own
+  `.scp` back and fails if a keyword has no case
+  (`ScpUnsupportedConstraintError`). A new constraint's own test is what catches
+  the omission.
+- **Examples, benchmarks and frontends.** `run_test_and_verify.bash` runs
+  `glasgow_scp_solver --parse-only` over the `.scp` the run wrote. That binary
+  exits **2** for an unknown keyword and **1** for any other read failure, and
+  only 2 fails the test. Its path comes from `build/scp_solver_path`, which
+  CMake generates beside the binaries, so no `add_test` registration needed
+  changing; the check simply skips outside a build tree. This lane matters
+  because some constraints are only ever posted by an example — `LexSmartTable`
+  wrote the un-parseable keyword `lex` for months precisely because its only
+  caller is `examples/smart_table_lex`.
+
+Two narrower things neither check demands:
+
+- **Not every instance need round-trip.** A view operand renders as
+  `(-X + 17)`, which the grammar does not parse; a plain `ScpReadError` is
+  tolerated. Only a missing *keyword* fails. The cost is that a model whose
+  first unreadable thing is a view hides any bad keyword later in the same file
+  — `n_queens` is one — which is part of why both lanes exist.
+- **Test-fixture constraints are exempt**, by the `test_...` naming convention
+  (`test_tabulated_product`, `test_product_fragment`). Use that prefix for an
+  ad-hoc Constraint that exists only to drive one piece of proof machinery.
+
+Worth knowing what this caught when it was turned on: `difference` and
+`cumulative_optional` had no reader case at all, and neither showed up in a hand
+audit of `constraint_type()` overrides done a fortnight earlier. It also turned
+up a genuine writer bug — `DifferenceConstraints::s_expr` rendered a
+half-reified edge's condition with `s_expr_term_of(Literal)`, which collapses a
+condition to the bare variable name, so `D >= 2` and `C = 1` were written
+identically and the `.scp` described a different problem than the one solved.
+
+Two related rules that fall out of the same principle — the `.scp` describes the
+*constraint*, not how it was propagated:
+
+- **Alternative propagators share a keyword.** `Regular`, `RegularLegacy` and
+  `RegularBacchus` all write `regular`. (Note the encodings do not all match:
+  RegularLegacy's OPB is byte-identical to Regular's and chains, whereas
+  RegularBacchus's upfront encoding labels rows cake has no counterpart for, so
+  a proof *it* emits still fails against cake's OPB.)
+- **Anonymous variables come back anonymous.** A variable created without a name
+  is written `_N`, which is exactly the spelling `Problem::check_name()`
+  reserves — so the reader recreates it unnamed rather than passing the name
+  through, mirroring what `post_autonumbered` does for `_N` constraint labels.
+
+## What `cake_pb_cp` does not encode
+
+Constraints whose keyword the verified encoder has no rule for, so they cannot
+chain at all no matter what the solver does. The solver still writes and reads
+them; the gap is upstream.
+
+| Constraint | keyword | reachable from |
+|---|---|---|
+| `BinPacking` | `binpacking` | MiniZinc, XCSP |
+| `MDD` | `mdd` | MiniZinc, XCSP |
+| `Power` / `PowerTable` | `power` | MiniZinc, XCSP |
+| `MinDistance` | `min_distance` | library only |
+| `Nogoods` (posted) | `nogoods` | library only |
+
+Also upstream: `notin` (no solver writer), views (affine operands), and `in`
+over a member list with **two or more variables** — that last one parses on both
+sides but fails at VeriPB, because the solver's `f[N][inlt/ingt/in]` flags are
+not cake's `x[id][i][ge/le/eq]` selectors (#487; one variable chains fine, which
+is why `in_var_sat` passes).
+
 Two complementary mechanisms:
 
 ## Part B — curated `.scp` chain harness (built)
@@ -94,6 +172,19 @@ Adding a constraint to the harness is: drop a `.scp` in `scp_cases/` and add one
 `add_scp_chain_test(<case> <mode>)` line.
 
 ## Part A — three-way proof check in the data-driven tests (sketch)
+
+**Superseded in part.** What actually landed instead of the three-way enum below
+is `gcs/constraints/innards/cake_probe.hh`: `verify_proof_and_dispose` calls
+`cake_probe_chain`, which runs the whole chain over the test's own `.scp` and
+logs a `CAKECHAIN <name> <outcome>` line. It is a *probe*, not an assertion — it
+never fails a test — and is off unless `GCS_TEST_CAKE` is set, so it is a way to
+measure coverage over the random instances rather than to gate on it. The
+reader-symmetry check above is the part of this idea that is on by default,
+because it is cheap and needs no external tools.
+
+The remainder of this section is the original design sketch, kept for the gating
+analysis (which still describes what would be needed to make the chain an
+assertion over random instances).
 
 The random/edge-case instances live in the `*_test` binaries, which already
 thread a `proofs` bool into `solve_for_tests*(p, proof_name, …)` and loop

--- a/gcs/constraints/difference/difference_constraints.cc
+++ b/gcs/constraints/difference/difference_constraints.cc
@@ -261,9 +261,14 @@ auto DifferenceConstraints::s_expr(const ProofModel * const model) const -> SExp
     for (const auto & e : _edges) {
         vector<SExpr> edge{tracker.s_expr_term_of(e.x), tracker.s_expr_term_of(e.y), SExpr::atom(e.d.to_string())};
         // A half-reified edge carries its condition as a fourth element, so
-        // that an unconditional system's s-expression is unchanged.
+        // that an unconditional system's s-expression is unchanged. It must be
+        // the full (variable op value) triple, the same spelling every other
+        // reified form writes: s_expr_term_of(Literal) renders a condition as
+        // the bare variable name, which silently drops the operator and value,
+        // so `C >= 2` and `C = 1` would come out identically as `C`.
         if (e.cond)
-            edge.push_back(tracker.s_expr_term_of(Literal{*e.cond}));
+            edge.push_back(SExpr::list(
+                {tracker.s_expr_term_of(e.cond->var), SExpr::atom(tracker.s_expr_name_of(e.cond->op)), SExpr::atom(e.cond->value.to_string())}));
         edges.push_back(SExpr::list(move(edge)));
     }
 

--- a/gcs/constraints/innards/constraints_test_utils.hh
+++ b/gcs/constraints/innards/constraints_test_utils.hh
@@ -4,11 +4,13 @@
 #include <gcs/current_state.hh>
 #include <gcs/exception.hh>
 #include <gcs/problem.hh>
+#include <gcs/scp_reader.hh>
 #include <gcs/search_heuristics.hh>
 #include <gcs/solve.hh>
 
 #include <gcs/constraints/innards/cake_probe.hh>
 
+#include <gcs/innards/s_expr.hh>
 #include <gcs/innards/variable_id_utils.hh>
 
 #include <util/enumerate.hh>
@@ -18,6 +20,7 @@
 #include <array>
 #include <cstdio>
 #include <cstdlib>
+#include <fstream>
 #include <functional>
 #include <iostream>
 #include <map>
@@ -153,6 +156,55 @@ namespace gcs::test_innards
     }
 
     /**
+     * \brief Assert that read_scp has a case for every constraint keyword the
+     * test's `.scp` contains.
+     *
+     * Writer/reader symmetry is not automatic: Constraint::s_expr() is a
+     * per-constraint override, so a new constraint can write a keyword read_scp
+     * has never heard of, and nothing notices until something tries to read that
+     * `.scp` back — the workflow-2 chain harness re-solves the `.scp` as its
+     * first step, so an unreadable keyword fails the chain before the verified
+     * encoder is even invoked. Running this from every proving constraint test
+     * means a new constraint's own test is what catches it.
+     *
+     * Deliberately narrow: only ScpUnsupportedConstraintError fails. Any other
+     * ScpReadError is a shape the reader knows about but cannot rebuild from
+     * this instance (a view operand, for one), which is a documented limitation
+     * rather than a missing keyword. Posting into a throwaway Problem is cheap
+     * next to the solve and veripb run that precede it.
+     *
+     * Constraint types named `test_...` are exempt: a few tests define an ad-hoc
+     * Constraint to drive one piece of proof machinery (see
+     * innards/tabulation_test.cc, innards/product_justify_test.cc), and those
+     * are not constraints the reader should know. Use that prefix when adding
+     * another.
+     */
+    inline auto check_scp_writer_reader_symmetry(const std::string & proof_name) -> void
+    {
+        std::ifstream scp_in{proof_name + ".scp"};
+        if (! scp_in)
+            return;
+        std::string scp{std::istreambuf_iterator<char>{scp_in}, std::istreambuf_iterator<char>{}};
+
+        Problem rebuilt;
+        try {
+            read_scp(rebuilt, scp);
+        }
+        catch (const ScpUnsupportedConstraintError & e) {
+            if (! e.operator_name().starts_with("test_"))
+                throw UnexpectedException{
+                    std::string{"the .scp writer emitted a constraint read_scp cannot read ("} + e.what() + "): add a case to gcs/scp_reader.cc"};
+        }
+        catch (const ScpReadError &) {
+            // A keyword the reader knows, in a shape it cannot rebuild. Not what
+            // this guard is for.
+        }
+        catch (const innards::SExprParseError &) {
+            // Likewise: a name the s-expression grammar cannot round-trip.
+        }
+    }
+
+    /**
      * \brief Verify a proof with VeriPB and, on success, dispose of it.
      *
      * Returns whether verification succeeded. The proof files are left in place
@@ -175,6 +227,7 @@ namespace gcs::test_innards
     {
         if (! run_veripb(proof_name + ".opb", proof_name + ".pbp"))
             return false;
+        check_scp_writer_reader_symmetry(proof_name);
         cake_probe_chain(proof_name); // PROBE: measure workflow-2 chain (no-op unless GCS_TEST_CAKE)
         dispose_of_proof_files(proof_name);
         return true;

--- a/gcs/constraints/lex/lex_smart_table.cc
+++ b/gcs/constraints/lex/lex_smart_table.cc
@@ -70,7 +70,12 @@ auto LexSmartTable::prepare(Propagators & propagators, State & initial_state, Pr
 
 auto LexSmartTable::constraint_type() const -> std::string
 {
-    return "lex";
+    // `lex_smart_table`, cake_pb_cp's spelling, not the bare `lex` this used to
+    // write --- which is not a keyword anything accepts, here or upstream, so
+    // the .scp of any model posting this constraint was unreadable. Note the
+    // keyword is all that lines up: this desugars through the full SmartTable
+    // encoding, several times the size of cake's rows, so it does not chain.
+    return "lex_smart_table";
 }
 
 auto LexSmartTable::s_expr(const innards::ProofModel * const model) const -> SExpr

--- a/gcs/constraints/mini_linear_test.cc
+++ b/gcs/constraints/mini_linear_test.cc
@@ -215,7 +215,7 @@ namespace
 
         auto constraint_type() const -> string override
         {
-            return "mini_linear_greater_equal";
+            return "test_mini_linear_greater_equal";
         }
     };
 

--- a/gcs/constraints/regular/regular_bacchus.cc
+++ b/gcs/constraints/regular/regular_bacchus.cc
@@ -443,7 +443,16 @@ auto RegularBacchus::install_propagators(Propagators & propagators) -> void
 
 auto RegularBacchus::constraint_type() const -> std::string
 {
-    return "regular_bacchus";
+    // `regular` for the same reason as RegularLegacy: the keyword names the
+    // constraint, not the propagator. Note that unlike Regular and
+    // RegularLegacy, a proof *this* variant emits still does not check against
+    // cake's OPB: the upfront Bacchus encoding labels its own per-(i, q, v)
+    // transition-extension rows @c[id][fwd<i>q<q>v<v>], which cake's encoding
+    // has no counterpart for, so veripb rejects the first pol that cites one.
+    // Conforming that is a separate, real proof-logging change; the keyword is
+    // right regardless, and re-solving this .scp (as the chain harness does)
+    // picks the default propagator and chains.
+    return "regular";
 }
 
 auto RegularBacchus::s_expr(const ProofModel * const model) const -> SExpr

--- a/gcs/constraints/regular/regular_legacy.cc
+++ b/gcs/constraints/regular/regular_legacy.cc
@@ -542,7 +542,11 @@ auto RegularLegacy::install_propagators(Propagators & propagators) -> void
 
 auto RegularLegacy::constraint_type() const -> std::string
 {
-    return "regular_legacy";
+    // `regular`, not `regular_legacy`: the `.scp` describes the constraint, not
+    // which of the three propagators was chosen to enforce it, and every
+    // consumer (cake_pb_cp, gcs::read_scp) keys off the constraint. This
+    // variant's OPB is byte-identical to Regular's, so it chain-verifies.
+    return "regular";
 }
 
 auto RegularLegacy::s_expr(const ProofModel * const model) const -> SExpr

--- a/gcs/scp_reader.cc
+++ b/gcs/scp_reader.cc
@@ -3,10 +3,12 @@
 #include <gcs/constraints/all_equal.hh>
 #include <gcs/constraints/among/among.hh>
 #include <gcs/constraints/at_most_one/at_most_one.hh>
+#include <gcs/constraints/bin_packing.hh>
 #include <gcs/constraints/circuit.hh>
 #include <gcs/constraints/comparison.hh>
 #include <gcs/constraints/count.hh>
 #include <gcs/constraints/cumulative.hh>
+#include <gcs/constraints/difference/difference_constraints.hh>
 #include <gcs/constraints/disjunctive.hh>
 #include <gcs/constraints/disjunctive_2d.hh>
 #include <gcs/constraints/divide.hh>
@@ -18,14 +20,18 @@
 #include <gcs/constraints/inverse.hh>
 #include <gcs/constraints/knapsack/knapsack.hh>
 #include <gcs/constraints/lex.hh>
+#include <gcs/constraints/lex_smart_table.hh>
 #include <gcs/constraints/linear/linear_equality.hh>
 #include <gcs/constraints/linear/linear_inequality.hh>
 #include <gcs/constraints/logical.hh>
+#include <gcs/constraints/mdd.hh>
+#include <gcs/constraints/min_distance.hh>
 #include <gcs/constraints/min_max.hh>
 #include <gcs/constraints/minus.hh>
 #include <gcs/constraints/modulus.hh>
 #include <gcs/constraints/multiply.hh>
 #include <gcs/constraints/n_value.hh>
+#include <gcs/constraints/nogoods/nogoods.hh>
 #include <gcs/constraints/parity.hh>
 #include <gcs/constraints/plus.hh>
 #include <gcs/constraints/power.hh>
@@ -65,6 +71,11 @@ using namespace gcs;
 using namespace gcs::innards;
 
 ScpReadError::ScpReadError(const string & w) : MessageException("Error reading .scp: " + w)
+{
+}
+
+ScpUnsupportedConstraintError::ScpUnsupportedConstraintError(const string & op) :
+    ScpReadError("unsupported constraint operator '" + op + "'"), _operator_name(op)
 {
 }
 
@@ -572,15 +583,24 @@ namespace
         post_constraint(problem, SymmetricAllDifferent{move(vars), as_integer(terms[3])}, label);
     }
 
-    auto read_at_most_one(Problem & problem, const map<string, IntegerVariableID> & variables, const vector<SExpr> & terms, const string & label)
-        -> void
+    auto read_at_most_one(Problem & problem, const map<string, IntegerVariableID> & variables, const string & op, const vector<SExpr> & terms,
+        const string & label) -> void
     {
         // (label at_most_one (vars...) val): at most one of the variables takes the
-        // value val (itself a variable or a constant).
+        // value val (itself a variable or a constant). `at_most_one_smart_table`
+        // is the same constraint reached through a SmartTable decomposition; it
+        // keeps its own keyword (which is also cake's spelling) and rebuilds as
+        // the matching class, so the term round-trips. It does not chain: cake's
+        // rule wants an integer where this writes a variable, and the SmartTable
+        // desugaring is a much larger OPB than cake's rows.
         if (terms.size() != 4)
-            throw ScpReadError{"at_most_one is (label at_most_one (vars...) val)"};
-        auto vars = resolve_variable_list(variables, terms[2], "the at_most_one variable list");
-        post_constraint(problem, AtMostOne{move(vars), resolve_variable(variables, terms[3])}, label);
+            throw ScpReadError{op + " is (label " + op + " (vars...) val)"};
+        auto vars = resolve_variable_list(variables, terms[2], ("the " + op + " variable list").c_str());
+        auto val = resolve_variable(variables, terms[3]);
+        if (op == "at_most_one_smart_table")
+            post_constraint(problem, AtMostOneSmartTable{move(vars), val}, label);
+        else
+            post_constraint(problem, AtMostOne{move(vars), val}, label);
     }
 
     auto read_sort(Problem & problem, const map<string, IntegerVariableID> & variables, const vector<SExpr> & terms, const string & label) -> void
@@ -636,6 +656,146 @@ namespace
         if (terms.size() != 3)
             throw ScpReadError{"seq_precede_chain is (label seq_precede_chain (vars...))"};
         post_constraint(problem, SeqPrecedeChain{resolve_variable_list(variables, terms[2], "the seq_precede_chain variable list")}, label);
+    }
+
+    auto read_difference(Problem & problem, const map<string, IntegerVariableID> & variables, const vector<SExpr> & terms, const string & label)
+        -> void
+    {
+        // (label difference ((x y d [(cond op value)]) ...)): one edge per
+        // difference constraint x - y <= d, propagated as a system rather than
+        // edge by edge. A half-reified edge carries its condition as a fourth
+        // element, which the writer omits entirely for an unconditional edge, so
+        // an unreified system's term is the three-element form throughout.
+        if (terms.size() != 3)
+            throw ScpReadError{"difference is (label difference ((x y d [cond]) ...))"};
+        vector<DifferenceEdge> edges;
+        for (const auto & edge_term : children_of(terms[2], "the difference edge list")) {
+            const auto & parts = children_of(edge_term, "a difference edge");
+            if (parts.size() != 3 && parts.size() != 4)
+                throw ScpReadError{"a difference edge must be (x y d) or (x y d cond)"};
+            DifferenceEdge edge{resolve_variable(variables, parts[0]), resolve_variable(variables, parts[1]), as_integer(parts[2]), nullopt};
+            if (parts.size() == 4)
+                edge.cond = resolve_condition(variables, parts[3]);
+            edges.push_back(move(edge));
+        }
+        post_constraint(problem, DifferenceConstraints{move(edges)}, label);
+    }
+
+    auto read_bin_packing(Problem & problem, const map<string, IntegerVariableID> & variables, const vector<SExpr> & terms, const string & label)
+        -> void
+    {
+        // (label binpacking (items...) (sizes...) loads (loads...)) or
+        // (label binpacking (items...) (sizes...) capacities (caps...)): item i
+        // has constant size sizes[i] and goes in bin items[i]. The tagged fifth
+        // term picks the form: `loads` gives one load *variable* per bin (each
+        // exactly the total size in that bin), `capacities` one constant upper
+        // bound per bin. cake_pb_cp has no binpacking rule, so this shape is
+        // ours; the tag is what keeps the two forms apart, since both trailing
+        // lists are per-bin and the same length.
+        if (terms.size() != 6)
+            throw ScpReadError{"binpacking is (label binpacking (items...) (sizes...) loads|capacities (per-bin...))"};
+        auto items = resolve_variable_list(variables, terms[2], "the binpacking item list");
+        auto sizes = resolve_integer_list(terms[3], "the binpacking size list");
+        const auto & form = terms[4].as_atom();
+        if (form == "loads")
+            post_constraint(
+                problem, BinPacking{move(items), move(sizes), resolve_variable_list(variables, terms[5], "the binpacking load list")}, label);
+        else if (form == "capacities")
+            post_constraint(problem, BinPacking{move(items), move(sizes), resolve_integer_list(terms[5], "the binpacking capacity list")}, label);
+        else
+            throw ScpReadError{"binpacking's fourth argument must be the tag `loads` or `capacities`, not '" + form + "'"};
+    }
+
+    // (label mdd (X1 ... Xn) (n0 n1 ... nn) ((layer-0-nodes) ...) (t1 ... tk)):
+    // a layered DAG read left to right, one layer per variable. `nodes_per_layer`
+    // has n + 1 entries (the node count at each layer boundary, layer 0 being the
+    // single-source root layer); layer i's entry lists, per source node in node
+    // order, that node's outgoing (symbol target) edges, where `target` indexes
+    // into layer i + 1; the trailing list is the accepting nodes of the final
+    // layer. Same edge spelling as regular, but per layer rather than shared, and
+    // the writer sorts each node's edges so the .scp is byte-stable.
+    auto read_mdd(Problem & problem, const map<string, IntegerVariableID> & variables, const vector<SExpr> & terms, const string & label) -> void
+    {
+        if (terms.size() != 6)
+            throw ScpReadError{"mdd is (label mdd (vars...) (nodes-per-layer...) ((layer-edges)...) (accepting...))"};
+        auto vars = resolve_variable_list(variables, terms[2], "the mdd variable list");
+
+        vector<long> nodes_per_layer;
+        for (const auto & n : children_of(terms[3], "the mdd nodes-per-layer list"))
+            nodes_per_layer.push_back(static_cast<long>(as_integer(n).raw_value));
+
+        const auto & layers = children_of(terms[4], "the mdd layer list");
+        vector<vector<unordered_map<Integer, long>>> layer_transitions;
+        for (const auto & layer : layers) {
+            vector<unordered_map<Integer, long>> nodes;
+            for (const auto & node : children_of(layer, "an mdd layer's node list")) {
+                unordered_map<Integer, long> edges;
+                for (const auto & edge : children_of(node, "an mdd node's edge list")) {
+                    const auto & pair = children_of(edge, "an mdd edge");
+                    if (pair.size() != 2)
+                        throw ScpReadError{"an mdd edge must be (symbol target)"};
+                    if (! edges.emplace(as_integer(pair[0]), static_cast<long>(as_integer(pair[1]).raw_value)).second)
+                        throw ScpReadError{"an mdd node has two edges on the same symbol"};
+                }
+                nodes.push_back(move(edges));
+            }
+            layer_transitions.push_back(move(nodes));
+        }
+
+        vector<long> accepting;
+        for (const auto & t : children_of(terms[5], "the mdd accepting-node list"))
+            accepting.push_back(static_cast<long>(as_integer(t).raw_value));
+
+        post_constraint(problem, MDD{move(vars), move(layer_transitions), move(nodes_per_layer), move(accepting)}, label);
+    }
+
+    auto resolve_matrix(const SExpr & e, const char * what) -> MinDistance::Matrix
+    {
+        MinDistance::Matrix matrix;
+        for (const auto & row : children_of(e, what))
+            matrix.push_back(resolve_integer_list(row, what));
+        return matrix;
+    }
+
+    auto read_min_distance(Problem & problem, const map<string, IntegerVariableID> & variables, const vector<SExpr> & terms, const string & label)
+        -> void
+    {
+        // (label min_distance (X1 ... Xn) Z ((d...)...) [((r...)...)]): the Xi
+        // pick sites, Z is a lower bound on the pairwise distance between the
+        // chosen sites, and the square matrix gives the distance between each
+        // pair of sites. The optional trailing matrix is the per-pair minimum
+        // *requirement*. The propagation strategy is deliberately absent: like
+        // the regular variants, the .scp names the constraint, not the
+        // propagator, so this reads back at the default strategy.
+        if (terms.size() != 5 && terms.size() != 6)
+            throw ScpReadError{"min_distance is (label min_distance (vars...) z ((distances...)...) [((requirements...)...)])"};
+        auto xs = resolve_variable_list(variables, terms[2], "the min_distance variable list");
+        auto z = resolve_variable(variables, terms[3]);
+        auto distances = resolve_matrix(terms[4], "the min_distance distance matrix");
+        if (terms.size() == 6)
+            post_constraint(
+                problem, MinDistance{move(xs), z, move(distances), resolve_matrix(terms[5], "the min_distance requirement matrix")}, label);
+        else
+            post_constraint(problem, MinDistance{move(xs), z, move(distances)}, label);
+    }
+
+    auto read_nogoods(Problem & problem, const map<string, IntegerVariableID> & variables, const vector<SExpr> & terms, const string & label) -> void
+    {
+        // (label nogoods (((V op v) ...) ...)): each inner list is one forbidden
+        // conjunction of variable conditions, spelled as the reification triples
+        // resolve_condition reads. Only *posted* nogoods appear -- the engine's
+        // learned-nogood store is installed directly on the propagators and is
+        // empty when the .scp is written, so it contributes nothing here.
+        if (terms.size() != 3)
+            throw ScpReadError{"nogoods is (label nogoods (((var op value) ...) ...))"};
+        vector<Nogood> nogoods;
+        for (const auto & nogood_term : children_of(terms[2], "the nogood list")) {
+            Nogood nogood;
+            for (const auto & condition : children_of(nogood_term, "a nogood"))
+                nogood.push_back(resolve_condition(variables, condition));
+            nogoods.push_back(move(nogood));
+        }
+        post_constraint(problem, Nogoods{move(nogoods)}, label);
     }
 
     auto read_knapsack(Problem & problem, const map<string, IntegerVariableID> & variables, const vector<SExpr> & terms, const string & label) -> void
@@ -758,13 +918,33 @@ auto gcs::read_scp(Problem & problem, string_view text) -> ScpModel
     map<string, IntegerVariableID> variables;
 
     // Variables: each declaration is (name lower upper).
+    //
+    // A variable created without a name is written as `_N`, which is exactly the
+    // spelling Problem::check_name() reserves and rejects -- so an anonymous
+    // variable has to be recreated anonymously, the same trick post_constraint
+    // uses for `_N` constraint labels. Problem numbers anonymous variables in
+    // creation order and the writer emits them in that order, so the k-th `_N`
+    // declaration must be `_k`; checking that keeps a hand-written document from
+    // quietly getting different variables than it names.
+    unsigned long long anonymous_so_far = 0;
     for (const auto & decl : section_items(sections[1], "variables")) {
         const auto & parts = children_of(decl, "a variable declaration");
         if (parts.size() != 3)
             throw ScpReadError{"a variable declaration must be (name lower upper)"};
         auto name = parts[0].as_atom();
-        auto var = problem.create_integer_variable(as_integer(parts[1]), as_integer(parts[2]), name);
-        if (! variables.emplace(name, var).second)
+        auto lower = as_integer(parts[1]), upper = as_integer(parts[2]);
+
+        optional<IntegerVariableID> var;
+        if (auto number = auto_number_of(name)) {
+            if (*number != ++anonymous_so_far)
+                throw ScpReadError{"anonymous variable '" + name + "' is declaration number " + std::to_string(anonymous_so_far) +
+                    " among the anonymous ones, so it would be created as '_" + std::to_string(anonymous_so_far) + "'"};
+            var = problem.create_integer_variable(lower, upper, nullopt);
+        }
+        else
+            var = problem.create_integer_variable(lower, upper, name);
+
+        if (! variables.emplace(name, *var).second)
             throw ScpReadError{"duplicate variable name '" + name + "'"};
     }
 
@@ -994,6 +1174,24 @@ auto gcs::read_scp(Problem & problem, string_view text) -> ScpModel
                     .with_strict(op.ends_with("_strict")),
                 label);
         }
+        else if (op == "cumulative_optional") {
+            // (label cumulative_optional (starts...) (lengths...) (heights...)
+            // (presences...) cap): cumulative over tasks that may be absent,
+            // presences[i] in {0,1} saying whether task i is scheduled at all.
+            // The presences list sits between the heights and the capacity,
+            // where the FlatZinc builtin puts it. Deliberately a keyword of its
+            // own rather than an optional argument to `cumulative`: the active
+            // flags carry a third conjunct, so re-deriving it as a plain
+            // cumulative would give a different, weaker encoding.
+            if (terms.size() != 7)
+                throw ScpReadError{"cumulative_optional is (label cumulative_optional (starts...) (lengths...) (heights...) (presences...) cap)"};
+            post_constraint(problem,
+                Cumulative{resolve_variable_list(variables, terms[2], "the cumulative_optional start list"),
+                    resolve_variable_list(variables, terms[3], "the cumulative_optional length list"),
+                    resolve_variable_list(variables, terms[4], "the cumulative_optional height list"),
+                    resolve_variable_list(variables, terms[5], "the cumulative_optional presence list"), resolve_variable(variables, terms[6])},
+                label);
+        }
         else if (op == "cumulative") {
             // (label cumulative (starts...) (lengths...) (heights...) cap): the
             // tasks [start, start + length) each occupy `height` of a shared
@@ -1026,8 +1224,8 @@ auto gcs::read_scp(Problem & problem, string_view text) -> ScpModel
         else if (op == "symmetric_all_different") {
             read_symmetric_all_different(problem, variables, terms, label);
         }
-        else if (op == "at_most_one") {
-            read_at_most_one(problem, variables, terms, label);
+        else if (op == "at_most_one" || op == "at_most_one_smart_table") {
+            read_at_most_one(problem, variables, op, terms, label);
         }
         else if (op == "among") {
             read_among(problem, variables, terms, label);
@@ -1041,8 +1239,35 @@ auto gcs::read_scp(Problem & problem, string_view text) -> ScpModel
         else if (op == "knapsack") {
             read_knapsack(problem, variables, terms, label);
         }
+        else if (op == "binpacking") {
+            read_bin_packing(problem, variables, terms, label);
+        }
+        else if (op == "difference") {
+            read_difference(problem, variables, terms, label);
+        }
+        else if (op == "mdd") {
+            read_mdd(problem, variables, terms, label);
+        }
+        else if (op == "min_distance") {
+            read_min_distance(problem, variables, terms, label);
+        }
+        else if (op == "nogoods") {
+            read_nogoods(problem, variables, terms, label);
+        }
         else if (op == "element_2d") {
             read_element_2d(problem, variables, terms, label);
+        }
+        else if (op == "lex_smart_table") {
+            // (label lex_smart_table (xs...) (ys...)): xs >_lex ys, enforced by a
+            // SmartTable decomposition rather than the LexGreaterThan propagator.
+            // Its own keyword, matching cake, because the encoding is a different
+            // (much larger) one, not just a different propagator.
+            if (terms.size() != 4)
+                throw ScpReadError{"lex_smart_table is (label lex_smart_table (xs...) (ys...))"};
+            post_constraint(problem,
+                LexSmartTable{resolve_variable_list(variables, terms[2], "the lex_smart_table first variable list"),
+                    resolve_variable_list(variables, terms[3], "the lex_smart_table second variable list")},
+                label);
         }
         else if (op.starts_with("lex_")) {
             read_lex(problem, variables, op, terms, label);
@@ -1057,7 +1282,7 @@ auto gcs::read_scp(Problem & problem, string_view text) -> ScpModel
             read_equals(problem, variables, op, terms, label);
         }
         else
-            throw ScpReadError{"unsupported constraint operator '" + op + "'"};
+            throw ScpUnsupportedConstraintError{op};
     }
 
     auto minimise_variable = objective.transform([&](const ObjectiveSpec & spec) { return resolve_objective(variables, spec); });

--- a/gcs/scp_reader.hh
+++ b/gcs/scp_reader.hh
@@ -26,6 +26,34 @@ namespace gcs
     };
 
     /**
+     * \brief The specific ScpReadError for a constraint keyword this reader has
+     * no case for at all, as opposed to a keyword it knows whose arguments were
+     * malformed or use a shape it cannot rebuild.
+     *
+     * The distinction is what lets the constraint tests assert writer/reader
+     * *symmetry* — that every keyword Constraint::s_expr() can emit is one
+     * read_scp accepts — without also demanding that every instance round-trip
+     * (a view operand, say, renders as `(-X + 17)`, which is a known and
+     * separate reader limitation).
+     *
+     * \ingroup Core
+     */
+    class ScpUnsupportedConstraintError : public ScpReadError
+    {
+    private:
+        std::string _operator_name;
+
+    public:
+        explicit ScpUnsupportedConstraintError(const std::string & op);
+
+        /// The keyword that had no case, for a caller that wants to classify it.
+        [[nodiscard]] auto operator_name() const -> const std::string &
+        {
+            return _operator_name;
+        }
+    };
+
+    /**
      * \brief What read_scp recovered from a `.scp` beyond the Problem it built:
      * the variables by name, and the objective if the document had one.
      *
@@ -74,11 +102,19 @@ namespace gcs
      * harness does) could not. Call Problem::minimise() with
      * ScpModel::minimise_variable to honour it.
      *
-     * Only a subset of constraints is supported so far (`abs`, `all_different`,
-     * `in`, the comparisons, the linear forms, `equals`/`not_equals`, `element`
-     * and `count`); an unsupported operator raises ScpReadError rather than
-     * being silently dropped. Throws ScpReadError (or SExprParseError) on
-     * malformed input.
+     * The reader is expected to accept **every** keyword Constraint::s_expr()
+     * can write: the workflow-2 chain harness re-solves the `.scp` as its first
+     * step, so a keyword with no case here fails the chain before the verified
+     * encoder is reached. The constraint tests enforce that (see
+     * test_innards::check_scp_writer_reader_symmetry), so adding a constraint
+     * means adding its case below. An unknown keyword raises
+     * ScpUnsupportedConstraintError rather than being silently dropped.
+     *
+     * What the reader does *not* promise is that every *instance* round-trips.
+     * A view operand renders as an s-expression list (`(-X + 17)`), which this
+     * grammar does not parse, and a few constraints accept shapes their public
+     * constructors cannot rebuild (a non-deterministic automaton, say). Those
+     * raise a plain ScpReadError. Throws SExprParseError on malformed input.
      *
      * \returns The variables by name, and the objective if there was one.
      */

--- a/gcs/scp_reader_test.cc
+++ b/gcs/scp_reader_test.cc
@@ -3,10 +3,12 @@
 #include <gcs/constraints/all_equal.hh>
 #include <gcs/constraints/among/among.hh>
 #include <gcs/constraints/at_most_one/at_most_one.hh>
+#include <gcs/constraints/bin_packing.hh>
 #include <gcs/constraints/circuit.hh>
 #include <gcs/constraints/comparison.hh>
 #include <gcs/constraints/count.hh>
 #include <gcs/constraints/cumulative.hh>
+#include <gcs/constraints/difference/difference_constraints.hh>
 #include <gcs/constraints/disjunctive.hh>
 #include <gcs/constraints/disjunctive_2d.hh>
 #include <gcs/constraints/divide.hh>
@@ -19,12 +21,17 @@
 #include <gcs/constraints/lex.hh>
 #include <gcs/constraints/linear.hh>
 #include <gcs/constraints/logical.hh>
+#include <gcs/constraints/mdd.hh>
+#include <gcs/constraints/min_distance.hh>
 #include <gcs/constraints/min_max.hh>
 #include <gcs/constraints/modulus.hh>
 #include <gcs/constraints/multiply.hh>
+#include <gcs/constraints/nogoods/nogoods.hh>
 #include <gcs/constraints/parity.hh>
 #include <gcs/constraints/power.hh>
 #include <gcs/constraints/regular/regular.hh>
+#include <gcs/constraints/regular/regular_bacchus.hh>
+#include <gcs/constraints/regular/regular_legacy.hh>
 #include <gcs/constraints/seq_precede_chain/seq_precede_chain.hh>
 #include <gcs/constraints/smart_table/smart_table.hh>
 #include <gcs/constraints/table/negative_table.hh>
@@ -1121,4 +1128,256 @@ TEST_CASE("read_scp: an objective survives write -> read -> write unchanged")
         CHECK(scp_a == scp_b);
         CHECK(scp_a.contains(maximise ? "(prob_type (maximize X))" : "(prob_type (minimize X))"));
     }
+}
+
+TEST_CASE("read_scp: binpacking enumerates correctly in both forms")
+{
+    // Two items of size 1 and 2 into two bins, so the four packings give loads
+    // (0,3), (2,1), (1,2), (3,0). The loads form pins them exactly; the
+    // capacities form only rules out the packings that overflow a bin of 2,
+    // which is the two that put both items together.
+    auto loads = enumerate(R"(
+        (
+            (version 1)
+            (variables (I0 0 1) (I1 0 1) (L0 0 3) (L1 0 3))
+            (constraints (_1 binpacking (I0 I1) (1 2) loads (L0 L1)))
+            (prob_type enumerate)
+        ))");
+
+    CHECK(loads ==
+        set<map<string, long long>>{
+            {{"I0", 0}, {"I1", 0}, {"L0", 3}, {"L1", 0}},
+            {{"I0", 0}, {"I1", 1}, {"L0", 1}, {"L1", 2}},
+            {{"I0", 1}, {"I1", 0}, {"L0", 2}, {"L1", 1}},
+            {{"I0", 1}, {"I1", 1}, {"L0", 0}, {"L1", 3}},
+        });
+
+    auto capacities = enumerate(R"(
+        (
+            (version 1)
+            (variables (I0 0 1) (I1 0 1))
+            (constraints (_1 binpacking (I0 I1) (1 2) capacities (2 2)))
+            (prob_type enumerate)
+        ))");
+
+    CHECK(capacities == set<map<string, long long>>{{{"I0", 0}, {"I1", 1}}, {{"I0", 1}, {"I1", 0}}});
+}
+
+TEST_CASE("read_scp: mdd enumerates correctly")
+{
+    // Three layers over two binary variables. Layer 0 is the root; the root
+    // splits on X0, and each layer-1 node accepts only the *other* value of X1,
+    // reaching node 0 (accepting) -- so exactly X0 != X1.
+    auto solutions = enumerate(R"(
+        (
+            (version 1)
+            (variables (X0 0 1) (X1 0 1))
+            (constraints (_1 mdd (X0 X1) (1 2 1) ((((0 0) (1 1))) (((1 0)) ((0 0)))) (0)))
+            (prob_type enumerate)
+        ))");
+
+    CHECK(solutions == set<map<string, long long>>{{{"X0", 0}, {"X1", 1}}, {{"X0", 1}, {"X1", 0}}});
+}
+
+TEST_CASE("read_scp: min_distance enumerates correctly, with and without requirements")
+{
+    // Three sites on a line at 0, 1, 3, so D = [[0,1,3],[1,0,2],[3,2,0]]. Z is
+    // the minimum pairwise distance between the two chosen sites, which for two
+    // positions is just D[X0][X1] (and 0 when they coincide).
+    static constexpr auto distances = "((0 1 3) (1 0 2) (3 2 0))";
+
+    auto solutions = enumerate(std::string{R"(
+        (
+            (version 1)
+            (variables (X0 0 2) (X1 0 2) (Z 0 3))
+            (constraints (_1 min_distance (X0 X1) Z )"} +
+        distances + R"())
+            (prob_type enumerate)
+        ))");
+
+    CHECK(solutions.size() == 9);
+    for (const auto & s : solutions) {
+        static constexpr long long d[3][3] = {{0, 1, 3}, {1, 0, 2}, {3, 2, 0}};
+        CHECK(s.at("Z") == d[s.at("X0")][s.at("X1")]);
+    }
+
+    // The requirements matrix additionally demands D[X0][X1] >= 3, which only
+    // the two site-0/site-2 orderings meet.
+    auto required = enumerate(std::string{R"(
+        (
+            (version 1)
+            (variables (X0 0 2) (X1 0 2) (Z 0 3))
+            (constraints (_1 min_distance (X0 X1) Z )"} +
+        distances + " ((0 3) (0 0))" + R"())
+            (prob_type enumerate)
+        ))");
+
+    CHECK(required == set<map<string, long long>>{{{"X0", 0}, {"X1", 2}, {"Z", 3}}, {{"X0", 2}, {"X1", 0}, {"Z", 3}}});
+}
+
+TEST_CASE("read_scp: nogoods enumerates correctly")
+{
+    // Two forbidden conjunctions over a 2x2 space, leaving the other two
+    // assignments. Written as the same (variable op value) triples the
+    // reification conditions use.
+    auto solutions = enumerate(R"(
+        (
+            (version 1)
+            (variables (A 0 1) (B 0 1))
+            (constraints (_1 nogoods (((A = 0) (B = 0)) ((A = 1) (B = 1)))))
+            (prob_type enumerate)
+        ))");
+
+    CHECK(solutions == set<map<string, long long>>{{{"A", 0}, {"B", 1}}, {{"A", 1}, {"B", 0}}});
+}
+
+TEST_CASE("read_scp: binpacking, mdd, min_distance and nogoods survive write -> read -> write unchanged")
+{
+    Problem original;
+    auto i0 = original.create_integer_variable(0_i, 1_i, "I0");
+    auto i1 = original.create_integer_variable(0_i, 1_i, "I1");
+    auto l0 = original.create_integer_variable(0_i, 3_i, "L0");
+    auto l1 = original.create_integer_variable(0_i, 3_i, "L1");
+    auto x0 = original.create_integer_variable(0_i, 1_i, "X0");
+    auto x1 = original.create_integer_variable(0_i, 1_i, "X1");
+    auto s0 = original.create_integer_variable(0_i, 2_i, "S0");
+    auto s1 = original.create_integer_variable(0_i, 2_i, "S1");
+    auto z = original.create_integer_variable(0_i, 3_i, "Z");
+
+    original.post(BinPacking{std::vector<IntegerVariableID>{i0, i1}, std::vector<Integer>{1_i, 2_i}, std::vector<IntegerVariableID>{l0, l1}});
+    original.post(BinPacking{std::vector<IntegerVariableID>{i0, i1}, std::vector<Integer>{1_i, 2_i}, std::vector<Integer>{2_i, 2_i}});
+    original.post(MDD{std::vector<IntegerVariableID>{x0, x1},
+        std::vector<std::vector<std::unordered_map<Integer, long>>>{{{{0_i, 0}, {1_i, 1}}}, {{{1_i, 0}}, {{0_i, 0}}}}, std::vector<long>{1, 2, 1},
+        std::vector<long>{0}});
+    original.post(MinDistance{std::vector<IntegerVariableID>{s0, s1}, z, MinDistance::Matrix{{0_i, 1_i, 3_i}, {1_i, 0_i, 2_i}, {3_i, 2_i, 0_i}},
+        MinDistance::Matrix{{0_i, 1_i}, {0_i, 0_i}}});
+    original.post(Nogoods{std::vector<Nogood>{{x0 == 0_i, x1 == 0_i}}});
+
+    auto scp_a = prove_to_scp(original, "scp_reader_newglobals_a");
+
+    Problem rebuilt;
+    read_scp(rebuilt, scp_a);
+    auto scp_b = prove_to_scp(rebuilt, "scp_reader_newglobals_b");
+
+    CHECK(scp_a == scp_b);
+    CHECK_FALSE(scp_a.empty());
+}
+
+TEST_CASE("read_scp: every regular propagator variant writes and reads back as `regular`")
+{
+    // The .scp names the constraint, not the propagator, so all three variants
+    // write the same `regular` term over the same automaton -- which is what
+    // lets a RegularLegacy or RegularBacchus proof be checked against a
+    // verified encoder that only knows `regular`.
+    auto automaton = []<typename Variant_>(const std::string & basename) {
+        Problem problem;
+        auto a = problem.create_integer_variable(0_i, 1_i, "A");
+        auto b = problem.create_integer_variable(0_i, 1_i, "B");
+        problem.post(Variant_{std::vector<IntegerVariableID>{a, b}, 2,
+            std::vector<std::unordered_map<Integer, long>>{{{0_i, 0}, {1_i, 1}}, {{0_i, 1}, {1_i, 0}}}, std::vector<long>{0}});
+        return prove_to_scp(problem, basename);
+    };
+
+    auto scp_plain = automaton.template operator()<Regular>("scp_reader_regvariant_plain");
+    auto scp_legacy = automaton.template operator()<RegularLegacy>("scp_reader_regvariant_legacy");
+    auto scp_bacchus = automaton.template operator()<RegularBacchus>("scp_reader_regvariant_bacchus");
+
+    CHECK(scp_legacy == scp_plain);
+    CHECK(scp_bacchus == scp_plain);
+    CHECK(scp_plain.contains("regular"));
+    CHECK_FALSE(scp_plain.contains("regular_legacy"));
+    CHECK_FALSE(scp_plain.contains("regular_bacchus"));
+
+    Problem rebuilt;
+    read_scp(rebuilt, scp_legacy);
+    CHECK(prove_to_scp(rebuilt, "scp_reader_regvariant_rebuilt") == scp_plain);
+}
+
+TEST_CASE("read_scp: difference enumerates correctly, unreified and half-reified")
+{
+    // A - B <= 0 and B - A <= 1, i.e. B - 1 <= A <= B over [0,2].
+    auto system = enumerate(R"(
+        (
+            (version 1)
+            (variables (A 0 2) (B 0 2))
+            (constraints (_1 difference ((A B 0) (B A 1))))
+            (prob_type enumerate)
+        ))");
+
+    CHECK(system ==
+        set<map<string, long long>>{{{"A", 0}, {"B", 0}}, {{"A", 0}, {"B", 1}}, {{"A", 1}, {"B", 1}}, {{"A", 1}, {"B", 2}}, {{"A", 2}, {"B", 2}}});
+
+    // The same first edge, now only in force when C = 1. C = 0 leaves A and B
+    // free, so the nine unconstrained pairs come back alongside the six that
+    // satisfy A - B <= 0.
+    auto reified = enumerate(R"(
+        (
+            (version 1)
+            (variables (A 0 2) (B 0 2) (C 0 1))
+            (constraints (_1 difference ((A B 0 (C = 1)))))
+            (prob_type enumerate)
+        ))");
+
+    CHECK(reified.size() == 9 + 6);
+    for (const auto & s : reified)
+        if (s.at("C") == 1)
+            CHECK(s.at("A") <= s.at("B"));
+}
+
+TEST_CASE("read_scp: difference survives write -> read -> write unchanged")
+{
+    Problem original;
+    auto a = original.create_integer_variable(0_i, 2_i, "A");
+    auto b = original.create_integer_variable(0_i, 2_i, "B");
+    auto c = original.create_integer_variable(0_i, 1_i, "C");
+    auto d = original.create_integer_variable(0_i, 3_i, "D");
+    original.post(DifferenceConstraints{std::vector<DifferenceEdge>{{a, b, 0_i}, {b, a, 1_i}, {a, b, 2_i, c == 1_i}, {b, a, 2_i, d >= 2_i}}});
+    auto scp_a = prove_to_scp(original, "scp_reader_difference_a");
+
+    Problem rebuilt;
+    read_scp(rebuilt, scp_a);
+    auto scp_b = prove_to_scp(rebuilt, "scp_reader_difference_b");
+
+    CHECK(scp_a == scp_b);
+    CHECK_FALSE(scp_a.empty());
+
+    // A condition must be written as the full (variable op value) triple. The
+    // writer used to render it as a bare Literal, which for `C = 1` on a {0,1}
+    // variable collapses to just `C` -- so `D >= 2` came out as `D`, and the
+    // .scp described a *different* problem than the one solved.
+    CHECK(scp_a.contains("(C = 1)"));
+    CHECK(scp_a.contains("(D >= 2)"));
+}
+
+TEST_CASE("read_scp: a .scp whose variables are all anonymous reads back")
+{
+    // A variable created without a name is written `_N`, which is exactly what
+    // Problem::check_name() reserves and rejects -- so the reader has to
+    // recreate it anonymously rather than passing the name through, or every
+    // .scp from a model that did not name its variables is unreadable.
+    Problem original;
+    auto x = original.create_integer_variable(0_i, 3_i);
+    auto y = original.create_integer_variable(0_i, 3_i);
+    original.post(LessThan{x, y});
+    auto scp_a = prove_to_scp(original, "scp_reader_anon_a");
+    CHECK(scp_a.contains("(_1 0 3)"));
+
+    Problem rebuilt;
+    read_scp(rebuilt, scp_a);
+    auto scp_b = prove_to_scp(rebuilt, "scp_reader_anon_b");
+    CHECK(scp_a == scp_b);
+
+    // Mixed named and anonymous: the anonymous ones are numbered among
+    // themselves, so a named declaration in between must not consume a number.
+    Problem mixed;
+    auto p = mixed.create_integer_variable(0_i, 3_i);
+    auto named = mixed.create_integer_variable(0_i, 3_i, "Named");
+    auto q = mixed.create_integer_variable(0_i, 3_i);
+    mixed.post(LessThan{p, named});
+    mixed.post(LessThan{named, q});
+    auto mixed_a = prove_to_scp(mixed, "scp_reader_anon_mixed_a");
+
+    Problem mixed_rebuilt;
+    read_scp(mixed_rebuilt, mixed_a);
+    CHECK(prove_to_scp(mixed_rebuilt, "scp_reader_anon_mixed_b") == mixed_a);
 }

--- a/run_test_and_verify.bash
+++ b/run_test_and_verify.bash
@@ -54,5 +54,39 @@ fi
 
 veripb "${proofname}.opb" "${proofname}.pbp" || exit 1
 
+# Writer/reader symmetry: whatever .scp the run wrote must be one gcs::read_scp
+# can rebuild. The chain harness re-solves the .scp as its first step, so a
+# constraint whose keyword the reader has never heard of fails the chain long
+# after the fact, in a place that looks like a solver bug. Checking it here
+# means the example that posts the constraint is what reports it. The constraint
+# tests do the same thing in-process (check_scp_writer_reader_symmetry); this
+# covers the examples, benchmarks and frontend binaries, which are where the
+# less-common constraints actually get posted.
+#
+# The solver's path comes from scp_solver_path, which CMake generates beside the
+# binaries; GCS_SCP_SOLVER overrides it. Both absent (running outside a build
+# tree) simply skips the check, as does a run that wrote no .scp.
+scp_solver=${GCS_SCP_SOLVER:-}
+if [[ -z $scp_solver ]] ; then
+    scp_solver_path_file=$(dirname "$prog")/scp_solver_path
+    [[ -r $scp_solver_path_file ]] && scp_solver=$(<"$scp_solver_path_file")
+fi
+
+# Only exit status 2 -- a keyword read_scp has no case for -- fails the test.
+# Status 1 is a keyword it knows in a shape it cannot rebuild: a view operand
+# renders as the list `(-X + 17)`, which the grammar does not parse, and that is
+# a documented limitation rather than a coverage gap. (It does mean a model
+# whose first unreadable thing is a view can hide a bad keyword later in the
+# same file; the in-process check in the constraint tests has the same
+# property, and between them the constraints are covered either way.)
+if [[ -n $scp_solver && -x $scp_solver && -e ${proofname}.scp ]] ; then
+    "$scp_solver" --parse-only "${proofname}.scp"
+    scp_read_status=$?
+    if [[ $scp_read_status -eq 2 ]] ; then
+        echo "$0: ${proofname}.scp names a constraint gcs::read_scp cannot read -- see dev_docs/workflow2_testing.md" 1>&2
+        exit 1
+    fi
+fi
+
 # Verification passed, so dispose of the proof unless asked to preserve it.
 dispose_proof "$proofname"

--- a/scp/glasgow_scp_solver.cc
+++ b/scp/glasgow_scp_solver.cc
@@ -59,8 +59,12 @@ auto main(int argc, char * argv[]) -> int
             ("proof-files-basename", "Basename for the .opb and .pbp files", //
                 cxxopts::value<string>()->default_value("scp"))              //
             ("all", "Find all solutions (implied by an objective)")          //
-            ("stats", "Print solve statistics")                              //
-            ("file", "The .scp file to solve", cxxopts::value<string>())     //
+            ("parse-only",
+                "Read the file and post its constraints, but do "
+                "not search: a cheap check that the .scp is one "
+                "this solver can rebuild")                               //
+            ("stats", "Print solve statistics")                          //
+            ("file", "The .scp file to solve", cxxopts::value<string>()) //
             ;
         options.parse_positional({"file"});
         options.positional_help("scp-file.scp");
@@ -91,10 +95,27 @@ auto main(int argc, char * argv[]) -> int
     try {
         model = read_scp(problem, text);
     }
+    catch (const ScpUnsupportedConstraintError & e) {
+        // Distinguished from every other read failure by its exit status, so a
+        // caller checking writer/reader symmetry can tell "this reader has no
+        // case for that keyword" (a gap to fix) from "this reader knows the
+        // keyword but cannot rebuild this instance" (a view operand, say --- a
+        // documented limitation). See run_test_and_verify.bash.
+        println(cerr, "Error: {}", e.what());
+        return 2;
+    }
     catch (const std::exception & e) {
         println(cerr, "Error: {}", e.what());
         return EXIT_FAILURE;
     }
+
+    // --parse-only stops here: read_scp has created the variables and posted
+    // every constraint, which is the whole question when the caller is checking
+    // that a written .scp can be read back (run_test_and_verify.bash does this
+    // for every proving example, so an unreadable keyword is caught by the
+    // example that writes it rather than by a chain run much later).
+    if (options_vars.contains("parse-only"))
+        return EXIT_SUCCESS;
 
     // read_scp resolves an objective but leaves posting it to us, so that a
     // caller who wants to enumerate an optimisation instance still can. Here we

--- a/verified_encodings/scp_cases/CMakeLists.txt
+++ b/verified_encodings/scp_cases/CMakeLists.txt
@@ -298,6 +298,20 @@ add_scp_chain_test(global_cardinality_closed_sat   none)
 add_scp_chain_test(global_cardinality_closed_unsat none)
 add_scp_chain_test(global_cardinality_gac_sat      none)
 add_scp_chain_test(global_cardinality_gac_unsat    none)
+# The fourth keyword, gacglobalcardinalityclosed: GAC and closed together. cake
+# maps all four keywords onto the same two-flag semantics, so the closed rows are
+# the same ones boundsglobalcardinalityclosed exercises -- but only this keyword
+# reaches them from the GAC propagator, which is a different set of proof steps.
+add_scp_chain_test(global_cardinality_gac_closed_sat none)
+
+# none (chain-only): the reified linear forms. cake reads the reification as a
+# leading (var op value) triple on lin_equals / lin_less_equal, exactly as the
+# writer emits it; these are the fully-reified (_iff) shapes, so both directions
+# of the biconditional are defined and enumeration exercises both. The unreified
+# lin_* cases above are strict; these stay none for the same eq-ladder reason as
+# the other reified families.
+add_scp_chain_test(lin_equals_iff_sat      none)
+add_scp_chain_test(lin_less_equal_iff_sat  none)
 
 # none (chain-only): regular (the sequence of variables is a word accepted by a
 # finite automaton). The writer emits cake's shape -- (vars...) nstates
@@ -341,6 +355,13 @@ add_scp_chain_test(disjunctive2d_sat      none)
 add_scp_chain_test(disjunctive2d_unsat    none)
 # Variable-size disjunctive2d: as disjunctive_var, per axis.
 add_scp_chain_test(disjunctive2d_var_sat  none)
+# The strict keywords, which keep zero-size tasks rather than dropping them (cake's
+# `strct`). Both cases put a zero-size task inside a wider one, which is the only
+# shape where strict and non-strict differ: 7 solutions here against 9 for
+# `disjunctive`, and 67 against 81 for `disjunctive2d`. A case with all-positive
+# sizes would exercise the keyword but assert nothing about the semantics.
+add_scp_chain_test(disjunctive_strict_sat   none)
+add_scp_chain_test(disjunctive2d_strict_sat none)
 
 # none (chain-only): cumulative. Tasks [start, start+length) each occupy `height`
 # of a shared resource; at every time point the total height of active tasks is at

--- a/verified_encodings/scp_cases/disjunctive2d_strict_sat.scp
+++ b/verified_encodings/scp_cases/disjunctive2d_strict_sat.scp
@@ -1,0 +1,1 @@
+( (version 1) (variables (X0 0 2) (X1 0 2) (Y0 0 2) (Y1 0 2)) (constraints (_1 disjunctive2d_strict (X0 X1) (Y0 Y1) (2 0) (2 2))) (prob_type enumerate) )

--- a/verified_encodings/scp_cases/disjunctive_strict_sat.scp
+++ b/verified_encodings/scp_cases/disjunctive_strict_sat.scp
@@ -1,0 +1,1 @@
+( (version 1) (variables (S0 0 2) (S1 0 2)) (constraints (_1 disjunctive_strict (S0 S1) (2 0))) (prob_type enumerate) )

--- a/verified_encodings/scp_cases/global_cardinality_gac_closed_sat.scp
+++ b/verified_encodings/scp_cases/global_cardinality_gac_closed_sat.scp
@@ -1,0 +1,1 @@
+( (version 1) (variables (X 0 2) (Y 0 2) (Z 0 2) (CA 0 3) (CB 0 3) (CC 0 3)) (constraints (_1 gacglobalcardinalityclosed (X Y Z) (0 1 2) (CA CB CC))) (prob_type enumerate) )

--- a/verified_encodings/scp_cases/lin_equals_iff_sat.scp
+++ b/verified_encodings/scp_cases/lin_equals_iff_sat.scp
@@ -1,0 +1,1 @@
+( (version 1) (variables (X 0 3) (Y 0 3) (B 0 3)) (constraints (_1 lin_equals_iff (B = 1) (1 X 1 Y) 3)) (prob_type enumerate) )

--- a/verified_encodings/scp_cases/lin_less_equal_iff_sat.scp
+++ b/verified_encodings/scp_cases/lin_less_equal_iff_sat.scp
@@ -1,0 +1,1 @@
+( (version 1) (variables (X 0 3) (Y 0 3) (B 0 3)) (constraints (_1 lin_less_equal_iff (B = 1) (1 X 1 Y) 2)) (prob_type enumerate) )


### PR DESCRIPTION
Falls out of an audit of what `cake_pb_cp` cannot encode. Everything here is
solver-side; nothing needs an upstream change.

## The gap

`Constraint::s_expr()` could write eight keywords `gcs::read_scp` had no case
for: `binpacking`, `cumulative_optional`, `difference`, `mdd`, `min_distance`,
`nogoods`, `at_most_one_smart_table` and `lex_smart_table`. Because the
workflow-2 chain harness re-solves the `.scp` as its first step, each of these
failed the chain *before* `cake_pb_cp` was reached — so the gap read as a solver
bug rather than the coverage hole it was, and no amount of upstream work would
have helped.

Three of the keywords were not even names anything accepts. `RegularLegacy` and
`RegularBacchus` wrote `regular_legacy` / `regular_bacchus`, and `LexSmartTable`
wrote a bare `lex`. The `.scp` describes the *constraint*, not which propagator
enforced it, so the two Regular variants now write `regular` and LexSmartTable
writes cake's spelling. RegularLegacy's OPB is byte-identical to Regular's, so
its proofs now chain-verify for free; RegularBacchus's upfront encoding labels
rows cake has no counterpart for, which is a separate, real conform.

Separately, *any* `.scp` from a model that did not name its variables was
unreadable: an anonymous variable is written `_N`, which is exactly the spelling
`Problem::check_name()` reserves and rejects. The reader now recreates such a
variable anonymously, mirroring `post_autonumbered`.

## A real writer bug on the way

`DifferenceConstraints::s_expr` rendered a half-reified edge's condition with
`s_expr_term_of(Literal)`, which renders a condition as the **bare variable
name**. `C = 1` and `D >= 2` both came out as just the variable, so the `.scp`
described a different problem than the one solved. Now written as the
`(var op value)` triple every other reified form uses.

## Keeping it that way

A hand audit is not enough — one done a fortnight before this branch missed
`difference` and `cumulative_optional` entirely, and the checks added here found
both on their first run. Two lanes:

- **Constraint tests, in process.** `verify_proof_and_dispose` reads the test's
  own `.scp` back and fails on `ScpUnsupportedConstraintError`, so a new
  constraint's own test reports the omission.
- **Examples, benchmarks, frontends.** `run_test_and_verify.bash` runs
  `glasgow_scp_solver --parse-only`, which exits 2 for an unknown keyword and 1
  for any other read failure; only 2 fails. The path comes from a
  CMake-generated `build/scp_solver_path`, so none of the ~200 `add_test`
  registrations needed changing. This lane earns its keep: `LexSmartTable` is
  only ever posted by an example, which is why its bad keyword survived.

Neither demands that every *instance* round-trip — a view operand renders as
`(-X + 17)`, a documented reader limitation rather than a coverage gap.
Constraints named `test_...` are exempt, for the ad-hoc fixtures in
`tabulation_test` and `product_justify_test`.

Both lanes were verified to fire by disabling a reader case and watching the
relevant test go red.

## Also

Five chain cases registered that already verified but had no test:
`gacglobalcardinalityclosed`, `disjunctive_strict`, `disjunctive2d_strict`,
`lin_equals_iff`, `lin_less_equal_iff`. The two strict cases put a zero-size
task inside a wider one, the only shape where strict and non-strict differ (7
solutions against 9; 67 against 81) — an all-positive-sizes case would exercise
the keyword while asserting nothing.

`dev_docs/workflow2_testing.md` gains the symmetry rule, a table of what
`cake_pb_cp` has no rule for at all (`binpacking`, `mdd`, `power`,
`min_distance`, `nogoods`) with which frontends reach each, and a note that `in`
over **two or more** variable members parses on both sides but fails at VeriPB
(#487; one variable chains, which is why `in_var_sat` passes). Part A's
three-way enum is marked superseded by the `cake_probe.hh` probe that landed
instead.

## Testing

`ctest` 648/648 green, GCC and clang 21. The chain harness is 165/165 with
`cake_pb_cp` on PATH.

🤖 Generated with [Claude Code](https://claude.com/claude-code)