### PR TITLE
disjunctive: certify detectable precedences

### DIFF
--- a/dev_docs/disjunctive-proof-logging.md
+++ b/dev_docs/disjunctive-proof-logging.md
@@ -1,17 +1,18 @@
 # Proof logging for `Disjunctive`
 
 This document explains how the `Disjunctive` propagator's proofs are
-backed by VeriPB. The propagator is time-table consistency specialised
-to `h_i = 1`, `capacity = 1`
+backed by VeriPB. The propagator runs time-table consistency
+specialised to `h_i = 1`, `capacity = 1`
 (see [`cumulative-proof-logging.md`](cumulative-proof-logging.md) for
-the general time-table proof machinery), but the *proofs* do not use
-the time-indexed vocabulary at all: at unit heights and capacity,
-every inference the propagator makes is a statement about one **pair**
-of tasks, and is justified directly against the declarative pairwise
-OPB encoding. There is no per-(task, time) scaffolding anywhere — no
-flags, no proof-only variables, no prefix emitted before search (a
-previous design bridged to cumulative-style time-indexed flags at
-`O(n × horizon)` cost; #495 has the measurements from removing it).
+the general time-table proof machinery) plus **detectable
+precedences**, but the *proofs* do not use the time-indexed vocabulary
+at all: at unit heights and capacity, every inference the propagator
+makes is a statement about one **pair** of tasks, and is justified
+directly against the declarative pairwise OPB encoding. There is no
+per-(task, time) scaffolding anywhere — no flags, no proof-only
+variables, no prefix emitted before search (a previous design bridged
+to cumulative-style time-indexed flags at `O(n × horizon)` cost; #495
+has the measurements from removing it).
 
 For the constraint itself — semantics, propagator, the strict / non-strict
 flag — read `gcs/constraints/disjunctive/disjunctive.{hh,cc}`.
@@ -96,7 +97,7 @@ encoding maximum) degrade gracefully: `need_gevar` emits trivial
 halves and pins the boundary atom at `ProofLevel::Top`, so the same
 uniform pol works at domain edges and on domain-wiping pushes.
 
-## The three inferences
+## The four inferences
 
 - **Mandatory-overflow contradiction.** Two tasks `i`, `j` whose
   mandatory parts overlap at some time. Then neither can finish
@@ -140,6 +141,81 @@ Blocker selection is greedy (deepest mandatory end for an lb-push,
 leftmost mandatory start for a ub-push); every non-fitting start is
 blocked, so a blocker always exists while the chain has ground to
 cover, and each step strictly advances.
