### PR TITLE
Report every component block through %%%mzn-stat, generically

### DIFF
--- a/gcs/constraints/difference/difference_graph.cc
+++ b/gcs/constraints/difference/difference_graph.cc
@@ -1117,6 +1117,13 @@ auto gcs::innards::install_difference_propagator(Propagators & propagators, Stat
     if (graph.edges.empty() && graph.static_bounds.empty() && graph.disallowed_conditions.empty())
         return;
 
+    // Both routes to a difference propagator come through here --- the posted
+    // DifferenceConstraints and the presolver that builds a graph out of donors
+    // --- so registering the simplification block here is what makes it reach a
+    // report either way. A null block is a caller that asked for none, and
+    // add_component_stats ignores it.
+    propagators.add_component_stats(simplify.stats);
+
     incremental.audit = incremental.audit || difference_audit_from_environment();
 
     Triggers triggers;

--- a/gcs/constraints/difference/difference_simplify.cc
+++ b/gcs/constraints/difference/difference_simplify.cc
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <optional>
 #include <queue>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -18,6 +19,8 @@ using std::optional;
 using std::pair;
 using std::priority_queue;
 using std::size_t;
+using std::string;
+using std::to_string;
 using std::vector;
 using std::ranges::reverse;
 
@@ -265,4 +268,36 @@ auto gcs::innards::simplify_difference_graph(size_t n, const vector<DifferenceSi
     }
 
     return outcome;
+}
+
+auto DifferenceSimplificationStats::component_name() const -> string
+{
+    return "difference_logic_simplify";
+}
+
+auto DifferenceSimplificationStats::summary() const -> string
+{
+    if (! ran)
+        return "did not run";
+
+    if (base_negative_cycle)
+        return "stopped on a negative cycle in the base graph, leaving the refutation to the propagator";
+
+    return "removed " + to_string(redundant_edges_removed) + " redundant and " + to_string(dead_edges_removed) + " dead edges, fixed " +
+        to_string(conditions_fixed) + " conditions, over " + to_string(rounds) + " rounds of " + to_string(nodes) + " nodes and " + to_string(edges) +
+        " edges";
+}
+
+auto DifferenceSimplificationStats::entries() const -> vector<StatsEntry>
+{
+    return {StatsEntry{"ran", ran ? 1 : 0}, StatsEntry{"rounds", static_cast<long long>(rounds)}, StatsEntry{"nodes", static_cast<long long>(nodes)},
+        StatsEntry{"edges", static_cast<long long>(edges)}, StatsEntry{"conditional_edges", static_cast<long long>(conditional_edges)},
+        StatsEntry{"redundant_edges_removed", static_cast<long long>(redundant_edges_removed)},
+        StatsEntry{"redundant_conditional_edges_removed", static_cast<long long>(redundant_conditional_edges_removed)},
+        StatsEntry{"dead_edges_removed", static_cast<long long>(dead_edges_removed)},
+        StatsEntry{"conditions_fixed", static_cast<long long>(conditions_fixed)},
+        StatsEntry{"isolated_nodes_removed", static_cast<long long>(isolated_nodes_removed)},
+        StatsEntry{"zero_weight_cycles", static_cast<long long>(zero_weight_cycles)},
+        StatsEntry{"nodes_on_zero_weight_cycles", static_cast<long long>(nodes_on_zero_weight_cycles)},
+        StatsEntry{"base_negative_cycle", base_negative_cycle ? 1 : 0}, StatsEntry{"milliseconds", static_cast<long long>(seconds * 1000.0)}};
 }

--- a/gcs/constraints/difference/difference_simplify.hh
+++ b/gcs/constraints/difference/difference_simplify.hh
@@ -2,8 +2,10 @@
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_DIFFERENCE_DIFFERENCE_SIMPLIFY_HH
 
 #include <gcs/integer.hh>
+#include <gcs/stats.hh>
 
 #include <cstddef>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -23,7 +25,7 @@ namespace gcs
      * \sa DifferenceConstraints::simplifying_at_root
      * \ingroup Constraints
      */
