### PR TITLE
disjunctive: overload checking, certified by re-encoding time in the proof

### DIFF
--- a/examples/rcpsp/rcpsp.cc
+++ b/examples/rcpsp/rcpsp.cc
@@ -399,6 +399,15 @@ auto main(int argc, char * argv[]) -> int
                 "default, so every resource is handled the same way and a variant comparison " //
                 "is not confounded by which resources happen to be unary) or disjunctive",     //
                 cxxopts::value<string>()->default_value("cumulative"))                         //
+            ("disjunctive-overload",
+                "Give every posted Disjunctive the overload check, which is off by default "     //
+                "because it has no certificate yet (#730). Measurement only: incompatible with " //
+                "--prove")                                                                       //
+            ("disjunctive-overload-max-window",
+                "Have the overload check decline a conflict whose smallest window holds more "  //
+                "than this many tasks, its certificate being cubic in that. Zero, the default," //
+                " takes every conflict",                                                        //
+                cxxopts::value<std::size_t>()->default_value("0"))                              //
             ("horizon",
                 "Override the planning horizon (0, the default, computes it from the " //
                 "instance). A value below the optimum cuts off solutions",             //
@@ -652,6 +661,12 @@ auto main(int argc, char * argv[]) -> int
     if (instance.source_task)
         problem.post(LinearLessThanEqual{WeightedSum{} + 1_i * starts[static_cast<std::size_t>(*instance.source_task)], 0_i});
 
+    // Off unless asked for: the overload check has no certificate, so this is a
+    // measurement switch rather than a model choice. See #730.
+    DisjunctiveRules disjunctive_rules;
+    disjunctive_rules.overload = options_vars["disjunctive-overload"].as<bool>();
+    disjunctive_rules.overload_max_window = options_vars["disjunctive-overload-max-window"].as<std::size_t>();
+
     for (std::size_t r = 0; r < instance.capacities.size(); ++r) {
         // A task that runs for no time never occupies a resource, so leaving it
         // out changes nothing but keeps the propagator and the proof smaller.
@@ -681,7 +696,7 @@ auto main(int argc, char * argv[]) -> int
                     user_durations.push_back(task_durations[i]);
                 }
             if (users.size() >= 2)
-                problem.post(Disjunctive{users, user_durations});
+                problem.post(Disjunctive{users, user_durations}.with_rules(disjunctive_rules));
         }
         else
             problem.post(Cumulative{task_starts, task_durations, task_demands, instance.capacities[r]});
@@ -694,7 +709,7 @@ auto main(int argc, char * argv[]) -> int
     // it has to share a propagator with it.
     if (machine_variant != "difference" && machine_starts.size() >= 2) {
         if (machine_variant == "disjunctive")
-            problem.post(Disjunctive{machine_starts, machine_durations});
+            problem.post(Disjunctive{machine_starts, machine_durations}.with_rules(disjunctive_rules));
         else if (machine_variant == "cumulative")
             problem.post(Cumulative{machine_starts, machine_durations, vector<Integer>(machine_starts.size(), 1_i), 1_i});
         else

--- a/examples/rcpsp/rcpsp.cc
+++ b/examples/rcpsp/rcpsp.cc
@@ -403,6 +403,10 @@ auto main(int argc, char * argv[]) -> int
                 "Give every posted Disjunctive the overload check, which is off by default "     //
                 "because it has no certificate yet (#730). Measurement only: incompatible with " //
                 "--prove")                                                                       //
