### PR TITLE
disjunctive: optional tasks, natively rather than by riding optional Cumulative

### DIFF
--- a/dev_docs/disjunctive-proof-logging.md
+++ b/dev_docs/disjunctive-proof-logging.md
@@ -415,5 +415,18 @@ would take from *this* encoding:
 - **Optional tasks for `Disjunctive2D`.** The 1D form has them
   (#735, above); the 2D 4-way separation clause would take the same
   two disjuncts per pair, but nothing asks for it yet.
+- **A `cake_pb_cp` encoder for the optional form.** The pairwise
+  encoding matches cake's for the non-optional constraint, which is
+  why disjunctive proofs chain-verify, and the optional form differs
+  from it by two literals per separation clause. Until cake has that,
+  `disjunctive_optional` / `disjunctive_strict_optional` are outside
+  the chain, which is what those names are for.
+- **Conditional pruning for an undecided task.** Its own bounds are
+  never pruned, because there is no conditional-bounds store and an
+  unconditional prune would be unsound if the task turns out absent.
+  The same applies to a precedence conditional on a presence, which
+  would need the presence literals *inside* the pols rather than only
+  in the reason. Both are real propagation left on the table, and
+  `Cumulative` leaves the same amount for the same reason.
 
 <!-- vim: set tw=72 spell spelllang=en : -->

--- a/dev_docs/disjunctive-proof-logging.md
+++ b/dev_docs/disjunctive-proof-logging.md
@@ -40,7 +40,9 @@ For a constant duration the flag's inequality folds to
 `s_i − s_j ≤ −l_i`; for a variable duration the `l_i` term stays on
 the left-hand side. Non-strict mode adds a reified `l_i ≤ 0` escape
 flag (`x[id][i][zw]`) per variable-duration task to the separation
-clause — a zero-length task does not constrain.
+clause — a zero-length task does not constrain. Optional tasks add
+their presence literals to the same clause, and nothing else (see
+below).
 
 ## The pairwise justification vocabulary
 
@@ -97,7 +99,7 @@ encoding maximum) degrade gracefully: `need_gevar` emits trivial
 halves and pins the boundary atom at `ProofLevel::Top`, so the same
 uniform pol works at domain edges and on domain-wiping pushes.
 
-## The four inferences
+## The inferences
 
 - **Mandatory-overflow contradiction.** Two tasks `i`, `j` whose
   mandatory parts overlap at some time. Then neither can finish
@@ -194,7 +196,9 @@ cover, and each step strictly advances.
 
 `DisjunctiveRules` switches time-tabling's pushes and detectable
 precedences on and off independently (both default on). It selects
-propagation strength only: same solutions, same OPB.
+propagation strength only: same solutions, same OPB. Presence
+falsification reads time-tabling's own placement scan, so it is under
+`time_table` with the pushes.
 
 The **mandatory-overlap contradiction is not switchable**. At an
 all-fixed leaf every task's mandatory part is its whole active
@@ -228,6 +232,75 @@ variable — the in-proof end introduction
 (`ProofLogger::introduce_bits_of`) exists for Cumulative's
 time-indexed `after` flags, which Disjunctive's proofs no longer use.
 
+### Optional tasks
+
+An optional task carries a `{0, 1}` presence variable. It reaches the
+encoding in exactly one place — two more disjuncts on the separation
+clause the pair already had:
+
+```
+before_{i,j} + before_{j,i} [+ zw_i + zw_j] + ¬p_i + ¬p_j  ≥ 1
+```
+
+The before-flag reifications stay **unconditional**:
+`before_{i,j} ⇔ s_i + l_i ≤ s_j` whatever the presences. That is the
+design, not an economy. Every justification in this document is a pol
+over those reification rows and the operands' bound-literal definition
+rows, so leaving them alone means **the pols do not change at all**:
+presence surfaces only where the *separation clause* is used, which is
+always the framework's closing reason-wrapped RUP. Each such RUP just
+has two more literals available in its reason. A presence posted as
+the constant 1 resolves to nothing at all (`innards::task_presence`,
+shared with `Cumulative`), so a non-optional model's OPB is unchanged
+byte for byte, and a constant 0 drops the task from the constraint
+entirely.
+
+Propagation follows `Cumulative`'s rules and for its reasons: an
+absent task is dropped; an **undecided** task contributes no mandatory
+part, is in nobody's blocker set, is not a detected predecessor or
+successor, and — the load-bearing part — **its own start bounds are
+never pruned**, because there is no conditional-bounds store and a
+prune valid only if the task is present would be unsound. Reasons
+carry `p_i = 1` as an explicit literal per task known present, rather
+than putting the variable in the reason's variable list: an undecided
+presence has no fact to record, and `generic_reason` would spend an
+order atom saying `0 ≤ p ≤ 1`.
+
+**Presence falsification.** When no start in `dom(s_j)` escapes the
+mandatory parts of the present tasks, `p_j = 0`. The derivation is the
+lb-push chain above, replayed over the *whole* domain, with "or task
+`j` is not here at all" carried as an extra disjunct on every deposit:
+
+```
+[s_j ≥ target] ∨ ¬p_j                (one RUP under reason per step)
+```
+
+so each step reads "either `j` starts later than this, or `j` is not
+here". The last step deposits nothing, exactly as the last step of a
+push does: its target is one past `j`'s upper bound, which the reason
+already refutes, so the closing RUP concludes the presence. The two
+pols per step are the ordinary ones — `emit_lb_chain_step` takes the
+extra disjunct as an argument and changes nothing else.
+
+Falsification is **conflict-shaped**, and that constrains what can
+test it. Once the chain has cornered the task, the reason context
+extended with "the task is present" is contradictory and every RUP
+under it is vacuously valid, so a mutation that merely *shortens* the
+chain is still sound and VeriPB is right to accept it. Corrupting the
+route is not a test; corrupt the destination. Hence the three lanes in
+`innards/disjunctive_mutations.hh`: `WrongTask` (argue about a task
+nothing has cornered), `ClaimOneTooFar` (draw the conclusion where it
+is false, on a fixture with exactly one placement left), and
+`EmitNothing` as the control. `cumulative_mutations.hh` records the
+same finding from the constraint this rule is modelled on.
+
+The strict-mode zero-length check below is where optional tasks meet
+#731's trap in its second form. That check and the mandatory-overlap
+scan are what make the propagator a *checker*, so both use the same
+`is_present` test as the profile: an undecided task that slipped past
+the leaf check would be one whose presence never got fixed, and the
+solver would report it as a solution.
+
 ### Non-strict zero-length escapes
 
 Whenever an inference fires, every involved task has a positive
@@ -249,6 +322,15 @@ declarative pairwise encoding alone is RUP-closable. With `s_z` and
 assignments and the encoded clause `before_{z,k} + before_{k,z} ≥ 1`
 unit-fails. So this contradiction is pure RUP — `JustifyUsingRUP{hints::Disjunctive{owner}}`
 (the typed hint is inert in proofs-off mode; the justification is still a bare RUP).
+
+With optional tasks the clause carries the pair's presence disjuncts
+too, so both tasks have to be *known present* for it to unit-fail —
+which is also the semantics, since an absent task sits wherever it
+likes. This is the only certified route to a strict optional
+disjunctive: a task consuming nothing for no time is invisible to a
+resource profile, so nothing built on `Cumulative` can express it, and
+MiniZinc's `fzn_disjunctive_strict_opt` had no solver redefinition at
+all before #735.
 
 ## 2D non-overlap (`Disjunctive2D` / `diffn`)
 