-    struct DifferenceSimplificationStats
+    struct DifferenceSimplificationStats final : ComponentStats
     {
         /// True if the stage actually ran. It runs once, from an initialiser,
         /// which is the root by construction (see
@@ -92,6 +94,31 @@ namespace gcs
         /// paid at the root, and the paper is explicit that it should be judged
         /// on its own.
         double seconds = 0.0;
+
+        /**
+         * \brief `difference_logic_simplify`, which is what a report has called
+         * this stage since before it was a ComponentStats.
+         *
+         * Not `difference_simplify` after the header, as the ComponentStats
+         * convention would otherwise have it. The names this feeds are already
+         * public --- `minizinc/CMakeLists.txt` pins
+         * `differenceLogicSimplifyRan` --- and a stage that reports under two
+         * different names across a version is worse than one whose identifier
+         * does not match its filename.
+         */
+        [[nodiscard]] auto component_name() const -> std::string override;
+        [[nodiscard]] auto summary() const -> std::string override;
+
+        /**
+         * \brief Every field, with \ref seconds rendered as whole milliseconds
+         * under the name `milliseconds`.
+         *
+         * A StatsEntry is an integer, and a duration is the one field here that
+         * is not. Milliseconds rather than truncated seconds because a stage
+         * that costs 900ms is worth telling apart from one that costs nothing,
+         * and `seconds=0` would not.
+         */
+        [[nodiscard]] auto entries() const -> std::vector<StatsEntry> override;
     };
 }
 

--- a/gcs/presolvers/difference_logic/difference_logic.cc
+++ b/gcs/presolvers/difference_logic/difference_logic.cc
@@ -23,6 +23,7 @@
 using namespace gcs;
 using namespace gcs::innards;
 
+using std::make_shared;
 using std::make_unique;
 using std::map;
 using std::move;
@@ -30,6 +31,8 @@ using std::nullopt;
 using std::optional;
 using std::shared_ptr;
 using std::size_t;
+using std::string;
+using std::to_string;
 using std::unique_ptr;
 using std::vector;
 
@@ -53,7 +56,11 @@ namespace
 }
 
 DifferenceLogic::DifferenceLogic(shared_ptr<DifferenceLogicStats> stats) :
-    _stats(move(stats)), _disable_lifted_donors(false), _simplify(true), _incremental()
+    // Always a block, whether or not anyone asked for one, exactly as
+    // CumulativeStrengthening does it: what reaches a report is what was
+    // registered, and a presolver that registers nothing is a presolver that
+    // cannot be told apart from one that did nothing.
+    _stats(stats ? move(stats) : make_shared<DifferenceLogicStats>()), _disable_lifted_donors(false), _simplify(true), _incremental()
 {
 }
 
@@ -100,6 +107,13 @@ auto DifferenceLogic::clone() const -> unique_ptr<Presolver>
 
 auto DifferenceLogic::run(Problem & problem, Propagators & propagators, State & initial_state, ProofLogger * const logger) -> bool
 {
+    // Registered before anything is decided, so that a run which lifts nothing
+    // still reports having looked --- and so that this block precedes the
+    // simplification stage's, which registers from inside
+    // install_difference_propagator further down. The counters are filled in at
+    // the end, into this same object.
+    propagators.add_component_stats(_stats);
+
     // Compile-time pins on the contract the enumeration below relies upon. The
     // helper matches the type Problem *stores*, which is what clone() returns,
     // and for both of these families that is the base; asking for the derived
@@ -330,8 +344,49 @@ auto DifferenceLogic::run(Problem & problem, Propagators & propagators, State & 
             stats.donor_propagators_disabled = propagators.disable_propagators_for_constraints(lifted_donors);
     }
 
-    if (_stats)
-        *_stats = stats;
+    // Assigning rather than replacing is what keeps a caller's handle, and the
+    // block registered at the top of this function, the same object.
+    *_stats = stats;
 
     return true;
+}
+
+auto DifferenceLogicStats::component_name() const -> string
+{
+    return "difference_logic";
+}
+
+auto DifferenceLogicStats::summary() const -> string
+{
+    if (0 == edges_lifted)
+        return "lifted nothing";
+
+    auto result = to_string(edges_lifted) + " edges lifted over " + to_string(nodes) + " nodes, " + to_string(comparison_edges_lifted) +
+        " from comparisons and " + to_string(half_reified_edges_lifted) + " half-reified";
+
+    // Lifting edges and then not installing anything is the interesting case to
+    // be able to see: it is what a threshold, or a graph too small to be worth
+    // a propagator, looks like from outside.
+    if (! propagator_installed)
+        return result + ", but no propagator was installed";
+
+    if (0 != donor_propagators_disabled)
+        result += ", retiring " + to_string(donor_propagators_disabled) + " donor propagators";
+
+    return result;
+}
+
+auto DifferenceLogicStats::entries() const -> vector<StatsEntry>
+{
+    return {StatsEntry{"edges_lifted", static_cast<long long>(edges_lifted)},
+        StatsEntry{"comparison_edges_lifted", static_cast<long long>(comparison_edges_lifted)},
+        StatsEntry{"half_reified_edges_lifted", static_cast<long long>(half_reified_edges_lifted)},
+        StatsEntry{"nodes", static_cast<long long>(nodes)}, StatsEntry{"propagator_installed", propagator_installed ? 1 : 0},
+        StatsEntry{"donor_propagators_disabled", static_cast<long long>(donor_propagators_disabled)},
+        StatsEntry{"skipped_not_two_terms", static_cast<long long>(skipped_not_two_terms)},
+        StatsEntry{"skipped_coefficients", static_cast<long long>(skipped_coefficients)},
+        StatsEntry{"skipped_reified", static_cast<long long>(skipped_reified)},
+        StatsEntry{"skipped_negated_view", static_cast<long long>(skipped_negated_view)},
+        StatsEntry{"skipped_degenerate", static_cast<long long>(skipped_degenerate)},
+        StatsEntry{"skipped_uncitable_row", static_cast<long long>(skipped_uncitable_row)}};
 }

