### PR TITLE
inferred_cumulative: lift every cover, dropping the visited-cover rule

### DIFF
--- a/dev_docs/certified-makespan-bounds.md
+++ b/dev_docs/certified-makespan-bounds.md
@@ -173,15 +173,24 @@ both collections through all three stages, verifies each honest proof, records
 each `+1`, and checks every bound against a makespan somebody has actually
 achieved.
 
-Rerun on 2026-08-11 against `main` at `83b31a5e`, with VeriPB 3.0.2, which is
-issue #708. The numbers below are that run's, and they supersede the
-single-resource-lifting figures that stood here before.
+Rerun on 2026-08-11 against `main` at `83b31a5e` (issue #708), and again the
+same day with the visited-cover rule removed (issue #726), both with VeriPB
+3.0.2. The numbers below are the second run's.
 
-Over both collections in all three stages — 330 runs, no failures — **107 of the
+Over both collections in all three stages — 330 runs, no failures — **106 of the
 110 instances get a certified bound**, 105 of them beating the critical path, and
-**34 are closed**: the bound equals the best makespan anybody found, so no search
+**43 are closed**: the bound equals the best makespan anybody found, so no search
 is needed at all. Every bound verifies, refuses its own `+1`, and sits at or
 below a schedule that exists.
+
+Against the #708 run, which is the same code but for that rule: nine more
+instances closed, and **none is now short of Sidorov's `L`** where nine were.
+The one instance that moved the wrong way is `pack_d/pack045`, whose certified
+bound went from 2042 to nothing. It is not a certification regression so much as
+a different cut being posted: its `L` is 2216 either way, its critical path is
+2712, so the bound was dominated and unusable before and is absent now. The
+rows on which the derivation does not reach the `L` its cuts carry are otherwise
+*the same twelve* in both runs.
 
 This is the first run in which Pack_d's two lifted stages were executed at all;
 before, that collection had only its capacity-one stage, and five of the largest
@@ -200,37 +209,42 @@ His twelve counts instances whose *unrounded* elastic lower bound improves on
 the previously known lower bound; his own closure test, run over the same
 artefact, gives twenty, and taking the ceiling of the bound — which is the
 integral quantity a solver could actually use — gives thirty-six. Ours counts
-instances whose certified bound *equals the best known makespan*. Thirty-four
+instances whose certified bound *equals the best known makespan*. Forty-three
 against thirty-six is the comparison closest to like-for-like; see
 `~/claude/tmp/sidorov-548/RESUME.md` for the reproduction of all four numbers.
 
-The largest bound is 3614. The median `.pbp` is 62 MB and the largest 3.9 GB
-(`pack_d/pack025`, both stages), which `veripb` checks in 144 s — the slowest
-check in the sweep. The whole 275-proof set verifies in 4058 s of checker time.
+The largest bound is 3614. The median `.pbp` is 77 MB and the largest 4.7 GB
+(`pack_d/pack025`, both stages), which `veripb` checks in 146 s — the slowest
+check in the sweep. The whole 275-proof set verifies in 3877 s of checker time,
+but that figure was measured at lower parallelism than the #708 run's 4058 s
+(three and six jobs against sixteen, because the larger proofs made sixteen
+concurrent checks exhaust memory), so the two are **not** comparable and neither
+is evidence about checking speed. Proof size is, and it barely moved: 135 GB
+across all 330 rows against 138 GB.
 
-Nine instances fall short of Sidorov's `L`, down from twenty-three before
-multi-resource lifting and Pack_d's lifted stages. On every one of them it is
-this presolver's *own* `L` that falls short while the derivation reaches it
-exactly: an inference gap and not a certification one. **All nine have `rhs 2`**,
-which is the remaining shape rather than a scattering — `pack/pack007`, `010`,
-`022`, `024`, `025`, `027`, short by exactly two apiece, and `pack_d/pack004`,
-`023`, `025`, short by twenty-three, fourteen and forty-four.
+**No instance falls short of Sidorov's `L`**, where nine did before #726 and
+twenty-three before multi-resource lifting and Pack_d's lifted stages. Fourteen
+now exceed it. The nine were not an inference gap in the lifting at all: they
+were the visited-cover rule discarding covers that lift to strictly stronger
+cuts, and every one recovered when it went.
 
-That gap has since been diagnosed, and it is not in the lifting: **all nine are
-the visited-cover rule** discarding covers that lift to strictly stronger cuts,
-and removing it recovers every one of them. See issue #726, which also shows the
-rule costs bound on twelve further instances that are *not* short here, because
-they had no published number to fall short of. These figures will move when that
-is settled, and this section is where they have to be re-measured.
+Twelve rows still certify less than the `L` their own cuts carry, and they are
+the same twelve as before: `pack/pack003` and `pack_d/pack003` and `pack_d/pack055`
+on the disjunctive stage, `pack_d/pack002` reaching 212 of 230, and
+`pack_d/pack033`, `035`, `045` and `053` certifying nothing of a four-figure `L`
+on the lifted stages. That is where the next certification work is, and it is a
+different question from the one #726 answered.
 
 The rerun also settles two questions that were open defaults:
 
 - **The lifting-call budget never binds.** `_max_lifting_calls` defaults to
-  20000; over the 220 runs that solve any lifting subproblem at all, the most any
-  instance uses is **1159**, and the ninetieth percentile is 877. So the budgeted
-  direction of issue #703 — spending the budget on covers Sidorov's early stop
-  would have abandoned — costs nothing on these collections, because the budget
-  is not what stops us.
+  20000; over the runs that solve any lifting subproblem at all, the most any
+  instance uses is **3361**, and the ninetieth percentile is 3111. (Before #726
+  removed the visited-cover rule those were 1159 and 877; lifting every cover
+  costs about five times the subproblems, and still does not approach the
+  budget.) So the budgeted direction of issue #703 — spending the budget on
+  covers Sidorov's early stop would have abandoned — costs nothing on these
+  collections, because the budget is not what stops us.
 - **Two-member cliques are not worth posting here.** With
   `with_minimum_clique_size(2)`, over Pack in both disjunctive-bearing stages and
   Pack_d in the capacity-one stage (165 runs), the posted set changes on nine of

--- a/dev_docs/inferred-cumulative.md
+++ b/dev_docs/inferred-cumulative.md
@@ -79,12 +79,19 @@ families only.
 tasks longest duration first, and give each the largest coefficient that keeps
 the inequality valid: `π₀ − v*`, where `v*` is the most the current left-hand
 side can weigh once that task is forced to run. The right-hand side never moves,
-which is what makes the ratio climb. A cover already inside the support of
-something lifted earlier is skipped, since lifting it again would re-derive the
-same constraint (the paper's Example 12) — **that premise is false, and the rule
-costs bound on 21 of the 110 instances; see issue #726 and the cover-family
-discussion below**. Constraints a model row already dominates are discarded, and
-the best `N_out` by capacity bound are kept.
+which is what makes the ratio climb. Constraints a model row already dominates
+are discarded, and the best `N_out` by capacity bound are kept.
+
+**One departure from the paper here.** Example 12 skips a cover already inside
+the support of something lifted earlier, since lifting it again would re-derive
+the same constraint. It would not: lifting is sequence-dependent, so a contained
+cover starts its own sequence and can reach a strictly stronger cut, and a cover
+ranking higher on `Σ dᵢ / (|C| − 1)` suppresses every better cover its own lifted
+support happens to contain. Measured over Pack and Pack-d, the rule cost bound on
+21 of the 110 instances and was the whole of a nine-instance shortfall against
+the published `L`. Every cover is lifted here. See issue #726, and the
+cover-family discussion below for why the reference implementation does not pay
+the same price.
 
 Budgets are the paper's: `N_cover`, `N_out`, and `N_calls` against the lifting
 subproblems, which are the bottleneck. The defaults here are 100, 5 and 2·10⁴,
@@ -192,16 +199,21 @@ and equal on the rest — so the corrected reading's best ternary cover is never
 worse *as a cover*, and is better on 61 rows.
 
 **That does not carry to the cuts, and this document used to claim it did.** A
-cover's own durations do not determine what it lifts to. Lifting is
-sequence-dependent, and the visited-cover rule above lets a cover that ranks
-higher on `Σ dᵢ / (|C| − 1)` suppress every better cover its lifted support
-happens to contain — so a *worse* cover, reached in a different order, can yield
-a *stronger* cut. Measured: on all nine instances where this presolver's `L`
-falls short of the published one, the corrected line is the reason. On
-`pack/pack007` the reference pipeline as shipped derives 40.5 and this presolver
-39, and running that same pipeline with the corrected line gives 39 exactly. The
-anatomy, and a corpus sweep showing the rule costs bound on 21 instances rather
-than those nine, are in issue #726.
+cover's own durations do not determine what it lifts to, because lifting is
+sequence-dependent — so a *worse* cover, reached in a different order, can yield
+a *stronger* cut. While the visited-cover rule was in place that was not merely
+theoretical: a cover ranking higher on `Σ dᵢ / (|C| − 1)` suppressed every better
+cover its lifted support happened to contain, and on all nine instances where
+this presolver's `L` fell short of the published one, the corrected line was the
+reason. On `pack/pack007` the reference pipeline as shipped derives 40.5 and this
+presolver derived 39; running that same pipeline with the corrected line gives 39
+exactly. That is what removing the rule (#726, and the departure noted under
+Algorithm 2) was for.
+
+The corrected line is still the one to keep. It is the line Sidorov says was
+intended, it is reproducible where a duration-against-index comparison is not,
+and once every cover is lifted the choice of representative no longer decides
+which covers get a chance.
 
 So a per-instance comparison against the paper's numbers is not a comparison
 over the same covers, and that is a likely cause in **both** directions — where

--- a/dev_docs/inferred-cumulative.md
+++ b/dev_docs/inferred-cumulative.md
@@ -120,11 +120,12 @@ counterpart, and which direction that costs depends on the budget:
   budget on hopeless covers and so possibly end *weaker* than he would.
 
 **Measured on 2026-08-11, and the budgeted half of that concern is empty here.**
-`_max_lifting_calls` defaults to 20000; over the 220 runs of the #708 artefact
-that solve any lifting subproblem at all, the most any instance uses is **1159**,
-with a ninetieth percentile of 877. The budget is not what stops us on Pack or
-Pack_d, so covers his early stop would have abandoned cost us nothing there —
-which leaves only the unbudgeted direction, where lifting them can only help.
+`_max_lifting_calls` defaults to 20000; over the runs of the #672 artefact that
+solve any lifting subproblem at all, the most any instance uses is **3361**, with
+a ninetieth percentile of 3111 — and 1159 and 877 before #726 stopped skipping
+covers. The budget is not what stops us on Pack or Pack_d either way, so covers
+his early stop would have abandoned cost us nothing there — which leaves only
+the unbudgeted direction, where lifting them can only help.
 
 Implementing it verbatim would be wrong: the estimate is an upper bound only
 while the unlifted coefficients stay at most one, which holds at `π₀ = 1` and

--- a/gcs/presolvers/inferred_cumulative/inferred_cumulative.cc
+++ b/gcs/presolvers/inferred_cumulative/inferred_cumulative.cc
@@ -264,8 +264,9 @@ namespace
 
         // Covers of more than three tasks go first, as they do in the reference
         // implementation: they are the ones the short-cover families cannot
-        // produce, and the visited-cover skip would otherwise let a ternary
-        // cover's lifted support swallow them.
+        // produce. With the visited-cover rule gone (#726) this no longer
+        // decides whether they are lifted at all, only the order, which still
+        // matters where `_max_lifting_calls` runs out.
         std::stable_sort(
             covers.begin(), covers.end(), [](const vector<size_t> & a, const vector<size_t> & b) { return (a.size() > 3) && (b.size() <= 3); });
 
@@ -483,9 +484,9 @@ auto InferredCumulative::run(Problem & problem, Propagators & propagators, State
 
     // One pass over every posted Cumulative rather than one pass each, because
     // Equation 4's lifting subproblem is over all of them at once. Everything
-    // downstream --- the cover budget, the visited rule, the subproblem budget,
-    // and how many constraints are posted --- is then global, which is what the
-    // reference implementation does with its single matrix.
+    // downstream --- the cover budget, the subproblem budget, and how many
+    // constraints are posted --- is then global, which is what the reference
+    // implementation does with its single matrix.
     vector<Donor> donors;
     vector<Task> tasks;
     map<pair<IntegerVariableID, IntegerVariableID>, size_t> task_of;
@@ -638,41 +639,29 @@ auto InferredCumulative::run(Problem & problem, Propagators & propagators, State
                 covers.push_back(pooled[i]);
     }
 
-    // Algorithm 2: lift each cover, skipping any whose support a previous
-    // lifting already established, and keeping the best `_max_posted` by
-    // capacity bound. Nothing here asks whether a constraint can be *proved* ---
-    // that comes after, so the gap between what the published method infers and
-    // what we can certify is a number rather than a design decision.
+    // Algorithm 2: lift every cover, and keep the best `_max_posted` by capacity
+    // bound. Nothing here asks whether a constraint can be *proved* --- that
+    // comes after, so the gap between what the published method infers and what
+    // we can certify is a number rather than a design decision.
+    //
+    // The paper's Example 12 skips a cover already inside the support of
+    // something lifted earlier, on the grounds that lifting it again re-derives
+    // the same constraint. **It does not.** Lifting is sequence-dependent (see
+    // `lift_cover`), so a contained cover starts its own sequence and can reach
+    // a strictly stronger cut; a cover ranking higher on `sum d_i / (|C| - 1)`
+    // then suppresses every better cover its own lifted support happens to
+    // contain. Measured over Pack and Pack-d, the rule cost bound on 21 of the
+    // 110 instances and was the whole of what used to be a nine-instance
+    // shortfall against the published `L`. The reference implementation has the
+    // identical rule and escapes it only by accident, through the
+    // `inv_A_longest` bug `collect_covers` documents. Removed in #726; the cost
+    // is roughly five times the lifting subproblems, which stays well inside
+    // `_max_lifting_calls`.
     vector<Cut> cuts;
-    vector<pair<set<size_t>, size_t>> visited;
     auto calls_left = _max_lifting_calls;
 
     for (const auto & cover : covers) {
         bump(&InferredCumulativeStats::covers_considered);
-
-        // Example 12: a cover already inside the support of something lifted
-        // earlier will re-derive it, so the subproblems are wasted.
-        //
-        // That premise is FALSE, and this rule costs bound. Lifting is
-        // sequence-dependent (see `lift_cover`), so a contained cover starts
-        // its own sequence and can reach a strictly stronger cut; measured, a
-        // higher-ranked cover suppresses better ones on 21 of the 110 Pack and
-        // Pack-d instances, and is the whole of the nine-instance shortfall in
-        // `certified-makespan-bounds.md`. The reference implementation has the
-        // identical rule and escapes it only by accident, through the
-        // `inv_A_longest` bug `collect_covers` documents. Kept for now because
-        // removing it is a change of inferred constraints and wants the
-        // artefact rerun behind it: issue #726.
-        auto already = false;
-        for (const auto & [support, cardinality] : visited)
-            if (cardinality <= cover.size() && std::includes(support.begin(), support.end(), cover.begin(), cover.end())) {
-                already = true;
-                break;
-            }
-        if (already) {
-            bump(&InferredCumulativeStats::dropped_visited);
-            continue;
-        }
 
         if (calls_left == 0)
             break;
@@ -696,12 +685,6 @@ auto InferredCumulative::run(Problem & problem, Propagators & propagators, State
                 support.push_back(i);
         if (support.size() < 2)
             continue;
-
-        set<size_t> unit;
-        for (size_t i = 0; i < tasks.size(); ++i)
-            if (lifted.coefficients[i] == 1_i)
-                unit.insert(i);
-        visited.emplace_back(move(unit), cover.size());
 
         // Dominance: a constraint some model row already implies term by term
         // says nothing new.

--- a/gcs/presolvers/inferred_cumulative/inferred_cumulative.cc
+++ b/gcs/presolvers/inferred_cumulative/inferred_cumulative.cc
@@ -160,9 +160,11 @@ namespace
     /// here. Its published results came from the shipped line, so the ternary
     /// covers here are not the ones its numbers were produced from. They are
     /// never *shorter* covers, which is not the same as never worse cuts: what
-    /// a cover lifts to is sequence-dependent, and the visited-cover rule in
-    /// `run` lets a higher-ranked cover suppress better ones, so the corrected
-    /// line loses bound on nine Pack instances. Issue #726, and the writeup.
+    /// a cover lifts to is sequence-dependent. While `run` still had the
+    /// visited-cover rule, a higher-ranked cover suppressed better ones and
+    /// this corrected line cost bound on nine Pack instances as a result; with
+    /// that rule gone (#726) every cover is lifted and the choice of
+    /// representative no longer decides which get a chance. See the writeup.
     [[nodiscard]] auto collect_covers(const vector<Task> & tasks, const vector<Integer> & demands, Integer capacity, size_t max_covers,
         size_t cover_cardinality) -> vector<vector<size_t>>
     {

--- a/gcs/presolvers/inferred_cumulative/inferred_cumulative.hh
+++ b/gcs/presolvers/inferred_cumulative/inferred_cumulative.hh
@@ -168,11 +168,6 @@ namespace gcs
         /// setting them aside. Per (donor, task), since a task can be a variable
         /// height on one donor and a constant on another.
         std::size_t converted_heights = 0;
-        /// Covers already inside the support of something lifted earlier, which
-        /// the paper's Example 12 says would re-derive it and waste the
-        /// subproblems. It would not: lifting is sequence-dependent, so this
-        /// counts covers that could have produced a stronger cut. See #726.
-        std::size_t dropped_visited = 0;
         /// Constraints some model row already implies term by term.
         std::size_t dropped_dominated = 0;
         std::size_t dropped_over_budget = 0;
@@ -220,7 +215,7 @@ namespace gcs
      * would. The cut that comes out can then be a consequence of several rows
      * together and of none of them alone, which is why one pass runs over the
      * whole problem rather than one pass per posted constraint, and why the
-     * budgets, the visited-cover rule and the output limit are all global.
+     * budgets and the output limit are both global.
      *
      * Restricted to donors with no optional tasks, and for this presolver's own
      * reason rather than a general one: it draws a cut's members from several

--- a/gcs/presolvers/inferred_cumulative/inferred_cumulative_test.cc
+++ b/gcs/presolvers/inferred_cumulative/inferred_cumulative_test.cc
@@ -8,11 +8,10 @@
  * reports and which the accounting assertion beside it keeps honest.
  *
  * The headline fixture is one task filling a resource of capacity five against
- * three of demand two, and its durations are load-bearing in a way that says
- * something about the published procedure: the cover of the three small tasks
- * has to outrank the ternary covers containing the big one, or Algorithm 2's
- * visited-cover rule skips it and no coefficient above one is ever produced.
- * See lifted_instance() for the two inequalities the durations must satisfy.
+ * three of demand two, and its durations are load-bearing: the cut only bites
+ * on a horizon the donor's own energy check clears. See lifted_instance() for
+ * the inequality they must satisfy, and for the second one that Algorithm 2's
+ * visited-cover rule used to impose before #726 removed it.
  *
  * That fixture is also the differential pair the issue asks for. Its conflict
  * graph is a star --- the big task fights each small one, no two small ones
@@ -146,18 +145,19 @@ namespace
     /// The headline fixture: one task filling a resource of capacity five, and
     /// three of demand two which fit in pairs but not in threes.
     ///
-    /// The durations are what make this the fixture it is. Algorithm 1 ranks
-    /// covers by the capacity bound of their own cover inequality, and
-    /// Algorithm 2 then refuses to lift a cover whose members a previous
-    /// lifting already brought together. So the equal-demand cover of the three
-    /// small tasks has to outrank the ternary covers containing the big one, or
-    /// it is skipped before it is ever lifted and no coefficient above one is
-    /// produced at all. That needs `d_big < d_small`. Meanwhile the cut only
-    /// bites on a horizon the donor's own energy check clears, which needs
-    /// `2 d_big > d_small`. Three against five satisfies both; four equal
-    /// durations satisfies neither, which is why the obvious version of this
-    /// fixture finds nothing. That is a property of the published procedure,
-    /// not of this implementation.
+    /// The durations are what make this the fixture it is. The cut only bites
+    /// on a horizon the donor's own energy check clears, which needs
+    /// `2 d_big > d_small`; three against five satisfies it and four equal
+    /// durations does not, which is why the obvious version of this fixture
+    /// finds nothing.
+    ///
+    /// It used to need a second inequality, `d_big < d_small`, so that the
+    /// equal-demand cover of the three small tasks outranked the ternary covers
+    /// containing the big one --- otherwise the visited-cover rule skipped it
+    /// before it was ever lifted and no coefficient above one was produced at
+    /// all. That rule is gone (#726), so the ranking no longer decides whether
+    /// a cover is lifted. The durations are left as they were: they satisfy
+    /// both, and the fixture is a weaker test of nothing if it is loosened.
     auto lifted_instance(int horizon) -> Instance
     {
         return Instance{{5_i, 2_i, 2_i, 2_i}, {3_i, 5_i, 5_i, 5_i}, 5_i, horizon};


### PR DESCRIPTION
Closes #726. **Stacked on #727** — base that first, or this diff includes its documentation corrections.

The paper's Example 12 skips a cover already inside the support of something lifted earlier, on the grounds that lifting it again re-derives the same constraint. It does not. Lifting is sequence-dependent — which `lift_cover` already cites Zemel 1978 for, as the reason its own ordering is load-bearing — so a contained cover starts its own sequence and can reach a strictly stronger cut. A cover ranking higher on `Σ dᵢ / (|C| − 1)` then suppresses every better cover its lifted support happens to contain, and the cover that ranks highest is not the one that lifts best.

#726 has the anatomy on `pack/pack007`, where our cut and Sidorov's differ in a single lifted coefficient. This is the change, and the artefact rerun behind it.

## What the artefact says

330 runs against this branch, VeriPB 3.0.2. The harness's own gate is clean — *every bound verifies, refuses its own `+1`, and sits at or below a schedule that exists* — and **`cuts_uncertifiable` stays 0**, so nothing the procedure now infers is beyond what the proof can reach. That was the open question when the issue was filed.

| | #708 baseline | this branch |
|---|---|---|
| instances with a certified bound | 107 | 106 |
| beating the critical path | 105 | 105 |
| **closed** (bound == best known) | 34 | **43** |
| **short of Sidorov's `L`** | 9 | **0** |
| exceeding Sidorov's `L` | 4 | **14** |
| `cuts_uncertifiable` | 0 | 0 |
| bounds exceeding a known schedule | 0 | 0 |

Twenty-one instances improve and none gets worse. The largest are all Pack_d: `pack021` 1268 → 1417, `pack028` 1821 → 1962, `pack025` 2016 → 2147, `pack019` 1429 → 1542.

## The one instance that moved the wrong way

`pack_d/pack045`'s certified bound went from 2042 to nothing, which is why the bounded count falls by one. It is worth being precise about, because it is not a certification regression: its `L` is 2216 either way, a different cut is posted, and the makespan bound is window-sensitive (#700). Its critical path is 2712, so 2042 was dominated and unusable before and is simply absent now — which is why `beats_critical` is unchanged at 105. The rows that certify less than the `L` their own cuts carry are otherwise **the same twelve** in both runs, so no new failure mode appeared; those twelve are now called out in the write-up as where the next certification work is.

## Cost

Lifting subproblems rise 4.8x in total, and the most any instance uses goes from 1159 to **3361** against a `_max_lifting_calls` default of 20000 — so the budget still does not bind, and #703 does not become urgent on account of this. Proof size barely moves, 135 GB against 138 GB across all 330 rows, because the number of posted cuts is capped at five either way and only *which* cuts changed.

**Checker time is not compared, deliberately.** The larger individual proofs made sixteen concurrent `veripb` runs exhaust memory — one `data_pack_d` cumulative instance peaks at 4.7 GB in the checker — so this sweep ran at three and six jobs where the baseline ran at sixteen. The totals are therefore not like-for-like and neither is evidence about checking speed. The doc says so where the figure appears.

## Alternatives measured, not assumed

Gating the rule to strictly smaller earlier covers (`cardinality < cover.size()`) was simulated over all 110 instances: **identical bounds on every one**, for 1.3% fewer subproblems. It buys nothing over removing the rule, at the price of a subtler invariant, so the rule goes rather than shrinks.

## Also here

`dropped_visited` goes with the rule — nothing read it, and it is one of the four counters #706 is about. The `inferred_cumulative_test` fixture's second duration inequality is no longer required and its comment says so; the durations are left alone, since loosening them would only weaken the fixture. The #703 budget figures in both write-ups are updated to the post-change numbers.

Verified: clang-format clean, 653/653 `ctest` with `GCS_TEST_CAP_DEFAULTS=OFF` (full enumeration), and the presolver test's own 37 VeriPB checks pass with every mutation still rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018FizeTcjBnMJqmqLWZz4qd