+            ("disjunctive-overload-temporary",
+                "Introduce the overload certificate's activity flags per firing and let backtracking " //
+                "delete them, rather than once at the proof's top level. Slower and larger, and here " //
+                "so that #730's measurement can be repeated rather than believed")                     //
             ("disjunctive-overload-max-window",
                 "Have the overload check decline a conflict whose smallest window holds more "  //
                 "than this many tasks, its certificate being cubic in that. Zero, the default," //
@@ -666,6 +670,8 @@ auto main(int argc, char * argv[]) -> int
     DisjunctiveRules disjunctive_rules;
     disjunctive_rules.overload = options_vars["disjunctive-overload"].as<bool>();
     disjunctive_rules.overload_max_window = options_vars["disjunctive-overload-max-window"].as<std::size_t>();
+    if (options_vars["disjunctive-overload-temporary"].as<bool>())
+        disjunctive_rules.overload_vocabulary_at = gcs::innards::ProofLevel::Temporary;
 
     for (std::size_t r = 0; r < instance.capacities.size(); ++r) {
         // A task that runs for no time never occupies a resource, so leaving it

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -104,6 +104,7 @@ add_library(glasgow_constraint_solver
         innards/literal.cc
         innards/power.cc
         innards/proofs/am1_from_pairs.cc
+        innards/proofs/comparator_network.cc
         innards/proofs/am1_from_row.cc
         innards/proofs/bits_encoding.cc
         innards/proofs/constraint_proof_model_data.cc
@@ -641,9 +642,12 @@ if(GCS_BUILD_TESTS)
 
     add_executable(am1_from_pairs_test innards/proofs/am1_from_pairs_test.cc)
     target_link_libraries(am1_from_pairs_test PRIVATE glasgow_constraint_solver)
+    add_executable(comparator_network_test innards/proofs/comparator_network_test.cc)
+    target_link_libraries(comparator_network_test PRIVATE glasgow_constraint_solver)
     # Verifies (and deliberately fails to verify) its own proofs internally, so
     # it needs no wrapper.
     add_test(NAME am1_from_pairs_test COMMAND $<TARGET_FILE:am1_from_pairs_test>)
+    add_test(NAME comparator_network_test COMMAND $<TARGET_FILE:comparator_network_test>)
 
     add_executable(am1_from_row_test innards/proofs/am1_from_row_test.cc)
     target_link_libraries(am1_from_row_test PRIVATE glasgow_constraint_solver)

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -280,6 +280,7 @@ if(GCS_BUILD_TESTS)
     add_executable(difference_test constraints/difference/difference_constraints_test.cc)
     add_executable(disjunctive_test constraints/disjunctive/disjunctive_test.cc)
     add_executable(disjunctive_optional_test constraints/disjunctive/disjunctive_optional_test.cc)
+    add_executable(disjunctive_overload_test constraints/disjunctive/disjunctive_overload_test.cc)
     add_executable(disjunctive_precedences_test constraints/disjunctive/disjunctive_precedences_test.cc)
     add_executable(disjunctive_2d_test constraints/disjunctive_2d/disjunctive_2d_test.cc)
     add_executable(divide_modulus_test constraints/divide_modulus/divide_modulus_test.cc)
@@ -327,7 +328,7 @@ if(GCS_BUILD_TESTS)
 
     foreach(test_target
             abs_test all_different_test all_different_except_test all_equal_test among_test at_most_one_test bin_packing_test comparison_test
-            count_test cumulative_test cumulative_overload_test cumulative_optional_test derived_cumulative_test difference_test disjunctive_test disjunctive_optional_test disjunctive_precedences_test disjunctive_2d_test divide_modulus_test element_test equals_test bounds_global_cardinality_test gac_global_cardinality_test in_test increasing_test inverse_test knapsack_test knapsack_upfront_test lex_test linear_test linear_constant_test
+            count_test cumulative_test cumulative_overload_test cumulative_optional_test derived_cumulative_test difference_test disjunctive_test disjunctive_optional_test disjunctive_overload_test disjunctive_precedences_test disjunctive_2d_test divide_modulus_test element_test equals_test bounds_global_cardinality_test gac_global_cardinality_test in_test increasing_test inverse_test knapsack_test knapsack_upfront_test lex_test linear_test linear_constant_test
             logical_test mdd_test min_distance_test min_distance_matching_test min_max_test mini_linear_test multiply_test n_value_test nogoods_test parity_test
             plus_minus_test power_test product_bounds_test product_justify_test regular_test regular_bacchus_test regular_legacy_test seq_precede_chain_test smart_table_test sort_test arg_sort_test symmetric_all_different_test
             negative_table_test table_test tabulation_test value_precede_test)
@@ -392,6 +393,15 @@ if(GCS_BUILD_TESTS)
         add_test(NAME disjunctive_optional_mutation_${mutation}
             COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_expect_verify_failure.bash
                 --basename disjunctive_optional_mutation_${mutation} $<TARGET_FILE:disjunctive_optional_test> --mutate=${mutation})
+    endforeach()
+    # The test writes several proofs under names of its own and checks each
+    # with veripb in-process, as cumulative_overload_test does, so the harness
+    # only has to run it.
+    add_test(NAME disjunctive_overload COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:disjunctive_overload_test>)
+    foreach(mutation emit_nothing skip_fold skip_energy rup_bridge)
+        add_test(NAME disjunctive_overload_mutation_${mutation}
+            COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_expect_verify_failure.bash
+                --basename disjunctive_overload_mutation_${mutation} $<TARGET_FILE:disjunctive_overload_test> --mutate=${mutation})
     endforeach()
     add_test(NAME disjunctive_precedences COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:disjunctive_precedences_test>)
     # Mutation lanes: each writes a deliberately corrupted proof of the

--- a/gcs/constraints/disjunctive/disjunctive.cc
+++ b/gcs/constraints/disjunctive/disjunctive.cc
@@ -484,6 +484,9 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
             // separation clause pair the before literals off into a constant,
             // and halving is exact.
             auto bridge_pair = [&](size_t i, size_t j, Integer t) -> ProofLine {
+                if (std::holds_alternative<disjunctive_proof_mutation::RupOverloadBridge>(mutation))
+                    return logger->emit_rup_proof_line(
+                        WPBSum{} + 1_i * ! activity_flag(i, t).flag + 1_i * ! activity_flag(j, t).flag >= 1_i, ProofLevel::Temporary);
                 auto half = [&](size_t x, size_t y) -> ProofLine {
                     PolBuilder pol;
                     pol.add(emit_before_pol(x, y, starts[x] >= t - min_len(x) + 1_i, starts[y] < t + 1_i));
@@ -1212,6 +1215,11 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                             // model that moved with a rule selection would be
                             // a different problem per setting.
                             auto justify = [&, tasks = smallest, lo = window_lo, hi = window_hi](const ReasonLiterals & reason) -> void {
+                                logger->emit_proof_comment(
+                                    "disjunctive overload w=" + std::to_string(tasks.size()) + " span=" + std::to_string((hi - lo).raw_value));
+                                if (std::holds_alternative<disjunctive_proof_mutation::OverloadEmitNothing>(mutation))
+                                    return;
+
                                 pin_escapes(reason, tasks);
 
                                 // A Temporary vocabulary does not outlive the
@@ -1250,14 +1258,18 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                                 // that, and the framework's closing RUP has
                                 // nothing left to do.
                                 PolBuilder total;
-                                for (Integer t = lo; t < hi; ++t) {
-                                    vector<ProofLiteralOrFlag> members;
+                                if (! std::holds_alternative<disjunctive_proof_mutation::SkipOverloadFold>(mutation))
+                                    for (Integer t = lo; t < hi; ++t) {
+                                        vector<ProofLiteralOrFlag> members;
+                                        for (auto i : tasks)
+                                            members.push_back(activity_flag(i, t).flag);
+                                        total.add(recover_am1_from_pairs(*logger, members, at_most_ones[t], ProofLevel::Temporary));
+                                    }
+                                if (! std::holds_alternative<disjunctive_proof_mutation::SkipOverloadEnergy>(mutation))
                                     for (auto i : tasks)
-                                        members.push_back(activity_flag(i, t).flag);
-                                    total.add(recover_am1_from_pairs(*logger, members, at_most_ones[t], ProofLevel::Temporary));
-                                }
-                                for (auto i : tasks)
-                                    total.add(energy_pol(i, lo, hi, reason));
+                                        total.add(energy_pol(i, lo, hi, reason));
+                                if (total.empty())
+                                    return;
                                 total.emit(*logger, ProofLevel::Temporary);
                             };
 

--- a/gcs/constraints/disjunctive/disjunctive.cc
+++ b/gcs/constraints/disjunctive/disjunctive.cc
@@ -12,12 +12,23 @@
 #include <gcs/innards/state.hh>
 
 #include <algorithm>
+#include <cstdlib>
+#include <iostream>
 #include <map>
 #include <memory>
 #include <optional>
+#include <string>
 #include <utility>
 #include <variant>
 #include <vector>
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+#include <print>
+using std::println;
+#else
+#include <fmt/core.h>
+using fmt::println;
+#endif
 
 using namespace gcs;
 using namespace gcs::innards;
@@ -34,6 +45,53 @@ using std::pair;
 using std::size_t;
 using std::unique_ptr;
 using std::vector;
+using std::ranges::sort;
+
+namespace
+{
+    /**
+     * Instrumentation for the overload check (issue #730). The rule has no
+     * certificate yet, so what has to be decided first is not how to write one
+     * but whether one is affordable: the proof-only comparator network in the
+     * issue costs O(w^3) lines for a window of w tasks --- 30k at w = 12,
+     * 133k at w = 20 --- against two pols for every inference the propagator
+     * makes today. Issue #731 recorded 982,065 detectable-precedence pushes in
+     * a single RCPSP proof, so a comparable overload firing rate would put the
+     * rule out of reach at any window size.
+     *
+     * Hence a static counter rather than a stats object threaded through the
+     * public API: this measures a design question, and goes away with the
+     * answer. Printed at exit when GCS_DISJUNCTIVE_OVERLOAD_STATS is set.
+     */
+    struct OverloadInstrumentation
+    {
+        unsigned long long calls = 0, windows_examined = 0, firings = 0, declined = 0;
+        std::map<size_t, unsigned long long> window_sizes, candidate_counts, declined_sizes;
+
+        ~OverloadInstrumentation()
+        {
+            if (! std::getenv("GCS_DISJUNCTIVE_OVERLOAD_STATS") || 0 == calls)
+                return;
+
+            auto histogram = [](const std::map<size_t, unsigned long long> & h) {
+                std::string result;
+                for (const auto & [k, v] : h)
+                    result += (result.empty() ? "" : ",") + std::to_string(k) + "=" + std::to_string(v);
+                return result;
+            };
+
+            println(std::cerr, "disjunctive_overload_calls: {}", calls);
+            println(std::cerr, "disjunctive_overload_firings: {}", firings);
+            println(std::cerr, "disjunctive_overload_declined: {}", declined);
+            println(std::cerr, "disjunctive_overload_windows_examined: {}", windows_examined);
+            println(std::cerr, "disjunctive_overload_window_sizes: {}", histogram(window_sizes));
+            println(std::cerr, "disjunctive_overload_declined_sizes: {}", histogram(declined_sizes));
+            println(std::cerr, "disjunctive_overload_candidate_counts: {}", histogram(candidate_counts));
+        }
+    };
+
+    OverloadInstrumentation overload_instrumentation;
+}
 
 Disjunctive::Disjunctive(vector<IntegerVariableID> starts, vector<IntegerVariableID> lengths) : _starts(move(starts)), _lengths(move(lengths))
 {
@@ -947,6 +1005,123 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                             }
                         }
                     }
+
+                // Overload checking, the capacity-one case of Cumulative's
+                // (OC'): if the tasks that must run entirely inside a window
+                // [a, b) carry more guaranteed duration than the window is
+                // wide, the state is infeasible.
+                //
+                // Last, rather than between the overflow scan and the bound
+                // pushes where Cumulative puts it, because what is being
+                // measured is the *marginal* firing rate: a state the rules
+                // above can already refute is not one this rule would have to
+                // pay a certificate for. That costs nothing in search shape,
+                // since either way the node is refuted inside the same
+                // propagation fixpoint.
+                //
+                // There is no certificate, so this refuses to run with a
+                // logger attached rather than emitting something VeriPB would
+                // reject --- or worse, an unjustified inference that no proof
+                // ever mentions. See disjunctive.hh's DisjunctiveRules.
+                if (rules.overload) {
+                    if (logger)
+                        throw UnexpectedException{
+                            "Disjunctive: the overload check has no certificate yet (#730), so it cannot be run with proof logging"};
+
+                    // Measuring what a firing would cost means measuring the
+                    // *smallest* window that refutes the state, since the
+                    // certificate is cubic in it: hence the full O(n^2) sweep
+                    // and a minimum over it, rather than stopping at the first
+                    // conflict.
+                    struct Candidate
+                    {
+                        size_t task;
+                        Integer est, lct, duration;
+                    };
+
+                    vector<Candidate> candidates;
+                    candidates.reserve(active_tasks.size());
+                    for (auto i : active_tasks) {
+                        // A task with no guaranteed duration carries no energy,
+                        // and one not known present might not be here to carry
+                        // any: counting either would manufacture a conflict.
+                        if (min_len(i) == 0_i || ! is_present(i))
+                            continue;
+                        auto [s_lo, s_hi] = state.bounds(starts[i]);
+                        candidates.push_back(Candidate{i, s_lo, s_hi + min_len(i), min_len(i)});
+                    }
+                    sort(candidates, [](const Candidate & a, const Candidate & b) { return a.lct < b.lct; });
+
+                    vector<Integer> window_starts;
+                    window_starts.reserve(candidates.size());
+                    for (const auto & c : candidates)
+                        window_starts.push_back(c.est);
+                    sort(window_starts);
+
+                    ++overload_instrumentation.calls;
+                    ++overload_instrumentation.candidate_counts[candidates.size()];
+
+                    // The windows worth trying are [a, b) with a an earliest
+                    // start and b a latest completion time; the tasks with
+                    // est >= a and lct <= b must all fit inside. Taking the
+                    // candidates in lct order makes the energy accumulate, so
+                    // the sweep is quadratic, and the first b to overflow for
+                    // a given a is the smallest window that does.
+                    vector<size_t> smallest;
+                    for (size_t w = 0; w < window_starts.size(); ++w) {
+                        if (w > 0 && window_starts[w] == window_starts[w - 1])
+                            continue;
+                        auto a = window_starts[w];
+
+                        Integer energy = 0_i;
+                        vector<size_t> inside;
+                        for (const auto & c : candidates) {
+                            if (c.est < a)
+                                continue;
+                            energy += c.duration;
+                            inside.push_back(c.task);
+                            ++overload_instrumentation.windows_examined;
+                            if (energy > c.lct - a) {
+                                if (smallest.empty() || inside.size() < smallest.size())
+                                    smallest = inside;
+                                break;
+                            }
+                        }
+                    }
+
+                    // A capped rule declines a conflict it cannot afford to
+                    // certify. Counted before the cap is applied, so the
+                    // histogram says what was on offer and not merely what was
+                    // taken.
+                    if (! smallest.empty()) {
+                        ++overload_instrumentation.firings;
+                        ++overload_instrumentation.window_sizes[smallest.size()];
+                        if (0 != rules.overload_max_window && smallest.size() > rules.overload_max_window) {
+                            ++overload_instrumentation.declined;
+                            ++overload_instrumentation.declined_sizes[smallest.size()];
+                            smallest.clear();
+                        }
+                    }
+
+                    if (! smallest.empty()) {
+
+                        // Passive mode detects and counts without acting, which
+                        // answers a different question: how many nodes of
+                        // *today's* search tree are overloaded. That number is
+                        // an upper bound rather than a cost, since a rule that
+                        // actually fired would have pruned the subtree the
+                        // later firings are counted in.
+                        static const bool passive = nullptr != std::getenv("GCS_DISJUNCTIVE_OVERLOAD_PASSIVE");
+                        if (! passive) {
+                            auto reason_vars = starts;
+                            for (auto i : smallest)
+                                if (is_var_len(i))
+                                    reason_vars.push_back(length_vars[i]);
+                            inference.contradiction(logger, JustifyUsingRUP{hints::Disjunctive{owner}}, reason_over(reason_vars));
+                            return PropagatorState::DisableUntilBacktrack;
+                        }
+                    }
+                }
             }
 
             // Strict-mode zero-length tasks: check that no zero-length task

--- a/gcs/constraints/disjunctive/disjunctive.cc
+++ b/gcs/constraints/disjunctive/disjunctive.cc
@@ -3,6 +3,7 @@
 #include <gcs/constraints/innards/task_presence.hh>
 #include <gcs/exception.hh>
 #include <gcs/innards/inference_tracker.hh>
+#include <gcs/innards/proofs/am1_from_pairs.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
 #include <gcs/innards/proofs/pol_builder.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
@@ -35,7 +36,9 @@ using namespace gcs::innards;
 
 using std::make_optional;
 using std::make_pair;
+using std::make_shared;
 using std::make_unique;
+using std::map;
 using std::max;
 using std::min;
 using std::move;
@@ -91,6 +94,24 @@ namespace
     };
 
     OverloadInstrumentation overload_instrumentation;
+
+    /**
+     * One (task, time) flag of the overload certificate's re-encoding, and the
+     * two rows defining it: `forward` is the flag implying both of its order
+     * literals, `backward` the clause the two of them imply it by. The bridge
+     * consumes the first and the energy telescope the second.
+     */
+    struct ActivityFlag
+    {
+        ProofFlag flag;
+        /// The flag implying each of its two order literals, one clause each
+        /// rather than the single row a conjunction reifies to. The bridge
+        /// cancels exactly one literal per operand, so a row carrying both
+        /// would leave the other behind and the pol would not close.
+        ProofLine implies_starts_by, implies_started;
+        /// The two of them implying the flag: what the energy sum telescopes.
+        ProofLine backward;
+    };
 }
 
 Disjunctive::Disjunctive(vector<IntegerVariableID> starts, vector<IntegerVariableID> lengths) : _starts(move(starts)), _lengths(move(lengths))