--- a/gcs/presolvers/difference_logic/difference_logic.hh
+++ b/gcs/presolvers/difference_logic/difference_logic.hh
@@ -4,9 +4,12 @@
 #include <gcs/constraints/difference/difference_incremental.hh>
 #include <gcs/constraints/difference/difference_simplify.hh>
 #include <gcs/presolver.hh>
+#include <gcs/stats.hh>
 
 #include <cstddef>
 #include <memory>
+#include <string>
+#include <vector>
 
 namespace gcs
 {
@@ -24,9 +27,16 @@ namespace gcs
      * they are how the tests, and the measurements, tell "working" from
      * "no-op". \sa DifferenceLogic
      *
+     * Being a ComponentStats is what puts those counts into a report without
+     * anything having to list them: `fzn-glasgow` renders every registered
+     * block through entries(), so a field added here reaches `%%%mzn-stat`
+     * by existing. Before that it did not --- propagator_installed and
+     * donor_propagators_disabled were filled in and read by nobody, which is
+     * the failure entries() is for.
+     *
      * \ingroup Presolvers
      */
-    struct DifferenceLogicStats
+    struct DifferenceLogicStats final : ComponentStats
     {
         /// Donors turned into graph edges: the number that matters.
         std::size_t edges_lifted = 0;
@@ -115,6 +125,10 @@ namespace gcs
         std::size_t skipped_uncitable_row = 0;
 
         ///@}
+
+        [[nodiscard]] auto component_name() const -> std::string override;
+        [[nodiscard]] auto summary() const -> std::string override;
+        [[nodiscard]] auto entries() const -> std::vector<StatsEntry> override;
     };
 
     /**

--- a/gcs/presolvers/difference_logic/difference_logic_test.cc
+++ b/gcs/presolvers/difference_logic/difference_logic_test.cc
@@ -762,8 +762,6 @@ namespace
         return count;
     }
 
-    // Every row ReifiedCompareLessThanOrMaybeEqual emits must carry an @label.
-    // The presolver's whole licence for lifting a comparison is that it can
     // The flat view both blocks reach a report through.
     //
     // These names are public. fzn-glasgow renders every registered block by
@@ -835,6 +833,8 @@ namespace
             cerr, "difference report: {} and {} entries", names_of(DifferenceLogicStats{}).size(), names_of(DifferenceSimplificationStats{}).size());
     }
 
+    // Every row ReifiedCompareLessThanOrMaybeEqual emits must carry an @label.
+    // The presolver's whole licence for lifting a comparison is that it can
     // cite the donor's row by name, and an unlabelled row cannot be cited at
     // all -- a `pol` would name something the OPB never defines.
     //

--- a/gcs/presolvers/difference_logic/difference_logic_test.cc
+++ b/gcs/presolvers/difference_logic/difference_logic_test.cc
@@ -505,7 +505,30 @@ namespace
     // skips -- is caught here and nowhere else.
     auto run_detection_tests() -> void
     {
-        auto check = [](const string & fixture, const DifferenceLogicStats & stats, const DifferenceLogicStats & expected) {
+        // What a fixture asserts, which is not the whole block: a designated
+        // initialiser naming three fields and defaulting the rest is how these
+        // read, and DifferenceLogicStats stopped being an aggregate when it
+        // became a ComponentStats. Mirroring only the fields `check` reads also
+        // stops a new field being silently defaulted into every fixture's
+        // expectations --- adding one here is a deliberate act.
+        // Declared in the same order as the fields in DifferenceLogicStats, so
+        // that a fixture's designated initialisers read as they did when they
+        // named that type directly.
+        struct Expected
+        {
+            size_t edges_lifted = 0;
+            size_t comparison_edges_lifted = 0;
+            size_t half_reified_edges_lifted = 0;
+            size_t nodes = 0;
+            bool propagator_installed = false;
+            size_t skipped_not_two_terms = 0;
+            size_t skipped_coefficients = 0;
+            size_t skipped_reified = 0;
+            size_t skipped_negated_view = 0;
+            size_t skipped_degenerate = 0;
+        };
+
+        auto check = [](const string & fixture, const DifferenceLogicStats & stats, const Expected & expected) {
             println(cerr,
                 "difference presolver detection {}: lifted {} ({} from comparisons, {} half-reified) over {} nodes, skipped {} not-two-terms, {} "
                 "coefficients, {} reified, {} negated-view, {} degenerate",
@@ -541,7 +564,7 @@ namespace
             p.post(LinearLessThanEqual{WeightedSum{} + 1_i * (x[0] + 2_i) + -1_i * x[2], 0_i});
             p.add_presolver(DifferenceLogic{stats});
             solve_with(p, SolveCallbacks{.trace = [](const CurrentState &) -> bool { return false; }});
-            check("five_plain_linears", *stats, DifferenceLogicStats{.edges_lifted = 5, .nodes = 4, .propagator_installed = true});
+            check("five_plain_linears", *stats, Expected{.edges_lifted = 5, .nodes = 4, .propagator_installed = true});
         }
 
         // Everything that must be skipped, one of each, plus two real edges so
@@ -585,7 +608,7 @@ namespace
             p.add_presolver(DifferenceLogic{stats});
             solve_with(p, SolveCallbacks{.trace = [](const CurrentState &) -> bool { return false; }});
             check("every_skip", *stats,
-                DifferenceLogicStats{.edges_lifted = 4,
+                Expected{.edges_lifted = 4,
                     .comparison_edges_lifted = 2,
                     .nodes = 4,
                     .propagator_installed = true,
@@ -630,7 +653,7 @@ namespace
             p.add_presolver(DifferenceLogic{stats});
             solve_with(p, SolveCallbacks{.trace = [](const CurrentState &) -> bool { return false; }});
             check("comparison_donors", *stats,
-                DifferenceLogicStats{.edges_lifted = 5,
+                Expected{.edges_lifted = 5,
                     .comparison_edges_lifted = 5,
                     .half_reified_edges_lifted = 1,
                     .nodes = 5,
@@ -653,8 +676,7 @@ namespace
             p.post(LinearLessThanEqual{WeightedSum{} + 1_i * x[2] + -1_i * x[3], -1_i});
             p.add_presolver(DifferenceLogic{stats});
             solve_with(p, SolveCallbacks{.trace = [](const CurrentState &) -> bool { return false; }});
-            check("mixed_donors", *stats,
-                DifferenceLogicStats{.edges_lifted = 3, .comparison_edges_lifted = 1, .nodes = 4, .propagator_installed = true});
+            check("mixed_donors", *stats, Expected{.edges_lifted = 3, .comparison_edges_lifted = 1, .nodes = 4, .propagator_installed = true});
         }
 
         // Half-reified donors, in every shape the propagator distinguishes: two
@@ -681,7 +703,7 @@ namespace
             p.add_presolver(DifferenceLogic{stats});
             solve_with(p, SolveCallbacks{.trace = [](const CurrentState &) -> bool { return false; }});
             check("reified_donors", *stats,
-                DifferenceLogicStats{.edges_lifted = 3,
+                Expected{.edges_lifted = 3,
                     .half_reified_edges_lifted = 2,
                     .nodes = 4,
                     .propagator_installed = true,
@@ -699,7 +721,7 @@ namespace
             p.post(LinearLessThanEqual{WeightedSum{} + 1_i * x[0] + -1_i * x[1], -1_i});
             p.add_presolver(DifferenceLogic{stats});
             solve_with(p, SolveCallbacks{.trace = [](const CurrentState &) -> bool { return false; }});
-            check("single_edge", *stats, DifferenceLogicStats{.edges_lifted = 1, .nodes = 2, .propagator_installed = false});
+            check("single_edge", *stats, Expected{.edges_lifted = 1, .nodes = 2, .propagator_installed = false});
         }
 
         // A model with nothing difference shaped in it: the presolver must stay
@@ -711,7 +733,7 @@ namespace
             p.post(AllDifferent{x});
             p.add_presolver(DifferenceLogic{stats});
             solve_with(p, SolveCallbacks{.trace = [](const CurrentState &) -> bool { return false; }});
-            check("nothing_to_lift", *stats, DifferenceLogicStats{.edges_lifted = 0, .nodes = 0, .propagator_installed = false});
+            check("nothing_to_lift", *stats, Expected{.edges_lifted = 0, .nodes = 0, .propagator_installed = false});
         }
 
         println(cerr, "difference presolver detection: ok");
@@ -742,6 +764,77 @@ namespace
 
     // Every row ReifiedCompareLessThanOrMaybeEqual emits must carry an @label.
     // The presolver's whole licence for lifting a comparison is that it can
+    // The flat view both blocks reach a report through.
+    //
+    // These names are public. fzn-glasgow renders every registered block by
+    // camel-casing component_name() onto each entry name, so `difference_logic`
+    // and `edges_lifted` are what make `differenceLogicEdgesLifted` --- and
+    // minizinc/CMakeLists.txt pins six of those exactly. Renaming a field, or
+    // dropping one from entries(), is therefore a user-visible change to
+    // statistics output and has to be a deliberate one. Asserted as an ordered
+    // list rather than a count so that a rename fails as a rename.
+    auto run_report_tests() -> void
+    {
+        auto names_of = [](const ComponentStats & block) -> vector<string> {
+            vector<string> result;
+            for (const auto & entry : block.entries())
+                result.push_back(entry.name);
+            return result;
+        };
+
+        auto joined = [](const vector<string> & names) -> string {
+            string result;
+            for (const auto & name : names)
+                result += (result.empty() ? "" : ", ") + name;
+            return result;
+        };
+
+        auto check_names = [&](const string & what, const ComponentStats & block, const string & expected_component,
+                               const vector<string> & expected) {
+            if (block.component_name() != expected_component)
+                throw UnexpectedException{"the " + what + " block calls itself '" + block.component_name() + "', expected '" + expected_component +
+                    "'. This is the first half of every %%%mzn-stat name it produces."};
+            if (names_of(block) != expected)
+                throw UnexpectedException{"the " + what + " block's flat view is [" + joined(names_of(block)) + "], expected [" + joined(expected) +
+                    "]. These names are public: fzn-glasgow camel-cases them into %%%mzn-stat names and minizinc/CMakeLists.txt pins six of "
+                    "them, so this is a user-visible change and not a tidy-up."};
+        };
+
+        // The anti-rot half, and the reason it is a size rather than a count:
+        // CumulativeStrengtheningStats works its field count out by dividing
+        // sizeof by eight, which is sound there because every field is eight
+        // bytes wide. These two mix bools, sizes and a double, so pin the size
+        // directly. Skipped where a size_t is not eight bytes, since then the
+        // number below means nothing.
+        //
+        // If this fails, a field was added or removed. Add it to entries() and
+        // to the list here --- do not just update the number, which is the one
+        // response that puts the field back out of sight.
+        if (8 == sizeof(size_t)) {
+            if (104 != sizeof(DifferenceLogicStats))
+                throw UnexpectedException{"DifferenceLogicStats is " + to_string(sizeof(DifferenceLogicStats)) +
+                    " bytes, expected 104: a field was added or removed, so entries() and the list below need it too."};
+            if (120 != sizeof(DifferenceSimplificationStats))
+                throw UnexpectedException{"DifferenceSimplificationStats is " + to_string(sizeof(DifferenceSimplificationStats)) +
+                    " bytes, expected 120: a field was added or removed, so entries() and the list below need it too."};
+        }
+
+        check_names("difference-logic presolver", DifferenceLogicStats{}, "difference_logic",
+            {"edges_lifted", "comparison_edges_lifted", "half_reified_edges_lifted", "nodes", "propagator_installed", "donor_propagators_disabled",
+                "skipped_not_two_terms", "skipped_coefficients", "skipped_reified", "skipped_negated_view", "skipped_degenerate",
+                "skipped_uncitable_row"});
+
+        // Named for what a report has always called this stage, not for the
+        // header it lives in: differenceLogicSimplifyRan is pinned upstream.
+        check_names("difference simplification", DifferenceSimplificationStats{}, "difference_logic_simplify",
+            {"ran", "rounds", "nodes", "edges", "conditional_edges", "redundant_edges_removed", "redundant_conditional_edges_removed",
+                "dead_edges_removed", "conditions_fixed", "isolated_nodes_removed", "zero_weight_cycles", "nodes_on_zero_weight_cycles",
+                "base_negative_cycle", "milliseconds"});
+
+        println(
+            cerr, "difference report: {} and {} entries", names_of(DifferenceLogicStats{}).size(), names_of(DifferenceSimplificationStats{}).size());
+    }
+
     // cite the donor's row by name, and an unlabelled row cannot be cited at
     // all -- a `pol` would name something the OPB never defines.
     //
@@ -1006,6 +1099,7 @@ auto main(int argc, char * argv[]) -> int
     string mode{argv[1]};
 
     if (mode == "detection") {
+        run_report_tests();
         run_detection_tests();
         for (auto donor : all_donors())
             run_differential_test(donor);

--- a/minizinc/CMakeLists.txt
+++ b/minizinc/CMakeLists.txt
@@ -75,6 +75,13 @@ set_tests_properties(minizinc-disjunctive-opt PROPERTIES SKIP_RETURN_CODE 66)
 # all four arrived as `int_lin_le`, which is the whole reason this needs no
 # predicate of its own; a flattener that started emitting `int_le` would
 # still lift four edges, but they would be counted here instead.
+#
+# These names are also the contract between ComponentStats::entries() and the
+# generic %%%mzn-stat loop in fzn_glasgow.cc: each is component_name() and an
+# entry name camel-cased together, so a rename on either side fails here rather
+# than in whatever is parsing the output. differenceLogicPropagatorInstalled is
+# one of the two fields that were filled in and reported to nobody until the
+# loop replaced the hand-written list, and is here so that stays fixed.
 add_test(NAME minizinc-differencelogic COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ differencelogic true true
     "-s --difference-logic"
     "^%%%mzn-stat: differenceLogicEdgesLifted=4$"
@@ -82,6 +89,7 @@ add_test(NAME minizinc-differencelogic COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/m
     "^%%%mzn-stat: differenceLogicNodes=4$"
     "^%%%mzn-stat: differenceLogicSkippedNotTwoTerms=1$"
     "^%%%mzn-stat: differenceLogicSkippedCoefficients=1$"
+    "^%%%mzn-stat: differenceLogicPropagatorInstalled=1$"
     "^%%%mzn-stat: differenceLogicSimplifyRan=1$")
 set_tests_properties(minizinc-differencelogic PROPERTIES SKIP_RETURN_CODE 66)
 

--- a/minizinc/fzn_glasgow.cc
+++ b/minizinc/fzn_glasgow.cc
@@ -18,6 +18,7 @@
 #endif
 
 #include <atomic>
+#include <cctype>
 #include <chrono>
 #include <condition_variable>
 #include <csignal>
@@ -98,6 +99,38 @@ namespace
     auto sig_int_or_term_handler(int) -> void
     {
         abort_flag.store(true);
+    }
+
+    /**
+     * \brief A component's flat entry name as a `%%%mzn-stat` name:
+     * `difference_logic` and `edges_lifted` give `differenceLogicEdgesLifted`.
+     *
+     * The statistics MiniZinc itself defines are camelCase (`peakDepth`,
+     * `solveTime`) and a solver's own are free-form, so snake_case would be
+     * legal and still wrong to read next to them. Translating here rather than
+     * asking blocks to spell their fields twice keeps the convention in the one
+     * file that has a reason to know it: a MiniZinc spelling is not something a
+     * presolver in `gcs/presolvers/` should have an opinion about.
+     *
+     * The component name leads because these names are flat and global ---
+     * `nodes` means one thing under `difference_logic` and another under
+     * `difference_logic_simplify`, and both are reported.
+     */
+    [[nodiscard]] auto mzn_stat_name(const string & component, const string & entry) -> string
+    {
+        string result;
+        bool capitalise_next = false;
+        for (auto c : component + "_" + entry) {
+            if ('_' == c)
+                capitalise_next = true;
+            else if (capitalise_next) {
+                result += static_cast<char>(toupper(static_cast<unsigned char>(c)));
+                capitalise_next = false;
+            }
+            else
+                result += c;
+        }
+        return result;
     }
 
     struct ExtractedData
@@ -1223,25 +1256,16 @@ auto main(int argc, char * argv[]) -> int
             println(cout, "%%%mzn-stat: peakDepth={}", stats.max_depth);
             println(cout, "%%%mzn-stat: restarts={}", stats.restarts);
             println(cout, "%%%mzn-stat: solveTime={:.3f}", duration_cast<milliseconds>(stats.solve_time).count() / 1000.0);
-            // A presolver that lifts nothing preserves the solution set, adds no
-            // OPB content and leaves every proof verifying, so these counts are
-            // the only way to tell "it worked" from "it silently did nothing".
-            if (difference_logic_stats) {
-                println(cout, "%%%mzn-stat: differenceLogicEdgesLifted={}", difference_logic_stats->edges_lifted);
-                println(cout, "%%%mzn-stat: differenceLogicComparisonEdgesLifted={}", difference_logic_stats->comparison_edges_lifted);
-                println(cout, "%%%mzn-stat: differenceLogicHalfReifiedEdgesLifted={}", difference_logic_stats->half_reified_edges_lifted);
-                println(cout, "%%%mzn-stat: differenceLogicNodes={}", difference_logic_stats->nodes);
-                println(cout, "%%%mzn-stat: differenceLogicSkippedNotTwoTerms={}", difference_logic_stats->skipped_not_two_terms);
-                println(cout, "%%%mzn-stat: differenceLogicSkippedCoefficients={}", difference_logic_stats->skipped_coefficients);
-                println(cout, "%%%mzn-stat: differenceLogicSkippedReified={}", difference_logic_stats->skipped_reified);
-                println(cout, "%%%mzn-stat: differenceLogicSkippedNegatedView={}", difference_logic_stats->skipped_negated_view);
-                println(cout, "%%%mzn-stat: differenceLogicSkippedDegenerate={}", difference_logic_stats->skipped_degenerate);
-                println(cout, "%%%mzn-stat: differenceLogicSkippedUncitableRow={}", difference_logic_stats->skipped_uncitable_row);
-                println(cout, "%%%mzn-stat: differenceLogicSimplifyRan={}", difference_simplification_stats->ran ? 1 : 0);
-                println(
-                    cout, "%%%mzn-stat: differenceLogicSimplifyRedundantEdgesRemoved={}", difference_simplification_stats->redundant_edges_removed);
-                println(cout, "%%%mzn-stat: differenceLogicSimplifyConditionsFixed={}", difference_simplification_stats->conditions_fixed);
-            }
+            // Every component that registered a block, rendered without this
+            // file knowing which components exist. A presolver that lifts
+            // nothing preserves the solution set, adds no OPB content and leaves
+            // every proof verifying, so these counts are the only way to tell
+            // "it worked" from "it silently did nothing" --- and listing them by
+            // hand here is how two of DifferenceLogicStats' twelve fields came
+            // to be filled in and reported to nobody.
+            for (const auto & component : stats.components())
+                for (const auto & entry : component->entries())
+                    println(cout, "%%%mzn-stat: {}={}", mzn_stat_name(component->component_name(), entry.name), entry.value);
             println(cout, "%%%mzn-stat-end");
             cout << flush;
         }