@@ -330,8 +412,8 @@ would take from *this* encoding:
 - **Not-first / not-last, and edge-finding** (#732, #733). The first
   genuinely set-based *pruning* rules, and they need whatever the
   overload check settles on first.
-- **Optional tasks (`*_opt`).** A presence flag per task gates the
-  encoded pairwise clauses; the pairwise pols would carry the
-  presence literals as extra residuals.
+- **Optional tasks for `Disjunctive2D`.** The 1D form has them
+  (#735, above); the 2D 4-way separation clause would take the same
+  two disjuncts per pair, but nothing asks for it yet.
 
 <!-- vim: set tw=72 spell spelllang=en : -->

--- a/dev_docs/frontend-support-matrix.md
+++ b/dev_docs/frontend-support-matrix.md
@@ -47,9 +47,9 @@ equivalent for that frontend's vocabulary).
 | maximum / minimum (constraint) | `ArrayMax` / `ArrayMin` | ✓ | ✓ (basic with `XCondition`; indexed form pending) | ? |
 | element | `Element` / `Element2D` | ✓ | ✓ (1D vector and constant-list; 2D matrix variable + constant) | ? |
 | channel (inverse) | `Inverse` | ✓ | ✓ (1- and 2-list inverse; one-to-many form `s UNSUPPORTED`) | ? |
-| noOverlap (Disjunctive) | `Disjunctive` (1D, var durations) / `Disjunctive2D` (2D, var sizes)[^disj] | ✓ (1D + 2D `diffn`, var durations/sizes) | ✓ (1D + 2D, var durations/sizes) | ? |
+| noOverlap (Disjunctive) | `Disjunctive` (1D, var durations, optional tasks) / `Disjunctive2D` (2D, var sizes)[^disj] | ✓ (1D + 2D `diffn`, var durations/sizes; `fzn_disjunctive_opt` and `fzn_disjunctive_strict_opt`) | ✓ (1D + 2D, var durations/sizes) | ? |
 | cumulative | `Cumulative`[^cum] | ✓ (var s/d/r/b) | ✓ (var s/d/r/b) | ? |
-| cumulative, optional tasks | `Cumulative` presence form[^cumopt] | ✓ (`fzn_cumulative_opt`, and `fzn_disjunctive_opt` riding it) | n/a — no such form in XCSP3 | ? |
+| cumulative, optional tasks | `Cumulative` presence form[^cumopt] | ✓ (`fzn_cumulative_opt`) | n/a — no such form in XCSP3 | ? |
 | binPacking | `BinPacking` (per-bin GAC)[^bp] | ✓ (`fzn_bin_packing` / `_capa` / `_load`) | ✓ (signatures 1/2/3; per-bin condition list `s UNSUPPORTED`) | ? |
 | knapsack | `Knapsack` | ✓ | ✓ (basic with two `XCondition`s; not yet exercised by a test) | ? |
 | circuit | `Circuit` | ✓ | ✓ (basic; sub-circuit with size param `s UNSUPPORTED`); semantics mismatch with XCSP3 spec, see #167 | ? |
@@ -81,7 +81,7 @@ addressed.
 
 ## Solver gaps tracked elsewhere
 
-- [#146](https://github.com/ciaranm/glasgow-constraint-solver/issues/146) — `Disjunctive`: 1D shipped (variable starts, constant *or* variable durations, strict and non-strict incl. zero-length escape; variable durations via the Cumulative end-proxy technique, fully VeriPB-certified — see #384). `Disjunctive2D` (2D `noOverlap` / `diffn`) shipped: variable origins, constant *or* variable sizes (rotation), strict and non-strict (incl. zero-area sizes via a reified zero-size escape clause), pairwise time-table strength, fully VeriPB-certified. k-D, optional tasks, and a sweep / cumulative-relaxation propagator are open follow-ups under the same issue.
+- [#146](https://github.com/ciaranm/glasgow-constraint-solver/issues/146) — `Disjunctive`: 1D shipped (variable starts, constant *or* variable durations, strict and non-strict incl. zero-length escape; variable durations via the Cumulative end-proxy technique, fully VeriPB-certified — see #384). `Disjunctive2D` (2D `noOverlap` / `diffn`) shipped: variable origins, constant *or* variable sizes (rotation), strict and non-strict (incl. zero-area sizes via a reified zero-size escape clause), pairwise time-table strength, fully VeriPB-certified. 1D optional tasks shipped (#735). k-D, 2D optional tasks, and a sweep / cumulative-relaxation propagator are open follow-ups under the same issue.
 - [#147](https://github.com/ciaranm/glasgow-constraint-solver/issues/147) — `Cumulative`: full `cumulative(var s, var d, var r, var b)` shipped with time-table propagation and VeriPB proofs (the `(le, int)` and `(le, var)` XCSP3 conditions). Edge-finding and energetic (stronger-than-time-table) propagation are open follow-ups under the same issue.
 - [#148](https://github.com/ciaranm/glasgow-constraint-solver/issues/148) — `BinPacking`: Stage 1 (checker), Stage 2 (per-bin bounds), and Stage 3 (per-bin partial-load DAG, per-bin GAC) all shipped. Open follow-ups: Shaw-style cardinality reasoning to push beyond per-bin towards (still-not-joint) joint GAC ([#209](https://github.com/ciaranm/glasgow-constraint-solver/issues/209)), and unification with `MDD` / `Knapsack` under #200. See `bin-packing.md`.
 - [#200](https://github.com/ciaranm/glasgow-constraint-solver/issues/200) — `Knapsack`: the default per-call DP implementation is kept as the default (its proofs verify 3.6–18× faster), with an opt-in upfront-DAG variant `KnapsackUpfront` (Stage 1 checker + Stage 2 full GAC with paper-style proof scaffolding at `ProofLevel::Top`) that produces 3–6× smaller proofs. Open follow-up: factor the layered-DAG infrastructure shared with `MDD` and `BinPacking` into a common framework. See `knapsack.md`.
@@ -97,11 +97,12 @@ addressed.
     [`cumulative-proof-logging.md`](cumulative-proof-logging.md)). MiniZinc
     redefines `fzn_cumulative_opt` to `glasgow_cumulative_opt`, splitting each
     `var opt int` start with `occurs`/`deopt` the way the Gecode and OR-Tools
-    libraries do; `fzn_disjunctive_opt` rides the same builtin at unit demands
-    and capacity 1. `fzn_disjunctive_strict_opt` deliberately does not: strict
-    disjunctive forbids a zero-duration task from sitting inside another, and a
-    task consuming nothing for no time is invisible to a resource profile.
-    XCSP3 defines no optional-task cumulative at all — every
+    libraries do. `fzn_disjunctive_opt` used to ride the same builtin at unit
+    demands and capacity 1, and `fzn_disjunctive_strict_opt` could not ride it
+    at all — strict disjunctive forbids a zero-duration task from sitting
+    inside another, and a task consuming nothing for no time is invisible to a
+    resource profile — so both now go to `Disjunctive`'s own presence form
+    instead (#735, see [^disj]). XCSP3 defines no optional-task cumulative at all — every
     `buildConstraintCumulative` overload in the parser is
     origins/lengths/heights[/ends] plus a condition — so there is nothing to
     map, and the XCSP frontend records that rather than leaving it open.
@@ -110,7 +111,7 @@ addressed.
     that gap is named rather than silently mismatched against the plain
     encoder.
 
-[^disj]: 1D `Disjunctive`: variable starts, constant *or* variable durations, strict/non-strict; time-table specialised to heights=1, capacity=1 (variable durations fold into the pairwise ordering flags directly, with a reified zero-length escape clause in non-strict mode). 2D `Disjunctive2D` (non-overlapping rectangles, variable origins, constant or variable sizes): pairwise time-table — mandatory-box overlap is a contradiction, and a pair forced to overlap on one axis is pushed apart on the other. Both are fully proof-logged pairwise against the declarative OPB encoding ([`disjunctive-proof-logging.md`](disjunctive-proof-logging.md)); 2D adds a 4-way separation clause per pair. Outside the envelope (k-D, optional tasks): XCSP3 raises an unsupported error.
+[^disj]: 1D `Disjunctive`: variable starts, constant *or* variable durations, strict/non-strict; time-table specialised to heights=1, capacity=1 (variable durations fold into the pairwise ordering flags directly, with a reified zero-length escape clause in non-strict mode). 2D `Disjunctive2D` (non-overlapping rectangles, variable origins, constant or variable sizes): pairwise time-table — mandatory-box overlap is a contradiction, and a pair forced to overlap on one axis is pushed apart on the other. Both are fully proof-logged pairwise against the declarative OPB encoding ([`disjunctive-proof-logging.md`](disjunctive-proof-logging.md)); 2D adds a 4-way separation clause per pair. 1D also takes **optional tasks**: a `{0, 1}` presence per task, added to the encoding as two more disjuncts on each pair's separation clause and nowhere else, so a constant-1 presence gives a byte-identical OPB. Absent tasks are dropped; undecided ones join no profile and have their own bounds left alone; a task with nowhere left to go has its presence falsified. MiniZinc reaches it through `fzn_disjunctive_opt` and `fzn_disjunctive_strict_opt`, the second of which nothing built on cumulative could have implemented. `cake_pb_cp` has no encoder for the optional form, so it is outside the verified-encoding chain; `constraint_type()` is `disjunctive_optional` / `disjunctive_strict_optional` so that gap is named rather than silently mismatched against the plain encoder. Outside the envelope (k-D, 2D optional tasks): XCSP3 raises an unsupported error.
 
 [^intaff]: `xcsp_glasgow_constraint_solver.cc` keeps `recognizeSpecialIntensionCases = false`, so every `<intension>` still arrives as one typed tree, but `post_intension_top_level` tries an affine peephole first for `le`, `lt`, `ge` and `gt`. Operands built only from variables, integers, `add`, `sub` and `neg` are folded into a single `LinearLessThanEqual` over the instance's own variables; anything else (a `mul`, a `dist`, …) falls back to the ordinary walk, and `eq` is deliberately excluded, because `Equals` over two variables is domain-consistent and a linear equality is only bounds-consistent. Measured on a 12-variable network of 31 such constraints, the peephole removes 31 auxiliary variables, 64 % of the OPB lines and 72 % of the proof lines.
 

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -61,6 +61,7 @@ add_library(glasgow_constraint_solver
         constraints/innards/recover_am1.cc
         constraints/innards/reified_state.cc
         constraints/innards/tabulation.cc
+        constraints/innards/task_presence.cc
         constraints/innards/triggers.cc
         constraints/innards/window_energy.cc
         constraints/inverse/inverse.cc

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -767,6 +767,21 @@ if(GCS_BUILD_TESTS)
             "GCS_TEST_MAX_SOLUTIONS=${GCS_TEST_MAX_SOLUTIONS};GCS_TEST_MAX_RECURSIONS=${GCS_TEST_MAX_RECURSIONS}")
     endif()
 
+    # Clear the runtime caps for the two lanes whose whole content is comparing
+    # one model's solution *set* against another's. A cap that fires truncates
+    # both sides at different points, and comparing the prefixes tests the
+    # search order rather than the semantics --- there is no independent oracle
+    # here for check_results()'s soundness-only fallback to lean on. Safe to
+    # uncap because these lanes write no proofs at all, and proof size and
+    # VeriPB time are what the caps exist to bound; the instances are 2-3 tasks
+    # over four start values, so the enumeration is bounded by construction. The
+    # test also fails loudly if a cap ever does fire, rather than comparing
+    # prefixes.
+    foreach(mode bijection cumulative)
+        set_property(TEST disjunctive_optional_constraint_${mode} APPEND PROPERTY ENVIRONMENT
+            "GCS_TEST_MAX_SOLUTIONS=;GCS_TEST_MAX_RECURSIONS=")
+    endforeach()
+
     # Pin the linear incremental threshold per test variant: 0 = always incremental,
     # a huge value = always stateless, so CI exercises both linear propagation paths.
     # APPEND so the runtime-cap environment set just above is preserved.

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -279,6 +279,7 @@ if(GCS_BUILD_TESTS)
     add_executable(cumulative_optional_test constraints/cumulative/cumulative_optional_test.cc)
     add_executable(difference_test constraints/difference/difference_constraints_test.cc)
     add_executable(disjunctive_test constraints/disjunctive/disjunctive_test.cc)
+    add_executable(disjunctive_optional_test constraints/disjunctive/disjunctive_optional_test.cc)
     add_executable(disjunctive_precedences_test constraints/disjunctive/disjunctive_precedences_test.cc)
     add_executable(disjunctive_2d_test constraints/disjunctive_2d/disjunctive_2d_test.cc)
     add_executable(divide_modulus_test constraints/divide_modulus/divide_modulus_test.cc)
@@ -326,7 +327,7 @@ if(GCS_BUILD_TESTS)
 
     foreach(test_target
             abs_test all_different_test all_different_except_test all_equal_test among_test at_most_one_test bin_packing_test comparison_test
-            count_test cumulative_test cumulative_overload_test cumulative_optional_test derived_cumulative_test difference_test disjunctive_test disjunctive_precedences_test disjunctive_2d_test divide_modulus_test element_test equals_test bounds_global_cardinality_test gac_global_cardinality_test in_test increasing_test inverse_test knapsack_test knapsack_upfront_test lex_test linear_test linear_constant_test
+            count_test cumulative_test cumulative_overload_test cumulative_optional_test derived_cumulative_test difference_test disjunctive_test disjunctive_optional_test disjunctive_precedences_test disjunctive_2d_test divide_modulus_test element_test equals_test bounds_global_cardinality_test gac_global_cardinality_test in_test increasing_test inverse_test knapsack_test knapsack_upfront_test lex_test linear_test linear_constant_test
             logical_test mdd_test min_distance_test min_distance_matching_test min_max_test mini_linear_test multiply_test n_value_test nogoods_test parity_test
             plus_minus_test power_test product_bounds_test product_justify_test regular_test regular_bacchus_test regular_legacy_test seq_precede_chain_test smart_table_test sort_test arg_sort_test symmetric_all_different_test
             negative_table_test table_test tabulation_test value_precede_test)
@@ -379,6 +380,18 @@ if(GCS_BUILD_TESTS)
     foreach(mode strict nonstrict)
         add_test(NAME disjunctive_constraint_${mode}
             COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:disjunctive_test> ${mode})
+    endforeach()
+    foreach(mode enumerate falsify bijection cumulative objective)
+        add_test(NAME disjunctive_optional_constraint_${mode}
+            COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:disjunctive_optional_test> ${mode})
+    endforeach()
+    # Mutation lanes for the presence falsification: see
+    # innards/disjunctive_mutations.hh for why the list is short and what each
+    # one has to break.
+    foreach(mutation emit_nothing wrong_task one_too_far)
+        add_test(NAME disjunctive_optional_mutation_${mutation}
+            COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_expect_verify_failure.bash
+                --basename disjunctive_optional_mutation_${mutation} $<TARGET_FILE:disjunctive_optional_test> --mutate=${mutation})
     endforeach()
     add_test(NAME disjunctive_precedences COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:disjunctive_precedences_test>)
     # Mutation lanes: each writes a deliberately corrupted proof of the

--- a/gcs/constraints/cumulative/cumulative.cc
+++ b/gcs/constraints/cumulative/cumulative.cc
@@ -131,22 +131,6 @@ auto Cumulative::clone() const -> unique_ptr<Constraint>
     return result;
 }
 
-auto gcs::innards::cumulative_task_presence(const optional<IntegerVariableID> & posted) -> CumulativeTaskPresence
-{
-    if (! posted)
-        return CumulativeTaskPresence{};
-
-    if (! is_constant_variable(*posted))
-        return CumulativeTaskPresence{*posted, false};
-
-    auto value = constant_value_of(*posted);
-    if (value == 1_i)
-        return CumulativeTaskPresence{};
-    if (value == 0_i)
-        return CumulativeTaskPresence{*posted, true};
-    throw InvalidProblemDefinitionException{"Cumulative: presences must be within {0, 1}"};
-}
-
 auto Cumulative::prepare(Propagators &, State & initial_state, ProofModel * const) -> bool
 {
     auto n = _starts.size();
@@ -167,11 +151,11 @@ auto Cumulative::prepare(Propagators &, State & initial_state, ProofModel * cons
     // Resolve each task's presence to the variable that has to appear in its
     // active flag, or nullopt when the task is unconditionally present ---
     // by the same rule anything pinning these flags has to apply, which is why
-    // cumulative_task_presence is shared rather than open-coded here.
+    // task_presence is shared rather than open-coded here.
     _presence.assign(n, std::nullopt);
     vector<bool> never_present(n, false);
     for (size_t i = 0; i < n; ++i) {
-        auto resolved = cumulative_task_presence(_presences.empty() ? std::nullopt : make_optional(_presences[i]));
+        auto resolved = task_presence(_presences.empty() ? std::nullopt : make_optional(_presences[i]), "Cumulative");
         _presence[i] = resolved.literal;
         never_present[i] = resolved.never_present;
 

--- a/gcs/constraints/cumulative/derived_cumulative.cc
+++ b/gcs/constraints/cumulative/derived_cumulative.cc
@@ -70,7 +70,7 @@ auto gcs::innards::install_derived_cumulative(
     vector<bool> never_present(n, false);
     inputs->presence.reserve(n);
     for (size_t i = 0; i < n; ++i) {
-        auto resolved = cumulative_task_presence(spec.tasks[i].presence);
+        auto resolved = task_presence(spec.tasks[i].presence, "Cumulative");
         inputs->presence.push_back(resolved.literal);
         never_present[i] = resolved.never_present;
     }

--- a/gcs/constraints/cumulative/derived_cumulative.hh
+++ b/gcs/constraints/cumulative/derived_cumulative.hh
@@ -81,7 +81,7 @@ namespace gcs::innards
         /// The presence argument the donor was posted with at `position`, or
         /// nullopt when the donor is not an optional-task Cumulative. As
         /// posted, not as resolved: install_derived_cumulative puts it through
-        /// cumulative_task_presence, exactly as the donor did, so that the
+        /// task_presence, exactly as the donor did, so that the
         /// reasons this constraint gives carry the presence literal its
         /// donor's active flag was reified on --- and so that a task the donor
         /// dropped as constantly absent is dropped here too.

--- a/gcs/constraints/cumulative/donor_view.cc
+++ b/gcs/constraints/cumulative/donor_view.cc
@@ -85,7 +85,7 @@ auto gcs::innards::cumulative_donor_view(const Cumulative & donor, const State &
         // duration does. The largest duration still allowed is what says
         // whether it can run at all, and is the same bound the donor windowed
         // its flags with.
-        auto presence = cumulative_task_presence(view.presences.empty() ? nullopt : make_optional(view.presences[i]));
+        auto presence = task_presence(view.presences.empty() ? nullopt : make_optional(view.presences[i]), "Cumulative");
         if (state.upper_bound(length) <= 0_i || height_value <= 0_i || presence.never_present) {
             view.height_bounded_by[i] = nullopt;
             // Usually there is nothing here to set aside, because the donor

--- a/gcs/constraints/cumulative/propagate.hh
+++ b/gcs/constraints/cumulative/propagate.hh
@@ -3,6 +3,7 @@
 
 #include <gcs/constraint_id.hh>
 #include <gcs/constraints/cumulative/cumulative.hh>
+#include <gcs/constraints/innards/task_presence.hh>
 #include <gcs/innards/proofs/proof_line.hh>
 #include <gcs/innards/proofs/proof_logger-fwd.hh>
 #include <gcs/innards/proofs/proof_only_variables.hh>
@@ -19,47 +20,6 @@
 
 namespace gcs::innards
 {
-    /**
-     * \brief What a Cumulative's presence argument for one task comes to: what
-     * its activity flags are reified on, and whether it has any at all.
-     *
-     * \sa cumulative_task_presence
-     *
-     * \ingroup Innards
-     */
-    struct CumulativeTaskPresence
-    {
-        /// The {0, 1} variable the task's active flag carries as a third
-        /// conjunct, or nullopt when the task is unconditionally present and
-        /// the flag is the two-way AND.
-        std::optional<IntegerVariableID> literal;
-
-        /// Whether the task was posted as constantly absent, in which case
-        /// Cumulative leaves it out of the constraint altogether: it has no
-        /// flags, no terms in any capacity row, and nothing may cite it.
-        bool never_present = false;
-    };
-
-    /**
-     * \brief How a Cumulative resolves the presence argument it was posted
-     * with for one task, given that argument (nullopt for a constraint posted
-     * without presences at all).
-     *
-     * Only a *constant* argument resolves away: a variable presence keeps its
-     * conjunct even when its domain is already a singleton, because the
-     * encoding has to say what it means without appealing to a domain the OPB
-     * does not record.
-     *
-     * Shared, and deliberately so. A derived Cumulative pins its donor's
-     * activity flags, so it has to reach exactly the same verdict about which
-     * of them carry a presence literal as the donor did when it built them; a
-     * second copy of this rule would be one edit away from disagreeing, and the
-     * disagreement would show up as a rejected proof a long way from here.
-     *
-     * \ingroup Innards
-     */
-    [[nodiscard]] auto cumulative_task_presence(const std::optional<IntegerVariableID> & posted) -> CumulativeTaskPresence;
-
     /**
      * \brief Everything Cumulative's propagator reads: the task data, the
      * per-time proof flags it pins, and the per-time capacity lines it builds
@@ -86,7 +46,7 @@ namespace gcs::innards
 
         /// Sized to the task count. nullopt for a task that is unconditionally
         /// present; otherwise the {0, 1} variable saying whether it is
-        /// scheduled at all, as cumulative_task_presence resolves it. A derived
+        /// scheduled at all, as task_presence resolves it. A derived
         /// Cumulative fills this in from its donors', so that the reasons it
         /// gives carry the same presence literals the flags it pins were
         /// reified on.

--- a/gcs/constraints/disjunctive/disjunctive.cc
+++ b/gcs/constraints/disjunctive/disjunctive.cc
@@ -710,7 +710,14 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                                     bound = chain.back().target;
                                 }
                             }
-                            if (logger && chain.empty())
+                            // When nothing fits anywhere, every start in the
+                            // domain is blocked and so a blocker exists at
+                            // cur_lb; an empty chain there is an internal
+                            // inconsistency. Under ClaimOneTooFar a start does
+                            // still fit, and the chain running out is the whole
+                            // point, so the invariant is stated where it holds
+                            // rather than gated on the mutation.
+                            if (logger && chain.empty() && new_lb > cur_ub)
                                 throw UnexpectedException{"Disjunctive: no blocker for a presence falsification"};
 
                             auto justify = [&, j, cur_lb, chain](const ReasonLiterals & reason) -> void {

--- a/gcs/constraints/disjunctive/disjunctive.cc
+++ b/gcs/constraints/disjunctive/disjunctive.cc
@@ -1,5 +1,6 @@
 #include <gcs/constraints/disjunctive/disjunctive.hh>
 #include <gcs/constraints/disjunctive/hints.hh>
+#include <gcs/constraints/innards/task_presence.hh>
 #include <gcs/exception.hh>
 #include <gcs/innards/inference_tracker.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
@@ -21,6 +22,7 @@
 using namespace gcs;
 using namespace gcs::innards;
 
+using std::make_optional;
 using std::make_pair;
 using std::make_unique;
 using std::max;
@@ -48,6 +50,19 @@ Disjunctive::Disjunctive(vector<IntegerVariableID> starts, vector<Integer> lengt
 {
 }
 
+Disjunctive::Disjunctive(vector<IntegerVariableID> starts, vector<IntegerVariableID> lengths, vector<IntegerVariableID> presences) :
+    Disjunctive(move(starts), move(lengths))
+{
+    _presences = move(presences);
+    if (_starts.size() != _presences.size())
+        throw InvalidProblemDefinitionException{"Disjunctive: starts and presences must have the same size"};
+    // A constant presence is checked here, by the rule that resolves it; a
+    // variable one is checked in prepare(), where its domain first becomes
+    // available.
+    for (const auto & p : _presences)
+        (void)task_presence(make_optional(p), "Disjunctive");
+}
+
 auto Disjunctive::with_strict(std::optional<bool> strict) -> Disjunctive &
 {
     _strict = strict.value_or(true);
@@ -66,12 +81,24 @@ auto Disjunctive::with_proof_mutation(DisjunctiveProofMutation mutation) -> Disj
     return *this;
 }
 
+auto Disjunctive::with_presence_mutation(DisjunctivePresenceMutation mutation) -> Disjunctive &
+{
+    _presence_mutation = mutation;
+    return *this;
+}
+
+auto Disjunctive::presences() const -> const vector<IntegerVariableID> &
+{
+    return _presences;
+}
+
 auto Disjunctive::clone() const -> unique_ptr<Constraint>
 {
-    auto cloned = make_unique<Disjunctive>(_starts, _lengths);
+    auto cloned = _presences.empty() ? make_unique<Disjunctive>(_starts, _lengths) : make_unique<Disjunctive>(_starts, _lengths, _presences);
     cloned->with_strict(_strict);
     cloned->with_rules(_rules);
     cloned->with_proof_mutation(_proof_mutation);
+    cloned->with_presence_mutation(_presence_mutation);
     return cloned;
 }
 
@@ -89,14 +116,40 @@ auto Disjunctive::prepare(Propagators &, State & initial_state, ProofModel * con
             throw InvalidProblemDefinitionException{"Disjunctive: lengths must be non-negative"};
     }
 
+    // Resolve each task's presence to the variable its separation clauses have
+    // to carry a disjunct on, or nullopt when the task is unconditionally
+    // present, by the rule Cumulative resolves its presences with --- the two
+    // constraints are alternative encodings of overlapping problems, so a
+    // presence argument one honours and the other drops would be a difference
+    // in meaning between them.
+    _presence.assign(n, nullopt);
+    vector<bool> never_present(n, false);
+    for (size_t i = 0; i < n; ++i) {
+        auto resolved = task_presence(_presences.empty() ? nullopt : make_optional(_presences[i]), "Disjunctive");
+        _presence[i] = resolved.literal;
+        never_present[i] = resolved.never_present;
+
+        // Only now are the domains available, which is why a variable presence
+        // is range-checked here rather than in the constructor.
+        if (resolved.literal && ! is_constant_variable(*resolved.literal)) {
+            auto [lo, hi] = initial_state.bounds(*resolved.literal);
+            if (lo < 0_i || hi > 1_i)
+                throw InvalidProblemDefinitionException{"Disjunctive: presences must be within {0, 1}"};
+        }
+    }
+
     // In non-strict mode, a task that is definitely zero-length cannot constrain
     // any other task, so drop it. A constant zero is dropped here; a variable
     // duration that *can* be zero stays active and gets a zero-length escape
     // flag (it might still take a positive value during search). In strict mode
     // every task participates (a zero-length task may not sit strictly inside
-    // another's active interval).
+    // another's active interval). A constantly-absent task is dropped in either
+    // mode: it occupies no time, so it constrains nothing and nothing
+    // constrains it, and it must appear nowhere in the encoding at all.
     _active_tasks.reserve(n);
     for (size_t i = 0; i < n; ++i) {
+        if (never_present[i])
+            continue;
         if (! _strict && is_constant_variable(_lengths[i]) && _length_vals[i] == 0_i)
             continue;
         _active_tasks.push_back(i);
@@ -128,7 +181,7 @@ auto Disjunctive::define_proof_model(ProofModel & model, const State &) -> void
     //     before_{i,j} <-> starts[i] + lengths[i] <= starts[j]
     //     before_{j,i} <-> starts[j] + lengths[j] <= starts[i]
     //   then one clause per pair:
-    //     before_{i,j} v before_{j,i}
+    //     before_{i,j} v before_{j,i} [ v presences[i] = 0 v presences[j] = 0 ]
     //
     // This is the only thing that goes into the OPB: the constraint's
     // declarative meaning, free of time-table or other propagator-specific
@@ -173,6 +226,17 @@ auto Disjunctive::define_proof_model(ProofModel & model, const State &) -> void
             for (auto r : {i, j})
                 if (_zero[r])
                     clause_sum += 1_i * *_zero[r];
+            // And so does an absent one, which is the whole of what optional
+            // tasks add to this encoding: the presence literal is the {0, 1}
+            // variable's single PB atom, so a pair of optional tasks costs two
+            // more terms in one clause they already had --- no extra flag, no
+            // extra row, and nothing else in the encoding has to know whether a
+            // task is optional. In particular the before flags stay reified
+            // *unconditionally* on the arithmetic, which is what keeps every
+            // justification below a pol over the same rows as before.
+            for (auto r : {i, j})
+                if (_presence[r])
+                    clause_sum += 1_i * (*_presence[r] == 0_i);
             // cake_pb_cp labels the separation clause @c[id][<i>_<j>sepal1].
             auto clause =
                 model.add_labelled_constraint(_constraint_id, std::to_string(i) + "_" + std::to_string(j) + "sepal1", move(clause_sum) >= 1_i);
@@ -192,13 +256,18 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
         // re-fire on variable-duration bound changes too.
         if (! is_constant_variable(_lengths[i]))
             triggers.on_bounds.emplace_back(_lengths[i]);
+        // A task starts blocking others the moment its presence is fixed to 1,
+        // and stops being anything at all when it is fixed to 0, so an optional
+        // task's presence has to wake the propagator as much as its start does.
+        if (_presence[i] && ! is_constant_variable(*_presence[i]))
+            triggers.on_instantiated.emplace_back(*_presence[i]);
     }
 
     propagators.install(
         constraint_id(),
         [starts = move(_starts), lengths = move(_length_vals), length_vars = move(_lengths), zero = move(_zero), strict = _strict,
-            active_tasks = move(_active_tasks), before_flags = move(_before_flags), clause_lines = move(_clause_lines), rules = _rules,
-            mutation = _proof_mutation,
+            active_tasks = move(_active_tasks), before_flags = move(_before_flags), clause_lines = move(_clause_lines), presence = move(_presence),
+            rules = _rules, mutation = _proof_mutation, presence_mutation = _presence_mutation,
             owner = constraint_id()](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
             // Current guaranteed (min) and possible (max) duration of task i:
             // for a constant duration both are the value; for a variable
@@ -206,6 +275,34 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
             auto is_var_len = [&](size_t i) -> bool { return ! is_constant_variable(length_vars[i]); };
             auto min_len = [&](size_t i) -> Integer { return is_var_len(i) ? state.lower_bound(length_vars[i]) : lengths[i]; };
             auto max_len = [&](size_t i) -> Integer { return is_var_len(i) ? state.upper_bound(length_vars[i]) : lengths[i]; };
+
+            // A task with no presence variable is always here. An optional one
+            // is here only once its presence is fixed to 1: until then it
+            // occupies no time as far as this propagator is concerned, blocks
+            // nothing, and nothing may be inferred about its start, since a
+            // prune that is only valid when the task is present would be plain
+            // wrong if it turns out absent. Fixed to 0, it is gone for good and
+            // every loop below skips it.
+            auto is_present = [&](size_t i) -> bool { return ! presence[i] || state.lower_bound(*presence[i]) == 1_i; };
+            auto is_absent = [&](size_t i) -> bool { return presence[i] && state.upper_bound(*presence[i]) == 0_i; };
+
+            // Presence enters a reason as an explicit literal per task known
+            // present, rather than by putting the variable in the reason's
+            // variable list: an undecided presence has no fact to record (a task
+            // not known present simply constrains nothing, and staying that way
+            // is monotone as the domain shrinks), and generic_reason would
+            // contribute the pair of trivial bounds 0 <= p <= 1 for it, which
+            // says nothing and costs an order atom on a variable whose whole
+            // encoding is one PB literal. Every inference below reasons only
+            // about tasks known present, so this one list serves all of them.
+            // The snapshot is taken once per call and stays accurate: the only
+            // presence this propagator ever changes is one it fixes to 0, and
+            // those were undecided, so absent from the list to begin with.
+            ReasonLiterals presence_lits;
+            for (auto i : active_tasks)
+                if (presence[i] && is_present(i))
+                    presence_lits.push_back(*presence[i] == 1_i);
+            auto reason_over = [&](const vector<IntegerVariableID> & vars) -> Reason { return with_extra(generic_reason(vars), presence_lits); };
 
             // The pairwise proof vocabulary. Everything the propagator infers
             // is justified through the encoded before-flags: a pol over a
@@ -289,10 +386,15 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
             // active interval. The TT pass misses that case; we catch it
             // below with an all-fixed pairwise check.
             //
+            // An absent task is out of the horizon as well as out of the
+            // profile: its start is unconstrained, so leaving it in would size
+            // mand_load by a domain nothing below ever indexes. An *undecided*
+            // task stays in, contributing no load but keeping room for the
+            // placements the falsification below has to scan.
             bool any = false;
             Integer t_lo = 0_i, t_hi = -1_i;
             for (auto i : active_tasks) {
-                if (max_len(i) == 0_i)
+                if (max_len(i) == 0_i || is_absent(i))
                     continue;
                 auto [s_lo, s_hi] = state.bounds(starts[i]);
                 auto lo = s_lo, hi = s_hi + max_len(i) - 1_i;
@@ -374,10 +476,23 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                 // concludes. `bound` is the running bound the step starts from
                 // (established by the reason for the first step, by the
                 // previous step's deposit after).
-                auto emit_lb_chain_step = [&](size_t j, size_t k, Integer bound, Integer target, bool final, const ReasonLiterals & reason) -> void {
+                //
+                // `absent` is the "or task j is not here at all" disjunct that
+                // the presence falsification below carries on every deposit, so
+                // each step reads "either j starts later than this, or j is not
+                // here"; nullopt for an ordinary push, whose task is known
+                // present. The dichotomy's two pols are the same either way:
+                // they are arithmetic over the before flags, which stay reified
+                // unconditionally, so presence never reaches them.
+                auto emit_lb_chain_step = [&](size_t j, size_t k, Integer bound, Integer target, bool final,
+                                              const optional<IntegerVariableCondition> & absent, const ReasonLiterals & reason) -> void {
                     emit_lb_dichotomy(j, k, bound, target, disjunctive_proof_mutation::None{});
-                    if (! final)
-                        logger->emit_rup_proof_line_under_reason(reason, WPBSum{} + 1_i * (starts[j] >= target) >= 1_i, ProofLevel::Temporary);
+                    if (! final) {
+                        auto deposit = WPBSum{} + 1_i * (starts[j] >= target);
+                        if (absent)
+                            deposit += 1_i * *absent;
+                        logger->emit_rup_proof_line_under_reason(reason, move(deposit) >= 1_i, ProofLevel::Temporary);
+                    }
                 };
                 auto emit_ub_chain_step = [&](size_t j, size_t k, Integer bound, Integer target, bool final, const ReasonLiterals & reason) -> void {
                     emit_ub_dichotomy(j, k, bound, target, disjunctive_proof_mutation::None{});
@@ -388,8 +503,11 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                 auto range = (t_hi - t_lo + 1_i).raw_value;
                 vector<int> mand_load(range, 0);
 
+                // Only a task known present puts a mandatory part into the
+                // profile. An undecided one might not be here at all, so its
+                // mandatory part is not mandatory.
                 for (auto i : active_tasks) {
-                    if (min_len(i) == 0_i)
+                    if (min_len(i) == 0_i || ! is_present(i))
                         continue;
                     auto lst = state.upper_bound(starts[i]);
                     auto eet = state.lower_bound(starts[i]) + min_len(i);
@@ -414,7 +532,7 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                         size_t pi = 0, pj = 0;
                         bool got_first = false, got_second = false;
                         for (auto i : active_tasks) {
-                            if (min_len(i) == 0_i)
+                            if (min_len(i) == 0_i || ! is_present(i))
                                 continue;
                             auto lst = state.upper_bound(starts[i]);
                             auto eet = state.lower_bound(starts[i]) + min_len(i);
@@ -455,7 +573,7 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                         if (is_var_len(pj))
                             reason_vars.push_back(length_vars[pj]);
                         inference.contradiction(
-                            logger, JustifyExplicitly{justify, ThenRUP::Yes, hints::Disjunctive{owner}}, generic_reason(reason_vars));
+                            logger, JustifyExplicitly{justify, ThenRUP::Yes, hints::Disjunctive{owner}}, reason_over(reason_vars));
                         return PropagatorState::DisableUntilBacktrack;
                     }
 
@@ -472,17 +590,29 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                     };
 
                     for (auto j : active_tasks) {
-                        if (min_len(j) == 0_i)
+                        // A task with no guaranteed duration blocks nothing and
+                        // fits everywhere, so there is neither a push nor a
+                        // falsification to be had from it. An absent one is not
+                        // here at all.
+                        if (min_len(j) == 0_i || is_absent(j))
                             continue;
                         auto [cur_lb, cur_ub] = state.bounds(starts[j]);
-                        if (cur_lb == cur_ub)
+                        // A fixed start leaves nothing to push, but an undecided
+                        // task with a fixed start can still be shown to have
+                        // nowhere to go.
+                        if (cur_lb == cur_ub && is_present(j))
                             continue;
 
                         auto lst_j = cur_ub, eet_j = cur_lb + min_len(j);
-                        auto fits_at = [&](Integer s) -> bool {
+                        // Only a task known present put anything into the
+                        // profile, so only that one has something to discount
+                        // before asking where it could go. An undecided task's
+                        // own mandatory part is not in mand_load and must not be
+                        // subtracted out of it.
+                        auto fits_at = [&, j](Integer s) -> bool {
                             for (Integer t = s; t < s + min_len(j); ++t) {
                                 auto load = mand_load[(t - t_lo).raw_value];
-                                if (lst_j < eet_j && t >= lst_j && t < eet_j)
+                                if (is_present(j) && lst_j < eet_j && t >= lst_j && t < eet_j)
                                     --load;
                                 if (load >= 1)
                                     return false;
@@ -500,11 +630,21 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                         // tighter than the profile (mandatory parts only grow
                         // within a pass), hence the clipping in the chain loops
                         // below.
-                        auto find_blocker = [&](size_t j, Integer bound, const auto & better) -> pair<size_t, pair<Integer, Integer>> {
+                        //
+                        // nullopt when there is none, which a push chain treats
+                        // as an internal inconsistency (must_find_blocker) but
+                        // the presence falsification does not: the
+                        // ClaimOneTooFar mutation deliberately runs a chain over
+                        // ground that is not all blocked, and running out of
+                        // blockers is exactly how it fails to close.
+                        auto find_blocker = [&](size_t j, Integer bound, const auto & better) -> optional<pair<size_t, pair<Integer, Integer>>> {
                             optional<size_t> blocker;
                             pair<Integer, Integer> best_mand{0_i, 0_i};
                             for (auto k : active_tasks) {
-                                if (k == j || min_len(k) == 0_i)
+                                // Only a task known present is in the profile,
+                                // and only a task in the profile can be what
+                                // made a start not fit.
+                                if (k == j || min_len(k) == 0_i || ! is_present(k))
                                     continue;
                                 auto lst_k = state.upper_bound(starts[k]);
                                 auto eet_k = state.lower_bound(starts[k]) + min_len(k);
@@ -515,8 +655,14 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                                 }
                             }
                             if (! blocker)
+                                return nullopt;
+                            return pair{*blocker, best_mand};
+                        };
+                        auto must_find_blocker = [&](size_t j, Integer bound, const auto & better) -> pair<size_t, pair<Integer, Integer>> {
+                            auto found = find_blocker(j, bound, better);
+                            if (! found)
                                 throw UnexpectedException{"Disjunctive: no blocker for a push chain step"};
-                            return {*blocker, best_mand};
+                            return *found;
                         };
 
                         // lb-push: scan upward to find the smallest fitting start,
@@ -525,15 +671,93 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                         // end -- clipped to new_lb, both because the profile may
                         // be staler than the bounds the steps cite and so the
                         // final step lands exactly on the inferred bound.
+                        auto deepest_end = [](const auto & a, const auto & b) { return a.second > b.second; };
                         auto new_lb = cur_lb;
                         while (new_lb <= cur_ub && ! fits_at(new_lb))
                             ++new_lb;
+
+                        if (! is_present(j)) {
+                            // Presence falsification. The task is undecided and,
+                            // if it were present, has nowhere left to start:
+                            // new_lb ran off the end of its domain. Replay the
+                            // lb-push chain over the whole domain with "task j is
+                            // absent" carried as an extra disjunct on every
+                            // deposit, so each step says "either j starts later
+                            // than this, or j is not here at all". The last step
+                            // deposits nothing, exactly as the last step of a
+                            // push does: its target is one past j's upper bound,
+                            // which the reason already refutes, so the
+                            // framework's closing RUP concludes the presence.
+                            //
+                            // The ClaimOneTooFar mutation fires where exactly
+                            // one placement is still open, so the conclusion is
+                            // wrong rather than the route to it. The chain then
+                            // stops short --- its last window has no blocker ---
+                            // and the closing RUP has nothing to close on, which
+                            // is what VeriPB must catch.
+                            if (new_lb <= cur_ub &&
+                                ! (std::holds_alternative<disjunctive_presence_mutation::ClaimOneTooFar>(presence_mutation) && new_lb == cur_ub))
+                                continue;
+
+                            vector<ChainStep> chain;
+                            if (logger) {
+                                Integer bound = cur_lb;
+                                while (bound <= cur_ub) {
+                                    auto found = find_blocker(j, bound, deepest_end);
+                                    if (! found)
+                                        break;
+                                    chain.push_back(ChainStep{found->first, min(found->second.second, cur_ub + 1_i)});
+                                    bound = chain.back().target;
+                                }
+                            }
+                            if (logger && chain.empty())
+                                throw UnexpectedException{"Disjunctive: no blocker for a presence falsification"};
+
+                            auto justify = [&, j, cur_lb, chain](const ReasonLiterals & reason) -> void {
+                                // The marker a test counts to show the rule
+                                // fired, and counts to zero on the twin instance
+                                // where it must not.
+                                logger->emit_proof_comment(
+                                    "disjunctive optional: task " + std::to_string(j) + " cannot be placed anywhere, so it is absent");
+
+                                vector<size_t> involved{j};
+                                for (const auto & step : chain)
+                                    involved.push_back(step.blocker);
+                                pin_escapes(reason, involved);
+
+                                // Which task's absence the deposits argue about:
+                                // the one being falsified, unless the WrongTask
+                                // mutation points them at some other optional
+                                // task.
+                                auto about = j;
+                                if (std::holds_alternative<disjunctive_presence_mutation::WrongTask>(presence_mutation))
+                                    for (auto k : active_tasks)
+                                        if (k != j && presence[k]) {
+                                            about = k;
+                                            break;
+                                        }
+
+                                auto steps =
+                                    std::holds_alternative<disjunctive_presence_mutation::EmitNothing>(presence_mutation) ? size_t{0} : chain.size();
+                                Integer bound = cur_lb;
+                                for (size_t step = 0; step < steps; ++step) {
+                                    emit_lb_chain_step(j, chain[step].blocker, bound, chain[step].target, step + 1 == steps,
+                                        make_optional(*presence[about] == 0_i), reason);
+                                    bound = chain[step].target;
+                                }
+                            };
+
+                            inference.infer_equal(logger, *presence[j], 0_i, JustifyExplicitly{justify, ThenRUP::Yes, hints::Disjunctive{owner}},
+                                reason_over(push_reason_vars));
+                            continue;
+                        }
+
                         if (new_lb > cur_lb) {
                             vector<ChainStep> chain;
                             if (logger) {
                                 Integer bound = cur_lb;
                                 while (bound < new_lb) {
-                                    auto [k, mand] = find_blocker(j, bound, [](const auto & a, const auto & b) { return a.second > b.second; });
+                                    auto [k, mand] = must_find_blocker(j, bound, deepest_end);
                                     chain.push_back(ChainStep{k, min(mand.second, new_lb)});
                                     bound = chain.back().target;
                                 }
@@ -546,13 +770,13 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                                 pin_escapes(reason, involved);
                                 Integer bound = cur_lb;
                                 for (size_t step = 0; step < chain.size(); ++step) {
-                                    emit_lb_chain_step(j, chain[step].blocker, bound, chain[step].target, step + 1 == chain.size(), reason);
+                                    emit_lb_chain_step(j, chain[step].blocker, bound, chain[step].target, step + 1 == chain.size(), nullopt, reason);
                                     bound = chain[step].target;
                                 }
                             };
 
                             inference.infer_greater_than_or_equal(logger, starts[j], new_lb,
-                                JustifyExplicitly{justify, ThenRUP::Yes, hints::Disjunctive{owner}}, generic_reason(push_reason_vars));
+                                JustifyExplicitly{justify, ThenRUP::Yes, hints::Disjunctive{owner}}, reason_over(push_reason_vars));
                         }
 
                         // ub-push: mirror of lb-push, scanning downward, each step
@@ -568,7 +792,7 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                             if (logger) {
                                 Integer bound = cur_ub;
                                 while (bound > new_ub) {
-                                    auto [k, mand] = find_blocker(j, bound, [](const auto & a, const auto & b) { return a.first < b.first; });
+                                    auto [k, mand] = must_find_blocker(j, bound, [](const auto & a, const auto & b) { return a.first < b.first; });
                                     chain.push_back(ChainStep{k, max(mand.first - min_len(j), new_ub)});
                                     bound = chain.back().target;
                                 }
@@ -587,7 +811,7 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                             };
 
                             inference.infer_less_than(logger, starts[j], new_ub + 1_i,
-                                JustifyExplicitly{justify, ThenRUP::Yes, hints::Disjunctive{owner}}, generic_reason(push_reason_vars));
+                                JustifyExplicitly{justify, ThenRUP::Yes, hints::Disjunctive{owner}}, reason_over(push_reason_vars));
                         }
                     }
                 }
@@ -629,9 +853,17 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                 // chains are built from, with the blocker's mandatory part
                 // playing no part -- the pol arithmetic never referred to it,
                 // only the profile scan that picked the blocker did.
+                //
+                // Both tasks have to be known present: a precedence is a
+                // statement that one of them finishes before the other starts,
+                // which says nothing at all if either might not be here. That
+                // rules out a *conditional* precedence, which would need the
+                // presence literals inside the pols rather than only in the
+                // reason; the falsification above is the only place presence
+                // reaches a proof line here.
                 if (rules.detectable_precedences)
                     for (auto j : active_tasks) {
-                        if (min_len(j) == 0_i)
+                        if (min_len(j) == 0_i || ! is_present(j))
                             continue;
                         // A task whose start is already fixed has no bound to
                         // push, and nothing is lost by leaving it alone: a
@@ -654,7 +886,7 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                         optional<size_t> predecessor, successor;
                         Integer predecessor_eet = 0_i, successor_lst = 0_i;
                         for (auto k : active_tasks) {
-                            if (k == j || min_len(k) == 0_i)
+                            if (k == j || min_len(k) == 0_i || ! is_present(k))
                                 continue;
                             auto [k_lb, k_ub] = state.bounds(starts[k]);
                             auto eet_k = k_lb + min_len(k);
@@ -684,7 +916,7 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                                     emit_lb_dichotomy(j, k, cur_lb, target, mutation);
                                 };
                                 inference.infer_greater_than_or_equal(logger, starts[j], target,
-                                    JustifyExplicitly{justify, ThenRUP::Yes, hints::Disjunctive{owner}}, generic_reason(push_reason_vars));
+                                    JustifyExplicitly{justify, ThenRUP::Yes, hints::Disjunctive{owner}}, reason_over(push_reason_vars));
                             }
                         }
 
@@ -704,7 +936,7 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                                     emit_ub_dichotomy(j, k, cur_ub, target, mutation);
                                 };
                                 inference.infer_less_than(logger, starts[j], target + 1_i,
-                                    JustifyExplicitly{justify, ThenRUP::Yes, hints::Disjunctive{owner}}, generic_reason(push_reason_vars));
+                                    JustifyExplicitly{justify, ThenRUP::Yes, hints::Disjunctive{owner}}, reason_over(push_reason_vars));
                             }
                         }
                     }
@@ -722,20 +954,27 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
             // any variable durations) fixed at vz, vk, l_k satisfying
             // vk < vz < vk + l_k, before_{z,k} = (vz <= vk) UPs to 0 and
             // before_{k,z} = (vk + l_k <= vz) UPs to 0, contradicting the
-            // encoded clause before_{z,k} + before_{k,z} >= 1.
+            // encoded clause before_{z,k} + before_{k,z} >= 1. With optional
+            // tasks the clause carries their presence disjuncts too, so both
+            // tasks must be known present for it to unit-fail --- which is also
+            // the semantics: an absent task sits wherever it likes. This is the
+            // second half of what makes the propagator a *checker*, so the
+            // presence test here has to be the same one the profile above uses,
+            // or an undecided task could slip past the leaf check that would
+            // have fixed its presence.
             for (auto z : active_tasks) {
                 if (! strict)
                     break;
                 if (max_len(z) > 0_i)
                     continue;
-                if (! state.has_single_value(starts[z]))
+                if (! state.has_single_value(starts[z]) || ! is_present(z))
                     continue;
                 auto vz = state.lower_bound(starts[z]);
                 for (auto k : active_tasks) {
                     // k must have a fixed, positive duration.
                     if (k == z || min_len(k) != max_len(k) || min_len(k) == 0_i)
                         continue;
-                    if (! state.has_single_value(starts[k]))
+                    if (! state.has_single_value(starts[k]) || ! is_present(k))
                         continue;
                     auto vk = state.lower_bound(starts[k]);
                     if (vk < vz && vz < vk + min_len(k)) {
@@ -744,7 +983,7 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                             reason_vars.push_back(length_vars[z]);
                         if (is_var_len(k))
                             reason_vars.push_back(length_vars[k]);
-                        inference.contradiction(logger, JustifyUsingRUP{hints::Disjunctive{owner}}, generic_reason(reason_vars));
+                        inference.contradiction(logger, JustifyUsingRUP{hints::Disjunctive{owner}}, reason_over(reason_vars));
                         return PropagatorState::DisableUntilBacktrack;
                     }
                 }
@@ -757,17 +996,32 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
 
 auto Disjunctive::constraint_type() const -> std::string
 {
-    return _strict ? "disjunctive_strict" : "disjunctive";
+    // The optional forms are named apart from the plain ones rather than
+    // sharing a name: cake_pb_cp dispatches on this, and it has no encoder for
+    // an optional disjunctive, so a shared name would silently offer it the
+    // non-optional encoding of a different constraint. Naming the gap is what
+    // makes it a miss rather than a mismatch.
+    if (_presences.empty())
+        return _strict ? "disjunctive_strict" : "disjunctive";
+    return _strict ? "disjunctive_strict_optional" : "disjunctive_optional";
 }
 
 auto Disjunctive::s_expr(const ProofModel * const model) const -> SExpr
 {
     auto & tracker = model->names_and_ids_tracker();
-    vector<SExpr> starts, lengths;
+    vector<SExpr> starts, lengths, presences;
     for (const auto & v : _starts)
         starts.push_back(tracker.s_expr_term_of(v));
     for (const auto & l : _lengths)
         lengths.push_back(is_constant_variable(l) ? SExpr::atom(constant_value_of(l).to_string()) : tracker.s_expr_term_of(l));
-    return SExpr::list(
-        {SExpr::atom(as_string(_constraint_id)), SExpr::atom(constraint_type()), SExpr::list(std::move(starts)), SExpr::list(std::move(lengths))});
+    for (const auto & p : _presences)
+        presences.push_back(tracker.s_expr_term_of(p));
+    vector<SExpr> terms{
+        SExpr::atom(as_string(_constraint_id)), SExpr::atom(constraint_type()), SExpr::list(std::move(starts)), SExpr::list(std::move(lengths))};
+    // The presences list sits where the FlatZinc builtin puts it, last, and is
+    // absent altogether for a non-optional constraint --- whose s-expression
+    // must stay exactly what it was.
+    if (! _presences.empty())
+        terms.push_back(SExpr::list(std::move(presences)));
+    return SExpr::list(std::move(terms));
 }

--- a/gcs/constraints/disjunctive/disjunctive.hh
+++ b/gcs/constraints/disjunctive/disjunctive.hh
@@ -65,6 +65,15 @@ namespace gcs
      * distinction is fully resolved at construction; with variable durations a
      * task may become zero-length during search.
      *
+     * Tasks may also be <em>optional</em>: the constructor taking a `presences`
+     * array makes task <em>i</em> conditional on a {0, 1} variable. A task with
+     * <em>presences[i] = 0</em> is absent &mdash; it occupies no time, so it may
+     * overlap anything and its start is unconstrained. The presence appears in
+     * the encoding as one more disjunct on each separation clause the task takes
+     * part in, and nowhere else, so a task posted with
+     * <em>presences[i] = 1</em> and one posted without presences at all produce
+     * the same OPB.
+     *
      * Propagation is time-table consistent at heights = 1, capacity = 1:
      * mandatory parts of distinct tasks may not overlap, and each task's
      * bounds are pushed away from time points already mandatorily occupied
@@ -73,6 +82,12 @@ namespace gcs
      * mandatory part on either task, so it prunes where time-tabling cannot.
      * Stronger reasoning (an overload check, not-first / not-last,
      * edge-finding) is left for future work.
+     *
+     * A task whose presence is still undecided is left out of the profile and
+     * out of every push, in either role: it blocks nothing, and nothing is
+     * inferred about its start, since a prune that is only valid when the task
+     * is present would be wrong if it turns out absent. If no start at all is
+     * left for such a task under the profile, its presence is inferred to be 0.
      *
      * \ingroup Constraints
      */
@@ -83,6 +98,23 @@ namespace gcs
         std::vector<IntegerVariableID> _lengths;
         bool _strict = true;
         std::vector<std::size_t> _active_tasks;
+
+        // Per-task presence, as posted; empty for the constructors that take no
+        // presences, where every task is unconditionally present. Resolved into
+        // _presence by prepare(); this copy exists for clone() and s_expr().
+        std::vector<IntegerVariableID> _presences;
+
+        // Per-task presence as resolved by innards::task_presence: nullopt for a
+        // task that is unconditionally present --- the non-optional
+        // constructors, or a presence argument that is the constant 1 --- which
+        // then needs no disjunct in its separation clauses and no presence
+        // literal in a reason, so it encodes and propagates exactly as it did
+        // before optional tasks existed. A task whose presence is the constant 0
+        // is dropped from _active_tasks and appears nowhere at all. Only
+        // *constant* presences resolve: a checker reads the OPB, not the initial
+        // State, so a variable whose domain happens to be a singleton keeps its
+        // disjunct.
+        std::vector<std::optional<IntegerVariableID>> _presence;
 
         // Length snapshots resolved in prepare(). _length_vals holds the
         // constant value for a constant duration (0 placeholder for a variable
@@ -114,6 +146,7 @@ namespace gcs
 
         DisjunctiveRules _rules;
         innards::DisjunctiveProofMutation _proof_mutation = innards::disjunctive_proof_mutation::None{};
+        innards::DisjunctivePresenceMutation _presence_mutation = innards::disjunctive_presence_mutation::None{};
 
         virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
         virtual auto define_proof_model(innards::ProofModel &, const innards::State &) -> void override;
@@ -132,6 +165,20 @@ namespace gcs
          */
         explicit Disjunctive(std::vector<IntegerVariableID> starts, std::vector<Integer> lengths);
 
+        /**
+         * \brief Optional-task form: `presences[i]` is a {0, 1} variable saying
+         * whether task `i` happens at all. An absent task occupies no time and
+         * has an unconstrained start.
+         *
+         * Each presence must be a variable whose domain is within {0, 1}, or
+         * the constant 0 or 1. A constant 1 is the same as leaving the task out
+         * of the optional form entirely, and encodes identically.
+         *
+         * \throws InvalidProblemDefinitionException if a presence's domain is
+         * not within {0, 1}, or if the arrays' sizes disagree.
+         */
+        explicit Disjunctive(std::vector<IntegerVariableID> starts, std::vector<IntegerVariableID> lengths, std::vector<IntegerVariableID> presences);
+
         /// Whether the tasks are strictly disjunctive (zero-length tasks also may
         /// not overlap); default true. Takes std::optional<bool> so a runtime flag
         /// can be passed straight through.
@@ -146,6 +193,19 @@ namespace gcs
         /// only, which assert that VeriPB rejects the result; see
         /// innards::DisjunctiveProofMutation.
         auto with_proof_mutation(innards::DisjunctiveProofMutation mutation) -> Disjunctive &;
+
+        /// Corrupt one step of the presence-falsification derivation. For tests
+        /// only, which assert that VeriPB rejects the result; see
+        /// innards::DisjunctivePresenceMutation.
+        auto with_presence_mutation(innards::DisjunctivePresenceMutation mutation) -> Disjunctive &;
+
+        /**
+         * \brief The presences this constraint was posted with.
+         *
+         * Empty for the non-optional constructors, which is how a caller asks
+         * "is this an optional-task Disjunctive?".
+         */
+        [[nodiscard]] auto presences() const -> const std::vector<IntegerVariableID> &;
 
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
         [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;

--- a/gcs/constraints/disjunctive/disjunctive_optional_test.cc
+++ b/gcs/constraints/disjunctive/disjunctive_optional_test.cc
@@ -121,6 +121,22 @@ namespace
         return ranges;
     }
 
+    // Every check in this file that compares two solution *sets* is vacuous
+    // against a truncated one. check_results() can degrade to a soundness check
+    // when a runtime cap fires, because it has an independent oracle to check
+    // against; two solvers that both stopped at the cap agree about nothing, and
+    // comparing their prefixes silently tests the search order instead of the
+    // semantics. So say so loudly: the fixture has outgrown the cap and wants
+    // shrinking, or its lane wants the cap cleared (which the two proof-free
+    // lanes do, since the caps exist to bound proof size and VeriPB time).
+    [[nodiscard]] auto enumerated_fully(const string & what) -> bool
+    {
+        if (! last_run_truncated())
+            return true;
+        println(cerr, "{}: a runtime cap truncated the enumeration, so the comparison would be vacuous", what);
+        return false;
+    }
+
     // Post the instance, returning the variables in enumeration order.
     auto post_optional_disjunctive(Problem & p, const vector<TaskSpec> & tasks, bool strict, DisjunctivePresenceMutation mutation)
         -> vector<IntegerVariableID>
@@ -411,6 +427,8 @@ namespace
                 Problem p;
                 auto all_vars = post_optional_disjunctive(p, tasks, strict, disjunctive_presence_mutation::None{});
                 solve_for_tests(p, nullopt, with_presences, tuple{all_vars});
+                if (! enumerated_fully("constant-presence equivalence " + std::to_string(k) + " (optional form)"))
+                    return false;
             }
             {
                 Problem p;
@@ -421,6 +439,8 @@ namespace
                     lengths_v.push_back(constant_variable(Integer{t.length.first}));
                 p.post(Disjunctive{starts, lengths_v}.with_strict(strict));
                 solve_for_tests(p, nullopt, without, tuple{starts});
+                if (! enumerated_fully("constant-presence equivalence " + std::to_string(k) + " (plain form)"))
+                    return false;
             }
             if (with_presences != without) {
                 println(cerr, "constant-presence equivalence {}: optional form has {} solutions, plain form has {}", k, with_presences.size(),
@@ -554,6 +574,8 @@ namespace
             all_vars = starts;
             all_vars.insert(all_vars.end(), presences.begin(), presences.end());
             solve_for_tests(p, nullopt, via_presence, tuple{all_vars});
+            if (! enumerated_fully("bijection " + tag + " (presence model)"))
+                return false;
         }
 
         {
@@ -575,6 +597,8 @@ namespace
             all_vars = starts;
             all_vars.insert(all_vars.end(), presences.begin(), presences.end());
             solve_for_tests(p, nullopt, via_duration, tuple{all_vars});
+            if (! enumerated_fully("bijection " + tag + " (variable-duration model)"))
+                return false;
         }
 
         if (via_presence != via_duration) {
@@ -601,6 +625,7 @@ namespace
     {
         set<vector<int>> via_disjunctive, via_cumulative;
 
+        bool fully = true;
         auto build = [&](bool as_cumulative, set<vector<int>> & into) {
             Problem p;
             vector<IntegerVariableID> starts, lengths_v, presences, all_vars;
@@ -619,10 +644,13 @@ namespace
             all_vars = starts;
             all_vars.insert(all_vars.end(), presences.begin(), presences.end());
             solve_for_tests(p, nullopt, into, tuple{all_vars});
+            fully &= enumerated_fully("vs cumulative " + tag + (as_cumulative ? " (cumulative model)" : " (disjunctive model)"));
         };
 
         build(false, via_disjunctive);
         build(true, via_cumulative);
+        if (! fully)
+            return false;
 
         if (via_disjunctive != via_cumulative) {
             println(cerr, "vs cumulative {}: disjunctive has {} solutions, cumulative has {}", tag, via_disjunctive.size(), via_cumulative.size());

--- a/gcs/constraints/disjunctive/disjunctive_optional_test.cc
+++ b/gcs/constraints/disjunctive/disjunctive_optional_test.cc
@@ -1,0 +1,979 @@
+#include <gcs/constraints/cumulative.hh>
+#include <gcs/constraints/disjunctive.hh>
+#include <gcs/constraints/innards/constraints_test_utils.hh>
+#include <gcs/constraints/linear.hh>
+#include <gcs/exception.hh>
+#include <gcs/problem.hh>
+#include <gcs/solve.hh>
+
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <optional>
+#include <random>
+#include <set>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+#include <version>
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+#include <print>
+#else
+#include <fmt/core.h>
+#include <fmt/ostream.h>
+#include <fmt/ranges.h>
+#endif
+
+using std::cerr;
+using std::flush;
+using std::ifstream;
+using std::make_optional;
+using std::max;
+using std::min;
+using std::mt19937;
+using std::nullopt;
+using std::optional;
+using std::pair;
+using std::set;
+using std::string;
+using std::tuple;
+using std::uniform_int_distribution;
+using std::vector;
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+using std::print;
+using std::println;
+#else
+using fmt::print;
+using fmt::println;
+#endif
+
+using namespace gcs;
+using namespace gcs::innards;
+using namespace gcs::test_innards;
+
+namespace
+{
+    // The comment the presence-falsification justification writes. Tests count
+    // it: a rule that never fires makes every other assertion about it vacuous,
+    // and a twin instance that must not fire is only checked by counting to
+    // zero.
+    const string falsification_marker = "disjunctive optional: task";
+
+    // One task of an optional-Disjunctive instance. A presence spec of {0, 1} is
+    // a genuine decision variable; {1, 1} and {0, 0} are the constants, which
+    // exercise the two ways prepare() resolves a presence away. A length spec of
+    // {a, b} with a != b is a variable duration.
+    struct TaskSpec
+    {
+        pair<int, int> start_range;
+        pair<int, int> length;
+        pair<int, int> presence;
+    };
+
+    [[nodiscard]] auto is_var(pair<int, int> spec) -> bool
+    {
+        return spec.first != spec.second;
+    }
+
+    // Solutions are (every start, then every *variable* length, then every
+    // *variable* presence, each in task order).
+    [[nodiscard]] auto make_is_satisfying(const vector<TaskSpec> & tasks, bool strict)
+    {
+        return [&tasks, strict](const vector<int> & vals) {
+            auto n = tasks.size();
+            vector<int> length(n), present(n);
+            size_t k = n;
+            for (size_t i = 0; i < n; ++i)
+                length[i] = is_var(tasks[i].length) ? vals.at(k++) : tasks[i].length.first;
+            for (size_t i = 0; i < n; ++i)
+                present[i] = is_var(tasks[i].presence) ? vals.at(k++) : tasks[i].presence.first;
+
+            for (size_t i = 0; i < n; ++i)
+                for (size_t j = i + 1; j < n; ++j) {
+                    // An absent task occupies no time, so it constrains nobody
+                    // and nobody constrains it.
+                    if (! present[i] || ! present[j])
+                        continue;
+                    // Non-strict: pairs involving a zero-length task float freely.
+                    if (! strict && (length[i] == 0 || length[j] == 0))
+                        continue;
+                    if (vals[i] + length[i] > vals[j] && vals[j] + length[j] > vals[i])
+                        return false;
+                }
+            return true;
+        };
+    }
+
+    [[nodiscard]] auto enumerated_ranges(const vector<TaskSpec> & tasks) -> vector<pair<int, int>>
+    {
+        vector<pair<int, int>> ranges;
+        for (const auto & t : tasks)
+            ranges.push_back(t.start_range);
+        for (const auto & t : tasks)
+            if (is_var(t.length))
+                ranges.push_back(t.length);
+        for (const auto & t : tasks)
+            if (is_var(t.presence))
+                ranges.push_back(t.presence);
+        return ranges;
+    }
+
+    // Post the instance, returning the variables in enumeration order.
+    auto post_optional_disjunctive(Problem & p, const vector<TaskSpec> & tasks, bool strict, DisjunctivePresenceMutation mutation)
+        -> vector<IntegerVariableID>
+    {
+        vector<IntegerVariableID> starts, lengths, presences, all_vars;
+        for (const auto & t : tasks) {
+            auto v = p.create_integer_variable(Integer{t.start_range.first}, Integer{t.start_range.second});
+            starts.push_back(v);
+            all_vars.push_back(v);
+        }
+        for (const auto & t : tasks) {
+            if (is_var(t.length)) {
+                auto v = p.create_integer_variable(Integer{t.length.first}, Integer{t.length.second});
+                lengths.push_back(v);
+                all_vars.push_back(v);
+            }
+            else
+                lengths.push_back(constant_variable(Integer{t.length.first}));
+        }
+        for (const auto & t : tasks) {
+            if (is_var(t.presence)) {
+                auto v = p.create_integer_variable(Integer{t.presence.first}, Integer{t.presence.second});
+                presences.push_back(v);
+                all_vars.push_back(v);
+            }
+            else
+                presences.push_back(constant_variable(Integer{t.presence.first}));
+        }
+        p.post(Disjunctive{starts, lengths, presences}.with_strict(strict).with_presence_mutation(mutation));
+        return all_vars;
+    }
+
+    auto run_optional_test(bool proofs, const string & tag, const vector<TaskSpec> & tasks, bool strict) -> void
+    {
+        print(cerr, "disjunctive{} optional {} n={}{}", strict ? "_strict" : "", tag, tasks.size(), proofs ? " with proofs:" : ":");
+        cerr << flush;
+
+        set<vector<int>> expected, actual;
+        build_expected(expected, make_is_satisfying(tasks, strict), enumerated_ranges(tasks));
+        println(cerr, " expecting {} solutions", expected.size());
+
+        Problem p;
+        auto all_vars = post_optional_disjunctive(p, tasks, strict, disjunctive_presence_mutation::None{});
+
+        auto proof_name = proofs ? make_optional("disjunctive_optional_test_" + tag) : nullopt;
+        solve_for_tests(p, proof_name, actual, tuple{all_vars});
+        check_results(proof_name, expected, actual);
+    }
+}
+
+namespace
+{
+    // How many times `needle` appears in the proof file. The falsification
+    // marker is the only thing tests read the .pbp for; everything else about
+    // the proof is VeriPB's business.
+    [[nodiscard]] auto count_in_proof(const string & proof_name, const string & needle) -> int
+    {
+        ifstream f{proof_name + ".pbp"};
+        if (! f) {
+            println(cerr, "could not open {}.pbp to count markers", proof_name);
+            return -1;
+        }
+        int count = 0;
+        for (string line; getline(f, line);)
+            if (line.find(needle) != string::npos)
+                ++count;
+        return count;
+    }
+
+    /// What the falsification marker count must be. Note the asymmetry: "must
+    /// fire" is a claim about the root, where the fixture is arranged so the
+    /// rule triggers before any branching, and it holds whatever the search
+    /// does afterwards. "Must never fire" is a claim about every node, so it is
+    /// only assertable on a fixture where the task fits under *every* partial
+    /// assignment --- otherwise the harness's seed-derived random branching
+    /// decides whether the rule fires below the root, and the test is flaky.
+    enum class MarkerCount
+    {
+        AtLeastOne,   ///< the rule must fire
+        Never,        ///< the rule must not fire at any node
+        Unconstrained ///< firing below the root is legitimate here; see above
+    };
+
+    struct FalsificationExpectation
+    {
+        MarkerCount markers;
+        int present_ones;      ///< how many solutions have this task present
+        size_t falsified_task; ///< index of the task under test
+    };
+
+    // Where the task's presence sits in an enumerated solution: after every
+    // start and every variable length, then in task order among the variable
+    // presences. Derived rather than written down per fixture, because getting
+    // it wrong reads a *start* instead and the assertion then passes or fails
+    // for reasons that have nothing to do with the rule.
+    [[nodiscard]] auto presence_position(const vector<TaskSpec> & tasks, size_t task) -> size_t
+    {
+        auto at = tasks.size();
+        for (const auto & t : tasks)
+            if (is_var(t.length))
+                ++at;
+        for (size_t i = 0; i < task; ++i)
+            if (is_var(tasks[i].presence))
+                ++at;
+        return at;
+    }
+
+    // A falsification fixture and its twin, checked as a pair: the same
+    // enumeration check as everywhere else, plus the marker count, plus what
+    // the task's presence is allowed to be in a solution.
+    auto run_falsification_test(const string & tag, const vector<TaskSpec> & tasks, const FalsificationExpectation & expect) -> bool
+    {
+        println(cerr, "disjunctive optional falsification {}", tag);
+
+        set<vector<int>> expected, actual;
+        build_expected(expected, make_is_satisfying(tasks, true), enumerated_ranges(tasks));
+
+        Problem p;
+        auto all_vars = post_optional_disjunctive(p, tasks, true, disjunctive_presence_mutation::None{});
+
+        auto proof_name = "disjunctive_optional_falsify_" + tag;
+        solve_for_tests(p, make_optional(proof_name), actual, tuple{all_vars});
+
+        auto markers = count_in_proof(proof_name, falsification_marker);
+        bool ok = true;
+        switch (expect.markers) {
+            using enum MarkerCount;
+        case AtLeastOne:
+            if (markers <= 0) {
+                println(cerr, "{}: falsification marker count is {}, expected at least one", tag, markers);
+                ok = false;
+            }
+            break;
+        case Never:
+            if (markers != 0) {
+                println(cerr, "{}: falsification marker count is {}, expected zero", tag, markers);
+                ok = false;
+            }
+            break;
+        case Unconstrained: break;
+        }
+
+        // How many solutions leave the task present, according to brute force.
+        // On a "must fire at the root" fixture, this being zero is the semantic
+        // half of the marker assertion; on a twin, its being positive is what
+        // says the rule did *not* fire at the root, whatever it did below.
+        int present_count = 0;
+        auto position = presence_position(tasks, expect.falsified_task);
+        for (const auto & sol : expected)
+            if (sol.at(position) == 1)
+                ++present_count;
+        if (present_count != expect.present_ones) {
+            println(cerr, "{}: brute force says task {} is present in {} solutions, fixture claims {}", tag, expect.falsified_task, present_count,
+                expect.present_ones);
+            ok = false;
+        }
+
+        check_results(make_optional(proof_name), expected, actual);
+        return ok;
+    }
+
+    // Write a deliberately corrupted proof of the given instance, under
+    // `proof_basename`, and leave the checking to
+    // run_test_and_expect_verify_failure.bash --- which passes only if VeriPB
+    // rejects it. A mutation that still verifies means the honest derivation
+    // had slack, which is a finding about the derivation.
+    auto write_mutated_proof(const vector<TaskSpec> & tasks, DisjunctivePresenceMutation mutation, const string & proof_basename) -> void
+    {
+        set<vector<int>> actual;
+        Problem p;
+        auto all_vars = post_optional_disjunctive(p, tasks, true, mutation);
+        // Deliberately not check_results: ClaimOneTooFar draws a wrong
+        // conclusion, so the solution set is wrong too, and that is the point.
+        solve_for_tests(p, make_optional(proof_basename), actual, tuple{all_vars});
+        println(cerr, "wrote a deliberately corrupted proof to {}.pbp", proof_basename);
+    }
+}
+
+namespace
+{
+    // The OPB's constraints, so two models can be compared line for line. The
+    // s-expression goes to the .scp, so what is left here is exactly the
+    // pseudo-Boolean model --- minus the `*` comment lines, which include the
+    // per-constraint block header naming the constraint type. That header is
+    // *meant* to differ between the two forms (they are different constraint
+    // types, and cake_pb_cp dispatches on the name), and it is the one thing
+    // here that is not part of the model.
+    [[nodiscard]] auto read_opb_constraints(const string & proof_name) -> optional<vector<string>>
+    {
+        ifstream f{proof_name + ".opb"};
+        if (! f)
+            return nullopt;
+        vector<string> lines;
+        for (string line; getline(f, line);)
+            if (! line.starts_with("*"))
+                lines.push_back(line);
+        return lines;
+    }
+
+    [[nodiscard]] auto opb_names_constraint_type(const string & proof_name, const string & type) -> bool
+    {
+        ifstream f{proof_name + ".opb"};
+        for (string line; getline(f, line);)
+            if (line.starts_with("* constraint " + type + " "))
+                return true;
+        return false;
+    }
+
+    auto report_opb_difference(const string & what, const vector<string> & plain, const vector<string> & optional_form) -> void
+    {
+        println(cerr, "{}: the optional form's OPB differs from the plain form's", what);
+        for (size_t i = 0; i < max(plain.size(), optional_form.size()); ++i) {
+            auto a = i < plain.size() ? plain[i] : "<end>";
+            auto b = i < optional_form.size() ? optional_form[i] : "<end>";
+            if (a != b)
+                println(cerr, "  line {}: plain {:?} vs optional {:?}", i + 1, a, b);
+        }
+    }
+
+    // The optional form must degenerate structurally, not by emitting a
+    // constant-true disjunct: posting every presence as the constant 1 has to
+    // produce the same OPB as not passing presences at all. That is what keeps
+    // the non-optional constructors' encoding --- and every proof already
+    // written against it --- untouched by this feature.
+    auto check_constant_presence_encoding_is_unchanged(bool strict) -> bool
+    {
+        vector<pair<int, int>> start_ranges{{0, 3}, {0, 3}, {0, 4}};
+        vector<int> lengths{2, 2, 3};
+
+        auto build = [&](bool optional_form, const string & proof_name) -> optional<vector<string>> {
+            Problem p;
+            vector<IntegerVariableID> starts, lengths_v, presences;
+            for (auto & [lo, hi] : start_ranges)
+                starts.push_back(p.create_integer_variable(Integer{lo}, Integer{hi}));
+            for (auto l : lengths)
+                lengths_v.push_back(constant_variable(Integer{l}));
+            for (size_t i = 0; i < starts.size(); ++i)
+                presences.push_back(constant_variable(1_i));
+
+            if (optional_form)
+                p.post(Disjunctive{starts, lengths_v, presences}.with_strict(strict));
+            else
+                p.post(Disjunctive{starts, lengths_v}.with_strict(strict));
+
+            set<vector<int>> results;
+            solve_for_tests(p, make_optional(proof_name), results, tuple{starts});
+            auto opb = read_opb_constraints(proof_name);
+            auto expected_type = string{strict ? "disjunctive_strict" : "disjunctive"} + (optional_form ? "_optional" : "");
+            bool named_right = opb_names_constraint_type(proof_name, expected_type);
+            dispose_of_proof_files(proof_name);
+            if (! named_right) {
+                println(cerr, "constant-presence encoding check: the {} form's OPB does not name itself {}", optional_form ? "optional" : "plain",
+                    expected_type);
+                return nullopt;
+            }
+            return opb;
+        };
+
+        auto suffix = strict ? "_strict" : "";
+        auto plain = build(false, string{"disjunctive_optional_encoding_plain"} + suffix);
+        auto optional_form = build(true, string{"disjunctive_optional_encoding_opt"} + suffix);
+        if (! plain || ! optional_form) {
+            println(cerr, "constant-presence encoding check: could not read an OPB back");
+            return false;
+        }
+        if (*plain != *optional_form) {
+            report_opb_difference("constant-presence encoding check", *plain, *optional_form);
+            return false;
+        }
+
+        // Solution-set equivalence too, over a random corpus: the OPB check
+        // above says the two models are the same pseudo-Boolean formula, and
+        // this says the two constraints propagate to the same solutions, which
+        // is the property a user of the new constructor actually relies on.
+        mt19937 rand(*get_seed());
+        for (int k = 0; k < 15; ++k) {
+            uniform_int_distribution<> n_dist(2, 3), lo_dist(0, 3), span_dist(0, 3), len_dist(0, 3);
+            auto n = static_cast<size_t>(n_dist(rand));
+            vector<TaskSpec> tasks;
+            for (size_t i = 0; i < n; ++i) {
+                auto lo = lo_dist(rand);
+                auto len = len_dist(rand);
+                tasks.push_back(TaskSpec{{lo, min(lo + span_dist(rand), 3)}, {len, len}, {1, 1}});
+            }
+
+            set<vector<int>> with_presences, without;
+            {
+                Problem p;
+                auto all_vars = post_optional_disjunctive(p, tasks, strict, disjunctive_presence_mutation::None{});
+                solve_for_tests(p, nullopt, with_presences, tuple{all_vars});
+            }
+            {
+                Problem p;
+                vector<IntegerVariableID> starts, lengths_v;
+                for (const auto & t : tasks)
+                    starts.push_back(p.create_integer_variable(Integer{t.start_range.first}, Integer{t.start_range.second}));
+                for (const auto & t : tasks)
+                    lengths_v.push_back(constant_variable(Integer{t.length.first}));
+                p.post(Disjunctive{starts, lengths_v}.with_strict(strict));
+                solve_for_tests(p, nullopt, without, tuple{starts});
+            }
+            if (with_presences != without) {
+                println(cerr, "constant-presence equivalence {}: optional form has {} solutions, plain form has {}", k, with_presences.size(),
+                    without.size());
+                return false;
+            }
+        }
+        return true;
+    }
+
+    // What optional tasks are allowed to cost the encoding, stated as a diff.
+    // Build the same instance twice --- once with genuine {0, 1} presence
+    // variables, once with the same variables created and left out of the
+    // constraint --- so the two problems declare identical variables and the
+    // OPBs are comparable line for line. Every line must then match, except the
+    // separation clauses, each of which must be the plain form's clause with
+    // exactly the two presence literals appended.
+    //
+    // This is the design commitment #735 is built on: presence rides on the
+    // clause the pair already had, so no proof step gets a new row to cite and
+    // the pols are the ones that were there before.
+    auto check_optional_costs_only_the_clause_literals(bool strict) -> bool
+    {
+        vector<pair<int, int>> start_ranges{{0, 3}, {0, 3}, {0, 4}};
+        vector<int> lengths{2, 2, 3};
+
+        auto build = [&](bool optional_form, const string & proof_name) -> optional<vector<string>> {
+            Problem p;
+            vector<IntegerVariableID> starts, lengths_v, presences;
+            for (auto & [lo, hi] : start_ranges)
+                starts.push_back(p.create_integer_variable(Integer{lo}, Integer{hi}));
+            for (auto l : lengths)
+                lengths_v.push_back(constant_variable(Integer{l}));
+            // Created either way, so the variable declarations match; only the
+            // optional form hands them to the constraint.
+            for (size_t i = 0; i < starts.size(); ++i)
+                presences.push_back(p.create_integer_variable(0_i, 1_i));
+
+            if (optional_form)
+                p.post(Disjunctive{starts, lengths_v, presences}.with_strict(strict));
+            else
+                p.post(Disjunctive{starts, lengths_v}.with_strict(strict));
+
+            set<vector<int>> results;
+            solve_for_tests(p, make_optional(proof_name), results, tuple{starts});
+            auto opb = read_opb_constraints(proof_name);
+            dispose_of_proof_files(proof_name);
+            return opb;
+        };
+
+        auto suffix = strict ? "_strict" : "";
+        auto plain = build(false, string{"disjunctive_optional_diff_plain"} + suffix);
+        auto optional_form = build(true, string{"disjunctive_optional_diff_opt"} + suffix);
+        if (! plain || ! optional_form) {
+            println(cerr, "optional-encoding diff: could not read an OPB back");
+            return false;
+        }
+        if (plain->size() != optional_form->size()) {
+            report_opb_difference("optional-encoding diff (line count)", *plain, *optional_form);
+            return false;
+        }
+
+        int clauses_grown = 0;
+        for (size_t i = 0; i < plain->size(); ++i) {
+            const auto &a = (*plain)[i], &b = (*optional_form)[i];
+            if (a == b)
+                continue;
+            // The only permitted difference: the plain clause, with presence
+            // literals inserted before its `>= 1 ;` tail. Anything else --- a
+            // changed coefficient, a changed degree, a new row --- is the
+            // encoding drifting rather than being extended.
+            auto tail = a.find(">=");
+            if (tail == string::npos || ! b.starts_with(a.substr(0, tail)) || ! b.ends_with(a.substr(tail))) {
+                report_opb_difference("optional-encoding diff", *plain, *optional_form);
+                return false;
+            }
+            // Two tasks per clause, so two added terms, each a negated presence
+            // atom at coefficient 1: "1 ~i[_4][b0] 1 ~i[_5][b0]". Nothing may be
+            // scaled, and nothing positive may appear --- a presence entering
+            // any other way would be a different encoding.
+            auto added = b.substr(tail, b.size() - a.size());
+            vector<string> tokens;
+            for (size_t at = added.find_first_not_of(' '); at != string::npos; at = added.find_first_not_of(' ', at)) {
+                auto end = added.find(' ', at);
+                tokens.push_back(added.substr(at, end == string::npos ? string::npos : end - at));
+                at = end;
+            }
+            bool literals_ok = tokens.size() == 4;
+            for (size_t t = 0; literals_ok && t + 1 < tokens.size(); t += 2)
+                literals_ok = tokens[t] == "1" && tokens[t + 1].starts_with("~");
+            if (! literals_ok) {
+                println(cerr, "optional-encoding diff: line {} gained {:?}, which is not a pair of unit negated presence literals", i + 1, added);
+                return false;
+            }
+            ++clauses_grown;
+        }
+
+        // Three tasks, so three pairs, so three separation clauses --- and if
+        // the diff were empty the check above would pass vacuously.
+        if (clauses_grown != 3) {
+            println(cerr, "optional-encoding diff: {} clauses grew, expected 3", clauses_grown);
+            return false;
+        }
+        println(cerr, "optional-encoding diff{}: {} separation clauses grew, everything else is identical", suffix, clauses_grown);
+        return true;
+    }
+}
+
+namespace
+{
+    // Semantic drift detector. Model the same instance two ways --- presence
+    // Booleans, and durations channelled to {0, d} under the non-strict
+    // reading, where a zero-duration task places no constraint on anything ---
+    // and require the same solution set under the bijection
+    // present_i = 1 <-> d_i = d. This pins "absent occupies no time" against a
+    // formulation that shares none of the optional-task code path.
+    auto check_bijection(const string & tag, const vector<TaskSpec> & tasks) -> bool
+    {
+        set<vector<int>> via_presence, via_duration;
+
+        {
+            Problem p;
+            vector<IntegerVariableID> starts, lengths_v, presences, all_vars;
+            for (const auto & t : tasks)
+                starts.push_back(p.create_integer_variable(Integer{t.start_range.first}, Integer{t.start_range.second}));
+            for (const auto & t : tasks) {
+                lengths_v.push_back(constant_variable(Integer{t.length.first}));
+                presences.push_back(p.create_integer_variable(0_i, 1_i));
+            }
+            p.post(Disjunctive{starts, lengths_v, presences}.with_strict(false));
+            all_vars = starts;
+            all_vars.insert(all_vars.end(), presences.begin(), presences.end());
+            solve_for_tests(p, nullopt, via_presence, tuple{all_vars});
+        }
+
+        {
+            Problem p;
+            vector<IntegerVariableID> starts, lengths_v, presences, all_vars;
+            for (const auto & t : tasks)
+                starts.push_back(p.create_integer_variable(Integer{t.start_range.first}, Integer{t.start_range.second}));
+            for (const auto & t : tasks) {
+                // d_i in {0, d}, channelled to the presence Boolean. A duration
+                // of 0 makes both branches the same variable, which is the
+                // honest encoding of "this task occupies nothing either way".
+                auto d = p.create_integer_variable(0_i, Integer{t.length.first});
+                auto present = p.create_integer_variable(0_i, 1_i);
+                p.post(LinearEquality{WeightedSum{} + 1_i * d + -Integer{t.length.first} * present, 0_i});
+                lengths_v.push_back(d);
+                presences.push_back(present);
+            }
+            p.post(Disjunctive{starts, lengths_v}.with_strict(false));
+            all_vars = starts;
+            all_vars.insert(all_vars.end(), presences.begin(), presences.end());
+            solve_for_tests(p, nullopt, via_duration, tuple{all_vars});
+        }
+
+        if (via_presence != via_duration) {
+            println(
+                cerr, "bijection {}: presence model has {} solutions, variable-duration model has {}", tag, via_presence.size(), via_duration.size());
+            for (const auto & sol : via_presence)
+                if (! via_duration.contains(sol))
+                    println(cerr, "  only in the presence model: {}", sol);
+            for (const auto & sol : via_duration)
+                if (! via_presence.contains(sol))
+                    println(cerr, "  only in the variable-duration model: {}", sol);
+            return false;
+        }
+        println(cerr, "bijection {}: {} solutions agree", tag, via_presence.size());
+        return true;
+    }
+
+    // The routing this constraint replaces. `fzn_disjunctive_opt` used to
+    // decompose to `fzn_cumulative_opt` at unit demands and capacity one, so the
+    // non-strict optional Disjunctive must agree with that Cumulative exactly.
+    // Not a redundant cross-check: it is the evidence that switching the mznlib
+    // redefinition over changes nothing but the encoding and the proof.
+    auto check_matches_optional_cumulative(const string & tag, const vector<TaskSpec> & tasks) -> bool
+    {
+        set<vector<int>> via_disjunctive, via_cumulative;
+
+        auto build = [&](bool as_cumulative, set<vector<int>> & into) {
+            Problem p;
+            vector<IntegerVariableID> starts, lengths_v, presences, all_vars;
+            for (const auto & t : tasks)
+                starts.push_back(p.create_integer_variable(Integer{t.start_range.first}, Integer{t.start_range.second}));
+            for (const auto & t : tasks) {
+                lengths_v.push_back(constant_variable(Integer{t.length.first}));
+                presences.push_back(p.create_integer_variable(Integer{t.presence.first}, Integer{t.presence.second}));
+            }
+            if (as_cumulative) {
+                vector<IntegerVariableID> heights(tasks.size(), constant_variable(1_i));
+                p.post(Cumulative{starts, lengths_v, heights, presences, constant_variable(1_i)});
+            }
+            else
+                p.post(Disjunctive{starts, lengths_v, presences}.with_strict(false));
+            all_vars = starts;
+            all_vars.insert(all_vars.end(), presences.begin(), presences.end());
+            solve_for_tests(p, nullopt, into, tuple{all_vars});
+        };
+
+        build(false, via_disjunctive);
+        build(true, via_cumulative);
+
+        if (via_disjunctive != via_cumulative) {
+            println(cerr, "vs cumulative {}: disjunctive has {} solutions, cumulative has {}", tag, via_disjunctive.size(), via_cumulative.size());
+            for (const auto & sol : via_disjunctive)
+                if (! via_cumulative.contains(sol))
+                    println(cerr, "  only in the disjunctive model: {}", sol);
+            for (const auto & sol : via_cumulative)
+                if (! via_disjunctive.contains(sol))
+                    println(cerr, "  only in the cumulative model: {}", sol);
+            return false;
+        }
+        println(cerr, "vs cumulative {}: {} solutions agree", tag, via_disjunctive.size());
+        return true;
+    }
+}
+
+namespace
+{
+    // The motivating use case: maximise the number of scheduled tasks, with the
+    // optimum proved. This is also the only test that puts a presence variable
+    // in the objective, so it is what exercises presence literals on the
+    // objective's proof path.
+    auto check_objective(const string & tag, const vector<TaskSpec> & tasks, int expected_optimum) -> bool
+    {
+        Problem p;
+        vector<IntegerVariableID> starts, lengths_v, presences;
+        for (const auto & t : tasks)
+            starts.push_back(p.create_integer_variable(Integer{t.start_range.first}, Integer{t.start_range.second}));
+        for (const auto & t : tasks) {
+            lengths_v.push_back(constant_variable(Integer{t.length.first}));
+            presences.push_back(p.create_integer_variable(0_i, 1_i));
+        }
+        p.post(Disjunctive{starts, lengths_v, presences});
+
+        auto scheduled = p.create_integer_variable(0_i, Integer(static_cast<long long>(tasks.size())), "scheduled");
+        WeightedSum count;
+        for (const auto & v : presences)
+            count += 1_i * v;
+        p.post(LinearEquality{count + -1_i * scheduled, 0_i});
+        p.maximise(scheduled);
+
+        auto proof_name = "disjunctive_optional_objective_" + tag;
+        optional<int> best;
+        solve_for_tests_with_callbacks(
+            p, make_optional(proof_name),
+            [&](const CurrentState & s) -> bool {
+                best = static_cast<int>(s(scheduled).raw_value);
+                return true;
+            },
+            [](const CurrentState &) -> bool { return true; });
+
+        bool ok = true;
+        if (best != make_optional(expected_optimum)) {
+            println(cerr, "objective {}: optimum is {}, expected {}", tag, best ? std::to_string(*best) : "none", expected_optimum);
+            ok = false;
+        }
+        if (! verify_proof_and_dispose(proof_name)) {
+            println(cerr, "objective {}: proof did not verify", tag);
+            ok = false;
+        }
+        else
+            println(cerr, "objective {}: optimum {} verified", tag, expected_optimum);
+        return ok;
+    }
+}
+
+namespace
+{
+    auto expect_bad_presence_throws(const char * label, pair<int, int> presence_domain) -> bool
+    {
+        Problem p;
+        auto s = p.create_integer_variable(0_i, 3_i, "s");
+        auto s2 = p.create_integer_variable(0_i, 3_i, "s2");
+        auto present = p.create_integer_variable(Integer{presence_domain.first}, Integer{presence_domain.second}, "present");
+        p.post(Disjunctive{vector<IntegerVariableID>{s, s2}, vector<IntegerVariableID>{constant_variable(2_i), constant_variable(2_i)},
+            vector<IntegerVariableID>{present, constant_variable(1_i)}});
+        try {
+            solve(p, [](const CurrentState &) { return true; });
+        }
+        catch (const InvalidProblemDefinitionException &) {
+            return true;
+        }
+        println(cerr, "{}: expected InvalidProblemDefinitionException", label);
+        return false;
+    }
+
+    auto expect_constant_presence_out_of_range_throws() -> bool
+    {
+        Problem p;
+        auto s = p.create_integer_variable(0_i, 3_i, "s");
+        auto s2 = p.create_integer_variable(0_i, 3_i, "s2");
+        try {
+            p.post(Disjunctive{vector<IntegerVariableID>{s, s2}, vector<IntegerVariableID>{constant_variable(2_i), constant_variable(2_i)},
+                vector<IntegerVariableID>{constant_variable(2_i), constant_variable(1_i)}});
+        }
+        catch (const InvalidProblemDefinitionException &) {
+            return true;
+        }
+        println(cerr, "constant presence 2: expected InvalidProblemDefinitionException");
+        return false;
+    }
+
+    auto expect_mismatched_sizes_throws() -> bool
+    {
+        Problem p;
+        auto s = p.create_integer_variable(0_i, 3_i, "s");
+        try {
+            p.post(Disjunctive{vector<IntegerVariableID>{s}, vector<IntegerVariableID>{constant_variable(2_i)}, vector<IntegerVariableID>{}});
+        }
+        catch (const InvalidProblemDefinitionException &) {
+            return true;
+        }
+        println(cerr, "mismatched presence array size: expected InvalidProblemDefinitionException");
+        return false;
+    }
+}
+
+namespace
+{
+    // The sharp-margin falsification family. Unit-length blockers at fixed
+    // starts, one time point apart, leave no two consecutive free times
+    // anywhere in the optional task's reach --- so it can go nowhere, while
+    // dropping any single blocker opens a gap it fits in. Task 0 is the
+    // optional one under test; the rest are present and start-fixed. Capacity
+    // is one here, so the blockers have to be pairwise disjoint themselves,
+    // which is what makes "saturated" mean "alternating" rather than "stacked".
+    //
+    // `last_blocker` is where the wall stops: at 7 the whole domain is covered
+    // and the chain runs four steps (blocked times 1, 3, 5 and 7); at 5 the tail
+    // has room for exactly one placement, start 6, which is the twin the
+    // one-too-far mutation needs.
+    [[nodiscard]] auto sharp_margin_tasks(int last_blocker) -> vector<TaskSpec>
+    {
+        vector<TaskSpec> tasks{TaskSpec{{0, 6}, {2, 2}, {0, 1}}}; // the optional task under test
+        for (int t = 1; t <= last_blocker; t += 2)
+            tasks.push_back(TaskSpec{{t, t}, {1, 1}, {1, 1}});
+        return tasks;
+    }
+}
+
+auto main(int argc, char * argv[]) -> int
+{
+    establish_and_announce_seed(argc, argv);
+
+    // Mutation lanes come in through run_test_and_expect_verify_failure.bash,
+    // which prepends its own flags, so the mutation is selected by scanning
+    // argv rather than from the positional mode. The harness runs veripb and
+    // passes only if it rejects what we write here; all this binary has to do
+    // is write the corrupted proof and exit successfully.
+    optional<DisjunctivePresenceMutation> mutation;
+    vector<TaskSpec> mutation_tasks;
+    string proof_basename = "disjunctive_optional_mutation";
+    for (int a = 1; a < argc; ++a) {
+        string arg = argv[a];
+        // The deposits argue about a different optional task than the one being
+        // falsified, so nothing the chain establishes is about the conclusion.
+        // Needs a second optional task to point at.
+        if (arg == "--mutate=wrong_task") {
+            mutation = disjunctive_presence_mutation::WrongTask{};
+            mutation_tasks = sharp_margin_tasks(7);
+            mutation_tasks.push_back(TaskSpec{{0, 6}, {2, 2}, {0, 1}});
+        }
+        // The control: no chain at all. If this lane ever starts verifying, the
+        // chain is decoration and the other mutations are checking nothing.
+        else if (arg == "--mutate=emit_nothing") {
+            mutation = disjunctive_presence_mutation::EmitNothing{};
+            mutation_tasks = sharp_margin_tasks(7);
+        }
+        // Sharp margin: on the twin where exactly one placement still fits,
+        // falsifying anyway is a wrong inference, and the chain runs out of
+        // blockers before it can pretend otherwise.
+        else if (arg == "--mutate=one_too_far") {
+            mutation = disjunctive_presence_mutation::ClaimOneTooFar{};
+            mutation_tasks = sharp_margin_tasks(5);
+        }
+        else if (arg == "--proof-files-basename" && a + 1 < argc)
+            proof_basename = argv[++a];
+    }
+
+    if (mutation) {
+        write_mutated_proof(mutation_tasks, *mutation, proof_basename);
+        return EXIT_SUCCESS;
+    }
+
+    string mode = argc >= 2 ? argv[1] : "enumerate";
+    bool ok = true;
+
+    if (mode == "enumerate") {
+        // Rejections first: a presence outside {0, 1} and a mismatched array
+        // are modelling errors, not silently-reinterpreted input.
+        ok &= expect_bad_presence_throws("presence 0..2", {0, 2});
+        ok &= expect_bad_presence_throws("presence -1..1", {-1, 1});
+        ok &= expect_constant_presence_out_of_range_throws();
+        ok &= expect_mismatched_sizes_throws();
+        if (! ok)
+            return EXIT_FAILURE;
+
+        for (bool strict : {true, false}) {
+            ok &= check_constant_presence_encoding_is_unchanged(strict);
+            ok &= check_optional_costs_only_the_clause_literals(strict);
+        }
+        if (! ok)
+            return EXIT_FAILURE;
+
+        vector<pair<string, vector<TaskSpec>>> data{
+            // Two optional tasks that cannot both be scheduled where they are,
+            // but either or both may simply be absent.
+            {"pair", {{{0, 3}, {2, 2}, {0, 1}}, {{0, 3}, {2, 2}, {0, 1}}}},
+            // Room for both, so presence never matters.
+            {"roomy", {{{0, 7}, {2, 2}, {0, 1}}, {{0, 7}, {2, 2}, {0, 1}}}},
+            // One mandatory task and one optional one it can block.
+            {"one_mandatory", {{{0, 2}, {3, 3}, {1, 1}}, {{0, 2}, {2, 2}, {0, 1}}}},
+            // A constantly-absent task: it must drop out entirely, so its start
+            // is free and it overlaps whatever it likes.
+            {"const_absent", {{{0, 2}, {3, 3}, {0, 0}}, {{0, 2}, {3, 3}, {1, 1}}}},
+            // A zero-length task: under the strict reading it may not sit inside
+            // another, unless it is absent, which is the case Cumulative cannot
+            // express and this constraint exists to certify.
+            {"zero_length", {{{0, 3}, {0, 0}, {0, 1}}, {{0, 3}, {2, 2}, {1, 1}}}},
+            // Two zero-length optional tasks and one real one.
+            {"two_zero", {{{0, 2}, {0, 0}, {0, 1}}, {{0, 2}, {0, 0}, {0, 1}}, {{0, 2}, {2, 2}, {1, 1}}}},
+            // A variable duration on an optional task: the zero-length escape
+            // and the presence disjunct are on the same clause.
+            {"var_length", {{{0, 3}, {0, 2}, {0, 1}}, {{0, 3}, {2, 2}, {1, 1}}}},
+            // Both variable-duration and both optional.
+            {"var_both", {{{0, 3}, {1, 2}, {0, 1}}, {{0, 3}, {0, 2}, {0, 1}}}},
+            // A task that cannot fit even alone once the fixed one is placed:
+            // its presence is false at the root, with no search needed.
+            {"never_fits", {{{1, 1}, {2, 2}, {0, 1}}, {{1, 1}, {2, 2}, {1, 1}}}},
+            // Three optional tasks over a tight horizon.
+            {"three_tight", {{{0, 2}, {2, 2}, {0, 1}}, {{0, 2}, {1, 1}, {0, 1}}, {{0, 2}, {1, 1}, {0, 1}}}},
+            // Negative starts.
+            {"neg_start", {{{-2, 1}, {2, 2}, {0, 1}}, {{-2, 1}, {2, 2}, {0, 1}}}},
+            // A fixed start on an optional task: nothing to push, but its
+            // presence can still be decided.
+            {"fixed_start", {{{1, 1}, {2, 2}, {0, 1}}, {{0, 2}, {2, 2}, {1, 1}}}},
+            // Mixed constants: one always present, one always absent, one free.
+            {"mixed_consts", {{{0, 2}, {2, 2}, {1, 1}}, {{0, 2}, {2, 2}, {0, 0}}, {{0, 2}, {2, 2}, {0, 1}}}},
+        };
+
+        mt19937 rand(*get_seed());
+        // Random instances for breadth, all tasks optional so the presence
+        // cross-product is exercised everywhere. Kept small: enumeration is over
+        // starts times durations times presences, so the space grows fast.
+        for (int k = 0; k < 20; ++k) {
+            uniform_int_distribution<> n_dist(2, 3), lo_dist(0, 3), span_dist(0, 3), len_dist(0, 3), pres_dist(0, 3), var_len_dist(0, 3);
+            vector<TaskSpec> tasks;
+            auto n = n_dist(rand);
+            for (int i = 0; i < n; ++i) {
+                auto lo = lo_dist(rand);
+                auto len = len_dist(rand);
+                auto p = pres_dist(rand);
+                // One in four durations is a variable, spanning down to zero.
+                auto length = var_len_dist(rand) == 0 ? pair{0, len} : pair{len, len};
+                tasks.push_back(TaskSpec{{lo, min(lo + span_dist(rand), 3)}, length, p == 0 ? pair{1, 1} : (p == 1 ? pair{0, 0} : pair{0, 1})});
+            }
+            data.emplace_back("random" + std::to_string(k), tasks);
+        }
+
+        for (bool proofs : {false, true}) {
+            if (proofs && ! can_run_veripb())
+                continue;
+            for (bool strict : {true, false})
+                for (const auto & [tag, tasks] : data)
+                    run_optional_test(proofs, tag + (strict ? "_strict" : "_nonstrict"), tasks, strict);
+        }
+    }
+    else if (mode == "falsify") {
+        if (! can_run_veripb()) {
+            println(cerr, "veripb not available, skipping falsification tests");
+            return EXIT_SUCCESS;
+        }
+
+        // Sharp margin: the blockers leave no two consecutive free times in the
+        // optional task's reach, so it can go nowhere, the rule fires at the
+        // root, and its presence is false in every solution.
+        ok &= run_falsification_test(
+            "sharp", sharp_margin_tasks(7), FalsificationExpectation{.markers = MarkerCount::AtLeastOne, .present_ones = 0, .falsified_task = 0});
+
+        // Twin, one blocker short: the tail of the horizon has room for exactly
+        // one placement, start 6. That one surviving solution is what says the
+        // rule did not fire at the root. It legitimately *does* fire below the
+        // root, once branching has ruled that start out, so the marker count
+        // here is a function of the search seed and is not asserted on.
+        ok &= run_falsification_test("twin_window", sharp_margin_tasks(5),
+            FalsificationExpectation{.markers = MarkerCount::Unconstrained, .present_ones = 1, .falsified_task = 0});
+
+        // The twin that carries the marker-count-zero assertion: the optional
+        // task's whole domain sits in free space, so nothing blocks it at the
+        // root or below it, whatever the search does.
+        ok &= run_falsification_test("twin_free", {{{0, 1}, {2, 2}, {0, 1}}, {{4, 4}, {1, 1}, {1, 1}}, {{6, 6}, {1, 1}, {1, 1}}},
+            FalsificationExpectation{.markers = MarkerCount::Never, .present_ones = 2, .falsified_task = 0});
+
+        // A second optional task, so the wrong-task mutation has somewhere
+        // wrong to point. Both are falsified.
+        auto two_optional = sharp_margin_tasks(7);
+        two_optional.push_back(TaskSpec{{0, 6}, {2, 2}, {0, 1}});
+        ok &= run_falsification_test(
+            "two_optional", two_optional, FalsificationExpectation{.markers = MarkerCount::AtLeastOne, .present_ones = 0, .falsified_task = 0});
+
+        if (! ok)
+            return EXIT_FAILURE;
+    }
+    else if (mode == "bijection") {
+        ok &= check_bijection("pair", {{{0, 3}, {2, 2}, {0, 1}}, {{0, 3}, {2, 2}, {0, 1}}});
+        ok &= check_bijection("three", {{{0, 3}, {2, 2}, {0, 1}}, {{0, 3}, {1, 1}, {0, 1}}, {{0, 3}, {2, 2}, {0, 1}}});
+        ok &= check_bijection("zero_edge", {{{0, 2}, {0, 0}, {0, 1}}, {{0, 2}, {2, 2}, {0, 1}}});
+        ok &= check_bijection("neg_start", {{{-2, 1}, {2, 2}, {0, 1}}, {{-2, 1}, {2, 2}, {0, 1}}});
+        if (! ok)
+            return EXIT_FAILURE;
+    }
+    else if (mode == "cumulative") {
+        ok &= check_matches_optional_cumulative("pair", {{{0, 3}, {2, 2}, {0, 1}}, {{0, 3}, {2, 2}, {0, 1}}});
+        ok &= check_matches_optional_cumulative("three", {{{0, 3}, {2, 2}, {0, 1}}, {{0, 3}, {1, 1}, {0, 1}}, {{0, 3}, {2, 2}, {0, 1}}});
+        ok &= check_matches_optional_cumulative("zero_edge", {{{0, 2}, {0, 0}, {0, 1}}, {{0, 2}, {2, 2}, {0, 1}}});
+        ok &= check_matches_optional_cumulative("neg_start", {{{-2, 1}, {2, 2}, {0, 1}}, {{-2, 1}, {2, 2}, {0, 1}}});
+
+        mt19937 rand(*get_seed());
+        for (int k = 0; k < 25; ++k) {
+            uniform_int_distribution<> n_dist(2, 3), lo_dist(-1, 3), span_dist(0, 3), len_dist(0, 3), pres_dist(0, 2);
+            vector<TaskSpec> tasks;
+            auto n = n_dist(rand);
+            for (int i = 0; i < n; ++i) {
+                auto lo = lo_dist(rand);
+                auto len = len_dist(rand);
+                auto pv = pres_dist(rand);
+                tasks.push_back(TaskSpec{{lo, min(lo + span_dist(rand), 3)}, {len, len}, pv == 0 ? pair{1, 1} : (pv == 1 ? pair{0, 0} : pair{0, 1})});
+            }
+            ok &= check_matches_optional_cumulative("random" + std::to_string(k), tasks);
+        }
+        if (! ok)
+            return EXIT_FAILURE;
+    }
+    else if (mode == "objective") {
+        if (! can_run_veripb()) {
+            println(cerr, "veripb not available, skipping objective tests");
+            return EXIT_SUCCESS;
+        }
+        // Three tasks of length 2 over t in 0..3: at most two fit end to end,
+        // so the optimum is 2.
+        ok &= check_objective("pack_two", {{{0, 2}, {2, 2}, {0, 1}}, {{0, 2}, {2, 2}, {0, 1}}, {{0, 2}, {2, 2}, {0, 1}}}, 2);
+        // One task is longer than the whole horizon left to it, so the optimum
+        // is one short of the count.
+        ok &= check_objective("one_too_big", {{{0, 0}, {5, 5}, {0, 1}}, {{0, 2}, {2, 2}, {0, 1}}, {{2, 4}, {2, 2}, {0, 1}}}, 2);
+        if (! ok)
+            return EXIT_FAILURE;
+    }
+    else {
+        println(cerr, "unknown mode {}", mode);
+        return EXIT_FAILURE;
+    }
+
+    return ok ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/gcs/constraints/innards/disjunctive_mutations.hh
+++ b/gcs/constraints/innards/disjunctive_mutations.hh
@@ -6,8 +6,9 @@
 /**
  * \file
  *
- * Deliberate corruptions of `Disjunctive`'s detectable-precedence proof steps,
- * which exist so that a test can show the honest derivation is tight to what it
+ * Deliberate corruptions of `Disjunctive`'s detectable-precedence and
+ * presence-falsification proof steps, which exist so that a test can show the
+ * honest derivation is tight to what it
  * claims. They live here, in the innards, rather than beside the constraint they
  * corrupt: a header a user of the library includes should not advertise a way to
  * make the solver emit deliberately wrong proofs. Same reason as
@@ -88,6 +89,67 @@ namespace gcs::innards
     using DisjunctiveProofMutation =
         std::variant<disjunctive_proof_mutation::None, disjunctive_proof_mutation::EmitNothing, disjunctive_proof_mutation::SkipRefutation,
             disjunctive_proof_mutation::SkipTargetFold, disjunctive_proof_mutation::LooseDetectionBound, disjunctive_proof_mutation::PushOneTooFar>;
+
+    /**
+     * \brief Deliberate corruptions of the presence-falsification derivation,
+     * for testing only. VeriPB must reject each of them.
+     *
+     * What can serve as a test here is narrower than for a bound push, and
+     * worth understanding before adding to this list: presence falsification is
+     * a *conflict-shaped* rule, whose content is "this task cannot be here at
+     * all". Once the chain has cornered the task, the reason context extended
+     * with "the task is present" is contradictory, and every RUP under it is
+     * vacuously valid. A mutation that merely shortens the chain therefore
+     * produces a shorter but still *sound* derivation, and VeriPB is right to
+     * accept it. Corrupting the route is not a test; corrupt the destination.
+     * `cumulative_mutations.hh` records the same finding, from the constraint
+     * this rule is modelled on.
+     *
+     * So the two that bite are \ref disjunctive_presence_mutation::WrongTask,
+     * which argues about a task nothing has cornered, and \ref
+     * disjunctive_presence_mutation::ClaimOneTooFar, which draws the conclusion
+     * where it is false. \ref disjunctive_presence_mutation::EmitNothing is the
+     * control that says the chain is required at all.
+     *
+     * All but ClaimOneTooFar change nothing except the proof: the same
+     * presences are falsified, the same solutions reported, and the OPB is
+     * untouched. ClaimOneTooFar necessarily changes the inference, since making
+     * the conclusion wrong is the whole point of it.
+     *
+     * \ingroup Innards
+     */
+    namespace disjunctive_presence_mutation
+    {
+        /// Emit the honest derivation.
+        struct None
+        {
+        };
+
+        /// Carry some other optional task's presence literal on the chain's
+        /// deposits, so the derivation argues about a task that is not the one
+        /// being falsified.
+        struct WrongTask
+        {
+        };
+
+        /// Fire on an instance where exactly one placement still fits, claiming
+        /// the task is absent when it is not. The "bound + 1 must fail" check
+        /// for this rule: it corrupts the conclusion rather than the route to
+        /// it, which is what a margin of exactly one unit is there to expose.
+        struct ClaimOneTooFar
+        {
+        };
+
+        /// Emit no chain at all, leaving the inference to the framework's
+        /// wrapping RUP. Not a corruption but a control: if VeriPB accepts
+        /// this, the chain is decoration and no mutation of it can be caught.
+        struct EmitNothing
+        {
+        };
+    }
+
+    using DisjunctivePresenceMutation = std::variant<disjunctive_presence_mutation::None, disjunctive_presence_mutation::WrongTask,
+        disjunctive_presence_mutation::ClaimOneTooFar, disjunctive_presence_mutation::EmitNothing>;
 }
 
 #endif

--- a/gcs/constraints/innards/task_presence.cc
+++ b/gcs/constraints/innards/task_presence.cc
@@ -1,0 +1,27 @@
+#include <gcs/constraints/innards/task_presence.hh>
+#include <gcs/exception.hh>
+
+#include <string>
+
+using std::optional;
+using std::string;
+using std::string_view;
+
+using namespace gcs;
+using namespace gcs::innards;
+
+auto gcs::innards::task_presence(const optional<IntegerVariableID> & posted, string_view constraint_name) -> TaskPresence
+{
+    if (! posted)
+        return TaskPresence{};
+
+    if (! is_constant_variable(*posted))
+        return TaskPresence{*posted, false};
+
+    auto value = constant_value_of(*posted);
+    if (value == 1_i)
+        return TaskPresence{};
+    if (value == 0_i)
+        return TaskPresence{*posted, true};
+    throw InvalidProblemDefinitionException{string{constraint_name} + ": presences must be within {0, 1}"};
+}

--- a/gcs/constraints/innards/task_presence.hh
+++ b/gcs/constraints/innards/task_presence.hh
@@ -1,0 +1,79 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_INNARDS_TASK_PRESENCE_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_INNARDS_TASK_PRESENCE_HH
+
+#include <gcs/variable_id.hh>
+
+#include <optional>
+#include <string_view>
+
+/**
+ * \file
+ *
+ * What a scheduling constraint's `presences` argument means for one task, in
+ * one place. `Cumulative` and `Disjunctive` both take optional tasks, they
+ * encode them differently (a conjunct on a per-time activity flag; a disjunct
+ * on a pairwise separation clause), and they must nonetheless agree exactly on
+ * *which* presences resolve away at prepare() time and which survive into the
+ * OPB --- so that rule lives here rather than once per constraint.
+ */
+
+namespace gcs::innards
+{
+    /**
+     * \brief What a scheduling constraint's presence argument for one task
+     * comes to: what its encoding has to be conditioned on, and whether the
+     * task is there at all.
+     *
+     * \sa task_presence
+     *
+     * \ingroup Innards
+     */
+    struct TaskPresence
+    {
+        /// The {0, 1} variable the task's encoding has to carry --- Cumulative
+        /// as a third conjunct on each activity flag, Disjunctive as a disjunct
+        /// on each separation clause the task appears in --- or nullopt when the
+        /// task is unconditionally present and the encoding is the one a
+        /// constraint posted without presences at all would write.
+        std::optional<IntegerVariableID> literal;
+
+        /// Whether the task was posted as constantly absent, in which case it is
+        /// left out of the constraint altogether: no flags, no terms in any row,
+        /// and nothing may cite it.
+        bool never_present = false;
+    };
+
+    /**
+     * \brief How a scheduling constraint resolves the presence argument it was
+     * posted with for one task, given that argument (nullopt for a constraint
+     * posted without presences at all).
+     *
+     * Only a *constant* argument resolves away: a variable presence keeps its
+     * literal even when its domain is already a singleton, because the encoding
+     * has to say what it means without appealing to a domain the OPB does not
+     * record. That is what makes "post every presence as the constant 1" produce
+     * a byte-identical OPB to not passing presences at all, which both
+     * constraints' tests check.
+     *
+     * Shared, and deliberately so, for two independent reasons. A *derived*
+     * Cumulative pins its donor's activity flags, so it has to reach exactly the
+     * same verdict about which of them carry a presence literal as the donor did
+     * when it built them; and `Disjunctive` and `Cumulative` are two encodings
+     * of overlapping problems that a modeller may swap between, so a presence
+     * argument one of them resolves away and the other does not would be a
+     * difference in meaning with nothing recording it.
+     *
+     * \param constraint_name what to call the constraint in the rejection
+     * message, since the modeller met this argument under that name and not
+     * under this function's.
+     *
+     * \throws InvalidProblemDefinitionException if a constant argument is
+     * outside {0, 1}. A variable one is range-checked by the caller, at
+     * prepare() time, where its domain is first available.
+     *
+     * \ingroup Innards
+     */
+    [[nodiscard]] auto task_presence(const std::optional<IntegerVariableID> & posted, std::string_view constraint_name) -> TaskPresence;
+}
+
+#endif

--- a/gcs/scp_reader.cc
+++ b/gcs/scp_reader.cc
@@ -1159,6 +1159,24 @@ auto gcs::read_scp(Problem & problem, string_view text) -> ScpModel
                     .with_strict(op.ends_with("_strict")),
                 label);
         }
+        else if (op == "disjunctive_optional" || op == "disjunctive_strict_optional") {
+            // (label disjunctive_optional (starts...) (lengths...)
+            // (presences...)): disjunctive over tasks that may be absent,
+            // presences[i] in {0,1} saying whether task i happens at all. The
+            // presences list goes last, where the FlatZinc builtin puts it.
+            // Deliberately a keyword of its own rather than an optional argument
+            // to `disjunctive`: each separation clause carries the pair's
+            // presence disjuncts, so re-deriving it as a plain disjunctive would
+            // give a different and strictly stronger constraint.
+            if (terms.size() != 5)
+                throw ScpReadError{"disjunctive_optional is (label " + op + " (starts...) (lengths...) (presences...))"};
+            post_constraint(problem,
+                Disjunctive{resolve_variable_list(variables, terms[2], "the disjunctive_optional start list"),
+                    resolve_variable_list(variables, terms[3], "the disjunctive_optional length list"),
+                    resolve_variable_list(variables, terms[4], "the disjunctive_optional presence list")}
+                    .with_strict(op == "disjunctive_strict_optional"),
+                label);
+        }
         else if (op == "disjunctive2d" || op == "disjunctive2d_strict") {
             // (label disjunctive2d (xs...) (ys...) (widths...) (heights...)): the
             // rectangles [x, x + w) x [y, y + h) pairwise do not overlap. As for

--- a/gcs/scp_reader_test.cc
+++ b/gcs/scp_reader_test.cc
@@ -669,6 +669,27 @@ TEST_CASE("read_scp: disjunctive enumerates correctly")
     }
 }
 
+TEST_CASE("read_scp: disjunctive_optional enumerates correctly")
+{
+    // Two length-2 tasks in 0..3 that may each be absent: they need separating
+    // only when both are present.
+    for (const auto & s : enumerate("( (version 1) (variables (S0 0 3) (S1 0 3) (P0 0 1) (P1 0 1)) (constraints (_1 disjunctive_optional (S0 S1) (2 "
+                                    "2) (P0 P1))) (prob_type enumerate) )")) {
+        auto d = s.at("S0") - s.at("S1");
+        CHECK((s.at("P0") == 0 || s.at("P1") == 0 || d >= 2 || d <= -2));
+    }
+    // The strict form differs only over zero-length tasks, which a present task
+    // may not contain: task 1 has length 0, so when both are present its start
+    // may not sit strictly inside 0's. This is the case that has no route
+    // through Cumulative at all.
+    for (const auto & s : enumerate("( (version 1) (variables (S0 0 3) (S1 0 3) (P0 0 1) (P1 0 1)) (constraints (_1 disjunctive_strict_optional (S0 "
+                                    "S1) (3 0) (P0 P1))) (prob_type enumerate) )"))
+        if (s.at("P0") == 1 && s.at("P1") == 1) {
+            bool zero_inside = s.at("S0") < s.at("S1") && s.at("S1") < s.at("S0") + 3;
+            CHECK_FALSE(zero_inside);
+        }
+}
+
 TEST_CASE("read_scp: disjunctive2d enumerates correctly")
 {
     // Two 2x2 rectangles in a 0..3 x 0..3 grid must not overlap, so they are
@@ -709,11 +730,15 @@ TEST_CASE("read_scp: regular, disjunctive, disjunctive2d and cumulative survive 
     auto s1 = original.create_integer_variable(0_i, 3_i, "S1");
     auto y0 = original.create_integer_variable(0_i, 3_i, "Y0");
     auto y1 = original.create_integer_variable(0_i, 3_i, "Y1");
+    auto p0 = original.create_integer_variable(0_i, 1_i, "P0");
+    auto p1 = original.create_integer_variable(0_i, 1_i, "P1");
     original.post(Regular{std::vector<IntegerVariableID>{x0, x1}, 2,
         std::vector<std::unordered_map<Integer, long>>{{{0_i, 0}, {1_i, 1}}, {{0_i, 1}, {1_i, 0}}}, std::vector<long>{0}});
     original.post(Disjunctive{std::vector<IntegerVariableID>{s0, s1}, std::vector<Integer>{2_i, 2_i}}); // strict -> disjunctive_strict
     original.post(
         Disjunctive{std::vector<IntegerVariableID>{s0, s1}, std::vector<Integer>{2_i, 2_i}}.with_strict(false)); // non-strict -> disjunctive
+    original.post(Disjunctive{std::vector<IntegerVariableID>{s0, s1}, as_constant_variables(std::vector<Integer>{2_i, 2_i}),
+        std::vector<IntegerVariableID>{p0, p1}}); // -> disjunctive_strict_optional
     original.post(Disjunctive2D{std::vector<IntegerVariableID>{s0, s1}, std::vector<IntegerVariableID>{y0, y1}, std::vector<Integer>{2_i, 2_i},
         std::vector<Integer>{2_i, 2_i}}
             .with_strict(false));

--- a/minizinc/CMakeLists.txt
+++ b/minizinc/CMakeLists.txt
@@ -65,8 +65,15 @@ set_tests_properties(minizinc-cumulative-opt PROPERTIES SKIP_RETURN_CODE 66)
 add_test(NAME minizinc-cumulative-opt-obj COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash --fzn-pattern glasgow_cumulative_opt --reference-solver chuffed $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ cumulativeoptobjtest false true)
 set_tests_properties(minizinc-cumulative-opt-obj PROPERTIES SKIP_RETURN_CODE 66)
 
-add_test(NAME minizinc-disjunctive-opt COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash --fzn-pattern glasgow_cumulative_opt --reference-solver chuffed $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ disjunctiveopttest true true)
+add_test(NAME minizinc-disjunctive-opt COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash --fzn-pattern glasgow_disjunctive_opt --reference-solver chuffed $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ disjunctiveopttest true true)
 set_tests_properties(minizinc-disjunctive-opt PROPERTIES SKIP_RETURN_CODE 66)
+
+# The strict optional form, which had no redefinition at all before #735: no
+# route through cumulative can express "a present zero-duration task may not sit
+# inside another", so this one used to keep the library decomposition and go
+# uncertified.
+add_test(NAME minizinc-disjunctive-strict-opt COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash --fzn-pattern glasgow_disjunctive_strict_opt --reference-solver chuffed $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ disjunctivestrictopttest true true)
+set_tests_properties(minizinc-disjunctive-strict-opt PROPERTIES SKIP_RETURN_CODE 66)
 
 # The difference-logic presolver is invisible to solution equivalence and to
 # proof verification alike, so this one also asserts on its counters: four

--- a/minizinc/fzn_glasgow.cc
+++ b/minizinc/fzn_glasgow.cc
@@ -810,6 +810,16 @@ auto main(int argc, char * argv[]) -> int
                 auto strict = (id == "glasgow_disjunctive_strict");
                 problem.post(Disjunctive{starts, lengths}.with_strict(strict));
             }
+            else if (id == "glasgow_disjunctive_opt" || id == "glasgow_disjunctive_strict_opt") {
+                // Optional tasks: the presence Booleans arrive as an array of
+                // var bool, which the FlatZinc reader already presents as 0/1
+                // integer variables --- exactly what Disjunctive wants.
+                const auto & starts = arg_as_array_of_var(data, args, 0);
+                const auto & lengths = arg_as_array_of_var(data, args, 1);
+                const auto & presences = arg_as_array_of_var(data, args, 2);
+                auto strict = (id == "glasgow_disjunctive_strict_opt");
+                problem.post(Disjunctive{starts, lengths, presences}.with_strict(strict));
+            }
             else if (id == "glasgow_diffn" || id == "glasgow_diffn_nonstrict") {
                 const auto & xs = arg_as_array_of_var(data, args, 0);
                 const auto & ys = arg_as_array_of_var(data, args, 1);

--- a/minizinc/mznlib/fzn_disjunctive_opt.mzn
+++ b/minizinc/mznlib/fzn_disjunctive_opt.mzn
@@ -1,17 +1,19 @@
-include "fzn_cumulative_opt.mzn";
+predicate glasgow_disjunctive_opt(array[int] of var int: s,
+    array[int] of var int: d, array[int] of var bool: o);
 
-% Optional-task disjunctive is optional-task cumulative with unit demands and
-% capacity 1: at most one present task can occupy any time point. Zero-duration
-% tasks are never active under either reading, which is exactly the non-strict
-% semantics this predicate carries (disjunctive_opt routes to
-% disjunctive_strict_opt whenever every duration is known positive, so the
-% zero-duration case is the one that reaches here).
+% An optional start is a presence Boolean and an underlying integer, which
+% occurs/deopt split apart. deopt is undefined on a value fixed absent, so
+% guard it the way the Gecode and OR-Tools libraries do: a definitely-absent
+% task gets any start at all, since nothing constrains it.
 %
-% There is deliberately no fzn_disjunctive_strict_opt redefinition: strict
-% disjunctive additionally forbids a zero-duration task from sitting inside
-% another task, and a task that consumes no resource for no time is invisible to
-% Cumulative. That one keeps the library decomposition.
+% This used to route to fzn_cumulative_opt at unit demands and capacity 1,
+% which was correct but gave an optional disjunctive the time-indexed
+% O(n x horizon) encoding that issue #495 removed from the non-optional form,
+% and cost it detectable precedences. Disjunctive takes presences natively now
+% (#735), so the pairwise O(n^2) encoding applies here too.
 predicate fzn_disjunctive_opt(array[int] of var opt int: s,
     array[int] of var int: d) =
     forall(i in index_set(d)) (d[i] >= 0)
-    /\ fzn_cumulative_opt(s, d, [1 | i in index_set(d)], 1);
+    /\ glasgow_disjunctive_opt(
+        [ if is_fixed(si) /\ absent(fix(si)) then 0 else deopt(si) endif | si in s ],
+        d, [ occurs(si) | si in s ]);

--- a/minizinc/mznlib/fzn_disjunctive_strict_opt.mzn
+++ b/minizinc/mznlib/fzn_disjunctive_strict_opt.mzn
@@ -1,0 +1,19 @@
+predicate glasgow_disjunctive_strict_opt(array[int] of var int: s,
+    array[int] of var int: d, array[int] of var bool: o);
+
+% Strict optional disjunctive: as fzn_disjunctive_opt, but a present
+% zero-duration task may not sit strictly inside a present task's active
+% interval either.
+%
+% This predicate has no redefinition in most solvers' libraries, and could not
+% have one here before #735. A task consuming nothing for no time is invisible
+% to a resource profile, so no route through cumulative can express it; the
+% pairwise separation clause can, and does, with an all-fixed check whose proof
+% is a bare RUP against that clause. Zero durations are the only case where it
+% differs from fzn_disjunctive_opt at all.
+predicate fzn_disjunctive_strict_opt(array[int] of var opt int: s,
+    array[int] of var int: d) =
+    forall(i in index_set(d)) (d[i] >= 0)
+    /\ glasgow_disjunctive_strict_opt(
+        [ if is_fixed(si) /\ absent(fix(si)) then 0 else deopt(si) endif | si in s ],
+        d, [ occurs(si) | si in s ]);

--- a/minizinc/tests/disjunctiveopttest.mzn
+++ b/minizinc/tests/disjunctiveopttest.mzn
@@ -1,9 +1,10 @@
 include "globals.mzn";
 
-% Optional-task disjunctive, routed through glasgow_cumulative_opt with unit
-% demands and capacity 1. A zero-duration task is in the array on purpose: it is
-% what stops disjunctive_opt short-circuiting into disjunctive_strict_opt (which
-% it does whenever every duration is known positive), so this is the path the
+% Optional-task disjunctive, on the native builtin (it used to route through
+% glasgow_cumulative_opt at unit demands and capacity 1; issue #735). A
+% zero-duration task is in the array on purpose: it is what stops
+% disjunctive_opt short-circuiting into disjunctive_strict_opt (which it does
+% whenever every duration is known positive), so this is the path the
 % redefinition actually covers --- and the non-strict semantics, under which a
 % zero-duration task may sit anywhere, including inside another task.
 array[1..3] of int: durations = [2, 2, 0];

--- a/minizinc/tests/disjunctivestrictopttest.mzn
+++ b/minizinc/tests/disjunctivestrictopttest.mzn
@@ -1,0 +1,15 @@
+include "globals.mzn";
+
+% Strict optional disjunctive: the case that had no redefinition before #735 and
+% could not have had one built on cumulative, because a task consuming nothing
+% for no time is invisible to a resource profile. Task 3 has duration zero, and
+% under the strict reading a *present* zero-duration task may not sit inside a
+% present task's active interval --- which is the only thing separating this
+% model's solution set from disjunctiveopttest's.
+array[1..3] of int: durations = [2, 2, 0];
+
+array[1..3] of var opt 0..3: s;
+
+constraint disjunctive_strict(s, durations);
+
+output ["ENUMSOL: " ++ show(s)];


### PR DESCRIPTION
Closes #735. **Stacked on #734** (detectable precedences) — review that first; the base here is its tip.

`Disjunctive` takes optional tasks natively, instead of `fzn_disjunctive_opt` routing through `fzn_cumulative_opt` at unit demands and capacity one.

## The encoding

The bet the issue asks to check first held: the separation clause the pair already had gains two disjuncts, and that is the entire difference.

```
before_{i,j} + before_{j,i} [+ zw_i + zw_j] + ~p_i + ~p_j  >= 1
```

The before-flag reifications stay **unconditional** — `before_{i,j} <-> s_i + l_i <= s_j` whatever the presences — so **the pols do not change at all**. Every justification is a pol over exactly the rows that were there before; presence surfaces only where the *separation clause* is used, which is always the framework's closing reason-wrapped RUP, and those just get two more literals in their reason. No new flag, no new row, no new proof step shape.

Two tests pin that down rather than leaving it as a claim:

- posting every presence as the constant 1 gives a **byte-identical OPB** to not passing presences at all (as `cumulative_optional_test` does);
- and a line-for-line OPB diff of the same instance with and without presences, which permits *nothing* but a pair of unit negated presence literals appended to each separation clause — a changed coefficient, a changed degree or a new row fails it. The diff on the fixture is exactly `1 ~i[_4][b0] 1 ~i[_5][b0]` on each of the three clauses.

## Propagation

`Cumulative`'s rules, for the reasons recorded there. Absent tasks are dropped. An **undecided** task contributes no mandatory part, blocks nobody, is nobody's detected predecessor or successor, and — the load-bearing part — **has its own start bounds left alone**, because there is no conditional-bounds store and a prune valid only if the task is present would be unsound.

**Presence falsification** when no start is left: the lb-push chain replayed over the whole domain with "or task `j` is not here" on every deposit, so the closing RUP concludes `p_j = 0`. That is `emit_lb_chain_step` with one extra disjunct; the two pols per step are the ordinary ones.

Presence enters reasons as an explicit `p_i = 1` literal per task known present rather than through the reason's variable list, so an undecided presence costs nothing and `generic_reason` never spends an order atom saying `0 <= p <= 1`.

## The trap, in a second form

#731 found that gating the mandatory-overlap scan stopped the propagator being a *checker*. Presence brings the same hazard: the overlap scan and the strict zero-length leaf check both now use the same `is_present` as the profile, so an undecided task cannot slip past the check that would have fixed its presence.

## Frontends

`fzn_disjunctive_opt` goes to the native builtin. **`fzn_disjunctive_strict_opt` gains a redefinition for the first time** — there could not have been one before, because a task consuming nothing for no time is invisible to a resource profile, so nothing built on cumulative expresses "a present zero-duration task may not sit inside another". It kept the library decomposition and went uncertified. Its lane enumerates 61 solutions against Gecode and Chuffed and verifies the proof. Both lanes grep the flattened model for the builtin, so neither can pass against a decomposition that never called it.

`constraint_type()` is `disjunctive_optional` / `disjunctive_strict_optional`, so the `cake_pb_cp` gap is *named* rather than silently mismatched against the plain encoder. `read_scp` parses both and round-trips them.

## Testing

`disjunctive_optional_test` with five modes — enumerate / falsify / bijection / cumulative / objective — plus three ctest mutation lanes.

Two independent cross-checks say the semantics did not drift: durations channelled to `{0, d}` under the non-strict reading (shares none of the optional-task code path), and **the optional `Cumulative` at unit demands and capacity one that `fzn_disjunctive_opt` used to route through** — which is the evidence that switching the redefinition changes nothing but the encoding and the proof.

The mutation list is short, and deliberately: falsification is *conflict-shaped*, so once the chain has cornered the task the reason context extended with "the task is present" is contradictory and every RUP under it is vacuously valid. A mutation that merely shortens the chain is still sound and VeriPB is right to accept it — `cumulative_mutations.hh` records the same finding. So the lanes are `wrong_task` (argue about a task nothing has cornered), `one_too_far` (draw the conclusion where it is false) and `emit_nothing` as the control. All three are rejected **on the closing RUP** — not on a `Propagation engine error`, which is how #731's five lanes were once green for the wrong reason — and the honest fixture underneath each verifies.

`innards::task_presence` is hoisted out of `cumulative/propagate.hh` into `constraints/innards/`, so the two schedulers cannot disagree about which presence arguments resolve away at prepare() time. No behaviour change.

## Checks

- `ctest`: **668/668** green.
- clang 21 build clean (no new warnings in the touched files); clang-format 21 clean.
- Left open, and recorded in `disjunctive-proof-logging.md`: a `cake_pb_cp` encoder for the optional form, 2D optional tasks, and conditional pruning for an undecided task (which `Cumulative` leaves on the table for the same reason).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018FizeTcjBnMJqmqLWZz4qd