@@ -326,6 +347,11 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
         [starts = move(_starts), lengths = move(_length_vals), length_vars = move(_lengths), zero = move(_zero), strict = _strict,
             active_tasks = move(_active_tasks), before_flags = move(_before_flags), clause_lines = move(_clause_lines), presence = move(_presence),
             rules = _rules, mutation = _proof_mutation, presence_mutation = _presence_mutation,
+            // The overload certificate's vocabulary, kept across firings when
+            // it lives at Top. A shared_ptr rather than a member because the
+            // propagator is invoked through a const callable, and the cache is
+            // proof-side state that no inference reads.
+            activity = make_shared<map<pair<size_t, long long>, ActivityFlag>>(),
             owner = constraint_id()](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
             // Current guaranteed (min) and possible (max) duration of task i:
             // for a constant duration both are the value; for a variable
@@ -378,7 +404,7 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
             // into the flag's row); a variable duration l_a additionally
             // cites its current lower bound (the reason covers it).
             auto emit_before_pol = [&](size_t a, size_t b, const optional<IntegerVariableCondition> & cond_a,
-                                       const optional<IntegerVariableCondition> & cond_b) -> void {
+                                       const optional<IntegerVariableCondition> & cond_b) -> ProofLine {
                 auto & tracker = logger->names_and_ids_tracker();
                 PolBuilder pol;
                 pol.add(before_flags.at(make_pair(a, b)).forward_line);
@@ -402,7 +428,7 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                     add_defining_row(length_vars[a] >= state.lower_bound(length_vars[a]));
                 if (cond_b)
                     add_defining_row(*cond_b);
-                pol.saturate().emit(*logger, ProofLevel::Temporary);
+                return pol.saturate().emit(*logger, ProofLevel::Temporary);
             };
 
             // The current-bound literals on a task's start, or nullopt for a
@@ -425,6 +451,71 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
             // bound) so the separation clauses reduce to their before-flag
             // disjunctions. No-op in strict mode / for always-positive
             // durations.
+            // --- the overload certificate's re-encoding of time --------------
+            //
+            // An activity flag says a task occupies a time point:
+            //     act_{i,t} <-> s_i >= t - p_i + 1  AND  s_i < t + 1
+            // which is a conjunction of two order literals the encoding
+            // already mints, so it costs two reds and adds nothing to the
+            // model. Cached when it lives at Top, its definition saying
+            // nothing about the search state; the cache is cleared per firing
+            // at Temporary, where backtracking deletes the rows behind it.
+            auto activity_flag = [&](size_t i, Integer t) -> const ActivityFlag & {
+                auto key = make_pair(i, t.raw_value);
+                if (auto found = activity->find(key); found != activity->end())
+                    return found->second;
+                auto started = starts[i] >= t - min_len(i) + 1_i, starts_by = starts[i] < t + 1_i;
+                auto both = WPBSum{} + 1_i * started + 1_i * starts_by >= 2_i;
+                auto flag = logger->create_proof_flag("dovl");
+                auto implies_started =
+                    logger->emit_red_proof_lines_forward_reifying(WPBSum{} + 1_i * started >= 1_i, flag, rules.overload_vocabulary_at);
+                auto implies_starts_by =
+                    logger->emit_red_proof_lines_forward_reifying(WPBSum{} + 1_i * starts_by >= 1_i, flag, rules.overload_vocabulary_at);
+                auto backward = logger->emit_red_proof_lines_reverse_reifying(both, flag, rules.overload_vocabulary_at);
+                return activity->emplace(key, ActivityFlag{flag, implies_starts_by, implies_started, backward}).first->second;
+            };
+
+            // Two tasks cannot both occupy time t. This is the step
+            // `Cumulative` never has to take, its OPB stating the capacity row
+            // outright: here it is derived from the pairwise encoding. Each
+            // direction is the before flag's [r] row plus the two operands'
+            // order-literal definitions, which cancels the starts and lands on
+            // degree p_x + (t - p_x + 1) - t = 1; the two directions plus the
+            // separation clause pair the before literals off into a constant,
+            // and halving is exact.
+            auto bridge_pair = [&](size_t i, size_t j, Integer t) -> ProofLine {
+                auto half = [&](size_t x, size_t y) -> ProofLine {
+                    PolBuilder pol;
+                    pol.add(emit_before_pol(x, y, starts[x] >= t - min_len(x) + 1_i, starts[y] < t + 1_i));
+                    pol.add(activity_flag(x, t).implies_started);
+                    pol.add(activity_flag(y, t).implies_starts_by);
+                    return pol.saturate().emit(*logger, ProofLevel::Temporary);
+                };
+                PolBuilder pol;
+                pol.add(half(i, j));
+                pol.add(half(j, i));
+                pol.add(clause_lines.at(make_pair(min(i, j), max(i, j))));
+                return pol.divide_by(2_i).emit(*logger, ProofLevel::Temporary);
+            };
+
+            // A task in the window occupies at least lb(l) of its time points.
+            // Summing the backward rows telescopes --- each order literal
+            // appears once positively and once negatively --- and what is left
+            // over at the two ends are the p thresholds below the window,
+            // which hold because the task starts inside it, and the p above,
+            // which fail because it finishes inside. Both follow from bounds
+            // the reason carries, so one reason-wrapped RUP each.
+            auto energy_pol = [&](size_t i, Integer lo, Integer hi, const ReasonLiterals & reason) -> ProofLine {
+                PolBuilder pol;
+                for (Integer t = lo; t < hi; ++t)
+                    pol.add(activity_flag(i, t).backward);
+                for (Integer v = lo - min_len(i) + 1_i; v <= lo; ++v)
+                    pol.add(logger->emit_rup_proof_line_under_reason(reason, WPBSum{} + 1_i * (starts[i] >= v) >= 1_i, ProofLevel::Temporary));
+                for (Integer v = hi - min_len(i) + 1_i; v <= hi; ++v)
+                    pol.add(logger->emit_rup_proof_line_under_reason(reason, WPBSum{} + 1_i * (starts[i] < v) >= 1_i, ProofLevel::Temporary));
+                return pol.emit(*logger, ProofLevel::Temporary);
+            };
+
             auto pin_escapes = [&](const ReasonLiterals & reason, const vector<size_t> & tasks) -> void {
                 for (auto r : tasks)
                     if (zero[r])
@@ -1019,15 +1110,7 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                 // since either way the node is refuted inside the same
                 // propagation fixpoint.
                 //
-                // There is no certificate, so this refuses to run with a
-                // logger attached rather than emitting something VeriPB would
-                // reject --- or worse, an unjustified inference that no proof
-                // ever mentions. See disjunctive.hh's DisjunctiveRules.
                 if (rules.overload) {
-                    if (logger)
-                        throw UnexpectedException{
-                            "Disjunctive: the overload check has no certificate yet (#730), so it cannot be run with proof logging"};
-
                     // Measuring what a firing would cost means measuring the
                     // *smallest* window that refutes the state, since the
                     // certificate is cubic in it: hence the full O(n^2) sweep
@@ -1068,6 +1151,7 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                     // the sweep is quadratic, and the first b to overflow for
                     // a given a is the smallest window that does.
                     vector<size_t> smallest;
+                    Integer window_lo = 0_i, window_hi = 0_i;
                     for (size_t w = 0; w < window_starts.size(); ++w) {
                         if (w > 0 && window_starts[w] == window_starts[w - 1])
                             continue;
@@ -1082,8 +1166,11 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                             inside.push_back(c.task);
                             ++overload_instrumentation.windows_examined;
                             if (energy > c.lct - a) {
-                                if (smallest.empty() || inside.size() < smallest.size())
+                                if (smallest.empty() || inside.size() < smallest.size()) {
                                     smallest = inside;
+                                    window_lo = a;
+                                    window_hi = c.lct;
+                                }
                                 break;
                             }
                         }
@@ -1117,7 +1204,65 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                             for (auto i : smallest)
                                 if (is_var_len(i))
                                     reason_vars.push_back(length_vars[i]);
-                            inference.contradiction(logger, JustifyUsingRUP{hints::Disjunctive{owner}}, reason_over(reason_vars));
+
+                            // The certificate re-encodes time inside the
+                            // proof. Nothing here touches the OPB, which stays
+                            // the pairwise encoding whatever the rules say:
+                            // the model is the statement being verified, so a
+                            // model that moved with a rule selection would be
+                            // a different problem per setting.
+                            auto justify = [&, tasks = smallest, lo = window_lo, hi = window_hi](const ReasonLiterals & reason) -> void {
+                                pin_escapes(reason, tasks);
+
+                                // A Temporary vocabulary does not outlive the
+                                // firing that made it, so what the cache holds
+                                // from last time has been deleted and citing
+                                // it would be citing a dead row.
+                                if (ProofLevel::Top != rules.overload_vocabulary_at)
+                                    activity->clear();
+
+                                // (1) The vocabulary: a flag per (task, time)
+                                // saying the task occupies that time.
+                                for (auto i : tasks)
+                                    for (Integer t = lo; t < hi; ++t)
+                                        (void)activity_flag(i, t);
+
+                                // (2) The bridge, which is what `Cumulative`
+                                // never needs: its OPB states the capacity row
+                                // outright, and here it has to be derived. Per
+                                // ordered pair and time, the before flag's [r]
+                                // row plus the two operands' order-literal
+                                // definitions cancels the starts and lands on
+                                // degree p_x + (t - p_x + 1) - t = 1.
+                                map<Integer, vector<vector<ProofLine>>> at_most_ones;
+                                for (Integer t = lo; t < hi; ++t) {
+                                    auto & tri = at_most_ones[t];
+                                    tri.resize(tasks.size());
+                                    for (size_t b = 0; b < tasks.size(); ++b)
+                                        for (size_t a = 0; a < b; ++a)
+                                            tri[b].push_back(bridge_pair(tasks[a], tasks[b], t));
+                                }
+
+                                // (3) The fold, and (4) the energies, summed:
+                                // the folds say at most one task occupies each
+                                // of the window's hi - lo times, the energies
+                                // say the tasks between them need more than
+                                // that, and the framework's closing RUP has
+                                // nothing left to do.
+                                PolBuilder total;
+                                for (Integer t = lo; t < hi; ++t) {
+                                    vector<ProofLiteralOrFlag> members;
+                                    for (auto i : tasks)
+                                        members.push_back(activity_flag(i, t).flag);
+                                    total.add(recover_am1_from_pairs(*logger, members, at_most_ones[t], ProofLevel::Temporary));
+                                }
+                                for (auto i : tasks)
+                                    total.add(energy_pol(i, lo, hi, reason));
+                                total.emit(*logger, ProofLevel::Temporary);
+                            };
+
+                            inference.contradiction(
+                                logger, JustifyExplicitly{justify, ThenRUP::Yes, hints::Disjunctive{owner}}, reason_over(reason_vars));
                             return PropagatorState::DisableUntilBacktrack;
                         }
                     }

--- a/gcs/constraints/disjunctive/disjunctive.hh
+++ b/gcs/constraints/disjunctive/disjunctive.hh
@@ -44,24 +44,37 @@ namespace gcs
         /// duration than the window is wide is infeasible. Conflict-only, and
         /// the capacity-one case of what CumulativeRules::overload does.
         ///
-        /// Off by default, and unlike the other two this one cannot be turned
-        /// on with proofs enabled: it has no certificate yet. The only known
-        /// one against the pairwise encoding is the proof-only comparator
-        /// network of issue #730, which costs O(w^3) proof lines for a window
-        /// of w tasks, against two pols for every inference the propagator
-        /// makes today. The flag exists so that the firing rate and the window
-        /// sizes can be measured with proofs off, which is what decides
-        /// whether that certificate is affordable at all.
+        /// Certified by re-encoding time *in the proof*: an activity flag per
+        /// (task, time) introduced by redundance over order literals the
+        /// encoding already has, a pol per ordered pair and time bridging the
+        /// pairwise separation rows to a per-time at-most-one, that folded by
+        /// recover_am1_from_pairs, and the tasks' energies telescoped against
+        /// it. The OPB is untouched: see #730, and \ref overload_vocabulary_at
+        /// for where the re-encoding lives.
         bool overload = false;
 
         /// Refuse an overload conflict whose smallest window holds more than
-        /// this many tasks; zero, the default, takes every conflict. Since the
-        /// certificate is cubic in the window, a cap is the one knob that
-        /// makes its cost bounded rather than merely finite --- at the price
-        /// of a weaker rule, because a state whose only overloaded window is
-        /// larger than the cap goes unrefuted. Whether that price is worth
-        /// paying is a measurement, not a preference: see \ref overload.
+        /// this many tasks; zero, the default, takes every conflict. Measured
+        /// on generated RCPSP (#730), every cap closes fewer instances *and*
+        /// costs more proof lines than no cap, declining a conflict deferring
+        /// the work rather than removing it --- so this exists to reproduce
+        /// that result, not because some cap is expected to pay.
         std::size_t overload_max_window = 0;
+
+        /// Where the overload certificate's activity flags and their per-time
+        /// at-most-ones are introduced.
+        ///
+        /// `Top` derives each once and lets every later firing cite it, which
+        /// costs a standing database; `Temporary` derives them per firing and
+        /// lets backtracking delete them, which pays for them again every
+        /// time. The received objection to `Top` is that hint-free RUP costs
+        /// O(live database), so anything left standing taxes the rest of the
+        /// proof --- but measured, that tax is flat to within noise from 4,692
+        /// to 38,460 standing rows, and `Top` wins on lines and on checking
+        /// time by a margin that grows with the firing count. Hence the
+        /// default. The switch stays so the measurement can be repeated
+        /// in-solver rather than believed.
+        innards::ProofLevel overload_vocabulary_at = innards::ProofLevel::Top;
     };
 
     /**

--- a/gcs/constraints/disjunctive/disjunctive.hh
+++ b/gcs/constraints/disjunctive/disjunctive.hh
@@ -39,6 +39,29 @@ namespace gcs
         /// earliest end, and the predecessor's upper bound down to the
         /// successor's latest start less its own duration.
         bool detectable_precedences = true;
+
+        /// The overload check: a window whose fully-contained tasks carry more
+        /// duration than the window is wide is infeasible. Conflict-only, and
+        /// the capacity-one case of what CumulativeRules::overload does.
+        ///
+        /// Off by default, and unlike the other two this one cannot be turned
+        /// on with proofs enabled: it has no certificate yet. The only known
+        /// one against the pairwise encoding is the proof-only comparator
+        /// network of issue #730, which costs O(w^3) proof lines for a window
+        /// of w tasks, against two pols for every inference the propagator
+        /// makes today. The flag exists so that the firing rate and the window
+        /// sizes can be measured with proofs off, which is what decides
+        /// whether that certificate is affordable at all.
+        bool overload = false;
+
+        /// Refuse an overload conflict whose smallest window holds more than
+        /// this many tasks; zero, the default, takes every conflict. Since the
+        /// certificate is cubic in the window, a cap is the one knob that
+        /// makes its cost bounded rather than merely finite --- at the price
+        /// of a weaker rule, because a state whose only overloaded window is
+        /// larger than the cap goes unrefuted. Whether that price is worth
+        /// paying is a measurement, not a preference: see \ref overload.
+        std::size_t overload_max_window = 0;
     };
 
     /**

--- a/gcs/constraints/disjunctive/disjunctive_overload_test.cc
+++ b/gcs/constraints/disjunctive/disjunctive_overload_test.cc
@@ -1,0 +1,250 @@
+/* Overload checking for Disjunctive, and its certificate.
+ *
+ * The trap #655 established applies here unchanged: this rule fires nowhere in
+ * the existing corpus, so a green suite says nothing about it. Every fixture
+ * below therefore comes with a *control* --- the same instance with the rule
+ * off --- and the test fails if the control already reaches the conclusion,
+ * because then the fixture is measuring something else. The comparison is at
+ * the *root*: this rule is conflict-only, so an instance it refutes is
+ * unsatisfiable without it too, and only searched for rather than reasoned
+ * about. Comparing satisfiability would therefore compare nothing.
+ *
+ * The sharp fixture is three tasks of duration three whose starts all lie in
+ * [0, 5], so each must run entirely inside a window eight wide while together
+ * they need nine. No two mandatory parts overlap and no precedence is
+ * detectable between any pair, so time-tabling and detectable precedences are
+ * both silent: the refutation is the overload check's alone.
+ *
+ * Unlike presence falsification (see disjunctive_mutations.hh), an overload's
+ * reason context is not contradictory until the argument makes it so, so
+ * corrupting the *route* is a real test here and not merely a shorter sound
+ * derivation. That is why the mutation lanes below skip halves of the endgame
+ * rather than only corrupting its destination.
+ */
+
+#include <gcs/constraints/disjunctive.hh>
+#include <gcs/constraints/innards/constraints_test_utils.hh>
+#include <gcs/problem.hh>
+#include <gcs/solve.hh>
+
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+#include <version>
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+#include <print>
+#else
+#include <fmt/core.h>
+#include <fmt/ostream.h>
+#endif
+
+using std::cerr;
+using std::ifstream;
+using std::make_optional;
+using std::nullopt;
+using std::optional;
+using std::pair;
+using std::string;
+using std::vector;
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+using std::println;
+#else
+using fmt::println;
+#endif
+
+using namespace gcs;
+using namespace gcs::innards;
+
+namespace
+{
+    struct Instance
+    {
+        vector<pair<int, int>> start_ranges;
+        vector<int> lengths;
+    };
+
+    auto fail(const string & message) -> void
+    {
+        println(cerr, "disjunctive_overload_test: {}", message);
+        exit(EXIT_FAILURE);
+    }
+
+    auto post(Problem & p, const Instance & inst, DisjunctiveRules rules, DisjunctiveProofMutation mutation) -> vector<IntegerVariableID>
+    {
+        vector<IntegerVariableID> starts;
+        vector<Integer> lengths;
+        for (const auto & [lo, hi] : inst.start_ranges)
+            starts.push_back(p.create_integer_variable(Integer{lo}, Integer{hi}));
+        for (auto l : inst.lengths)
+            lengths.push_back(Integer{l});
+        p.post(Disjunctive{starts, lengths}.with_rules(rules).with_proof_mutation(mutation));
+        return starts;
+    }
+
+    /// What root propagation alone came to, and how many overload markers the
+    /// proof carries. Satisfiability is no use as a control here: the rule is
+    /// conflict-only, so an instance it refutes is unsatisfiable with the rule
+    /// off as well --- just found by searching rather than by reasoning. What
+    /// separates the rules is whether the *root* closes.
+    struct Probe
+    {
+        bool refuted_at_root = false;
+        bool satisfiable = false;
+        int markers = 0;
+    };
+
+    auto count_overload_markers(const string & basename) -> int
+    {
+        ifstream f{basename + ".pbp"};
+        string line;
+        auto count = 0;
+        while (getline(f, line))
+            if (line.find("disjunctive overload w=") != string::npos)
+                ++count;
+        return count;
+    }
+
+    auto probe(const Instance & inst, DisjunctiveRules rules, const optional<string> & proof_name,
+        DisjunctiveProofMutation mutation = disjunctive_proof_mutation::None{}) -> Probe
+    {
+        Problem p;
+        post(p, inst, rules, mutation);
+        Probe result;
+        // Refuted at the root means propagation reached a contradiction before
+        // any branching: no search node and no solution. The solution check is
+        // not redundant, an all-fixed instance being answered without ever
+        // branching.
+        auto reached_a_node = false;
+        solve_with(p,
+            SolveCallbacks{.solution = [&](const CurrentState &) -> bool {
+                               result.satisfiable = true;
+                               return false;
+                           },
+                .trace = [&](const CurrentState &) -> bool {
+                    reached_a_node = true;
+                    return false;
+                }},
+            proof_name ? make_optional<ProofOptions>(ProofFileNames{*proof_name}) : nullopt);
+        result.refuted_at_root = ! reached_a_node && ! result.satisfiable;
+        if (proof_name)
+            result.markers = count_overload_markers(*proof_name);
+        return result;
+    }
+
+    const DisjunctiveRules all_rules{.overload = true};
+    const DisjunctiveRules no_overload{.overload = false};
+}
+
+auto main(int argc, char * argv[]) -> int
+{
+    // Proofs only where veripb is installed, as every constraint test does:
+    // a run without it still checks the propagation, and says so by writing no
+    // proof rather than by writing one nothing looks at.
+    auto proofs = gcs::test_innards::can_run_veripb();
+
+    // Three tasks of three, every start in [0, 5]: none may begin before 0 and
+    // all must be done by 8, so eight time units have to hold nine of work.
+    // Every *pair* fits in eight, so no pairwise rule sees anything, and no
+    // task has a mandatory part (latest start 5 is past earliest end 3), so
+    // time-tabling is silent too.
+    const Instance sharp{{{0, 5}, {0, 5}, {0, 5}}, {3, 3, 3}};
+
+    // Mutation mode: emit one deliberately corrupted proof of `sharp` and stop,
+    // for run_test_and_expect_verify_failure.bash to hand to veripb.
+    {
+        optional<DisjunctiveProofMutation> mutation;
+        string proof_basename = "disjunctive_overload_mutation";
+        for (auto a = 1; a < argc; ++a) {
+            string arg = argv[a];
+            if (arg == "--mutate=emit_nothing")
+                mutation = disjunctive_proof_mutation::OverloadEmitNothing{};
+            else if (arg == "--mutate=skip_fold")
+                mutation = disjunctive_proof_mutation::SkipOverloadFold{};
+            else if (arg == "--mutate=skip_energy")
+                mutation = disjunctive_proof_mutation::SkipOverloadEnergy{};
+            else if (arg == "--mutate=rup_bridge")
+                mutation = disjunctive_proof_mutation::RupOverloadBridge{};
+            else if (arg == "--proof-files-basename" && a + 1 < argc)
+                proof_basename = argv[++a];
+        }
+
+        if (mutation) {
+            auto result = probe(sharp, all_rules, make_optional(proof_basename), *mutation);
+            if (result.markers == 0)
+                fail("mutation mode: no overload was justified, so the proof is empty");
+            println(cerr, "wrote a deliberately corrupted proof to {}.pbp", proof_basename);
+            return EXIT_SUCCESS;
+        }
+    }
+
+    // The rule refutes it, and --- the half that makes the fixture worth
+    // having --- nothing else does.
+    {
+        auto with_rule = probe(sharp, all_rules, proofs ? make_optional("disjunctive_overload_sharp") : nullopt);
+        if (with_rule.satisfiable)
+            fail("sharp: a solution was reported, but nine units do not fit in eight");
+        if (! with_rule.refuted_at_root)
+            fail("sharp: the rule did not close the root");
+        if (proofs && with_rule.markers != 1)
+            fail("sharp: expected exactly one overload marker, got " + std::to_string(with_rule.markers));
+        if (proofs && ! gcs::test_innards::run_veripb("disjunctive_overload_sharp.opb", "disjunctive_overload_sharp.pbp"))
+            fail("sharp: veripb rejected the overload certificate");
+
+        auto without_rule = probe(sharp, no_overload, nullopt);
+        if (without_rule.refuted_at_root)
+            fail("sharp: the root closed with the rule off, so the fixture says nothing about the rule");
+    }
+
+    // The margin of one: widen the window by a single unit and it fits, so
+    // nothing above is refuting on a technicality.
+    {
+        const Instance loose{{{0, 6}, {0, 6}, {0, 6}}, {3, 3, 3}};
+        auto result = probe(loose, all_rules, proofs ? make_optional("disjunctive_overload_loose") : nullopt);
+        if (result.refuted_at_root)
+            fail("loose: the root closed, but nine units fit in exactly nine");
+        if (proofs && result.markers != 0)
+            fail("loose: an overload was claimed where the work fits");
+        if (proofs && ! gcs::test_innards::run_veripb("disjunctive_overload_loose.opb", "disjunctive_overload_loose.pbp"))
+            fail("loose: veripb rejected the proof");
+    }
+
+    // Both vocabulary placements certify the same refutation. They differ only
+    // in whether the activity flags outlive the firing that made them, so a
+    // difference here would be a bug in one of them rather than a fact about
+    // the instance.
+    if (proofs)
+        for (auto at : {ProofLevel::Top, ProofLevel::Temporary}) {
+            DisjunctiveRules rules{.overload = true};
+            rules.overload_vocabulary_at = at;
+            auto name = string{"disjunctive_overload_"} + (at == ProofLevel::Top ? "top" : "temporary");
+            auto result = probe(sharp, rules, make_optional(name));
+            if (! result.refuted_at_root)
+                fail(name + ": the root did not close");
+            if (result.markers != 1)
+                fail(name + ": expected exactly one overload marker, got " + std::to_string(result.markers));
+            if (! gcs::test_innards::run_veripb(name + ".opb", name + ".pbp"))
+                fail(name + ": veripb rejected the certificate");
+        }
+
+    // A window the rule must not touch: two tasks that genuinely fit, where a
+    // sloppy sweep would still find "a" window if it counted a task whose lct
+    // falls outside it.
+    {
+        const Instance fits{{{0, 0}, {5, 5}, {2, 2}}, {2, 3, 3}};
+        auto result = probe(fits, all_rules, proofs ? make_optional("disjunctive_overload_fits") : nullopt);
+        if (result.refuted_at_root)
+            fail("fits: refuted a feasible schedule");
+        if (proofs && result.markers != 0)
+            fail("fits: an overload was claimed on a schedule that fits");
+        if (proofs && ! gcs::test_innards::run_veripb("disjunctive_overload_fits.opb", "disjunctive_overload_fits.pbp"))
+            fail("fits: veripb rejected the proof");
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/gcs/constraints/innards/disjunctive_mutations.hh
+++ b/gcs/constraints/innards/disjunctive_mutations.hh
@@ -84,11 +84,43 @@ namespace gcs::innards
         struct PushOneTooFar
         {
         };
+
+        /// Emit no overload certificate at all, leaving the contradiction to
+        /// the framework's wrapping RUP. The control for that rule: unlike
+        /// presence falsification, an overload's reason context is *not*
+        /// contradictory until the argument makes it so, which is why the
+        /// route mutations below bite where that rule's could not.
+        struct OverloadEmitNothing
+        {
+        };
+
+        /// Leave the per-time at-most-ones out of the overload endgame, so
+        /// nothing says the window can hold only one task at a time and the
+        /// energies have no supply to exceed.
+        struct SkipOverloadFold
+        {
+        };
+
+        /// Leave the tasks' energies out of the overload endgame, so nothing
+        /// says how much work the window must contain.
+        struct SkipOverloadEnergy
+        {
+        };
+
+        /// Conclude each pair's per-time at-most-one by bare `rup` rather than
+        /// by the bridge pol. The step with no counterpart in Cumulative, and
+        /// the one worth knowing propagation cannot make: getting from the
+        /// pairwise encoding to a statement about a time point is arithmetic,
+        /// not propagation.
+        struct RupOverloadBridge
+        {
+        };
     }
 
-    using DisjunctiveProofMutation =
-        std::variant<disjunctive_proof_mutation::None, disjunctive_proof_mutation::EmitNothing, disjunctive_proof_mutation::SkipRefutation,
-            disjunctive_proof_mutation::SkipTargetFold, disjunctive_proof_mutation::LooseDetectionBound, disjunctive_proof_mutation::PushOneTooFar>;
+    using DisjunctiveProofMutation = std::variant<disjunctive_proof_mutation::None, disjunctive_proof_mutation::EmitNothing,
+        disjunctive_proof_mutation::SkipRefutation, disjunctive_proof_mutation::SkipTargetFold, disjunctive_proof_mutation::LooseDetectionBound,
+        disjunctive_proof_mutation::PushOneTooFar, disjunctive_proof_mutation::OverloadEmitNothing, disjunctive_proof_mutation::SkipOverloadFold,
+        disjunctive_proof_mutation::SkipOverloadEnergy, disjunctive_proof_mutation::RupOverloadBridge>;
 
     /**
      * \brief Deliberate corruptions of the presence-falsification derivation,

--- a/gcs/innards/proofs/comparator_network.cc
+++ b/gcs/innards/proofs/comparator_network.cc
@@ -1,0 +1,159 @@
+#include <gcs/innards/proofs/comparator_network.hh>
+#include <gcs/innards/proofs/names_and_ids_tracker.hh>
+#include <gcs/innards/proofs/pol_builder.hh>
+
+#include <string>
+
+using namespace gcs;
+using namespace gcs::innards;
+
+using std::move;
+using std::string;
+using std::to_string;
+using std::vector;
+
+ComparatorNetwork::ComparatorNetwork(ProofLogger & logger, int width, ProofLevel level) :
+    _logger(logger), _width(width), _level(level), _span((Integer{1LL << width}) - 1_i),
+    // Twice a wire's span, so that a transfer lemma --- which adds two record
+    // rows and divides by a separation row's guard coefficient --- comes out at
+    // exactly one. Larger would still be sound and would make that division
+    // land short.
+    _big(2_i * ((Integer{1LL << width}) - 1_i))
+{
+}
+
+auto ComparatorNetwork::width() const -> int
+{
+    return _width;
+}
+
+auto ComparatorNetwork::span() const -> Integer
+{
+    return _span;
+}
+
+auto ComparatorNetwork::big() const -> Integer
+{
+    return _big;
+}
+
+auto ComparatorNetwork::next_name(const string & stem) -> string
+{
+    return stem + to_string(_counter++);
+}
+
+auto ComparatorNetwork::fresh_wire(const string & stem) -> ProofWire
+{
+    ProofWire wire;
+    auto name = next_name(stem);
+    for (auto t = 0; t < _width; ++t)
+        wire.bits.push_back(_logger.create_proof_flag(name + "b" + to_string(t)));
+    return wire;
+}
+
+auto ComparatorNetwork::terms(const ProofWire & wire, Integer sign) const -> WPBSum
+{
+    WPBSum sum;
+    add_terms(sum, wire, sign);
+    return sum;
+}
+
+auto ComparatorNetwork::add_terms(WPBSum & sum, const ProofWire & wire, Integer sign) const -> void
+{
+    for (auto t = 0; t < _width; ++t)
+        sum += (sign * Integer{1LL << t}) * wire.bits[t];
+}
+
+auto ComparatorNetwork::pin(const ProofWire & wire, Integer value) -> void
+{
+    for (auto t = 0; t < _width; ++t) {
+        auto on = 0 != ((value.raw_value >> t) & 1);
+        WPBSum sum;
+        if (on)
+            sum += 1_i * wire.bits[t];
+        else
+            sum += 1_i * ! wire.bits[t];
+        _logger.emit_red_proof_line(
+            move(sum) >= 1_i, {{wire.bits[t], on ? ProofLiteralOrFlag{TrueLiteral{}} : ProofLiteralOrFlag{FalseLiteral{}}}}, _level);
+    }
+}
+
+auto ComparatorNetwork::compare(const ProofWire & a, const ProofWire & b, const string & stem) -> Comparator
+{
+    auto selector = _logger.create_proof_flag(next_name(stem) + "sel");
+    auto lo = fresh_wire(stem + "lo"), hi = fresh_wire(stem + "hi");
+
+    // The selector, reifying `a <= b`. Both proofgoals autoprove: the negated
+    // goal pins the selector, since a wire's span cannot reach the guard
+    // coefficient, and the surviving row is then the goal itself.
+    WPBSum fwd;
+    add_terms(fwd, b, 1_i);
+    add_terms(fwd, a, -1_i);
+    fwd += _big * ! selector;
+    auto forward = _logger.emit_red_proof_line(move(fwd) >= 0_i, {{selector, ProofLiteralOrFlag{FalseLiteral{}}}}, _level);
+
+    WPBSum rev;
+    add_terms(rev, a, 1_i);
+    add_terms(rev, b, -1_i);
+    rev += _big * selector;
+    auto reverse = _logger.emit_red_proof_line(move(rev) >= 1_i, {{selector, ProofLiteralOrFlag{TrueLiteral{}}}}, _level);
+
+    // The bitwise muxes: `out_t <-> (sel AND on_true_t) OR (~sel AND
+    // on_false_t)`, four clauses per bit, each a `red` whose single-variable
+    // witness makes both proofgoals autoprove.
+    struct Mux
+    {
+        const ProofWire &out, &on_true, &on_false;
+    };
+    const Mux muxes[]{{lo, a, b}, {hi, b, a}};
+
+    // Per output, the four record rows: multiply the bit-`t` mux clause by
+    // `2^t` and sum, which turns a family of clauses about bits into one
+    // inequality about the wires they encode. The guard coefficient comes out
+    // at `span` and stays there.
+    auto record = [&](const Mux & m, int which) -> ProofLine {
+        PolBuilder pol;
+        for (auto t = 0; t < _width; ++t) {
+            const auto &out = m.out.bits[t], &on_t = m.on_true.bits[t], &on_f = m.on_false.bits[t];
+            WPBSum clause;
+            switch (which) {
+            case 0: clause += 1_i * ! selector, clause += 1_i * ! on_t, clause += 1_i * out; break;
+            case 1: clause += 1_i * selector, clause += 1_i * ! on_f, clause += 1_i * out; break;
+            case 2: clause += 1_i * ! selector, clause += 1_i * on_t, clause += 1_i * ! out; break;
+            default: clause += 1_i * selector, clause += 1_i * on_f, clause += 1_i * ! out; break;
+            }
+            auto witness = (which < 2) ? ProofLiteralOrFlag{TrueLiteral{}} : ProofLiteralOrFlag{FalseLiteral{}};
+            pol.add(_logger.emit_red_proof_line(move(clause) >= 1_i, {{out, witness}}, _level), Integer{1LL << t});
+        }
+        return pol.emit(_logger, _level);
+    };
+
+    auto lo_ge_a = record(muxes[0], 0);
+    auto lo_ge_b = record(muxes[0], 1);
+    auto lo_le_a = record(muxes[0], 2);
+    auto lo_le_b = record(muxes[0], 3);
+    auto hi_ge_b = record(muxes[1], 0);
+    auto hi_ge_a = record(muxes[1], 1);
+    auto hi_le_b = record(muxes[1], 2);
+    auto hi_le_a = record(muxes[1], 3);
+
+    // Built in one go with every member named, rather than default-constructed
+    // and filled in: a designated initialiser that leaves members out is a
+    // -Wmissing-field-initializers error on the one CI lane that builds with
+    // -Werror. The rows are emitted above rather than inline here so that the
+    // order they come out in stays the order they are derived in, which
+    // declaration order would otherwise decide.
+    return Comparator{.selector = selector,
+        .lo = lo,
+        .hi = hi,
+        .forward = forward,
+        .reverse = reverse,
+        .lo_ge_a = lo_ge_a,
+        .lo_le_a = lo_le_a,
+        .lo_ge_b = lo_ge_b,
+        .lo_le_b = lo_le_b,
+        .hi_ge_b = hi_ge_b,
+        .hi_le_b = hi_le_b,
+        .hi_ge_a = hi_ge_a,
+        .hi_le_a = hi_le_a};
+}

--- a/gcs/innards/proofs/comparator_network.hh
+++ b/gcs/innards/proofs/comparator_network.hh
@@ -1,0 +1,137 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_INNARDS_PROOFS_COMPARATOR_NETWORK_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_INNARDS_PROOFS_COMPARATOR_NETWORK_HH
+
+#include <gcs/innards/proofs/proof_line.hh>
+#include <gcs/innards/proofs/proof_logger-fwd.hh>
+#include <gcs/innards/proofs/proof_logger.hh>
+#include <gcs/innards/proofs/proof_only_variables.hh>
+#include <gcs/integer.hh>
+
+#include <string>
+#include <vector>
+
+namespace gcs::innards
+{
+    /**
+     * \brief A proof-only bit-encoded integer: `width` fresh flags, read as
+     * `sum_t 2^t * bits[t]`.
+     *
+     * Nothing in the model mentions a wire. It exists only between the `red`
+     * that introduces its bits and the deletion that removes them, which is
+     * what lets a propagator sort its tasks inside a proof without the OPB
+     * acquiring a sorting network --- or, for that matter, a time index.
+     *
+     * Bits rather than ProofModel::create_proof_only_integer_variable_in_proof,
+     * which is a *model*-side call and so unavailable to a propagator: a wire
+     * introduced during search cannot be a model variable, and does not need to
+     * be, every step below being cutting planes over the bits.
+     *
+     * \ingroup Innards
+     */
+    struct ProofWire
+    {
+        std::vector<ProofFlag> bits;
+    };
+
+    /**
+     * \brief One comparator's outputs, and the rows saying what they are.
+     *
+     * `selector` is true exactly when `a <= b`, so `lo` takes `a` and `hi`
+     * takes `b`; each output is muxed bitwise on it. The four record rows are
+     * the conditional statements a later lemma consumes --- `lo_ge_a` is
+     * `selector -> lo >= a`, and so on --- each one `pol`, built by multiplying
+     * the bit-`t` mux clause by `2^t` and summing.
+     *
+     * The guard coefficient on a record row comes out at `span` (the largest
+     * value a wire of this width can take) and is deliberately left there:
+     * a transfer lemma adds two of them and divides by a separation row's
+     * guard coefficient, which is a clean one only while `2 * span` does not
+     * exceed it.
+     *
+     * \ingroup Innards
+     */
+    struct Comparator
+    {
+        ProofFlag selector;
+        ProofWire lo, hi;
+
+        /// `selector -> b >= a`, and `~selector -> a >= b + 1`.
+        ProofLine forward, reverse;
+
+        /// The muxed record rows, `guard -> output (>= or <=) input`.
+        ProofLine lo_ge_a, lo_le_a, lo_ge_b, lo_le_b;
+        ProofLine hi_ge_b, hi_le_b, hi_ge_a, hi_le_a;
+    };
+
+    /**
+     * \brief Builds proof-only comparator networks over bit-encoded integer
+     * wires.
+     *
+     * The construction is the one issue #730 verified in simulation: wires
+     * introduced by redundance, sorted by a network of comparators, with order
+     * facts carried across each comparator and telescoped at the end. Its
+     * distinguishing property is that it is *duration-magnitude invariant* ---
+     * cost depends on the number of wires and only logarithmically on their
+     * range --- which is what makes it the certificate of choice where a
+     * time-indexed re-encoding would be too wide.
+     *
+     * Every step is emitted at the level the network was built with, so a
+     * caller that wants the whole thing gone on backtracking asks for
+     * ProofLevel::Temporary and a caller amortising it over many firings asks
+     * for ProofLevel::Top.
+     *
+     * \ingroup Innards
+     */
+    class ComparatorNetwork
+    {
+    private:
+        ProofLogger & _logger;
+        int _width;
+        ProofLevel _level;
+        Integer _span, _big;
+        long long _counter = 0;
+
+        [[nodiscard]] auto next_name(const std::string & stem) -> std::string;
+
+    public:
+        /**
+         * `width` bits per wire, which must be enough for every value the
+         * caller pins or bounds. `big` is the guard coefficient every
+         * conditional row carries; it has to dominate twice a wire's span, so
+         * that a transfer lemma's division comes out at one, and the caller's
+         * own rows have to be raised to it (see \ref raise_guard).
+         */
+        explicit ComparatorNetwork(ProofLogger &, int width, ProofLevel);
+
+        [[nodiscard]] auto width() const -> int;
+        [[nodiscard]] auto span() const -> Integer;
+        [[nodiscard]] auto big() const -> Integer;
+
+        /// A fresh wire, its bits unconstrained until something pins or defines
+        /// them.
+        [[nodiscard]] auto fresh_wire(const std::string & stem) -> ProofWire;
+
+        /// `sign * wire` as pseudo-Boolean terms, for building a row about it.
+        [[nodiscard]] auto terms(const ProofWire &, Integer sign) const -> WPBSum;
+
+        /// The same, appended to a sum already under construction, which is
+        /// what a row mentioning several wires needs.
+        auto add_terms(WPBSum &, const ProofWire &, Integer sign) const -> void;
+
+        /**
+         * Fix a fresh wire to a constant, one `red` per bit. The witness is
+         * single-variable and the wire is fresh, so both proofgoals autoprove
+         * and no subproof is needed.
+         */
+        auto pin(const ProofWire &, Integer value) -> void;
+
+        /**
+         * Introduce a comparator over two wires already in play: a selector
+         * reifying `a <= b` by two `red`s, four bitwise muxes per output bit,
+         * and the eight conditional record rows those give by `pol`.
+         */
+        [[nodiscard]] auto compare(const ProofWire & a, const ProofWire & b, const std::string & stem) -> Comparator;
+    };
+}
+
+#endif