### PR DESCRIPTION
Stacked on #712, which is where `ComponentStats` comes from. Follow-up to the
`%%%mzn-stat` gap raised in review there.

## The gap

`fzn-glasgow` listed the difference-logic counters by hand, one `println` per
field. That is how two of `DifferenceLogicStats`' twelve fields —
`propagator_installed` and `donor_propagators_disabled` — came to be filled in
and reported to nobody. Nothing was going to notice: they are counters on a
presolver that is invisible to solution equivalence and to proof verification
alike, which is the reason the block exists in the first place.

`ComponentStats::entries()` is the flat name/value view that removes the need
for a list. So the frontend now walks `Stats::components()` and knows about no
component in particular:

```cpp
for (const auto & component : stats.components())
    for (const auto & entry : component->entries())
        println(cout, "%%%mzn-stat: {}={}", mzn_stat_name(component->component_name(), entry.name), entry.value);
```

Fourteen hand-written lines out, three in. The report gains thirteen statistics
it was not carrying, and gains any future block by that block existing.

## Every existing name is preserved

This is the compatibility surface, and it is the whole reason `mzn_stat_name`
exists rather than the entry names being emitted raw. `component_name()` and the
entry name are joined and camel-cased, so `difference_logic` and `edges_lifted`
still make `differenceLogicEdgesLifted`, exactly as the hand-written line did.
All thirteen previously-emitted names come out unchanged.

