### PR TITLE
Reach with_minimum_clique_size from the rcpsp example

### DIFF
--- a/examples/rcpsp/CMakeLists.txt
+++ b/examples/rcpsp/CMakeLists.txt
@@ -70,6 +70,26 @@ add_test(NAME rcpsp_dzn_inferred_cumulative_mutated COMMAND ${GCS_BASH} ${CMAKE_
     --basename rcpsp_dzn_inferred_cumulative_mutated
     $<TARGET_FILE:rcpsp> --dzn ${CMAKE_CURRENT_SOURCE_DIR}/sample.dzn --infer-cumulative --mutate-makespan-bound)
 
+# The minimum clique size, which the mutation is what makes testable at all.
+# A plain verify lane cannot see this flag: raising the minimum removes a
+# derived Cumulative, and a proof with one fewer honest derivation in it
+# verifies exactly as happily as one with it, so such a lane would pass with the
+# forward deleted --- the same shape as the paragraph above, one flag further
+# along. Running it against --mutate-makespan-bound inverts that, and the lane
+# is the sibling of rcpsp_dzn_inferred_disjunctive_mutated rather than a variant
+# of rcpsp_dzn_inferred: at the default of three, sample.dzn's one clique is
+# posted, its makespan bound derived, the mutation corrupts it and veripb
+# refuses, which is what that lane asserts. At five no clique survives, so no
+# bound is derived, the mutation has nothing to corrupt, and the honest proof
+# verifies --- which is what this lane asserts. So the two disagree on the same
+# instance under the same mutation, and disagree only because the flag arrives.
+# Five rather than two: sample.dzn's only clique has three members, so a lane at
+# two is byte-identical to the default and would pass with the flag deleted.
+add_test(NAME rcpsp_dzn_inferred_min_clique_size COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash
+    --basename rcpsp_dzn_inferred_min_clique_size
+    $<TARGET_FILE:rcpsp> --dzn ${CMAKE_CURRENT_SOURCE_DIR}/sample.dzn --infer-disjunctive --mutate-makespan-bound
+    --infer-disjunctive-min-clique-size 5)
+
 # Enumeration rather than optimisation, so this one reaches the COMPLETE
 # ENUMERATION conclusion, which none of the others do.
 add_test(NAME rcpsp_all COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash --basename rcpsp_all

--- a/examples/rcpsp/rcpsp.cc
+++ b/examples/rcpsp/rcpsp.cc
@@ -322,6 +322,10 @@ auto main(int argc, char * argv[]) -> int
             ("infer-disjunctive-posted",                                                                 //
                 "Cap how many cliques are posted (Sidorov's N_out)",                                     //
                 cxxopts::value<std::size_t>()->default_value("5"))                                       //
+            ("infer-disjunctive-min-clique-size",                                                        //
+                "Smallest clique worth posting; two makes every conflicting pair a candidate, which "    //
+                "is what Sidorov's binary covers are",                                                   //
+                cxxopts::value<std::size_t>()->default_value("3"))                                       //
             ("infer-cumulative",                                                                         //
                 "Run the InferredCumulative presolver, which lifts cover inequalities over the "         //
                 "resources' capacity rows into implied Cumulatives with non-unit heights",               //
@@ -722,8 +726,10 @@ auto main(int argc, char * argv[]) -> int
     auto disjunctive_stats = std::make_shared<InferredDisjunctiveStats>();
     auto infer_disjunctive = options_vars["infer-disjunctive"].as<bool>();
     if (infer_disjunctive) {
-        auto presolver = InferredDisjunctive{disjunctive_stats}.with_budgets(
-            options_vars["infer-disjunctive-candidates"].as<std::size_t>(), options_vars["infer-disjunctive-posted"].as<std::size_t>());
+        auto presolver = InferredDisjunctive{disjunctive_stats}
+                             .with_budgets(options_vars["infer-disjunctive-candidates"].as<std::size_t>(),
+                                 options_vars["infer-disjunctive-posted"].as<std::size_t>())
+                             .with_minimum_clique_size(options_vars["infer-disjunctive-min-clique-size"].as<std::size_t>());
         if (infer_makespan_bound)
             presolver.with_makespan(makespan);
         if (mutate_makespan_bound)


### PR DESCRIPTION
Prerequisite for the #708 artefact rerun, so that it can also answer #707.

`InferredDisjunctive::with_minimum_clique_size` has existed since #663, but
nothing outside the unit tests could set it: the `rcpsp` example wires
`with_budgets` and not this, so the default of three is the only value the
presolver has ever been run at on a real instance. #707 asks whether two is
better, and says the measurement is the #672 artefact rerun over both
collections and all three stages. That sweep drives the solver through this
example, so the flag has to exist first.

Wiring only. The default is unchanged, so anything that does not pass
`--infer-disjunctive-min-clique-size` behaves exactly as before.

Rebased onto `0e7cf85a`, so it now sits on top of #712 rather than two merges back.

## That it is not a no-op

A flag that is parsed, accepted and then dropped passes every check this
example has, so it was checked by response. Over `data_pack/pack008.dzn`:

| `--infer-disjunctive-min-clique-size` | cliques_found | cliques_posted | capacity_bound |
|---|---|---|---|
| 2 | 10 | 5 | 44 |
| 3 (default) | 10 | 5 | 44 |
| 5 | 9 | 5 | 44 |
| 8 | 1 | 1 | 44 |
| 11 | 0 | 0 | 0 |
| 12 | 0 | 0 | 0 |

Monotone in the right direction, and the bound collapses once no clique
survives at all.

Two and three agreeing there is a result rather than a gap: #707 predicts
exactly that for the cross-check targets, whose cliques run to ten members
and more, so a two-member clique never displaces one under `_max_posted = 5`.
It is why the question needs the whole collection, which is what the rerun
will give it.

## The lane, and why it is shaped the way it is

`rcpsp_dzn_inferred_min_clique_size` covers the forward.

A plain verify lane would not have. Raising the minimum *removes* a derived
Cumulative, and a proof with one fewer honest derivation in it verifies
exactly as happily as one with it — so a `run_test_and_verify.bash` lane at
any value passes with the forward deleted. That is the shape the comment above
the two mutated lanes already warns about, one flag further along, and it is
why this lane is a sibling of `rcpsp_dzn_inferred_disjunctive_mutated` rather
than a variant of `rcpsp_dzn_inferred`: the two disagree on the same instance
under the same mutation, and disagree only because the flag arrives.

- at three, `sample.dzn`'s one clique is posted, its makespan bound is derived,
  `--mutate-makespan-bound` corrupts it, and veripb refuses — the existing lane;
- at five no clique survives, so there is no bound, the mutation has nothing to
  corrupt, and the honest proof verifies — this lane.

Five rather than two, per the review: `sample.dzn`'s only clique has three
members, so a lane at two is byte-identical to the default and would pass with
the flag deleted.

**Verified by mutation.** With `.with_minimum_clique_size(...)` deleted from the
wiring, `rcpsp_dzn_inferred_min_clique_size` fails and the other three
`rcpsp_dzn_inferred*` lanes still pass, so it isolates the forward rather than
the presolver. Restored, all 21 `rcpsp` lanes pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)