### PR TITLE
inferred_cumulative: correct two claims #726 falsified

### DIFF
--- a/dev_docs/certified-makespan-bounds.md
+++ b/dev_docs/certified-makespan-bounds.md
@@ -216,6 +216,13 @@ which is the remaining shape rather than a scattering — `pack/pack007`, `010`,
 `022`, `024`, `025`, `027`, short by exactly two apiece, and `pack_d/pack004`,
 `023`, `025`, short by twenty-three, fourteen and forty-four.
 
+That gap has since been diagnosed, and it is not in the lifting: **all nine are
+the visited-cover rule** discarding covers that lift to strictly stronger cuts,
+and removing it recovers every one of them. See issue #726, which also shows the
+rule costs bound on twelve further instances that are *not* short here, because
+they had no published number to fall short of. These figures will move when that
+is settled, and this section is where they have to be re-measured.
+
 The rerun also settles two questions that were open defaults:
 
 - **The lifting-call budget never binds.** `_max_lifting_calls` defaults to

--- a/dev_docs/inferred-cumulative.md
+++ b/dev_docs/inferred-cumulative.md
@@ -81,8 +81,10 @@ the inequality valid: `π₀ − v*`, where `v*` is the most the current left-ha
 side can weigh once that task is forced to run. The right-hand side never moves,
 which is what makes the ratio climb. A cover already inside the support of
 something lifted earlier is skipped, since lifting it again would re-derive the