The translation lives in the frontend rather than in the blocks. MiniZinc's own
statistics are camelCase (`peakDepth`, `solveTime`) and a solver's own are
free-form, so snake_case would be legal and still wrong to read next to them —
but a presolver in `gcs/presolvers/` should not have an opinion about a MiniZinc
spelling, and asking blocks to write their field names twice is how the two
copies drift.

One consequence worth stating plainly, since it is the one judgement call here:
**`DifferenceSimplificationStats::component_name()` is `difference_logic_simplify`,
not `difference_simplify` after its header.** The ComponentStats convention says
to name a block after the header it lives in. But `differenceLogicSimplifyRan` is
already pinned in `minizinc/CMakeLists.txt` and already public, and a stage that
reports under two different names across a version is worse than one whose
identifier does not match its filename. Overrule me if you disagree — it is one
string and one comment.

## Registration

`DifferenceLogicStats` registers at the top of `DifferenceLogic::run`, before
anything is decided, so a run that lifts nothing still reports having looked.
The counters are assigned into that same object at the end, so a caller's handle
and the registered block stay the same object — the identity trap #712's own
tests were extended for.

The simplification block registers inside `install_difference_propagator`,
because that is where both routes to a difference propagator meet: it reports
whether it was reached through the presolver or through posted
`DifferenceConstraints`.

