### PR TITLE
Turn on -Werror for the ubuntu-26.04 GCC CI lane, so a new warning cannot land unnoticed

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -28,9 +28,15 @@ jobs:
         # clang + libstdc++ toolchain (including the clang-only lifetime
         # annotation probe tests) and keeps the (faster) capped defaults, as
         # do the macOS lanes, which build with Apple Clang + libc++.
+        #
+        # The ubuntu-26.04 default-GCC lane is also the one lane that builds with
+        # -Werror, so a new compiler warning fails CI instead of landing unnoticed.
+        # It is that lane and no other: GCC's warning baseline has been zero since
+        # #710, whereas clang and Apple Clang still have a few hundred pre-existing
+        # warnings each. See the GCS_WERROR option in CMakeLists.txt.
         include:
           - { os: ubuntu-24.04, caps: 'OFF' }
-          - { os: ubuntu-26.04, caps: 'OFF' }
+          - { os: ubuntu-26.04, caps: 'OFF', werror: 'ON' }
           - { os: ubuntu-26.04, cc: clang, cxx: clang++ }
           - { os: macos-15 }
           - { os: macos-26 }
@@ -78,7 +84,7 @@ jobs:
       env:
         CC: ${{ matrix.cc }}
         CXX: ${{ matrix.cxx }}
-      run: cmake --preset release -B ${{github.workspace}}/build ${{ matrix.caps == 'OFF' && '-DGCS_TEST_CAP_DEFAULTS=OFF' || '' }}
+      run: cmake --preset release -B ${{github.workspace}}/build ${{ matrix.caps == 'OFF' && '-DGCS_TEST_CAP_DEFAULTS=OFF' || '' }} ${{ matrix.werror == 'ON' && '-DGCS_WERROR=ON' || '' }}
 
     - name: Build
       run: cmake --build ${{github.workspace}}/build --parallel $(nproc 2>/dev/null || sysctl -n hw.logicalcpu)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,6 +136,27 @@ option(GCS_TEST_CAP_DEFAULTS "Apply default solution/recursion caps to constrain
 set(GCS_TEST_MAX_SOLUTIONS "300" CACHE STRING "Default per-solve solution cap for data-driven constraint tests (when GCS_TEST_CAP_DEFAULTS)")
 set(GCS_TEST_MAX_RECURSIONS "1500" CACHE STRING "Default per-solve search-node cap for data-driven constraint tests (when GCS_TEST_CAP_DEFAULTS)")
 
+# Promote warnings to errors. Deliberately OFF by default: shipping -Werror in a
+# library is a bad deal for the people building it, because every compiler that
+# invents a new warning breaks their build for reasons that have nothing to do
+# with them. It is turned on for exactly one CI lane (the ubuntu-26.04 default-GCC
+# lane in .github/workflows/cmake.yml), which is enough to stop a new warning
+# landing unnoticed -- there is otherwise no compiler -Werror anywhere, so a warning
+# in new code is invisible to every lane and the build goes green with it in.
+#
+# Only the GCC lane, on purpose: clang and Apple Clang still have a few hundred
+# pre-existing warnings each (mostly -Winconsistent-missing-override and
+# -Wunused-lambda-capture), and MSVC is on /W3 with no equivalent, so those lanes
+# would fail immediately. GCC's baseline has been zero since #710. This option has
+# no effect on MSVC.
+#
+# It applies to the fetched dependencies too, since it is a global option set before
+# the FetchContent subdirectories are added. That is intentional -- it is what was
+# tested, and it means a dependency bump that introduces a warning is caught rather
+# than absorbed. (The xcsp3parser targets are the exception: they carry -w, which
+# leaves no warning to promote.)
+option(GCS_WERROR "Treat compiler warnings as errors (CI lane only; not for normal builds)" OFF)
+
 # Compiler flag checks always run so results are available for target-specific use.
 include(CheckCXXCompilerFlag)
 unset(COMPILER_SUPPORTS_MARCH_NATIVE CACHE)
@@ -182,6 +203,10 @@ if(PROJECT_IS_TOP_LEVEL)
     else()
         add_compile_options(-W)
         add_compile_options(-Wall)
+
+        if(GCS_WERROR)
+            add_compile_options(-Werror) # see the GCS_WERROR option above: CI lane only
+        endif()
 
         if(COMPILER_SUPPORTS_NO_RESTRICT)
             add_compile_options(-Wno-restrict) # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=104336


### PR DESCRIPTION
Closes #718.

There is no compiler `-Werror` anywhere in the build or the workflows — the only `-Werror` in the repository is on clang-format. A warning introduced by new code is therefore invisible to all ten lanes: the build goes green with the warning in it and nothing ever says so. Checking for it has had to be a manual pre-merge step costing a full local release build per PR.

Shipping `-Werror` by default is still not wanted — it breaks other people's builds every time a new compiler invents a warning, which is a bad deal for a library. So this adds a `GCS_WERROR` option defaulting `OFF`, and switches it on from the matrix for one lane only, reusing the conditional the workflow already has for `GCS_TEST_CAP_DEFAULTS`:

```yaml
- { os: ubuntu-26.04, caps: 'OFF', werror: 'ON' }
```

A normal build is completely unaffected, and there is no path by which the flag reaches a release or a downstream packager.

## That lane and no other

GCC's warning baseline has been zero since #710, so it can carry this today. The clang lane is still at roughly 153 warnings (mostly `-Winconsistent-missing-override` and `-Wunused-lambda-capture`) and macOS has the same debt with Apple Clang; MSVC is on `/W3` with no cheap equivalent. Cleaning up clang is worth doing on its own, but bundling it here would block this.

## Verified, both directions

- Configured with `-DGCS_WERROR=ON -DGCS_TEST_CAP_DEFAULTS=OFF` and built the full release tree on GCC 15.2.0: **all 410 TUs, exit 0, zero warnings**, fetched dependencies included.
- Confirmed the flag is not a no-op: compiling an unused variable with the resulting flag set fails with `error: unused variable [-Werror=unused-variable]`.
- A default configure has `GCS_WERROR:BOOL=OFF` and no `-Werror` anywhere in its compile lines.

## Two ways this will eventually go red, both accepted deliberately

1. **GitHub bumps the image's GCC within the release** and a point release invents a warning. That reddens the lane and blocks PRs until someone fixes it — which is the trade being taken: it breaks our CI on one lane instead of users' builds everywhere, and the fix is either a real one or a narrow `-Wno-`.
2. **A fetched dependency bump.** The option is global, so `catch2`, `cxxopts`, `json` and `gch_small_vector` are promoted too. They are clean today — that is part of what the trial build establishes — and catching a dependency's new warning rather than absorbing it is the intended behaviour. The fetched `xcsp3parser` targets are already immune: #710 gave them `-w`, and a suppressed warning cannot be promoted. (Verified: `-w` does defeat `-Werror` on GCC, and `samplesXcsp3`, the one parser target without `-w`, is `EXCLUDE_FROM_ALL` and never built.)

The real acceptance test is this PR's own ubuntu-26.04 lane, which now builds with the flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)