-same constraint (the paper's Example 12). Constraints a model row already
-dominates are discarded, and the best `N_out` by capacity bound are kept.
+same constraint (the paper's Example 12) — **that premise is false, and the rule
+costs bound on 21 of the 110 instances; see issue #726 and the cover-family
+discussion below**. Constraints a model row already dominates are discarded, and
+the best `N_out` by capacity bound are kept.
 
 Budgets are the paper's: `N_cover`, `N_out`, and `N_calls` against the lifting
 subproblems, which are the bottleneck. The defaults here are 100, 5 and 2·10⁴,
@@ -184,14 +186,29 @@ line**, and over the Pack and Pack-d instances the two readings pick a different
 representative on 306 of 314 resource rows. The ternary cover family that comes
 out differs on 164 of those rows and on 103 of the 110 instances.
 
-The difference runs one way. The shipped line's pick is **never longer** than the
-intended one — shorter on 542 of the 922 (demand, row) pairs and equal on the
-rest — so the corrected reading's best ternary cover is never worse, and is
-better on 61 rows. A per-instance comparison against the paper's numbers is
-therefore not a comparison over the same covers, and where this presolver's `L`
-beats the published one that is a likely cause. It is also the one place where
-reproducing the method as *described* means out-performing the artefact as
-*shipped*, which is the opposite of the usual risk and worth saying out loud.
+The difference runs one way in the *covers*. The shipped line's pick is **never
+longer** than the intended one — shorter on 542 of the 922 (demand, row) pairs
+and equal on the rest — so the corrected reading's best ternary cover is never
+worse *as a cover*, and is better on 61 rows.
+
+**That does not carry to the cuts, and this document used to claim it did.** A
+cover's own durations do not determine what it lifts to. Lifting is
+sequence-dependent, and the visited-cover rule above lets a cover that ranks
+higher on `Σ dᵢ / (|C| − 1)` suppress every better cover its lifted support
+happens to contain — so a *worse* cover, reached in a different order, can yield
+a *stronger* cut. Measured: on all nine instances where this presolver's `L`
+falls short of the published one, the corrected line is the reason. On
+`pack/pack007` the reference pipeline as shipped derives 40.5 and this presolver
+39, and running that same pipeline with the corrected line gives 39 exactly. The
+anatomy, and a corpus sweep showing the rule costs bound on 21 instances rather
+than those nine, are in issue #726.
+
+So a per-instance comparison against the paper's numbers is not a comparison
+over the same covers, and that is a likely cause in **both** directions — where
+this presolver's `L` beats the published one and where it falls short. Reproducing
+the method as *described* is not, as this section once said, a place where doing
+so out-performs the artefact as *shipped*; on the instances where the two differ
+today it is the other way round.
 
 ## The certified fraction, which is the number this exists to produce
 

--- a/gcs/presolvers/inferred_cumulative/inferred_cumulative.cc
+++ b/gcs/presolvers/inferred_cumulative/inferred_cumulative.cc
@@ -158,8 +158,11 @@ namespace
     /// inv_A_longest[a]`); Sidorov confirms the intended line is
     /// `durations[ix] > durations[inv_A_longest[a]]`, which is what happens
     /// here. Its published results came from the shipped line, so the ternary
-    /// covers here are not the ones its numbers were produced from --- never
-    /// worse ones, which is the awkward direction. See the writeup.
+    /// covers here are not the ones its numbers were produced from. They are
+    /// never *shorter* covers, which is not the same as never worse cuts: what
+    /// a cover lifts to is sequence-dependent, and the visited-cover rule in
+    /// `run` lets a higher-ranked cover suppress better ones, so the corrected
+    /// line loses bound on nine Pack instances. Issue #726, and the writeup.
     [[nodiscard]] auto collect_covers(const vector<Task> & tasks, const vector<Integer> & demands, Integer capacity, size_t max_covers,
         size_t cover_cardinality) -> vector<vector<size_t>>
     {
@@ -649,6 +652,17 @@ auto InferredCumulative::run(Problem & problem, Propagators & propagators, State
 
         // Example 12: a cover already inside the support of something lifted
         // earlier will re-derive it, so the subproblems are wasted.
+        //
+        // That premise is FALSE, and this rule costs bound. Lifting is
+        // sequence-dependent (see `lift_cover`), so a contained cover starts
+        // its own sequence and can reach a strictly stronger cut; measured, a
+        // higher-ranked cover suppresses better ones on 21 of the 110 Pack and
+        // Pack-d instances, and is the whole of the nine-instance shortfall in
+        // `certified-makespan-bounds.md`. The reference implementation has the
+        // identical rule and escapes it only by accident, through the
+        // `inv_A_longest` bug `collect_covers` documents. Kept for now because
+        // removing it is a change of inferred constraints and wants the
+        // artefact rerun behind it: issue #726.
         auto already = false;
         for (const auto & [support, cardinality] : visited)
             if (cardinality <= cover.size() && std::includes(support.begin(), support.end(), cover.begin(), cover.end())) {

--- a/gcs/presolvers/inferred_cumulative/inferred_cumulative.hh
+++ b/gcs/presolvers/inferred_cumulative/inferred_cumulative.hh
@@ -169,7 +169,9 @@ namespace gcs
         /// height on one donor and a constant on another.
         std::size_t converted_heights = 0;
         /// Covers already inside the support of something lifted earlier, which
-        /// would re-derive it and waste the subproblems (paper, Example 12).
+        /// the paper's Example 12 says would re-derive it and waste the
+        /// subproblems. It would not: lifting is sequence-dependent, so this
+        /// counts covers that could have produced a stronger cut. See #726.
         std::size_t dropped_visited = 0;
         /// Constraints some model row already implies term by term.
         std::size_t dropped_dominated = 0;


### PR DESCRIPTION
Documentation only — no behaviour change. Corrects two claims that the diagnosis in #726 falsified, both about the visited-cover rule and the cover family it interacts with, and both argued rather than measured when they were written.

## The cover-family claim

`dev_docs/inferred-cumulative.md` reasoned from a measured premise to an unsupported conclusion:

> The shipped line's pick is **never longer** than the intended one — shorter on 542 of the 922 (demand, row) pairs and equal on the rest — so the corrected reading's best ternary cover is never worse

The premise is true and stays. The conclusion does not follow: a cover's own durations do not determine what it lifts to. Lifting is sequence-dependent, and the visited-cover rule lets a cover ranking higher on `Σ dᵢ / (|C| − 1)` suppress every better cover its lifted support happens to contain — so a worse cover, reached in a different order, can yield a stronger cut.

Measured, on all nine instances where this presolver's `L` falls short of the published one, the corrected line is the reason. On `pack/pack007` the reference pipeline as shipped derives 40.5 and this presolver 39; running that same pipeline with the corrected line gives 39 exactly. So the section's closing claim — that this is "the one place where reproducing the method as *described* means out-performing the artefact as *shipped*" — is the wrong way round on the instances where the two differ today.

## The visited-cover rule's premise

Stated in three places (`inferred_cumulative.cc`'s loop, the `dropped_visited` doc comment in `inferred_cumulative.hh`, and Algorithm 2's description in `inferred-cumulative.md`) as skipping covers that "would re-derive" an earlier cut. They would not, and the rule costs bound on **21 of the 110** Pack and Pack-d instances — the nine in `certified-makespan-bounds.md` are only the ones that had a published number to fall short of.

Each of the three now says so and points at #726. `certified-makespan-bounds.md`'s shortfall paragraph gains a note that the gap is diagnosed, is not in the lifting, and that its figures move when #726 is settled.

## Why nothing changes behaviour here

Removing the rule changes which constraints are inferred, so it wants the #672 artefact behind it — reading `cuts_uncertifiable`, proof size and checker time as well as the bound. That is #726's job, not this PR's. This one only stops the tree asserting things that are not true in the meantime.

Verified: clang-format clean, `inferred_cumulative_presolver_test` builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018FizeTcjBnMJqmqLWZz4qd