--- a/gcs/innards/proofs/comparator_network_test.cc
+++ b/gcs/innards/proofs/comparator_network_test.cc
@@ -1,0 +1,166 @@
+/* Proof-only comparator networks over bit-encoded integer wires.
+ *
+ * Nothing here goes near a Disjunctive. The component's whole job is to
+ * introduce wires that exist only inside a proof and to say, in cutting
+ * planes, what a comparator does to them --- so it is tested on a micro model
+ * with no constraints at all, into which two wires are pinned to constants and
+ * a comparator is run.
+ *
+ * The model being *satisfiable* is the point, and the trap #656 walked into:
+ * against an unsatisfiable one every RUP step is vacuously valid and a
+ * corrupted derivation sails through. Here the only way to reach a
+ * contradiction is to pin a claim the comparator's own rows refute, which is
+ * what each `Claim` below does.
+ *
+ * Three things are checked, for every ordered pair of small values:
+ *
+ *   1. the wires and the comparator are introduced without VeriPB objecting,
+ *      which is a statement about the redundance witnesses rather than about
+ *      the arithmetic;
+ *   2. `lo` really is the smaller input and `hi` the larger --- claiming
+ *      otherwise is refuted;
+ *   3. claiming what is *true* of them is not refuted, so the rows are not
+ *      simply contradictory.
+ */
+
+#include <gcs/constraints/innards/constraints_test_utils.hh>
+#include <gcs/innards/proofs/comparator_network.hh>
+#include <gcs/innards/proofs/names_and_ids_tracker.hh>
+#include <gcs/innards/proofs/pol_builder.hh>
+#include <gcs/innards/proofs/proof_logger.hh>
+#include <gcs/innards/proofs/proof_model.hh>
+
+#include <cstdlib>
+#include <iostream>
+#include <string>
+#include <version>
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+#include <print>
+#else
+#include <fmt/core.h>
+#include <fmt/ostream.h>
+#endif
+
+using std::cerr;
+using std::move;
+using std::string;
+using std::to_string;
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+using std::println;
+#else
+using fmt::println;
+#endif
+
+using namespace gcs;
+using namespace gcs::innards;
+using namespace gcs::test_innards;
+
+namespace
+{
+    auto fail(const string & message) -> void
+    {
+        println(cerr, "comparator network test failure: {}", message);
+        std::exit(EXIT_FAILURE);
+    }
+
+    enum class Claim
+    {
+        /// Introduce the wires and the comparator and stop. Must verify, and
+        /// says nothing beyond "the reds are well formed".
+        Nothing,
+        /// `lo >= a + 1` where a is the smaller input: false, so the record
+        /// rows must refute it.
+        LoIsNotTheSmaller,
+        /// `hi + 1 <= b` where b is the larger input: false likewise.
+        HiIsNotTheLarger,
+        /// `lo <= a` and `hi >= b`, which are true: must NOT be refuted, or
+        /// the comparator's rows are contradictory and prove anything.
+        TheTruth
+    };
+
+    auto check(int a_value, int b_value, Claim claim, const string & tag, bool expect_accepted) -> void
+    {
+        auto proof_name = "comparator_network_" + to_string(a_value) + "_" + to_string(b_value) + "_" + tag;
+        ProofOptions proof_options{proof_name};
+        NamesAndIDsTracker tracker(proof_options);
+        ProofModel model(proof_options, tracker);
+        // A model with no constraints: everything below is a conservative
+        // extension of nothing, so a contradiction can only come from the
+        // claim under test.
+        model.finalise();
+
+        ProofLogger logger(proof_options, tracker);
+        tracker.switch_from_model_to_proof(&logger);
+        logger.start_proof(model);
+        tracker.emit_delayed_proof_steps();
+
+        ComparatorNetwork network(logger, 4, ProofLevel::Top);
+        auto a = network.fresh_wire("a"), b = network.fresh_wire("b");
+        network.pin(a, Integer{a_value});
+        network.pin(b, Integer{b_value});
+        auto c = network.compare(a, b, "c");
+
+        auto smaller = a_value <= b_value ? a : b;
+        auto larger = a_value <= b_value ? b : a;
+
+        auto claim_row = [&](WPBSum sum, Integer rhs) { logger.emit_rup_proof_line(move(sum) >= rhs, ProofLevel::Top); };
+
+        switch (claim) {
+        case Claim::Nothing: break;
+        case Claim::LoIsNotTheSmaller: {
+            WPBSum claim_sum;
+            network.add_terms(claim_sum, c.lo, 1_i);
+            network.add_terms(claim_sum, smaller, -1_i);
+            claim_row(move(claim_sum), 1_i);
+        } break;
+        case Claim::HiIsNotTheLarger: {
+            WPBSum claim_sum;
+            network.add_terms(claim_sum, larger, 1_i);
+            network.add_terms(claim_sum, c.hi, -1_i);
+            claim_row(move(claim_sum), 1_i);
+        } break;
+        case Claim::TheTruth: {
+            WPBSum lo_claim;
+            network.add_terms(lo_claim, smaller, 1_i);
+            network.add_terms(lo_claim, c.lo, -1_i);
+            claim_row(move(lo_claim), 0_i);
+            WPBSum hi_claim;
+            network.add_terms(hi_claim, c.hi, 1_i);
+            network.add_terms(hi_claim, larger, -1_i);
+            claim_row(move(hi_claim), 0_i);
+        } break;
+        }
+        logger.conclude_none();
+        tracker.finalise();
+
+        auto accepted = run_veripb(proof_name + ".opb", proof_name + ".pbp");
+        if (accepted != expect_accepted)
+            fail("a=" + to_string(a_value) + " b=" + to_string(b_value) + " (" + tag + "): veripb " + (accepted ? "accepted" : "rejected") +
+                " where it should have done the opposite");
+        dispose_of_proof_files(proof_name);
+    }
+}
+
+auto main(int, char *[]) -> int
+{
+    if (! can_run_veripb()) {
+        println(cerr, "veripb not found, skipping");
+        return EXIT_SUCCESS;
+    }
+
+    for (auto a = 0; a < 6; ++a)
+        for (auto b = 0; b < 6; ++b) {
+            check(a, b, Claim::Nothing, "plain", true);
+            check(a, b, Claim::TheTruth, "truth", true);
+            // The two that say the rows have content: claiming the low output
+            // is not the smaller input, or the high one not the larger, has to
+            // fail --- and does so by the RUP not going through, which is what
+            // a false claim against sound rows looks like.
+            check(a, b, Claim::LoIsNotTheSmaller, "lo_wrong", false);
+            check(a, b, Claim::HiIsNotTheLarger, "hi_wrong", false);
+        }
+
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Closes the measurement half of #730 and lands the first of its two certificates.

## What this is

`Disjunctive` gets an overload check — a window whose fully-contained tasks carry more duration than the window is wide is infeasible — and a certificate for it that **does not touch the OPB**. The model stays the pairwise `before` encoding whatever the rules say, because the model is the statement being verified and one that varied with a rule selection would be a different problem per setting.

The vocabulary is introduced in the proof instead:

1. **Activity flags.** `act_{i,t} <-> s_i >= t - p_i + 1 AND s_i < t + 1`, a conjunction of two order literals the encoding already mints. Three reds, deliberately — one clause per conjunct rather than the single row a conjunction reifies to, because the bridge cancels exactly one literal per operand and a row carrying both would leave the other behind. Created lazily per `(i, t)` a firing needs, and cached.
2. **The bridge**, the step `Cumulative` never takes, its OPB stating the capacity row outright. Per ordered pair and time, the before flag's `[r]` row plus the two operands' order-literal definitions cancels the starts and lands on degree `p_x + (t - p_x + 1) - t = 1`; both directions plus the separation clause pair the before literals off into a constant, and halving is exact.
3. **The fold**, `recover_am1_from_pairs` per time point.
4. **The energy telescope**: each task's backward clauses summed, every order literal appearing once positively and once negatively so the pairs cancel and the degree falls to `lb(l)`. What is left at the window's edges holds because the task starts and finishes inside it, which the reason already carries.

## Why it is worth having

Measured on generated RCPSP (`--machine-fraction 0.8`, sizes 15–35, ten seeds, 30 s): **8 of 50 instances close without the rule, 49 with it.** On the eight both close, 12,169,134 nodes become 3,916 and 59.9 s becomes 0.043 s. Full tables in #730.

`overload_max_window` is there to reproduce a negative result rather than because some cap is expected to pay: every cap closes fewer instances *and* costs more proof lines than no cap, declining a conflict deferring the work rather than removing it.

## Where the vocabulary lives

`DisjunctiveRules::overload_vocabulary_at` picks `Top` (derive once, cache) or `Temporary` (rebuild per firing, let backtracking delete it). The received objection to `Top` is that hint-free RUP costs `O(live database)`, so anything standing taxes the rest of the proof — but measured, that tax is flat to within noise from 4,692 to 38,460 standing rows, and `Top` wins on lines and on checking time by a margin that grows with the firing count. Hence the default, and hence keeping the switch: the measurement should be repeatable in-solver rather than believed.

## Testing

`disjunctive_overload_test.cc`. #655's trap applies unchanged — the rule fires nowhere in the existing corpus — plus one twist: satisfiability is no use as a control for a conflict-only rule, since an instance it refutes is unsatisfiable without it too. Every fixture is therefore compared at the **root**, and fails if the root closes with the rule off.

Four mutation lanes, all rejected. Unlike presence falsification, an overload's reason context is not contradictory until the argument makes it so, so corrupting the route is a real test here and two of the four remove half of the endgame apiece. `rup_bridge` is the interesting one: it says propagation cannot get from the pairwise encoding to a statement about a time point.

Separately checked: full enumeration under `--all --prove` on five instances gives identical solution counts to the baseline, and VeriPB reports `VERIFIED COMPLETE ENUMERATION` for each.

## Still to come (#730)

The comparator-network certificate for long horizons, and a crossover parameter selecting between them. Measured in Python on identical models, the two cross at a horizon of about nine times the window size — this one is `O(w^2 H)`, the network is `O(w^3)` and flat in the horizon.

Stacked on #736.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018FizeTcjBnMJqmqLWZz4qd