+
+- **Detectable precedences** (issue #731, step 2 of #729). The
+  precedence `k ≪ j` is *detectable* when `j` cannot finish before
+  `k` starts on bounds alone, `lb(s_j) + lb(l_j) > ub(s_k)`. Then
+  `before_{j,k}` is false, the separation clause forces
+  `before_{k,j}`, and reading that both ways round gives
+
+  ```
+  s_j ≥ lb(s_k) + lb(l_k)      pushing the successor up
+  s_k ≤ ub(s_j) − lb(l_k)      pushing the predecessor down
+  ```
+
+  Each detected precedence justifies its own push, so a push cites
+  only the *best* detected predecessor (latest earliest-end) or
+  successor (earliest latest-start): no set, and no chain. Vilím's
+  O(n log n) form keeps the detected predecessors in a Θ-tree and
+  pushes to the whole set's earliest completion time, which is
+  stronger and needs an energy argument (see the follow-ups).
+
+  **The proof is exactly one step of the push chain above**, with
+  `final = true` and no deposit: one pol refuting the reverse
+  precedence from the running bound, one folding the surviving
+  precedence onto the target order literal. Nothing new was needed
+  for it, which is the point — the detection condition
+  `lb(s_j) + lb(l_j) > ub(s_k)` is *precisely* the condition under
+  which the refuting pol's degree comes out positive, and it is also
+  the condition a chain step's blocker satisfies. Where the two rules
+  differ is only in what the propagator has to notice: a chain step's
+  blocker is found by scanning the profile, so it must have a
+  non-empty mandatory part, while the pol arithmetic never cared
+  whether it did. A detected predecessor with an empty mandatory part
+  is invisible to time-tabling and prunes here.
+
+  Two guards, both inherited from the pushes above: a task with no
+  guaranteed duration is skipped (there is no positive `lb(l)` to pin
+  its zero-length escape false with), and so is a task whose start is
+  already fixed. The second loses nothing: a precedence detected
+  between a fixed task and an unfixed one is the same precedence read
+  the other way round, so it pushes the unfixed one and fails there
+  if it must, and two fixed tasks that collide both have mandatory
+  parts, which is the overflow contradiction.
+
+  Each push writes one `%` comment naming the pair and the direction,
+  which is what lets a test count what fired rather than only that the
+  rule compiled. It is also the only thing this rule adds to a proof
+  beyond its two pols: a 2 GB RCPSP proof over a unary machine carried
+  982,065 of them, about 2% of the file, alongside the per-node
+  comments every proof already writes.
+
+### Rule selection, and what always runs
+
+`DisjunctiveRules` switches time-tabling's pushes and detectable
+precedences on and off independently (both default on). It selects
+propagation strength only: same solutions, same OPB.
+
+The **mandatory-overlap contradiction is not switchable**. At an
+all-fixed leaf every task's mandatory part is its whole active
+interval, so that scan is what makes the propagator a *checker*; a
+selection that stopped it running would not be weaker propagation but
+a solver reporting assignments that violate the constraint.
+`disjunctive_precedences_test` enumerates its fixture under
+`{time_table = false}` for exactly this reason — the extra solutions
+would show up there.
+
+### Which of the two pols is load-bearing
+
+Both are emitted, and on some instances either one alone suffices:
+the closing RUP can sometimes get the other's content by unit
+propagation over the operands' bit encodings. That depends on the
+particular arithmetic, not on the rule, and the propagator cannot
+cheaply tell which case it is in — so it always emits both, as the
+push chains do. The mutation lanes therefore run on a fixture where
+each half is needed (`disjunctive_precedences_test`'s `tight`), which
+is not the fixture that best *demonstrates* the rule; a fixture
+chosen for one job does not do the other, and both are in the test.
 
 ### Variable durations
 
@@ -234,6 +310,26 @@ proof *strategy* along with its parameters.
 
 ## Open follow-ups
 
+The standard suite's remaining rungs are tracked by #729. What each
+would take from *this* encoding:
+
+- **The set-based form of detectable precedences.** The rule above
+  pushes to `max_k eet_k` over the detected predecessors; Vilím's
+  pushes to `ect(Ω)`, the *set's* earliest completion time, which is
+  larger when the predecessors cannot all fit before it. That is an
+  energy statement about a set, so it is the same obstacle as the
+  overload check below, not a variation on the pairwise proof.
+- **An overload check** (#730). The conclusion,
+  `Σ_{i∈Ω} p_i > lct(Ω) − est(Ω)`, is already in this document's
+  vocabulary; the derivation is the problem, and giving `Disjunctive`
+  per-time `active_{i,t}` flags to reach it would reintroduce exactly
+  the scaffolding #495 removed. #730 records a machine-checked
+  construction that avoids them — a proof-only comparator network over
+  bit-encoded wires — verified for `k = 3 … 8` at equal durations, and
+  a refutation rather than a propagator so far.
+- **Not-first / not-last, and edge-finding** (#732, #733). The first
+  genuinely set-based *pruning* rules, and they need whatever the
+  overload check settles on first.
 - **Optional tasks (`*_opt`).** A presence flag per task gates the
   encoded pairwise clauses; the pairwise pols would carry the
   presence literals as extra residuals.

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -278,6 +278,7 @@ if(GCS_BUILD_TESTS)
     add_executable(cumulative_optional_test constraints/cumulative/cumulative_optional_test.cc)
     add_executable(difference_test constraints/difference/difference_constraints_test.cc)
     add_executable(disjunctive_test constraints/disjunctive/disjunctive_test.cc)
+    add_executable(disjunctive_precedences_test constraints/disjunctive/disjunctive_precedences_test.cc)
     add_executable(disjunctive_2d_test constraints/disjunctive_2d/disjunctive_2d_test.cc)
     add_executable(divide_modulus_test constraints/divide_modulus/divide_modulus_test.cc)
     add_executable(element_test constraints/element/element_test.cc)
@@ -324,7 +325,7 @@ if(GCS_BUILD_TESTS)
 
     foreach(test_target
             abs_test all_different_test all_different_except_test all_equal_test among_test at_most_one_test bin_packing_test comparison_test
-            count_test cumulative_test cumulative_overload_test cumulative_optional_test derived_cumulative_test difference_test disjunctive_test disjunctive_2d_test divide_modulus_test element_test equals_test bounds_global_cardinality_test gac_global_cardinality_test in_test increasing_test inverse_test knapsack_test knapsack_upfront_test lex_test linear_test linear_constant_test
+            count_test cumulative_test cumulative_overload_test cumulative_optional_test derived_cumulative_test difference_test disjunctive_test disjunctive_precedences_test disjunctive_2d_test divide_modulus_test element_test equals_test bounds_global_cardinality_test gac_global_cardinality_test in_test increasing_test inverse_test knapsack_test knapsack_upfront_test lex_test linear_test linear_constant_test
             logical_test mdd_test min_distance_test min_distance_matching_test min_max_test mini_linear_test multiply_test n_value_test nogoods_test parity_test
             plus_minus_test power_test product_bounds_test product_justify_test regular_test regular_bacchus_test regular_legacy_test seq_precede_chain_test smart_table_test sort_test arg_sort_test symmetric_all_different_test
             negative_table_test table_test tabulation_test value_precede_test)
@@ -377,6 +378,15 @@ if(GCS_BUILD_TESTS)
     foreach(mode strict nonstrict)
         add_test(NAME disjunctive_constraint_${mode}
             COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:disjunctive_test> ${mode})
+    endforeach()
+    add_test(NAME disjunctive_precedences COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:disjunctive_precedences_test>)
+    # Mutation lanes: each writes a deliberately corrupted proof of the
+    # sharp-margin fixture, and passes only if veripb rejects it. Distinct
+    # basenames so the lanes do not race over one set of proof files.
+    foreach(mutation emit_nothing skip_refutation skip_fold loose_bound one_too_far)
+        add_test(NAME disjunctive_precedences_mutation_${mutation}
+            COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_expect_verify_failure.bash
+                --basename disjunctive_precedences_mutation_${mutation} $<TARGET_FILE:disjunctive_precedences_test> --mutate=${mutation})
     endforeach()
     foreach(mode strict nonstrict)
         add_test(NAME disjunctive_2d_constraint_${mode}

--- a/gcs/constraints/disjunctive/disjunctive.cc
+++ b/gcs/constraints/disjunctive/disjunctive.cc
@@ -54,10 +54,24 @@ auto Disjunctive::with_strict(std::optional<bool> strict) -> Disjunctive &
     return *this;
 }
 
+auto Disjunctive::with_rules(DisjunctiveRules rules) -> Disjunctive &
+{
+    _rules = rules;
+    return *this;
+}
+
+auto Disjunctive::with_proof_mutation(DisjunctiveProofMutation mutation) -> Disjunctive &
+{
+    _proof_mutation = mutation;
+    return *this;
+}
+
 auto Disjunctive::clone() const -> unique_ptr<Constraint>
 {
     auto cloned = make_unique<Disjunctive>(_starts, _lengths);
     cloned->with_strict(_strict);
+    cloned->with_rules(_rules);
+    cloned->with_proof_mutation(_proof_mutation);
     return cloned;
 }
 
@@ -183,7 +197,8 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
     propagators.install(
         constraint_id(),
         [starts = move(_starts), lengths = move(_length_vals), length_vars = move(_lengths), zero = move(_zero), strict = _strict,
-            active_tasks = move(_active_tasks), before_flags = move(_before_flags), clause_lines = move(_clause_lines),
+            active_tasks = move(_active_tasks), before_flags = move(_before_flags), clause_lines = move(_clause_lines), rules = _rules,
+            mutation = _proof_mutation,
             owner = constraint_id()](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
             // Current guaranteed (min) and possible (max) duration of task i:
             // for a constant duration both are the value; for a variable
@@ -289,6 +304,87 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
             }
 
             if (any) {
+                // Variable durations join the reason for the push proofs (the
+                // pols and mandatory parts read lb(l)). For a constant-only
+                // instance this is just the starts, leaving the proof
+                // byte-identical.
+                auto push_reason_vars = starts;
+                for (auto i : active_tasks)
+                    if (is_var_len(i))
+                        push_reason_vars.push_back(length_vars[i]);
+
+                // The mutation switches, unpacked once for both dichotomies
+                // below. Everything but a mutation lane passes None, so all
+                // four come out false; see innards/disjunctive_mutations.hh
+                // for what each one breaks and why VeriPB has to notice.
+                struct DichotomyMutation
+                {
+                    bool emit_nothing, skip_refutation, skip_target_fold, loose_bound;
+                };
+                auto unpack_mutation = [](const DisjunctiveProofMutation & mut) -> DichotomyMutation {
+                    return {std::holds_alternative<disjunctive_proof_mutation::EmitNothing>(mut),
+                        std::holds_alternative<disjunctive_proof_mutation::SkipRefutation>(mut),
+                        std::holds_alternative<disjunctive_proof_mutation::SkipTargetFold>(mut),
+                        std::holds_alternative<disjunctive_proof_mutation::LooseDetectionBound>(mut)};
+                };
+
+                // The two pols of one pairwise dichotomy on task j's lower
+                // bound, against a single other task k: with the running bound
+                // established, j's next lb(l_j) slots reach past ub(s_k), so
+                // "j finishes before k starts" is impossible and the encoded
+                // pairwise clause forces "k finishes before j starts", which
+                // advances j's bound to `target` in one dichotomy. Both
+                // time-tabling's push chains and detectable precedences infer
+                // through this same shape; only how they choose k and target
+                // differs. `mut` is honest for everything but a mutation lane.
+                auto emit_lb_dichotomy = [&](size_t j, size_t k, Integer bound, Integer target, const DisjunctiveProofMutation & mut) -> void {
+                    auto [emit_nothing, skip_refutation, skip_target_fold, loose_bound] = unpack_mutation(mut);
+                    if (emit_nothing)
+                        return;
+                    // Left branch: j finishing before k contradicts the
+                    // running bound -- s_j >= bound plus lb(l_j) reaches past
+                    // ub(s_k), forcing bf_{j,k} false.
+                    if (! skip_refutation)
+                        emit_before_pol(j, k, starts[j] >= (loose_bound ? bound - 1_i : bound), start_ub_lit(k));
+                    // Right branch: k finishing before j puts s_j at k's
+                    // earliest end or later, folded onto the target order
+                    // literal's definition row: bf_{k,j} -> s_j >= target.
+                    if (! skip_target_fold)
+                        emit_before_pol(k, j, start_lb_lit(k), starts[j] < target);
+                };
+                // The mirror image, on j's upper bound: k finishing before j
+                // is impossible under the running bound -- s_j would be at k's
+                // earliest end or later, past bound -- so j finishes before k,
+                // capping s_j at k's latest start minus lb(l_j).
+                auto emit_ub_dichotomy = [&](size_t j, size_t k, Integer bound, Integer target, const DisjunctiveProofMutation & mut) -> void {
+                    auto [emit_nothing, skip_refutation, skip_target_fold, loose_bound] = unpack_mutation(mut);
+                    if (emit_nothing)
+                        return;
+                    if (! skip_refutation)
+                        emit_before_pol(k, j, start_lb_lit(k), starts[j] < bound + (loose_bound ? 2_i : 1_i));
+                    if (! skip_target_fold)
+                        emit_before_pol(j, k, starts[j] >= target + 1_i, start_ub_lit(k));
+                };
+
+                // One step of a time-tabling push chain, which is one
+                // dichotomy plus, for a non-final step, a deposit of the
+                // advanced bound under the reason so the next step's left
+                // branch unit-propagates from it. The final target is exactly
+                // the inferred bound, which the framework's closing RUP
+                // concludes. `bound` is the running bound the step starts from
+                // (established by the reason for the first step, by the
+                // previous step's deposit after).
+                auto emit_lb_chain_step = [&](size_t j, size_t k, Integer bound, Integer target, bool final, const ReasonLiterals & reason) -> void {
+                    emit_lb_dichotomy(j, k, bound, target, disjunctive_proof_mutation::None{});
+                    if (! final)
+                        logger->emit_rup_proof_line_under_reason(reason, WPBSum{} + 1_i * (starts[j] >= target) >= 1_i, ProofLevel::Temporary);
+                };
+                auto emit_ub_chain_step = [&](size_t j, size_t k, Integer bound, Integer target, bool final, const ReasonLiterals & reason) -> void {
+                    emit_ub_dichotomy(j, k, bound, target, disjunctive_proof_mutation::None{});
+                    if (! final)
+                        logger->emit_rup_proof_line_under_reason(reason, WPBSum{} + 1_i * (starts[j] < target + 1_i) >= 1_i, ProofLevel::Temporary);
+                };
+
                 auto range = (t_hi - t_lo + 1_i).raw_value;
                 vector<int> mand_load(range, 0);
 
@@ -302,6 +398,13 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                             ++mand_load[(t - t_lo).raw_value];
                 }
 
+                // The mandatory-overlap contradiction runs whatever the rule
+                // selection is: at an all-fixed leaf every task's mandatory part
+                // is its whole active interval, so this scan is what makes the
+                // propagator a *checker*, and a rule selection that stopped it
+                // running would not be a weakening of propagation but a solver
+                // that reports assignments violating the constraint. Only the
+                // bound pushes below are time-tabling's to switch off.
                 for (auto idx = 0; idx < range; ++idx)
                     if (mand_load[idx] > 1) {
                         auto violating_t = t_lo + Integer{idx};
@@ -356,183 +459,255 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                         return PropagatorState::DisableUntilBacktrack;
                     }
 
-                // Variable durations join the reason for the push proofs (the
-                // pols and mandatory parts read lb(l)). For a constant-only
-                // instance this is just the starts, leaving the proof
-                // byte-identical.
-                auto push_reason_vars = starts;
-                for (auto i : active_tasks)
-                    if (is_var_len(i))
-                        push_reason_vars.push_back(length_vars[i]);
-
-                // One step of an lb/ub-push chain: a single blocking task and
-                // the start bound the pair dichotomy advances to (the
-                // blocker's mandatory end for an lb-push, its latest start
-                // minus lb(l_j) for a ub-push). One step per BLOCKER, however
-                // long the blocker: with the running bound established, j's
-                // next lb(l_j) slots reach into the blocker's mandatory part,
-                // so "j finishes before k starts" is impossible and the
-                // encoded pairwise clause forces "k finishes before j starts",
-                // which advances the bound in one dichotomy.
-                struct ChainStep
-                {
-                    size_t blocker;
-                    Integer target;
-                };
-
-                // Per-step proof emitter. `bound` is the running bound the
-                // step starts from (established by the reason for the first
-                // step, by the previous step's deposit after), `final` says
-                // whether the framework's closing RUP concludes the target
-                // instead of an explicit intermediate deposit.
-                auto emit_lb_chain_step = [&](size_t j, size_t k, Integer bound, Integer target, bool final, const ReasonLiterals & reason) -> void {
-                    // Left branch: j finishing before k contradicts the
-                    // running bound -- s_j >= bound plus lb(l_j) reaches past
-                    // ub(s_k), forcing bf_{j,k} false.
-                    emit_before_pol(j, k, starts[j] >= bound, start_ub_lit(k));
-                    // Right branch: k finishing before j puts s_j at k's
-                    // mandatory end or later, folded onto the target order
-                    // literal's definition row: bf_{k,j} -> s_j >= target.
-                    emit_before_pol(k, j, start_lb_lit(k), starts[j] < target);
-                    // Intermediate steps deposit the advanced bound under the
-                    // reason so the next step's left branch unit-propagates
-                    // from it; the final target is exactly the inferred
-                    // bound, which the framework's closing RUP concludes.
-                    if (! final)
-                        logger->emit_rup_proof_line_under_reason(reason, WPBSum{} + 1_i * (starts[j] >= target) >= 1_i, ProofLevel::Temporary);
-                };
-                auto emit_ub_chain_step = [&](size_t j, size_t k, Integer bound, Integer target, bool final, const ReasonLiterals & reason) -> void {
-                    // Mirror of the lb step. Left branch: k finishing before j
-                    // is impossible under the running bound -- s_j would be at
-                    // k's mandatory end or later, past bound.
-                    emit_before_pol(k, j, start_lb_lit(k), starts[j] < bound + 1_i);
-                    // Right branch: j finishing before k caps s_j at k's
-                    // latest start minus lb(l_j), folded onto the target order
-                    // literal's definition row: bf_{j,k} -> s_j <= target.
-                    emit_before_pol(j, k, starts[j] >= target + 1_i, start_ub_lit(k));
-                    if (! final)
-                        logger->emit_rup_proof_line_under_reason(reason, WPBSum{} + 1_i * (starts[j] < target + 1_i) >= 1_i, ProofLevel::Temporary);
-                };
-
-                for (auto j : active_tasks) {
-                    if (min_len(j) == 0_i)
-                        continue;
-                    auto [cur_lb, cur_ub] = state.bounds(starts[j]);
-                    if (cur_lb == cur_ub)
-                        continue;
-
-                    auto lst_j = cur_ub, eet_j = cur_lb + min_len(j);
-                    auto fits_at = [&](Integer s) -> bool {
-                        for (Integer t = s; t < s + min_len(j); ++t) {
-                            auto load = mand_load[(t - t_lo).raw_value];
-                            if (lst_j < eet_j && t >= lst_j && t < eet_j)
-                                --load;
-                            if (load >= 1)
-                                return false;
-                        }
-                        return true;
+                if (rules.time_table) {
+                    // One step of an lb/ub-push chain: a single blocking task and
+                    // the start bound the pair dichotomy advances to (the
+                    // blocker's mandatory end for an lb-push, its latest start
+                    // minus lb(l_j) for a ub-push). One step per BLOCKER, however
+                    // long the blocker -- see emit_lb_dichotomy above.
+                    struct ChainStep
+                    {
+                        size_t blocker;
+                        Integer target;
                     };
 
-                    // A blocker for a chain step at running bound `bound`: a
-                    // task (other than j) whose mandatory part intersects the
-                    // window [bound, bound + lb(l_j)). Every non-fitting start
-                    // is blocked, so while the chain has ground to cover one
-                    // exists; `better` picks the most useful of two candidate
-                    // mandatory parts (deepest end for an lb-push, leftmost
-                    // start for a ub-push). Reads current bounds, which may be
-                    // tighter than the profile (mandatory parts only grow
-                    // within a pass), hence the clipping in the chain loops
-                    // below.
-                    auto find_blocker = [&](size_t j, Integer bound, const auto & better) -> pair<size_t, pair<Integer, Integer>> {
-                        optional<size_t> blocker;
-                        pair<Integer, Integer> best_mand{0_i, 0_i};
+                    for (auto j : active_tasks) {
+                        if (min_len(j) == 0_i)
+                            continue;
+                        auto [cur_lb, cur_ub] = state.bounds(starts[j]);
+                        if (cur_lb == cur_ub)
+                            continue;
+
+                        auto lst_j = cur_ub, eet_j = cur_lb + min_len(j);
+                        auto fits_at = [&](Integer s) -> bool {
+                            for (Integer t = s; t < s + min_len(j); ++t) {
+                                auto load = mand_load[(t - t_lo).raw_value];
+                                if (lst_j < eet_j && t >= lst_j && t < eet_j)
+                                    --load;
+                                if (load >= 1)
+                                    return false;
+                            }
+                            return true;
+                        };
+
+                        // A blocker for a chain step at running bound `bound`: a
+                        // task (other than j) whose mandatory part intersects the
+                        // window [bound, bound + lb(l_j)). Every non-fitting start
+                        // is blocked, so while the chain has ground to cover one
+                        // exists; `better` picks the most useful of two candidate
+                        // mandatory parts (deepest end for an lb-push, leftmost
+                        // start for a ub-push). Reads current bounds, which may be
+                        // tighter than the profile (mandatory parts only grow
+                        // within a pass), hence the clipping in the chain loops
+                        // below.
+                        auto find_blocker = [&](size_t j, Integer bound, const auto & better) -> pair<size_t, pair<Integer, Integer>> {
+                            optional<size_t> blocker;
+                            pair<Integer, Integer> best_mand{0_i, 0_i};
+                            for (auto k : active_tasks) {
+                                if (k == j || min_len(k) == 0_i)
+                                    continue;
+                                auto lst_k = state.upper_bound(starts[k]);
+                                auto eet_k = state.lower_bound(starts[k]) + min_len(k);
+                                if (lst_k < eet_k && lst_k < bound + min_len(j) && eet_k > bound &&
+                                    (! blocker || better(pair{lst_k, eet_k}, best_mand))) {
+                                    blocker = k;
+                                    best_mand = pair{lst_k, eet_k};
+                                }
+                            }
+                            if (! blocker)
+                                throw UnexpectedException{"Disjunctive: no blocker for a push chain step"};
+                            return {*blocker, best_mand};
+                        };
+
+                        // lb-push: scan upward to find the smallest fitting start,
+                        // then justify with one dichotomy step per blocker, each
+                        // advancing the running bound to the blocker's mandatory
+                        // end -- clipped to new_lb, both because the profile may
+                        // be staler than the bounds the steps cite and so the
+                        // final step lands exactly on the inferred bound.
+                        auto new_lb = cur_lb;
+                        while (new_lb <= cur_ub && ! fits_at(new_lb))
+                            ++new_lb;
+                        if (new_lb > cur_lb) {
+                            vector<ChainStep> chain;
+                            if (logger) {
+                                Integer bound = cur_lb;
+                                while (bound < new_lb) {
+                                    auto [k, mand] = find_blocker(j, bound, [](const auto & a, const auto & b) { return a.second > b.second; });
+                                    chain.push_back(ChainStep{k, min(mand.second, new_lb)});
+                                    bound = chain.back().target;
+                                }
+                            }
+
+                            auto justify = [&, j, cur_lb, chain](const ReasonLiterals & reason) -> void {
+                                vector<size_t> involved{j};
+                                for (const auto & step : chain)
+                                    involved.push_back(step.blocker);
+                                pin_escapes(reason, involved);
+                                Integer bound = cur_lb;
+                                for (size_t step = 0; step < chain.size(); ++step) {
+                                    emit_lb_chain_step(j, chain[step].blocker, bound, chain[step].target, step + 1 == chain.size(), reason);
+                                    bound = chain[step].target;
+                                }
+                            };
+
+                            inference.infer_greater_than_or_equal(logger, starts[j], new_lb,
+                                JustifyExplicitly{justify, ThenRUP::Yes, hints::Disjunctive{owner}}, generic_reason(push_reason_vars));
+                        }
+
+                        // ub-push: mirror of lb-push, scanning downward, each step
+                        // dropping the running bound to the blocker's latest start
+                        // minus lb(l_j) (the last start from which j finishes by
+                        // the time the blocker must have started), clipped to
+                        // new_ub.
+                        auto new_ub = cur_ub;
+                        while (new_ub >= cur_lb && ! fits_at(new_ub))
+                            --new_ub;
+                        if (new_ub < cur_ub) {
+                            vector<ChainStep> chain;
+                            if (logger) {
+                                Integer bound = cur_ub;
+                                while (bound > new_ub) {
+                                    auto [k, mand] = find_blocker(j, bound, [](const auto & a, const auto & b) { return a.first < b.first; });
+                                    chain.push_back(ChainStep{k, max(mand.first - min_len(j), new_ub)});
+                                    bound = chain.back().target;
+                                }
+                            }
+
+                            auto justify = [&, j, cur_ub, chain](const ReasonLiterals & reason) -> void {
+                                vector<size_t> involved{j};
+                                for (const auto & step : chain)
+                                    involved.push_back(step.blocker);
+                                pin_escapes(reason, involved);
+                                Integer bound = cur_ub;
+                                for (size_t step = 0; step < chain.size(); ++step) {
+                                    emit_ub_chain_step(j, chain[step].blocker, bound, chain[step].target, step + 1 == chain.size(), reason);
+                                    bound = chain[step].target;
+                                }
+                            };
+
+                            inference.infer_less_than(logger, starts[j], new_ub + 1_i,
+                                JustifyExplicitly{justify, ThenRUP::Yes, hints::Disjunctive{owner}}, generic_reason(push_reason_vars));
+                        }
+                    }
+                }
+
+                // Detectable precedences. The precedence k << j is
+                // *detectable* when j cannot finish before k starts on bounds
+                // alone:
+                //
+                //     lb(s_j) + lb(l_j)  >  ub(s_k)
+                //
+                // Then before_{j,k} is false, so the separation clause forces
+                // before_{k,j}: s_k + l_k <= s_j. That bounds j from below by
+                // k's earliest end, and (reading the same precedence the other
+                // way round) bounds k from above by j's latest start less
+                // l_k:
+                //
+                //     s_j >= lb(s_k) + lb(l_k)      pushing the successor up
+                //     s_k <= ub(s_j) - lb(l_k)      pushing the predecessor down
+                //
+                // Unlike time-tabling, this asks for no mandatory part on
+                // either task, and that is exactly where the extra strength
+                // is: when k does have one, detection says j's next lb(l_j)
+                // slots reach past ub(s_k) = k's mandatory start, so the
+                // window [lb(s_j), lb(s_j) + lb(l_j)) meets k's mandatory part
+                // and time-tabling has already pushed j at least this far. A
+                // predecessor whose mandatory part is empty pushes here and
+                // nowhere else.
+                //
+                // Each detected precedence justifies its own push on its own,
+                // so a push needs only the *best* detected predecessor (the
+                // one ending latest) or successor (the one starting earliest):
+                // no set-based reasoning, and no chain. Vilim's O(n log n)
+                // form keeps the detected predecessors in a Theta-tree and
+                // pushes to the whole set's earliest completion time, which is
+                // stronger and needs an energy argument; this is the pairwise
+                // version.
+                //
+                // The proof is one dichotomy of the shape time-tabling's push
+                // chains are built from, with the blocker's mandatory part
+                // playing no part -- the pol arithmetic never referred to it,
+                // only the profile scan that picked the blocker did.
+                if (rules.detectable_precedences)
+                    for (auto j : active_tasks) {
+                        if (min_len(j) == 0_i)
+                            continue;
+                        // A task whose start is already fixed has no bound to
+                        // push, and nothing is lost by leaving it alone: a
+                        // precedence detected between a fixed task and an
+                        // unfixed one is the same precedence read the other way
+                        // round, which pushes the unfixed one and fails there
+                        // if it must; and two fixed tasks that collide both
+                        // have mandatory parts, which is the always-on overlap
+                        // contradiction above.
+                        auto [cur_lb, cur_ub] = state.bounds(starts[j]);
+                        if (cur_lb == cur_ub)
+                            continue;
+
+                        // One scan for both pushes: k is a detected
+                        // predecessor of j when j cannot finish before k
+                        // starts, and a detected successor when k cannot
+                        // finish before j starts. A task with no guaranteed
+                        // duration is skipped, as everywhere else here: it
+                        // has no zero-length escape to pin false.
+                        optional<size_t> predecessor, successor;
+                        Integer predecessor_eet = 0_i, successor_lst = 0_i;
                         for (auto k : active_tasks) {
                             if (k == j || min_len(k) == 0_i)
                                 continue;
-                            auto lst_k = state.upper_bound(starts[k]);
-                            auto eet_k = state.lower_bound(starts[k]) + min_len(k);
-                            if (lst_k < eet_k && lst_k < bound + min_len(j) && eet_k > bound &&
-                                (! blocker || better(pair{lst_k, eet_k}, best_mand))) {
-                                blocker = k;
-                                best_mand = pair{lst_k, eet_k};
+                            auto [k_lb, k_ub] = state.bounds(starts[k]);
+                            auto eet_k = k_lb + min_len(k);
+                            if (cur_lb + min_len(j) > k_ub && (! predecessor || eet_k > predecessor_eet)) {
+                                predecessor = k;
+                                predecessor_eet = eet_k;
                             }
-                        }
-                        if (! blocker)
-                            throw UnexpectedException{"Disjunctive: no blocker for a push chain step"};
-                        return {*blocker, best_mand};
-                    };
-
-                    // lb-push: scan upward to find the smallest fitting start,
-                    // then justify with one dichotomy step per blocker, each
-                    // advancing the running bound to the blocker's mandatory
-                    // end -- clipped to new_lb, both because the profile may
-                    // be staler than the bounds the steps cite and so the
-                    // final step lands exactly on the inferred bound.
-                    auto new_lb = cur_lb;
-                    while (new_lb <= cur_ub && ! fits_at(new_lb))
-                        ++new_lb;
-                    if (new_lb > cur_lb) {
-                        vector<ChainStep> chain;
-                        if (logger) {
-                            Integer bound = cur_lb;
-                            while (bound < new_lb) {
-                                auto [k, mand] = find_blocker(j, bound, [](const auto & a, const auto & b) { return a.second > b.second; });
-                                chain.push_back(ChainStep{k, min(mand.second, new_lb)});
-                                bound = chain.back().target;
+                            if (eet_k > cur_ub && (! successor || k_ub < successor_lst)) {
+                                successor = k;
+                                successor_lst = k_ub;
                             }
                         }
 
-                        auto justify = [&, j, cur_lb, chain](const ReasonLiterals & reason) -> void {
-                            vector<size_t> involved{j};
-                            for (const auto & step : chain)
-                                involved.push_back(step.blocker);
-                            pin_escapes(reason, involved);
-                            Integer bound = cur_lb;
-                            for (size_t step = 0; step < chain.size(); ++step) {
-                                emit_lb_chain_step(j, chain[step].blocker, bound, chain[step].target, step + 1 == chain.size(), reason);
-                                bound = chain[step].target;
-                            }
-                        };
+                        auto one_too_far = std::holds_alternative<disjunctive_proof_mutation::PushOneTooFar>(mutation);
 
-                        inference.infer_greater_than_or_equal(logger, starts[j], new_lb,
-                            JustifyExplicitly{justify, ThenRUP::Yes, hints::Disjunctive{owner}}, generic_reason(push_reason_vars));
+                        // lb-push, to the predecessor's earliest end, clipped
+                        // to one past j's upper bound: a push that wipes the
+                        // domain is a contradiction, and the target has to
+                        // stay somewhere the order literal exists.
+                        if (predecessor) {
+                            auto target = min(predecessor_eet, cur_ub + 1_i) + (one_too_far ? 1_i : 0_i);
+                            if (target > cur_lb) {
+                                auto justify = [&, j, k = *predecessor, cur_lb, target](const ReasonLiterals & reason) -> void {
+                                    logger->emit_proof_comment(
+                                        "disjunctive detectable precedence " + std::to_string(k) + "<<" + std::to_string(j) + " push=lb");
+                                    pin_escapes(reason, {j, k});
+                                    emit_lb_dichotomy(j, k, cur_lb, target, mutation);
+                                };
+                                inference.infer_greater_than_or_equal(logger, starts[j], target,
+                                    JustifyExplicitly{justify, ThenRUP::Yes, hints::Disjunctive{owner}}, generic_reason(push_reason_vars));
+                            }
+                        }
+
+                        // ub-push, to the successor's latest start less j's
+                        // own guaranteed duration, clipped to one below j's
+                        // lower bound. cur_ub is the bound captured before
+                        // any push above landed: by the time the justification
+                        // runs, the state holds the pushed bound, which the
+                        // reason does not support.
+                        if (successor) {
+                            auto target = max(successor_lst - min_len(j), cur_lb - 1_i) - (one_too_far ? 1_i : 0_i);
+                            if (target < cur_ub) {
+                                auto justify = [&, j, k = *successor, cur_ub, target](const ReasonLiterals & reason) -> void {
+                                    logger->emit_proof_comment(
+                                        "disjunctive detectable precedence " + std::to_string(j) + "<<" + std::to_string(k) + " push=ub");
+                                    pin_escapes(reason, {j, k});
+                                    emit_ub_dichotomy(j, k, cur_ub, target, mutation);
+                                };
+                                inference.infer_less_than(logger, starts[j], target + 1_i,
+                                    JustifyExplicitly{justify, ThenRUP::Yes, hints::Disjunctive{owner}}, generic_reason(push_reason_vars));
+                            }
+                        }
                     }
-
-                    // ub-push: mirror of lb-push, scanning downward, each step
-                    // dropping the running bound to the blocker's latest start
-                    // minus lb(l_j) (the last start from which j finishes by
-                    // the time the blocker must have started), clipped to
-                    // new_ub.
-                    auto new_ub = cur_ub;
-                    while (new_ub >= cur_lb && ! fits_at(new_ub))
-                        --new_ub;
-                    if (new_ub < cur_ub) {
-                        vector<ChainStep> chain;
-                        if (logger) {
-                            Integer bound = cur_ub;
-                            while (bound > new_ub) {
-                                auto [k, mand] = find_blocker(j, bound, [](const auto & a, const auto & b) { return a.first < b.first; });
-                                chain.push_back(ChainStep{k, max(mand.first - min_len(j), new_ub)});
-                                bound = chain.back().target;
-                            }
-                        }
-
-                        auto justify = [&, j, cur_ub, chain](const ReasonLiterals & reason) -> void {
-                            vector<size_t> involved{j};
-                            for (const auto & step : chain)
-                                involved.push_back(step.blocker);
-                            pin_escapes(reason, involved);
-                            Integer bound = cur_ub;
-                            for (size_t step = 0; step < chain.size(); ++step) {
-                                emit_ub_chain_step(j, chain[step].blocker, bound, chain[step].target, step + 1 == chain.size(), reason);
-                                bound = chain[step].target;
-                            }
-                        };
-
-                        inference.infer_less_than(logger, starts[j], new_ub + 1_i,
-                            JustifyExplicitly{justify, ThenRUP::Yes, hints::Disjunctive{owner}}, generic_reason(push_reason_vars));
-                    }
-                }
             }
 
             // Strict-mode zero-length tasks: check that no zero-length task

--- a/gcs/constraints/disjunctive/disjunctive.hh
+++ b/gcs/constraints/disjunctive/disjunctive.hh
@@ -2,6 +2,7 @@
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_DISJUNCTIVE_DISJUNCTIVE_HH
 
 #include <gcs/constraint.hh>
+#include <gcs/constraints/innards/disjunctive_mutations.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/integer.hh>
 #include <gcs/variable_id.hh>
@@ -15,6 +16,31 @@
 
 namespace gcs
 {
+    /**
+     * \brief Which of Disjunctive's propagation rules are enabled.
+     *
+     * Both are on by default. Turning one off weakens propagation but never
+     * changes the solutions found, and never changes the OPB encoding: these
+     * select propagation strength only, and exist so that a test can attribute
+     * an inference to the rule that made it (and so that a fixture can show a
+     * rule is load-bearing by watching the other one fail to make its
+     * inference).
+     *
+     * \ingroup Constraints
+     */
+    struct DisjunctiveRules
+    {
+        /// Time-table: the mandatory-part load profile, its overflow
+        /// contradiction and the bound pushes away from blocked times.
+        bool time_table = true;
+
+        /// Detectable precedences: a pair whose ordering is forced by bounds
+        /// alone pushes the successor's lower bound up to the predecessor's
+        /// earliest end, and the predecessor's upper bound down to the
+        /// successor's latest start less its own duration.
+        bool detectable_precedences = true;
+    };
+
     /**
      * \brief Disjunctive (1D non-overlap) constraint: tasks with variable
      * origins; the durations may each be variables or constants (constants pass
@@ -42,8 +68,11 @@ namespace gcs
      * Propagation is time-table consistent at heights = 1, capacity = 1:
      * mandatory parts of distinct tasks may not overlap, and each task's
      * bounds are pushed away from time points already mandatorily occupied
-     * by another. Stronger reasoning (edge-finding, not-first / not-last)
-     * is left for future work.
+     * by another. On top of that, <em>detectable precedences</em> order the
+     * pairs whose ordering the bounds already force &mdash; which needs no
+     * mandatory part on either task, so it prunes where time-tabling cannot.
+     * Stronger reasoning (an overload check, not-first / not-last,
+     * edge-finding) is left for future work.
      *
      * \ingroup Constraints
      */
@@ -83,6 +112,9 @@ namespace gcs
         std::vector<std::uint8_t> _zero_escape;
         std::vector<std::optional<innards::ProofFlag>> _zero;
 
+        DisjunctiveRules _rules;
+        innards::DisjunctiveProofMutation _proof_mutation = innards::disjunctive_proof_mutation::None{};
+
         virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
         virtual auto define_proof_model(innards::ProofModel &, const innards::State &) -> void override;
         virtual auto install_propagators(innards::Propagators &) -> void override;
@@ -104,6 +136,16 @@ namespace gcs
         /// not overlap); default true. Takes std::optional<bool> so a runtime flag
         /// can be passed straight through.
         auto with_strict(std::optional<bool> strict = true) -> Disjunctive &;
+
+        /// Select which propagation rules are enabled (all of them, by
+        /// default). Propagation strength only: the solutions found and the OPB
+        /// encoding are the same whatever is selected.
+        auto with_rules(DisjunctiveRules rules) -> Disjunctive &;
+
+        /// Corrupt one step of the detectable-precedence derivation. For tests
+        /// only, which assert that VeriPB rejects the result; see
+        /// innards::DisjunctiveProofMutation.
+        auto with_proof_mutation(innards::DisjunctiveProofMutation mutation) -> Disjunctive &;
 
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
         [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;

--- a/gcs/constraints/disjunctive/disjunctive_precedences_test.cc
+++ b/gcs/constraints/disjunctive/disjunctive_precedences_test.cc
@@ -1,0 +1,719 @@
+#include <gcs/constraints/disjunctive.hh>
+#include <gcs/constraints/innards/constraints_test_utils.hh>
+#include <gcs/problem.hh>
+#include <gcs/solve.hh>
+
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <optional>
+#include <random>
+#include <set>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+#include <version>
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+#include <print>
+#else
+#include <fmt/core.h>
+#include <fmt/ostream.h>
+#include <fmt/ranges.h>
+#endif
+
+using std::cerr;
+using std::flush;
+using std::ifstream;
+using std::make_optional;
+using std::max;
+using std::min;
+using std::nullopt;
+using std::optional;
+using std::pair;
+using std::set;
+using std::string;
+using std::tuple;
+using std::vector;
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+using std::print;
+using std::println;
+#else
+using fmt::print;
+using fmt::println;
+#endif
+
+using namespace gcs;
+using namespace gcs::innards;
+using namespace gcs::test_innards;
+
+namespace
+{
+    // A fixture: a start range and a duration spec {lo, hi} per task, where
+    // lo == hi is a constant duration and lo < hi a variable one.
+    struct Instance
+    {
+        vector<pair<int, int>> start_ranges;
+        vector<pair<int, int>> length_specs;
+        bool strict = true;
+    };
+
+    auto is_variable_length(const Instance & inst, size_t i) -> bool
+    {
+        return inst.length_specs[i].first != inst.length_specs[i].second;
+    }
+
+    // The lengths a solution vector carries: starts first, then one entry per
+    // variable duration, in task order (what post() enumerates).
+    auto lengths_of(const Instance & inst, const vector<int> & vals) -> vector<int>
+    {
+        auto n = inst.start_ranges.size();
+        vector<int> lengths(n);
+        auto next = n;
+        for (size_t i = 0; i < n; ++i)
+            lengths[i] = is_variable_length(inst, i) ? vals.at(next++) : inst.length_specs[i].first;
+        return lengths;
+    }
+
+    auto is_satisfying(const Instance & inst, const vector<int> & vals) -> bool
+    {
+        auto n = inst.start_ranges.size();
+        auto lengths = lengths_of(inst, vals);
+        for (size_t i = 0; i < n; ++i)
+            for (size_t j = i + 1; j < n; ++j) {
+                // Non-strict: a pair involving a zero-length task floats.
+                if (! inst.strict && (lengths[i] == 0 || lengths[j] == 0))
+                    continue;
+                if (! (vals[i] + lengths[i] <= vals[j]) && ! (vals[j] + lengths[j] <= vals[i]))
+                    return false;
+            }
+        return true;
+    }
+
+    // Posts the instance, and hands back the starts (which every probe reads
+    // bounds from) and the full enumerated variable list (starts, then the
+    // variable durations).
+    struct Posted
+    {
+        vector<IntegerVariableID> starts;
+        vector<IntegerVariableID> all_vars;
+    };
+
+    auto post(Problem & p, const Instance & inst, DisjunctiveRules rules, DisjunctiveProofMutation mutation = disjunctive_proof_mutation::None{})
+        -> Posted
+    {
+        Posted posted;
+        vector<IntegerVariableID> lengths;
+        for (auto & [lo, hi] : inst.start_ranges) {
+            auto v = p.create_integer_variable(Integer{lo}, Integer{hi});
+            posted.starts.push_back(v);
+            posted.all_vars.push_back(v);
+        }
+        for (size_t i = 0; i < inst.start_ranges.size(); ++i)
+            if (is_variable_length(inst, i)) {
+                auto lv = p.create_integer_variable(Integer{inst.length_specs[i].first}, Integer{inst.length_specs[i].second});
+                lengths.push_back(lv);
+                posted.all_vars.push_back(lv);
+            }
+            else
+                lengths.push_back(constant_variable(Integer{inst.length_specs[i].first}));
+
+        p.post(Disjunctive{posted.starts, lengths}.with_strict(inst.strict).with_rules(rules).with_proof_mutation(mutation));
+        return posted;
+    }
+
+    // How many times each detectable-precedence push left its marker in a
+    // proof file. The propagator writes one comment per push it justifies, so
+    // a test can tell "the rule fired" from "the rule was compiled in and
+    // never triggered" --- and, on a negative twin, insist that it did not
+    // fire at all.
+    struct MarkerCounts
+    {
+        size_t lb = 0, ub = 0;
+
+        [[nodiscard]] auto total() const -> size_t
+        {
+            return lb + ub;
+        }
+    };
+
+    auto count_markers(const string & proof_name) -> MarkerCounts
+    {
+        MarkerCounts counts;
+        ifstream proof{proof_name + ".pbp"};
+        if (! proof) {
+            println(cerr, "could not read {}.pbp to count precedence markers", proof_name);
+            std::exit(EXIT_FAILURE);
+        }
+        string line;
+        while (getline(proof, line)) {
+            if (line.find("disjunctive detectable precedence") == string::npos)
+                continue;
+            if (line.find("push=lb") != string::npos)
+                ++counts.lb;
+            else if (line.find("push=ub") != string::npos)
+                ++counts.ub;
+        }
+        return counts;
+    }
+
+    // What one propagation at the root did: whether it refuted the instance,
+    // the start bounds it left behind, and which pushes fired getting there.
+    // Stopping at the first search node keeps all of that attributable to root
+    // reasoning --- a satisfiable instance would otherwise accumulate markers
+    // from deep in the search, which says nothing about the fixture.
+    struct RootProbe
+    {
+        bool refuted = false;
+        vector<pair<int, int>> start_bounds;
+        MarkerCounts markers;
+    };
+
+    auto solve_root_only(const Instance & inst, DisjunctiveRules rules, DisjunctiveProofMutation mutation, const optional<string> & proof_name)
+        -> RootProbe
+    {
+        Problem p;
+        auto posted = post(p, inst, rules, mutation);
+
+        RootProbe probe;
+        // Refuted means root propagation reached a contradiction: neither a
+        // search node nor a solution. The solution check is not redundant ---
+        // an instance whose variables are all fixed by propagation is answered
+        // without ever branching, so no node is ever traced.
+        bool reached_a_node = false, found_a_solution = false;
+        auto record = [&](const CurrentState & s) -> bool {
+            if (probe.start_bounds.empty())
+                for (const auto & v : posted.starts)
+                    probe.start_bounds.emplace_back(static_cast<int>(s.lower_bound(v).raw_value), static_cast<int>(s.upper_bound(v).raw_value));
+            return false;
+        };
+        solve_with(p,
+            SolveCallbacks{.solution = [&](const CurrentState & s) -> bool {
+                               found_a_solution = true;
+                               return record(s);
+                           },
+                .trace = [&](const CurrentState & s) -> bool {
+                    reached_a_node = true;
+                    return record(s);
+                }},
+            proof_name ? make_optional<ProofOptions>(ProofFileNames{*proof_name}) : nullopt);
+
+        probe.refuted = ! reached_a_node && ! found_a_solution;
+        return probe;
+    }
+
+    auto probe_root(const Instance & inst, DisjunctiveRules rules, const optional<string> & proof_name) -> RootProbe
+    {
+        auto probe = solve_root_only(inst, rules, disjunctive_proof_mutation::None{}, proof_name);
+        if (proof_name) {
+            probe.markers = count_markers(*proof_name);
+            verify_proof_and_clean_up(*proof_name);
+        }
+        return probe;
+    }
+
+    // The rule written out from its definition, iterated to a fixpoint, over a
+    // plain double loop sharing no code with the propagator. Bounds only: the
+    // rule never touches a duration, so the durations stay at their root lower
+    // bounds throughout. Returns nullopt when a push empties a domain, or when
+    // the always-on mandatory-overlap check finds a conflict.
+    //
+    // A fixpoint is well defined whatever order the pairs are visited in:
+    // raising a lower bound or lowering an upper bound can only make more
+    // precedences detectable, never fewer, so the rule is monotone and the
+    // propagator's own visiting order cannot matter.
+    //
+    // A task whose start is already fixed is never the one pushed, matching the
+    // propagator. Nothing is lost by that: a detected precedence between a
+    // fixed task and an unfixed one pushes the unfixed one just as far (that is
+    // the same precedence read the other way round), and a pair of fixed tasks
+    // that collide both have mandatory parts, which the always-on
+    // mandatory-overlap check below catches.
+    auto oracle_precedence_fixpoint(const Instance & inst) -> optional<vector<pair<int, int>>>
+    {
+        auto n = inst.start_ranges.size();
+        auto bounds = inst.start_ranges;
+        vector<int> min_len;
+        for (auto & [lo, hi] : inst.length_specs)
+            min_len.push_back(lo);
+
+        for (bool changed = true; changed;) {
+            changed = false;
+            // The mandatory-overlap contradiction, which runs whatever rules are
+            // selected (it is what makes the propagator a checker), and which
+            // the propagator scans for before it pushes anything.
+            for (size_t i = 0; i < n; ++i)
+                for (size_t j = i + 1; j < n; ++j) {
+                    if (min_len[i] == 0 || min_len[j] == 0)
+                        continue;
+                    auto lst_i = bounds[i].second, eet_i = bounds[i].first + min_len[i];
+                    auto lst_j = bounds[j].second, eet_j = bounds[j].first + min_len[j];
+                    if (lst_i < eet_i && lst_j < eet_j && lst_i < eet_j && lst_j < eet_i)
+                        return nullopt;
+                }
+            for (size_t j = 0; j < n; ++j) {
+                if (min_len[j] == 0 || bounds[j].first == bounds[j].second)
+                    continue;
+                for (size_t k = 0; k < n; ++k) {
+                    if (k == j || min_len[k] == 0)
+                        continue;
+                    // k << j detectable: j cannot finish before k starts.
+                    if (bounds[j].first + min_len[j] > bounds[k].second) {
+                        auto target = min(bounds[k].first + min_len[k], bounds[j].second + 1);
+                        if (target > bounds[j].first) {
+                            bounds[j].first = target;
+                            changed = true;
+                        }
+                    }
+                    // j << k detectable: k cannot finish before j starts.
+                    if (bounds[k].first + min_len[k] > bounds[j].second) {
+                        auto target = max(bounds[k].second - min_len[j], bounds[j].first - 1);
+                        if (target < bounds[j].second) {
+                            bounds[j].second = target;
+                            changed = true;
+                        }
+                    }
+                }
+                if (bounds[j].first > bounds[j].second)
+                    return nullopt;
+            }
+        }
+        return bounds;
+    }
+
+    auto fail(const string & message) -> void
+    {
+        println(cerr, "disjunctive precedences test failure: {}", message);
+        std::exit(EXIT_FAILURE);
+    }
+
+    // A full enumeration against brute force, with the proof verified. This is
+    // the soundness net: a bug in the rule removes solutions.
+    auto check_enumeration(const string & what, const Instance & inst, DisjunctiveRules rules, const optional<string> & proof_name) -> void
+    {
+        print(cerr, "disjunctive precedences {}{} starts={} lens={}{}", what, inst.strict ? " strict" : " nonstrict", inst.start_ranges,
+            inst.length_specs, proof_name ? " with proofs:" : ":");
+        cerr << flush;
+
+        vector<pair<int, int>> all_ranges = inst.start_ranges;
+        for (size_t i = 0; i < inst.start_ranges.size(); ++i)
+            if (is_variable_length(inst, i))
+                all_ranges.push_back(inst.length_specs[i]);
+
+        set<vector<int>> expected, actual;
+        build_expected(expected, [&](const vector<int> & vals) { return is_satisfying(inst, vals); }, all_ranges);
+        println(cerr, " expecting {} solutions", expected.size());
+
+        Problem p;
+        auto posted = post(p, inst, rules);
+        solve_for_tests(p, proof_name, actual, tuple{posted.all_vars});
+        check_results(proof_name, expected, actual);
+    }
+
+    auto read_file(const string & name) -> string
+    {
+        ifstream in{name, std::ios::binary};
+        if (! in)
+            fail("could not read " + name);
+        return string{std::istreambuf_iterator<char>{in}, std::istreambuf_iterator<char>{}};
+    }
+
+    // The OPB is the statement being verified, and nothing detectable
+    // precedences do may reach it: every fact the rule establishes is a
+    // derivation inside the proof. So the model must come out byte-identical
+    // however the rule is configured --- including under a mutation, which is
+    // proof-only too.
+    //
+    // VeriPB will happily verify a correct proof of the wrong model, so this is
+    // not a tidiness check: an inference that quietly became a model axiom
+    // would leave every proof in this file verifying and prove nothing about
+    // the solver.
+    auto check_opb_unaffected(const string & what, const Instance & inst) -> void
+    {
+        const string on = "disjunctive_precedences_opb_on", off = "disjunctive_precedences_opb_off", mutated = "disjunctive_precedences_opb_mutated";
+
+        solve_root_only(inst, DisjunctiveRules{}, disjunctive_proof_mutation::None{}, on);
+        solve_root_only(inst, DisjunctiveRules{.time_table = true, .detectable_precedences = false}, disjunctive_proof_mutation::None{}, off);
+        solve_root_only(inst, DisjunctiveRules{}, disjunctive_proof_mutation::SkipRefutation{}, mutated);
+
+        auto with_rule = read_file(on + ".opb");
+        if (with_rule != read_file(off + ".opb"))
+            fail("OPB differs with and without detectable precedences, on " + what);
+        if (with_rule != read_file(mutated + ".opb"))
+            fail("OPB differs under a proof mutation, on " + what);
+
+        for (const auto & name : {on, off, mutated})
+            dispose_of_proof_files(name);
+    }
+}
+
+auto main(int argc, char * argv[]) -> int
+{
+    establish_and_announce_seed(argc, argv);
+
+    const DisjunctiveRules all_rules{};
+    const DisjunctiveRules no_precedences{.time_table = true, .detectable_precedences = false};
+    // Isolate the precedence reasoning: with time-tabling off, any bound the
+    // propagator moves was moved by a detected precedence.
+    const DisjunctiveRules only_precedences{.time_table = false, .detectable_precedences = true};
+
+    auto proofs = can_run_veripb();
+
+    // The sharp-margin fixture. Task 0 runs for 3 units somewhere in [0, 3],
+    // task 1 for 3 units somewhere in [1, 10]. Neither has a mandatory part ---
+    // task 0's [3, 3) and task 1's [10, 4) are both empty --- so time-tabling
+    // has nothing to say at all.
+    //
+    // But task 1 cannot finish before task 0 starts: it cannot end before
+    // 1 + 3 = 4, and task 0 must start by 3. So 0 << 1, and task 1 starts no
+    // earlier than task 0's earliest end, 0 + 3 = 3.
+    //
+    // The margin is exactly one on both counts: detection has 4 against 3 + 1,
+    // and s_1 = 3 is still feasible, so a push to 4 would be false.
+    const Instance sharp{{{0, 3}, {1, 10}}, {{3, 3}, {3, 3}}};
+
+    // A fixture whose pushes all happen during search: no precedence is
+    // detectable at the root here (task 1 cannot end before 4, and task 0 need
+    // not start until 4), but once search raises lb(s_1) to 2, task 1 cannot end
+    // before 5 while task 0 must start by 4, so 0 << 1 and task 0 must finish by
+    // task 1's latest start. Every bound the pushes cite is then a search bound.
+    const Instance deep{{{-3, 4}, {1, 4}}, {{1, 1}, {3, 3}}};
+
+    // The fixture the mutation lanes corrupt, which is deliberately *not*
+    // `sharp`, and the reason is worth recording: on `sharp`, dropping either
+    // one of the two pols still verifies. Whether the closing RUP needs them
+    // both is a property of the particular arithmetic --- unit propagation over
+    // the operands' bit encodings sometimes closes the gap on its own --- and
+    // the propagator cannot cheaply tell which case it is in, so it always emits
+    // both, exactly as time-tabling's push chains do. A mutation lane needs a
+    // fixture where that is visible.
+    //
+    // Task 0 runs for 5 units in [7, 8], task 1 for 3 units in [6, 18]. Task 1
+    // cannot end before 6 + 3 = 9 while task 0 must start by 8, so 0 << 1, and
+    // task 1 starts no earlier than task 0's earliest end, 7 + 5 = 12. The
+    // margin is one on both counts: detection has 9 against 8 + 1, and s_1 = 12
+    // is feasible (task 0 at 7), so a push to 13 would be false. Every mutation
+    // below is rejected here, the one that weakens a cited bound by one
+    // included.
+    const Instance tight{{{7, 8}, {6, 18}}, {{5, 5}, {3, 3}}};
+
+    // Mutation mode: emit one deliberately corrupted proof of `tight` and stop,
+    // for run_test_and_expect_verify_failure.bash to hand to veripb.
+    // Time-tabling is off so every justification in the proof is a precedence
+    // push's, and the solve enumerates, so the proof is a complete enumeration
+    // however the derivation was corrupted. Branching here is the default, not
+    // the seeded random one, so the lanes are reproducible.
+    {
+        optional<DisjunctiveProofMutation> mutation;
+        string proof_basename = "disjunctive_precedences_mutation";
+        for (int a = 1; a < argc; ++a) {
+            string arg = argv[a];
+            if (arg == "--mutate=emit_nothing")
+                mutation = disjunctive_proof_mutation::EmitNothing{};
+            else if (arg == "--mutate=skip_refutation")
+                mutation = disjunctive_proof_mutation::SkipRefutation{};
+            else if (arg == "--mutate=skip_fold")
+                mutation = disjunctive_proof_mutation::SkipTargetFold{};
+            else if (arg == "--mutate=loose_bound")
+                mutation = disjunctive_proof_mutation::LooseDetectionBound{};
+            else if (arg == "--mutate=one_too_far")
+                mutation = disjunctive_proof_mutation::PushOneTooFar{};
+            else if (arg == "--proof-files-basename" && a + 1 < argc)
+                proof_basename = argv[++a];
+        }
+
+        if (mutation) {
+            Problem p;
+            post(p, tight, only_precedences, *mutation);
+            solve_with(p, SolveCallbacks{.solution = [&](const CurrentState &) -> bool { return true; }},
+                make_optional<ProofOptions>(ProofFileNames{proof_basename}));
+            if (count_markers(proof_basename).total() == 0)
+                fail("mutation mode: no precedence push was justified, so the proof is empty");
+            println(cerr, "wrote a deliberately corrupted proof to {}.pbp", proof_basename);
+            return EXIT_SUCCESS;
+        }
+    }
+
+    // The sharp fixture, and the claim that time-tabling cannot reach its
+    // conclusion. This is the whole point of the rule: it prunes where
+    // time-tabling is silent.
+    {
+        auto with_rule = probe_root(sharp, all_rules, proofs ? make_optional("disjunctive_precedences_sharp") : nullopt);
+        if (with_rule.refuted)
+            fail("sharp: refuted at the root, but it is satisfiable");
+        if (with_rule.start_bounds.at(1).first != 3)
+            fail("sharp: expected lb(s_1) = 3 at the root, got " + std::to_string(with_rule.start_bounds.at(1).first));
+        if (proofs && with_rule.markers.lb != 1)
+            fail("sharp: expected exactly one lb push marker, got " + std::to_string(with_rule.markers.lb));
+        if (proofs && with_rule.markers.ub != 0)
+            fail("sharp: an upper bound was pushed where nothing forces one");
+
+        auto without_rule = probe_root(sharp, no_precedences, nullopt);
+        if (without_rule.start_bounds != sharp.start_ranges)
+            fail("sharp: time-tabling alone moved a bound, so the fixture proves nothing");
+    }
+
+    // The mirror image, on an upper bound. Task 1 runs for 3 units somewhere
+    // in [4, 7], so it cannot end before 7; task 0 must start by 6, so task 1
+    // cannot finish before task 0 starts and 0 << 1. Task 0 must therefore
+    // finish by task 1's latest start, putting s_0 at 7 - 3 = 4 at the latest.
+    // Both mandatory parts are again empty, so time-tabling says nothing.
+    const Instance sharp_ub{{{0, 6}, {4, 7}}, {{3, 3}, {3, 3}}};
+
+    {
+        auto with_rule = probe_root(sharp_ub, all_rules, proofs ? make_optional("disjunctive_precedences_sharp_ub") : nullopt);
+        if (with_rule.refuted)
+            fail("sharp_ub: refuted at the root, but it is satisfiable");
+        if (with_rule.start_bounds.at(0).second != 4)
+            fail("sharp_ub: expected ub(s_0) = 4 at the root, got " + std::to_string(with_rule.start_bounds.at(0).second));
+        if (proofs && with_rule.markers.ub != 1)
+            fail("sharp_ub: expected exactly one ub push marker, got " + std::to_string(with_rule.markers.ub));
+
+        auto without_rule = probe_root(sharp_ub, no_precedences, nullopt);
+        if (without_rule.start_bounds != sharp_ub.start_ranges)
+            fail("sharp_ub: time-tabling alone moved a bound, so the fixture proves nothing");
+    }
+
+    // A negative twin: the same two tasks, short enough that neither ordering
+    // is forced. Nothing may be pushed and no marker may appear.
+    const Instance twin{{{0, 3}, {1, 10}}, {{1, 1}, {1, 1}}};
+
+    {
+        auto probe = probe_root(twin, all_rules, proofs ? make_optional("disjunctive_precedences_twin") : nullopt);
+        if (probe.start_bounds != twin.start_ranges)
+            fail("twin: a bound moved where no precedence is detectable");
+        if (proofs && probe.markers.total() != 0)
+            fail("twin: a push was justified where no precedence is detectable");
+    }
+
+    // A chain of three, where the pushes compose: 0 << 1 pushes task 1 up to
+    // 3, which is what makes 1 << 2 (detectable from the start) worth
+    // anything, pushing task 2 up to 6. No mandatory part appears at any
+    // point, so time-tabling stays silent throughout and every bound that
+    // moves was moved by this rule.
+    const Instance chain{{{0, 3}, {1, 6}, {4, 12}}, {{3, 3}, {3, 3}, {3, 3}}};
+
+    {
+        auto with_rule = probe_root(chain, all_rules, proofs ? make_optional("disjunctive_precedences_chain") : nullopt);
+        if (with_rule.refuted)
+            fail("chain: refuted at the root, but it is satisfiable");
+        auto oracle = oracle_precedence_fixpoint(chain);
+        if (! oracle || with_rule.start_bounds != *oracle)
+            fail("chain: the root bounds are not the rule's fixpoint");
+        if (with_rule.start_bounds.at(1).first != 3 || with_rule.start_bounds.at(2).first != 6)
+            fail("chain: expected lb(s_1) = 3 and lb(s_2) = 6 at the root");
+        if (proofs && with_rule.markers.total() != 2)
+            fail("chain: expected exactly two pushes, got " + std::to_string(with_rule.markers.total()));
+
+        auto without_rule = probe_root(chain, no_precedences, nullopt);
+        if (without_rule.start_bounds != chain.start_ranges)
+            fail("chain: time-tabling alone moved a bound, so the fixture proves nothing");
+    }
+
+    // A contradiction reached by the rule alone: task 1 has nowhere left to go
+    // once 0 << 1 pushes it past its own upper bound.
+    const Instance refuted{{{0, 3}, {1, 2}}, {{3, 3}, {3, 3}}};
+
+    {
+        auto with_rule = probe_root(refuted, only_precedences, proofs ? make_optional("disjunctive_precedences_refuted") : nullopt);
+        if (! with_rule.refuted)
+            fail("refuted: the rule did not refute at the root");
+        if (proofs && with_rule.markers.total() != 1)
+            fail("refuted: expected exactly one push marker, got " + std::to_string(with_rule.markers.total()));
+    }
+
+    // Pushes made against search bounds rather than root ones: nothing is
+    // detectable at the root here, so every push in the proof cites a bound
+    // search established, and the whole thing verifies as a complete
+    // enumeration.
+    {
+        auto root = probe_root(deep, only_precedences, nullopt);
+        if (root.start_bounds != deep.start_ranges)
+            fail("deep: a bound moved at the root, so the fixture is not testing search-state bounds");
+
+        auto name = "disjunctive_precedences_deep";
+        Problem p;
+        post(p, deep, only_precedences);
+        size_t solutions = 0;
+        solve_with(p, SolveCallbacks{.solution = [&](const CurrentState &) -> bool {
+            ++solutions;
+            return true;
+        }},
+            proofs ? make_optional<ProofOptions>(ProofFileNames{name}) : nullopt);
+        if (solutions == 0)
+            fail("deep: no solutions, but the fixture is satisfiable");
+        if (proofs) {
+            if (count_markers(name).total() == 0)
+                fail("deep: no precedence push anywhere in the search, so the fixture tests nothing");
+            verify_proof_and_clean_up(name);
+        }
+    }
+
+    // The mutation fixture, honestly derived: one push at the root, by a margin
+    // of one, and the proof the lanes below corrupt verifies before they do.
+    {
+        auto with_rule = probe_root(tight, only_precedences, proofs ? make_optional("disjunctive_precedences_tight") : nullopt);
+        if (with_rule.refuted)
+            fail("tight: refuted at the root, but it is satisfiable");
+        if (with_rule.start_bounds.at(1).first != 12)
+            fail("tight: expected lb(s_1) = 12 at the root, got " + std::to_string(with_rule.start_bounds.at(1).first));
+        if (proofs && with_rule.markers.lb != 1)
+            fail("tight: expected exactly one lb push marker, got " + std::to_string(with_rule.markers.lb));
+    }
+
+    // Variable durations, strict and non-strict. The pols cite lb(l) for a
+    // variable duration, and in non-strict mode every variable-duration task
+    // carries a zero-length escape flag that the justification has to pin
+    // false before the separation clause is usable.
+    for (auto strict : {true, false}) {
+        Instance var{{{0, 3}, {1, 10}}, {{3, 4}, {3, 4}}, strict};
+        auto label = strict ? "var_strict" : "var_nonstrict";
+        auto with_rule = probe_root(var, all_rules, proofs ? make_optional("disjunctive_precedences_" + string{label}) : nullopt);
+        if (with_rule.refuted)
+            fail(string{label} + ": refuted at the root, but it is satisfiable");
+        if (with_rule.start_bounds.at(1).first != 3)
+            fail(string{label} + ": expected lb(s_1) = 3 at the root");
+        if (proofs && with_rule.markers.lb != 1)
+            fail(string{label} + ": expected exactly one lb push marker");
+    }
+
+    // Oracle cross-check. Over a random corpus, with time-tabling off so that
+    // every bound the propagator moves was moved by this rule, the root bounds
+    // must be exactly the rule's own fixpoint --- which catches both
+    // under- and over-firing. Durations are all positive, so the strict-mode
+    // zero-length check cannot fire and confuse the comparison.
+    {
+        std::mt19937 rand(*get_seed());
+        // Start domains reach below zero: a push then lands on the order
+        // literals of a signed bit encoding (issue #553's shape).
+        std::uniform_int_distribution<> n_dist(2, 4), lo_dist(-4, 6), span_dist(0, 6), len_dist(1, 4);
+
+        size_t fired = 0, verified = 0;
+        for (int k = 0; k < 250; ++k) {
+            Instance inst;
+            auto n = n_dist(rand);
+            for (int i = 0; i < n; ++i) {
+                auto lo = lo_dist(rand), span = span_dist(rand);
+                inst.start_ranges.emplace_back(lo, lo + span);
+                auto len = len_dist(rand);
+                inst.length_specs.emplace_back(len, len);
+            }
+
+            auto oracle = oracle_precedence_fixpoint(inst);
+            // A bound moved without the instance being refuted, which is the
+            // case a marker must be attributable to: a refutation may equally
+            // have come from the always-on mandatory-overlap scan, which is not
+            // this rule and leaves no marker.
+            auto pushed = oracle && *oracle != inst.start_ranges;
+            // Verify a proof for the first few interesting instances rather than
+            // all of them: the cross-check is about which bounds move, and the
+            // fixtures above are where the derivation itself is scrutinised.
+            auto name =
+                ((pushed || ! oracle) && verified < 12) ? make_optional("disjunctive_precedences_oracle_" + std::to_string(verified)) : nullopt;
+            auto probe = probe_root(inst, only_precedences, proofs ? name : nullopt);
+
+            if (probe.refuted != ! oracle.has_value()) {
+                println(cerr, "oracle disagreement on starts={} lens={}: oracle refutes {}, propagator refutes {}", inst.start_ranges,
+                    inst.length_specs, ! oracle.has_value(), probe.refuted);
+                fail("oracle cross-check (refutation)");
+            }
+            if (oracle && probe.start_bounds != *oracle) {
+                println(cerr, "oracle disagreement on starts={} lens={}: oracle says {}, propagator says {}", inst.start_ranges, inst.length_specs,
+                    *oracle, probe.start_bounds);
+                fail("oracle cross-check (bounds)");
+            }
+            if (name)
+                ++verified;
+            if (pushed) {
+                ++fired;
+                if (proofs && name && probe.markers.total() == 0)
+                    fail("oracle cross-check: a push left no marker");
+            }
+
+            // The rule must not cost solutions, whatever the oracle says.
+            check_enumeration("random_" + std::to_string(k), inst, all_rules, nullopt);
+        }
+
+        if (fired == 0)
+            fail("oracle cross-check: nothing in the corpus had a detectable precedence, so nothing was compared");
+        println(cerr, "oracle cross-check: {} of 250 instances had a bound pushed at the root", fired);
+    }
+
+    // Two tasks sharing one start variable, which is UNSAT for positive
+    // durations: each pair is still encoded, so the rule can detect a
+    // precedence between a variable and itself and must not fall over.
+    {
+        Problem p;
+        auto shared = p.create_integer_variable(0_i, 3_i);
+        auto other = p.create_integer_variable(1_i, 10_i);
+        vector<IntegerVariableID> starts{shared, shared, other};
+        p.post(Disjunctive{starts, vector<Integer>{3_i, 3_i, 3_i}}.with_rules(only_precedences));
+
+        auto name = "disjunctive_precedences_dup";
+        bool reached_a_node = false, found_a_solution = false;
+        solve_with(p,
+            SolveCallbacks{.solution = [&](const CurrentState &) -> bool {
+                               found_a_solution = true;
+                               return false;
+                           },
+                .trace = [&](const CurrentState &) -> bool {
+                    reached_a_node = true;
+                    return false;
+                }},
+            proofs ? make_optional<ProofOptions>(ProofFileNames{name}) : nullopt);
+        if (found_a_solution)
+            fail("dup: two length-three tasks sharing a start cannot both be scheduled");
+        if (proofs) {
+            (void)reached_a_node;
+            verify_proof_and_clean_up(name);
+        }
+    }
+
+    // Nothing this rule does may reach the model.
+    {
+        check_opb_unaffected("sharp", sharp);
+        check_opb_unaffected("sharp_ub", sharp_ub);
+        check_opb_unaffected("chain", chain);
+        check_opb_unaffected("deep", deep);
+        check_opb_unaffected("tight", tight);
+
+        std::mt19937 rand(*get_seed());
+        std::uniform_int_distribution<> n_dist(2, 4), lo_dist(-2, 4), span_dist(0, 4), len_dist(0, 3);
+        for (int k = 0; k < 20; ++k) {
+            Instance inst;
+            auto n = n_dist(rand);
+            for (int i = 0; i < n; ++i) {
+                auto lo = lo_dist(rand), span = span_dist(rand);
+                inst.start_ranges.emplace_back(lo, lo + span);
+                auto len = len_dist(rand);
+                inst.length_specs.emplace_back(len, len);
+            }
+            check_opb_unaffected("random_" + std::to_string(k), inst);
+        }
+    }
+
+    // The solutions must survive the new rule, with the proof verified.
+    check_enumeration("sharp", sharp, all_rules, proofs ? make_optional("disjunctive_precedences_enum_sharp") : nullopt);
+    check_enumeration("sharp_ub", sharp_ub, all_rules, proofs ? make_optional("disjunctive_precedences_enum_sharp_ub") : nullopt);
+    check_enumeration("twin", twin, all_rules, proofs ? make_optional("disjunctive_precedences_enum_twin") : nullopt);
+    check_enumeration("chain", chain, all_rules, proofs ? make_optional("disjunctive_precedences_enum_chain") : nullopt);
+    check_enumeration("refuted", refuted, all_rules, proofs ? make_optional("disjunctive_precedences_enum_refuted") : nullopt);
+    check_enumeration("deep", deep, all_rules, proofs ? make_optional("disjunctive_precedences_enum_deep") : nullopt);
+    check_enumeration("tight", tight, all_rules, proofs ? make_optional("disjunctive_precedences_enum_tight") : nullopt);
+    // The mutation lanes' own configuration, enumerated honestly. This is also
+    // where a rule selection that stopped the propagator checking its own
+    // solutions would be caught: with time-tabling's pushes off, the
+    // mandatory-overlap scan is the only thing rejecting an overlapping leaf,
+    // and if it were gated too this enumeration would report solutions that are
+    // not.
+    check_enumeration("tight_precedences_only", tight, only_precedences, proofs ? make_optional("disjunctive_precedences_enum_tight_only") : nullopt);
+    for (auto strict : {true, false}) {
+        Instance var{{{0, 3}, {1, 6}}, {{3, 4}, {0, 3}}, strict};
+        check_enumeration(strict ? "var_strict" : "var_nonstrict", var, all_rules,
+            proofs ? make_optional("disjunctive_precedences_enum_var_" + string{strict ? "strict" : "nonstrict"}) : nullopt);
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/gcs/constraints/innards/disjunctive_mutations.hh
+++ b/gcs/constraints/innards/disjunctive_mutations.hh
@@ -1,0 +1,93 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_INNARDS_DISJUNCTIVE_MUTATIONS_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_INNARDS_DISJUNCTIVE_MUTATIONS_HH
+
+#include <variant>
+
+/**
+ * \file
+ *
+ * Deliberate corruptions of `Disjunctive`'s detectable-precedence proof steps,
+ * which exist so that a test can show the honest derivation is tight to what it
+ * claims. They live here, in the innards, rather than beside the constraint they
+ * corrupt: a header a user of the library includes should not advertise a way to
+ * make the solver emit deliberately wrong proofs. Same reason as
+ * `cumulative_mutations.hh`, and issue #669.
+ */
+
+namespace gcs::innards
+{
+    /**
+     * \brief Deliberate corruptions of the detectable-precedence derivation,
+     * for testing only.
+     *
+     * A proof that verifies is necessary but not sufficient: if the honest
+     * derivation has slack in it, a wrong one verifies too, and the rule's
+     * reasoning is then not being checked by anything. Each of these breaks one
+     * step of the emitted derivation in a way that must make VeriPB *reject* the
+     * proof; a mutation that still verifies is a finding about the honest
+     * derivation, not about the mutation.
+     *
+     * A detectable precedence is a bound *push*, so — unlike a conflict-shaped
+     * rule, where the reason context is already contradictory and every later
+     * RUP is vacuously valid — corrupting the route to the conclusion is a real
+     * test here as well as corrupting the conclusion. The two halves of the
+     * derivation are separately droppable, and each drop must be caught.
+     *
+     * All but \ref disjunctive_proof_mutation::PushOneTooFar change nothing but
+     * the proof: the same bounds are pushed, the same solutions reported, and
+     * the OPB is untouched. PushOneTooFar necessarily changes the inference,
+     * since making the conclusion false is the whole point of it.
+     *
+     * \ingroup Innards
+     */
+    namespace disjunctive_proof_mutation
+    {
+        /// Emit the honest derivation.
+        struct None
+        {
+        };
+
+        /// Emit no pols at all, leaving the push to the framework's wrapping
+        /// RUP. Not a corruption but a control: if VeriPB accepts this, the
+        /// derivation is decoration and no mutation of it can be caught.
+        struct EmitNothing
+        {
+        };
+
+        /// Skip the pol that refutes the reverse precedence, so nothing rules
+        /// out the successor finishing first and the separation clause never
+        /// forces the surviving direction.
+        struct SkipRefutation
+        {
+        };
+
+        /// Skip the pol that folds the surviving precedence onto the target
+        /// order literal, so the push has no route from "the predecessor
+        /// finishes first" to a bound on the successor's start.
+        struct SkipTargetFold
+        {
+        };
+
+        /// Cite a running bound one unit weaker than the reason supports, so
+        /// the refutation pol is one unit short of detecting the precedence.
+        /// On a margin-of-one instance that is exactly the difference between
+        /// a clause and a triviality.
+        struct LooseDetectionBound
+        {
+        };
+
+        /// Push the bound one unit past where the detected precedence puts it,
+        /// which is false. The "bound + 1 must fail" check for this rule:
+        /// it corrupts the conclusion rather than the route to it, which is
+        /// what a margin of exactly one unit is there to expose.
+        struct PushOneTooFar
+        {
+        };
+    }
+
+    using DisjunctiveProofMutation =
+        std::variant<disjunctive_proof_mutation::None, disjunctive_proof_mutation::EmitNothing, disjunctive_proof_mutation::SkipRefutation,
+            disjunctive_proof_mutation::SkipTargetFold, disjunctive_proof_mutation::LooseDetectionBound, disjunctive_proof_mutation::PushOneTooFar>;
+}
+
+#endif


### PR DESCRIPTION
Step 2 of #729, and it closes #731.

The precedence `k ≪ j` is *detectable* when `j` cannot finish before `k` starts on bounds alone, `lb(s_j) + lb(l_j) > ub(s_k)`. Then `before_{j,k}` is false, the separation clause forces `before_{k,j}`, and reading that both ways round pushes `s_j` up to k's earliest end and `s_k` down to j's latest start less `l_k`.

## The proof needed nothing new

#731 guessed this would be cheap because the conclusion is a statement about `before` flags. It is cheaper than that: **the justification is one step of the time-tabling push chain that was already there**, with `final = true` and no deposit — one pol refuting the reverse precedence from the running bound, one folding the surviving precedence onto the target order literal.

The detection condition is *precisely* the condition under which the refuting pol's degree comes out positive, and it is also the condition a chain step's blocker satisfies. So the two rules differ only in what the propagator has to notice: a chain step's blocker is picked by scanning the load profile, so it must have a non-empty mandatory part, while the pol arithmetic never cared whether it did. That is exactly where the extra strength is — **a detected predecessor whose mandatory part is empty is invisible to time-tabling and prunes here**.

This is the pairwise rule, pushing to `max_k eet_k` over the detected predecessors, not Vilím's set-based `ect(Ω)`. The set form is an energy statement about a set, so it is #730's problem rather than a variation on this one; the doc's follow-ups say so.

## Measured

Generated RCPSP with a unary machine (`--size 15 --machine disjunctive --machine-fraction 0.8`), 120 s limit. The seven of twelve seeds that close:

| seed | recursions | propagations | wall (s) |
|---|---|---|---|
| 1 | 1603 → 1599 | — | 0.0005 → 0.001 |
| 3 | 4,005,639 → 3,852,301 | 34.9M → 29.0M | 17.9 → 16.6 |
| 5 | 71,885 → 48,200 | 796k → 443k | 0.35 → 0.37 |
| 6 | 185,865 → 131,451 | 2.13M → 1.31M | 1.40 → 0.85 |
| 9 | 5,423,910 → 4,594,710 | 73.3M → 41.0M | 32.4 → 23.6 |
| 11 | 20,628,596 → 17,694,500 | 224.7M → 145.2M | 102.6 → 80.4 |
| 12 | 12,081,982 → 12,012,733 | 119.8M → 116.5M | 57.2 → 56.1 |

The five that time out reach the same best makespan (one reaches a better one), having explored more nodes for fewer propagations. On the MiniZinc `rcpsp/data_pack` instances, where almost every resource has capacity above one and so is a `Cumulative`, it is within noise: same makespans, differences under 1%.

The rule is live in real models with proofs on — a 2 GB RCPSP proof over a unary machine carried 982,065 pushes.

## Two things worth reading the diff for

**The mandatory-overlap contradiction is deliberately not selectable.** `DisjunctiveRules` switches time-tabling's *pushes* and detectable precedences independently, as `CumulativeRules` does, but the overlap scan always runs: at an all-fixed leaf it is what makes the propagator a checker, and gating it would not weaken propagation but report assignments that violate the constraint. Getting that wrong cost a round of results — with it gated, every mutation lane "failed" on a bad solution line rather than on the mutation, so five lanes were passing for entirely the wrong reason until the honest control caught it. `check_enumeration` under `{time_table = false}` is now the test for it.

**Neither pol is load-bearing everywhere.** On the `sharp` fixture, dropping either one of the two pols still verifies: unit propagation over the operands' bit encodings closes the gap by itself. Whether it can is a property of the particular arithmetic, not of the rule, and the propagator cannot cheaply tell which case it is in — so it emits both, as the push chains do. The mutation lanes therefore run on a separate `tight` fixture where each half is needed. The fixture that best *demonstrates* the rule and the fixture that makes its derivation *tight* are not the same fixture, and both are in the test.

## Testing

`disjunctive_precedences_test`, plus five mutation lanes. Fixtures with marker-count assertions, each with a twin run showing time-tabling alone moves nothing; an oracle that is the rule written out from its definition and iterated to a fixpoint, cross-checked against the root bounds over a 250-instance random corpus (both under- and over-firing, not just unsoundness); OPB byte-identical across every rule and mutation setting; enumeration against brute force with the proofs verified, including variable durations in strict and non-strict mode. All five mutations are rejected by VeriPB and the honest proof of the same fixture verifies.

Green under GCC 15 and clang 21, full `ctest` (542 tests) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018FizeTcjBnMJqmqLWZz4qd