Both blocks are now always allocated rather than only when a caller asks, as
`CumulativeStrengthening` already does it.

## Testing

Name preservation is what needed covering, and most of it already existed:
`minizinc-differencelogic` pins six stat names as exact line regexes, and it goes
through the real MiniZinc round trip. **Verified by mutation** — making
`mzn_stat_name` stop capitalising fails that test rather than silently renaming
every statistic the frontend emits.

Added on top of that:

- `differenceLogicPropagatorInstalled=1` joins the pinned patterns, so one of the
  two fields that previously reached nobody stays reachable.
- `run_report_tests` in `difference_logic_test.cc` asserts both blocks'
  `component_name()` and their entry names as an **ordered list**, so a rename
  fails as a rename rather than as a count.
- Each block's `sizeof` is pinned, which is the anti-rot half.
  `CumulativeStrengtheningStats` can count its fields by dividing `sizeof` by
  eight, because every field there is eight bytes wide; these two mix bools,
  sizes and a double, so the size is pinned directly instead, with the failure
  message saying to add the new field to `entries()` rather than just update the
  number. Skipped where `size_t` is not eight bytes.

`DifferenceLogicStats` stops being an aggregate, so the seven fixtures that
designated-initialised it use a test-local `Expected` mirroring the ten fields
the assertion actually reads. Mirroring only those also means a new field is not
silently defaulted into every fixture's expectations.

`ctest` 635/635 on GCC 15.2, 0 warnings.

## Not done

`xcsp_glasgow_constraint_solver.cc:2086` has the same hand-written list in the
XCSP idiom (`d DIFFERENCE LOGIC EDGES LIFTED ...`), and the same two fields are
missing from it. Left alone deliberately: that is a different output convention
with its own competition rules, and this PR is the MiniZinc follow-up. It should
get the same treatment, and the loop here is the shape to copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
