### PR TITLE
proofs: sort tasks inside a proof, and refute a window too small to hold them

### DIFF
--- a/gcs/innards/proofs/comparator_network.cc
+++ b/gcs/innards/proofs/comparator_network.cc
@@ -1,24 +1,41 @@
 #include <gcs/innards/proofs/comparator_network.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
 #include <gcs/innards/proofs/pol_builder.hh>
+#include <gcs/innards/proofs/proof_error.hh>
 
+#include <algorithm>
+#include <map>
+#include <optional>
 #include <string>
+#include <utility>
 
 using namespace gcs;
 using namespace gcs::innards;
 
+using std::holds_alternative;
+using std::map;
+using std::max;
 using std::move;
+using std::optional;
+using std::pair;
 using std::string;
 using std::to_string;
 using std::vector;
 
-ComparatorNetwork::ComparatorNetwork(ProofLogger & logger, int width, ProofLevel level) :
-    _logger(logger), _width(width), _level(level), _span((Integer{1LL << width}) - 1_i),
+ComparatorNetwork::ComparatorNetwork(ProofLogger & logger, int width, Integer horizon, ProofLevel level, ComparatorNetworkMutation mutation) :
+    _logger(logger), _width(width), _horizon(horizon), _level(level), _mutation(mutation), _span((Integer{1LL << width}) - 1_i),
     // Twice a wire's span, so that a transfer lemma --- which adds two record
     // rows and divides by a separation row's guard coefficient --- comes out at
-    // exactly one. Larger would still be sound and would make that division
-    // land short.
-    _big(2_i * ((Integer{1LL << width}) - 1_i))
+    // exactly one; and at least the horizon, so that a model row's own guard
+    // coefficient can be raised to it. Larger would still be sound and would
+    // make that division land short.
+    _big(max(2_i * ((Integer{1LL << width}) - 1_i), horizon)),
+    // Every case split divides by this, which is generous enough for the
+    // largest guard coefficient any lemma below accumulates (the gap lemma's
+    // `big + 3 * span`). Generous is safe because the negated goal cancels
+    // every record term exactly, so dividing can only touch the surviving guard
+    // literal.
+    _div(4_i * _big + 4_i * _span)
 {
 }
 
@@ -44,11 +61,18 @@ auto ComparatorNetwork::next_name(const string & stem) -> string
 
 auto ComparatorNetwork::fresh_wire(const string & stem) -> ProofWire
 {
-    ProofWire wire;
+    ProofWire wire{.id = _next_wire_id++, .bits = {}};
     auto name = next_name(stem);
     for (auto t = 0; t < _width; ++t)
         wire.bits.push_back(_logger.create_proof_flag(name + "b" + to_string(t)));
     return wire;
+}
+
+auto ComparatorNetwork::wire_over(const vector<ProofFlag> & bits) -> ProofWire
+{
+    if (static_cast<int>(bits.size()) != _width)
+        throw ProofError{"comparator network wire of the wrong width"};
+    return ProofWire{.id = _next_wire_id++, .bits = bits};
 }
 
 auto ComparatorNetwork::terms(const ProofWire & wire, Integer sign) const -> WPBSum
@@ -78,10 +102,80 @@ auto ComparatorNetwork::pin(const ProofWire & wire, Integer value) -> void
     }
 }
 
+auto ComparatorNetwork::add_task(const ProofWire & start, Integer duration) -> void
+{
+    if (duration < 1_i)
+        throw ProofError{"a zero-duration task does not participate in a comparator network"};
+
+    auto wire = fresh_wire("d");
+    pin(wire, duration);
+    _duration.emplace(start.id, wire);
+
+    // `duration >= 1`, load-bearing in the gap lemma, and the one place where
+    // unequal durations need something an equal-duration construction gets for
+    // free. "A starts at or after B, so A is not the one that finishes first"
+    // is only valid if B's duration is positive: with the duration subtracted
+    // out of the separation row the degree drops to zero, and a zero-duration
+    // task really can be "before" a task it starts level with. With equal
+    // durations this never comes up, the duration sitting in the degree as a
+    // constant.
+    _positivity.emplace(wire.id, _logger.emit_rup_proof_line(terms(wire, 1_i) >= 1_i, _level));
+    // And its upper bound, which is what makes a model row duration-relative.
+    // The pins are units, so this closes at once.
+    _duration_upper.emplace(wire.id, _logger.emit_rup_proof_line(terms(wire, -1_i) >= -duration, _level));
+}
+
+auto ComparatorNetwork::set_upper_bound(const ProofWire & start, ProofLine model_row) -> void
+{
+    PolBuilder builder;
+    builder.add(model_row).add(_duration_upper.at(_duration.at(start.id).id));
+    _upper.insert_or_assign(start.id, builder.emit(_logger, _level));
+}
+
+auto ComparatorNetwork::add_separation(const ProofWire & x, ProofFlag x_first_flag, ProofLine x_first_row, const ProofWire & y,
+    ProofFlag y_first_flag, ProofLine y_first_row, ProofLine clause, Integer guard_coefficient) -> void
+{
+    if (guard_coefficient > _big)
+        throw ProofError{"comparator network guard coefficient is too small for the model's rows"};
+
+    auto adopt = [&](const ProofWire & first, ProofFlag flag, ProofLine row) -> ProofLine {
+        // Subtract the pinned duration, putting the model's `y - x >= p_x` in
+        // the duration-relative form the network maintains across a mux.
+        PolBuilder relative;
+        relative.add(row).add(_duration_upper.at(_duration.at(first.id).id));
+        auto result = relative.emit(_logger, _level);
+
+        // Then raise the row's own big-M to the network's, using the literal
+        // axiom `~flag >= 0`, so that separation rows all carry the same guard
+        // coefficient whether they came from the model or from a comparator.
+        if (guard_coefficient == _big)
+            return result;
+        PolBuilder raised;
+        raised.add(! _logger.names_and_ids_tracker().xliteral_for(flag), _big - guard_coefficient, _logger.names_and_ids_tracker()).add(result);
+        return raised.emit(_logger, _level);
+    };
+
+    record_separation(x, adopt(x, x_first_flag, x_first_row), y, adopt(y, y_first_flag, y_first_row), clause);
+}
+
+auto ComparatorNetwork::record_separation(
+    const ProofWire & x, ProofLine when_first, const ProofWire & y, ProofLine when_other_first, ProofLine clause) -> void
+{
+    auto key = pair{std::min(x.id, y.id), std::max(x.id, y.id)};
+    _separations.insert_or_assign(key, Separation{.first = {{x.id, when_first}, {y.id, when_other_first}}, .clause = clause});
+}
+
+auto ComparatorNetwork::separation_between(const ProofWire & x, const ProofWire & y) const -> const Separation &
+{
+    return _separations.at(pair{std::min(x.id, y.id), std::max(x.id, y.id)});
+}
+
 auto ComparatorNetwork::compare(const ProofWire & a, const ProofWire & b, const string & stem) -> Comparator
 {
     auto selector = _logger.create_proof_flag(next_name(stem) + "sel");
+    auto d_a = _duration.at(a.id), d_b = _duration.at(b.id);
     auto lo = fresh_wire(stem + "lo"), hi = fresh_wire(stem + "hi");
+    auto d_lo = fresh_wire(stem + "dlo"), d_hi = fresh_wire(stem + "dhi");
 
     // The selector, reifying `a <= b`. Both proofgoals autoprove: the negated
     // goal pins the selector, since a wire's span cannot reach the guard
@@ -100,60 +194,489 @@ auto ComparatorNetwork::compare(const ProofWire & a, const ProofWire & b, const 
 
     // The bitwise muxes: `out_t <-> (sel AND on_true_t) OR (~sel AND
     // on_false_t)`, four clauses per bit, each a `red` whose single-variable
-    // witness makes both proofgoals autoprove.
-    struct Mux
-    {
-        const ProofWire &out, &on_true, &on_false;
+    // witness makes both proofgoals autoprove. Both the start and the duration
+    // are muxed on the one selector, because a comparator permutes whole tasks:
+    // without the durations following their starts the endgame cannot say what
+    // the gap between two sorted wires is.
+    //
+    // Every clause is introduced before any record row is built from them. A
+    // record row is a statement about an output's *value*, so a later red
+    // pinning one of that output's bits does not preserve it --- put one in the
+    // database early and the next bit's clause has a proofgoal it cannot
+    // discharge.
+    using MuxClauses = vector<vector<ProofLine>>;
+    auto introduce = [&](const ProofWire & out, const ProofWire & on_true, const ProofWire & on_false) -> MuxClauses {
+        MuxClauses clauses;
+        for (auto t = 0; t < _width; ++t) {
+            const auto &out_bit = out.bits[t], &on_t = on_true.bits[t], &on_f = on_false.bits[t];
+            vector<ProofLine> per_bit;
+            for (auto which = 0; which < 4; ++which) {
+                WPBSum clause;
+                switch (which) {
+                case 0: clause += 1_i * ! selector, clause += 1_i * ! on_t, clause += 1_i * out_bit; break;
+                case 1: clause += 1_i * selector, clause += 1_i * ! on_f, clause += 1_i * out_bit; break;
+                case 2: clause += 1_i * ! selector, clause += 1_i * on_t, clause += 1_i * ! out_bit; break;
+                default: clause += 1_i * selector, clause += 1_i * on_f, clause += 1_i * ! out_bit; break;
+                }
+                auto witness = (which < 2) ? ProofLiteralOrFlag{TrueLiteral{}} : ProofLiteralOrFlag{FalseLiteral{}};
+                per_bit.push_back(_logger.emit_red_proof_line(move(clause) >= 1_i, {{out_bit, witness}}, _level));
+            }
+            clauses.push_back(move(per_bit));
+        }
+        return clauses;
     };
-    const Mux muxes[]{{lo, a, b}, {hi, b, a}};
+
+    auto lo_clauses = introduce(lo, a, b);
+    auto hi_clauses = introduce(hi, b, a);
+    auto d_lo_clauses = introduce(d_lo, d_a, d_b);
+    auto d_hi_clauses = introduce(d_hi, d_b, d_a);
 
     // Per output, the four record rows: multiply the bit-`t` mux clause by
     // `2^t` and sum, which turns a family of clauses about bits into one
     // inequality about the wires they encode. The guard coefficient comes out
     // at `span` and stays there.
-    auto record = [&](const Mux & m, int which) -> ProofLine {
+    auto record = [&](const MuxClauses & clauses, int which) -> ProofLine {
         PolBuilder pol;
-        for (auto t = 0; t < _width; ++t) {
-            const auto &out = m.out.bits[t], &on_t = m.on_true.bits[t], &on_f = m.on_false.bits[t];
-            WPBSum clause;
-            switch (which) {
-            case 0: clause += 1_i * ! selector, clause += 1_i * ! on_t, clause += 1_i * out; break;
-            case 1: clause += 1_i * selector, clause += 1_i * ! on_f, clause += 1_i * out; break;
-            case 2: clause += 1_i * ! selector, clause += 1_i * on_t, clause += 1_i * ! out; break;
-            default: clause += 1_i * selector, clause += 1_i * on_f, clause += 1_i * ! out; break;
-            }
-            auto witness = (which < 2) ? ProofLiteralOrFlag{TrueLiteral{}} : ProofLiteralOrFlag{FalseLiteral{}};
-            pol.add(_logger.emit_red_proof_line(move(clause) >= 1_i, {{out, witness}}, _level), Integer{1LL << t});
-        }
+        for (auto t = 0; t < _width; ++t)
+            pol.add(clauses[t][which], Integer{1LL << t});
         return pol.emit(_logger, _level);
     };
 
-    auto lo_ge_a = record(muxes[0], 0);
-    auto lo_ge_b = record(muxes[0], 1);
-    auto lo_le_a = record(muxes[0], 2);
-    auto lo_le_b = record(muxes[0], 3);
-    auto hi_ge_b = record(muxes[1], 0);
-    auto hi_ge_a = record(muxes[1], 1);
-    auto hi_le_b = record(muxes[1], 2);
-    auto hi_le_a = record(muxes[1], 3);
-
-    // Built in one go with every member named, rather than default-constructed
-    // and filled in: a designated initialiser that leaves members out is a
-    // -Wmissing-field-initializers error on the one CI lane that builds with
-    // -Werror. The rows are emitted above rather than inline here so that the
-    // order they come out in stays the order they are derived in, which
-    // declaration order would otherwise decide.
-    return Comparator{.selector = selector,
+    // Braced initialisation is sequenced left to right, so naming every member
+    // here also fixes the order the record rows come out in.
+    Comparator c{.selector = selector,
+        .a = a,
+        .b = b,
+        .d_a = d_a,
+        .d_b = d_b,
         .lo = lo,
         .hi = hi,
+        .d_lo = d_lo,
+        .d_hi = d_hi,
         .forward = forward,
         .reverse = reverse,
-        .lo_ge_a = lo_ge_a,
-        .lo_le_a = lo_le_a,
-        .lo_ge_b = lo_ge_b,
-        .lo_le_b = lo_le_b,
-        .hi_ge_b = hi_ge_b,
-        .hi_le_b = hi_le_b,
-        .hi_ge_a = hi_ge_a,
-        .hi_le_a = hi_le_a};
+        .lo_ge_a = record(lo_clauses, 0),
+        .lo_le_a = record(lo_clauses, 2),
+        .lo_ge_b = record(lo_clauses, 1),
+        .lo_le_b = record(lo_clauses, 3),
+        .hi_ge_b = record(hi_clauses, 0),
+        .hi_le_b = record(hi_clauses, 2),
+        .hi_ge_a = record(hi_clauses, 1),
+        .hi_le_a = record(hi_clauses, 3),
+        .d_lo_ge_a = record(d_lo_clauses, 0),
+        .d_lo_le_a = record(d_lo_clauses, 2),
+        .d_lo_ge_b = record(d_lo_clauses, 1),
+        .d_lo_le_b = record(d_lo_clauses, 3),
+        .d_hi_ge_b = record(d_hi_clauses, 0),
+        .d_hi_le_b = record(d_hi_clauses, 2),
+        .d_hi_ge_a = record(d_hi_clauses, 1),
+        .d_hi_le_a = record(d_hi_clauses, 3)};
+
+    _duration.emplace(lo.id, d_lo);
+    _duration.emplace(hi.id, d_hi);
+
+    return c;
+}
+
+auto ComparatorNetwork::case_split(const WPBSumLE & goal, const vector<ProofLine> & guarded_halves) -> ProofLine
+{
+    // The goal holds under each polarity of a selector, so it holds. Each half
+    // is the goal plus a guard: adding the negated goal cancels every record
+    // term and leaves the guard alone, and the two guards then sum past one.
+    map<ProofGoal, Subproof> subproofs;
+    subproofs.emplace("#1", Subproof{[&](ProofLogger & sub_logger) {
+        // The negated goal is the last line added when the subproof opens.
+        auto negation = sub_logger.get_current_proof_line();
+        vector<ProofLine> guards;
+        for (const auto & half : guarded_halves) {
+            PolBuilder builder;
+            builder.add(half).add(negation).divide_by(_div);
+            guards.push_back(builder.emit(sub_logger, ProofLevel::Temporary));
+        }
+        PolBuilder builder;
+        for (const auto & guard : guards)
+            builder.add(guard);
+        builder.emit(sub_logger, ProofLevel::Temporary);
+    }});
+
+    return _logger.emit_red_proof_line(goal, {}, _level, subproofs);
+}
+
+auto ComparatorNetwork::derive_positivity(const ProofWire & out, const vector<pair<ProofLine, ProofWire>> & halves) -> void
+{
+    // `d_out >= 1`, carried through the mux, and needed by the *next*
+    // comparator's gap lemma, which is where the degree has to come from. Each
+    // guarded `d_out >= d_in` row is paired with THAT input's positivity:
+    // pairing them the other way round leaves the two durations in the sum
+    // instead of cancelling, which still derives something, just not the goal.
+    vector<ProofLine> rows;
+    for (const auto & [record, source] : halves) {
+        PolBuilder builder;
+        builder.add(record).add(_positivity.at(source.id));
+        rows.push_back(builder.emit(_logger, _level));
+    }
+
+    auto goal = terms(out, 1_i) >= 1_i;
+    _positivity.emplace(out.id,
+        holds_alternative<comparator_network_mutation::RupPositivity>(_mutation) ? _logger.emit_rup_proof_line(goal, _level)
+                                                                                 : case_split(goal, rows));
+}
+
+auto ComparatorNetwork::derive_preservation(const Comparator & c) -> ProofLine
+{
+    // `d_lo + d_hi - d_a - d_b >= 0`. New at unequal durations: the endgame
+    // sums the sorted wires' durations and needs that sum to be at least the
+    // instance's total work, which is only true because each comparator
+    // permutes rather than loses.
+    PolBuilder selected;
+    selected.add(c.d_lo_ge_a).add(c.d_hi_ge_b);
+    PolBuilder not_selected;
+    not_selected.add(c.d_lo_ge_b).add(c.d_hi_ge_a);
+
+    WPBSum goal;
+    add_terms(goal, c.d_lo, 1_i);
+    add_terms(goal, c.d_hi, 1_i);
+    add_terms(goal, c.d_a, -1_i);
+    add_terms(goal, c.d_b, -1_i);
+
+    if (holds_alternative<comparator_network_mutation::RupPreservation>(_mutation))
+        return _logger.emit_rup_proof_line(move(goal) >= 0_i, _level);
+    return case_split(move(goal) >= 0_i, {selected.emit(_logger, _level), not_selected.emit(_logger, _level)});
+}
+
+auto ComparatorNetwork::derive_gap(const Comparator & c) -> ProofLine
+{
+    // `hi - lo - d_lo >= 0`: the gap between the two outputs is the earlier
+    // task's duration, which is now a muxed record rather than a constant.
+    const auto & separation = separation_between(c.a, c.b);
+    auto a_first = separation.first.at(c.a.id), b_first = separation.first.at(c.b.id);
+
+    // One half per polarity of the selector. Under the guard one of the two
+    // inputs starts strictly later, so the separation cannot be resolved that
+    // way round: `later_first` is the row this refutes, `earlier_first` the one
+    // left standing, and the gap then reads off the outputs' record rows.
+    auto half = [&](ProofLine later_first, ProofLine earlier_first, ProofLine guard_row, const ProofWire & later_duration, ProofLine hi_ge,
+                    ProofLine lo_le, ProofLine d_lo_le) -> ProofLine {
+        // Starting later is only a reason not to finish first if the later
+        // task's duration is positive --- which has to be said, the duration no
+        // longer being a constant in the degree.
+        auto running = later_first;
+        if (! holds_alternative<comparator_network_mutation::DropPositivity>(_mutation)) {
+            PolBuilder builder;
+            builder.add(later_first).add(_positivity.at(later_duration.id));
+            running = builder.emit(_logger, _level);
+        }
+        {
+            PolBuilder builder;
+            builder.add(running).add(guard_row).divide_by(_big);
+            running = builder.emit(_logger, _level);
+        }
+        {
+            PolBuilder builder;
+            builder.add(running).add(separation.clause);
+            running = builder.emit(_logger, _level);
+        }
+        {
+            PolBuilder builder;
+            builder.add(running).multiply_by(_big).add(earlier_first);
+            running = builder.emit(_logger, _level);
+        }
+        PolBuilder builder;
+        builder.add(running).add(hi_ge).add(lo_le).add(d_lo_le);
+        return builder.emit(_logger, _level);
+    };
+
+    auto swapped = holds_alternative<comparator_network_mutation::SwapDurations>(_mutation);
+    auto when_a_is_later = half(a_first, b_first, c.reverse, c.d_a, c.hi_ge_a, c.lo_le_b, swapped ? c.d_lo_le_a : c.d_lo_le_b);
+    auto when_b_is_later = half(b_first, a_first, c.forward, c.d_b, c.hi_ge_b, c.lo_le_a, swapped ? c.d_lo_le_b : c.d_lo_le_a);
+
+    WPBSum goal;
+    add_terms(goal, c.hi, 1_i);
+    add_terms(goal, c.lo, -1_i);
+    add_terms(goal, c.d_lo, -1_i);
+
+    if (holds_alternative<comparator_network_mutation::RupGap>(_mutation))
+        return _logger.emit_rup_proof_line(move(goal) >= 0_i, _level);
+    return case_split(move(goal) >= 0_i, {when_a_is_later, when_b_is_later});
+}
+
+auto ComparatorNetwork::derive_dominance(const Comparator & c) -> ProofLine
+{
+    // `hi >= a`: the running maximum never decreases.
+    PolBuilder selected;
+    selected.add(c.hi_ge_b).add(c.forward);
+
+    WPBSum goal;
+    add_terms(goal, c.hi, 1_i);
+    add_terms(goal, c.a, -1_i);
+    return case_split(move(goal) >= 0_i, {selected.emit(_logger, _level), c.hi_ge_a});
+}
+
+auto ComparatorNetwork::derive_bound(const Comparator & c, const ProofWire & out, const ProofWire & d_out, ProofLine le_a, ProofLine le_b,
+    ProofLine d_le_a, ProofLine d_le_b) -> ProofLine
+{
+    // `horizon - out - d_out >= 0`, carried through the mux from the inputs'.
+    //
+    // Derived for BOTH outputs. Aliasing the low output's bound to the high
+    // one's --- on the grounds that lo <= hi --- would be a statement about the
+    // wrong wire: `horizon - hi - d_hi >= 0` is not `horizon - lo - d_lo >= 0`,
+    // and a later comparator consuming it as an input bound adds a row
+    // mentioning a wire that is no longer in play, so nothing cancels.
+    PolBuilder from_a;
+    from_a.add(_upper.at(c.a.id)).add(le_a).add(d_le_a);
+    PolBuilder from_b;
+    from_b.add(_upper.at(c.b.id)).add(le_b).add(d_le_b);
+
+    WPBSum goal;
+    add_terms(goal, out, -1_i);
+    add_terms(goal, d_out, -1_i);
+    return case_split(move(goal) >= -_horizon, {from_a.emit(_logger, _level), from_b.emit(_logger, _level)});
+}
+
+auto ComparatorNetwork::reify_separation(const ProofWire & x, const ProofWire & y, const string & stem) -> SeparationFlags
+{
+    auto name = next_name(stem);
+    SeparationFlags flags{.x_first = _logger.create_proof_flag(name + "f"),
+        .y_first = _logger.create_proof_flag(name + "b"),
+        .x_first_row = {},
+        .x_first_reverse = {},
+        .y_first_row = {},
+        .y_first_reverse = {}};
+
+    auto reify = [&](const ProofWire & first, const ProofWire & second, ProofFlag flag) -> pair<ProofLine, ProofLine> {
+        const auto & duration = _duration.at(first.id);
+
+        WPBSum forward;
+        add_terms(forward, second, 1_i);
+        add_terms(forward, first, -1_i);
+        add_terms(forward, duration, -1_i);
+        forward += _big * ! flag;
+        auto forward_line = _logger.emit_red_proof_line(move(forward) >= 0_i, {{flag, ProofLiteralOrFlag{FalseLiteral{}}}}, _level);
+
+        WPBSum reverse;
+        add_terms(reverse, first, 1_i);
+        add_terms(reverse, second, -1_i);
+        add_terms(reverse, duration, 1_i);
+        reverse += _big * flag;
+        auto reverse_line = _logger.emit_red_proof_line(move(reverse) >= 1_i, {{flag, ProofLiteralOrFlag{TrueLiteral{}}}}, _level);
+
+        return {forward_line, reverse_line};
+    };
+
+    std::tie(flags.x_first_row, flags.x_first_reverse) = reify(x, y, flags.x_first);
+    std::tie(flags.y_first_row, flags.y_first_reverse) = reify(y, x, flags.y_first);
+    return flags;
+}
+
+auto ComparatorNetwork::separate_from_gap(const ProofWire & x, const ProofWire & y, ProofLine gap) -> void
+{
+    // Register a separation between two wires the network has just *proved* are
+    // apart, rather than one the model gave it. The reverse half of "x runs
+    // first" contradicts the gap outright, so what comes out is the *unit*
+    // `x runs first` --- strictly stronger than the two-literal clause a model
+    // pair gives.
+    //
+    // Weaken it straight back, by adding the literal axiom for the other
+    // direction. A transfer lemma cancels a separation's clause against one
+    // guard from each of its two halves, which lands on a contradiction only
+    // when the clause has both literals: handed the unit it lands one literal
+    // short, sound but not closing, and the subproof then needs a
+    // database-wide RUP to finish. That is a real cost --- transfers are the
+    // cubic term here --- for a row that is only stronger than needed.
+    auto flags = reify_separation(x, y, "gap");
+    PolBuilder builder;
+    builder.add(flags.x_first_reverse)
+        .add(gap)
+        .divide_by(_big)
+        .add(_logger.names_and_ids_tracker().xliteral_for(flags.y_first), _logger.names_and_ids_tracker());
+    record_separation(x, flags.x_first_row, y, flags.y_first_row, builder.emit(_logger, _level));
+}
+
+auto ComparatorNetwork::transfer(const ProofWire & out, const ProofWire & other, const Comparator & c, ProofLine le_a, ProofLine ge_a, ProofLine le_b,
+    ProofLine ge_b, ProofLine d_le_a, ProofLine d_le_b) -> void
+{
+    // A separation between one of the comparator's outputs and a wire not in
+    // the comparator, from the separations its two *inputs* had with that wire,
+    // by cases on the selector. The duration record rows are what unequal
+    // durations add: without them `d_out` cannot be turned into `d_a` inside a
+    // case.
+    struct Branch
+    {
+        ProofLine le, ge, d_le;
+        const Separation * separation;
+        const ProofWire * input;
+    };
+
+    const auto & from_a = separation_between(c.a, other);
+    const auto & from_b = separation_between(c.b, other);
+    const Branch branches[]{{le_a, ge_a, d_le_a, &from_a, &c.a}, {le_b, ge_b, d_le_b, &from_b, &c.b}};
+
+    auto flags = reify_separation(out, other, "t");
+
+    WPBSum goal;
+    goal += 1_i * flags.x_first;
+    goal += 1_i * flags.y_first;
+
+    map<ProofGoal, Subproof> subproofs;
+    subproofs.emplace("#1", Subproof{[&](ProofLogger & sub_logger) {
+        // Under the negated goal neither flag holds, so both reverse halves
+        // fire: the output is not before the other wire, and the other wire is
+        // not before the output.
+        auto no_x = sub_logger.emit_rup_proof_line(WPBSum{} + 1_i * ! flags.x_first >= 1_i, ProofLevel::Temporary);
+        auto no_y = sub_logger.emit_rup_proof_line(WPBSum{} + 1_i * ! flags.y_first >= 1_i, ProofLevel::Temporary);
+
+        PolBuilder out_late_builder;
+        out_late_builder.add(flags.x_first_reverse).add(no_x, _big);
+        auto out_late = out_late_builder.emit(sub_logger, ProofLevel::Temporary);
+
+        PolBuilder other_late_builder;
+        other_late_builder.add(flags.y_first_reverse).add(no_y, _big);
+        auto other_late = other_late_builder.emit(sub_logger, ProofLevel::Temporary);
+
+        vector<ProofLine> kills;
+        for (const auto & branch : branches) {
+            // Rewrite both halves onto this input, then cancel each against the
+            // input's own separation row, leaving the selector's polarity and
+            // the separation's guard. The clause then removes the guard.
+            PolBuilder as_input;
+            as_input.add(out_late).add(branch.le).add(branch.d_le);
+            auto forwards = as_input.emit(sub_logger, ProofLevel::Temporary);
+
+            PolBuilder as_input_reverse;
+            as_input_reverse.add(other_late).add(branch.ge);
+            auto backwards = as_input_reverse.emit(sub_logger, ProofLevel::Temporary);
+
+            PolBuilder cancel_forwards;
+            cancel_forwards.add(forwards).add(branch.separation->first.at(branch.input->id)).divide_by(_big);
+            forwards = cancel_forwards.emit(sub_logger, ProofLevel::Temporary);
+
+            PolBuilder cancel_backwards;
+            cancel_backwards.add(backwards).add(branch.separation->first.at(other.id)).divide_by(_big);
+            backwards = cancel_backwards.emit(sub_logger, ProofLevel::Temporary);
+
+            PolBuilder kill;
+            kill.add(forwards).add(backwards).add(branch.separation->clause).divide_by(2_i);
+            kills.push_back(kill.emit(sub_logger, ProofLevel::Temporary));
+        }
+
+        PolBuilder both;
+        both.add(kills[0]).add(kills[1]);
+        both.emit(sub_logger, ProofLevel::Temporary);
+    }});
+
+    auto clause = _logger.emit_red_proof_line(move(goal) >= 1_i, {}, _level, subproofs);
+    record_separation(out, flags.x_first_row, other, flags.y_first_row, clause);
+}
+
+auto ComparatorNetwork::sort(const vector<ProofWire> & tasks) -> SortedTasks
+{
+    // Selection sort: each pass runs a maximum along the live wires, leaving
+    // the smaller output of each comparator behind for the next pass. A
+    // comparison network of a smarter shape would emit fewer comparators, but
+    // this one has the property the endgame needs --- every pass ends holding a
+    // gap row from its own maximum to each of its leftovers --- and the cost is
+    // dominated by the transfers either way.
+    if (tasks.size() < 2)
+        throw ProofError{"a comparator network needs at least two tasks to sort"};
+
+    SortedTasks result{.chain = {}, .preserved = {}, .top_upper_bound = {}};
+
+    auto live = tasks;
+    optional<ProofWire> previous_maximum, first_maximum;
+    map<int, ProofLine> previous_gaps;
+
+    while (live.size() > 1) {
+        auto running = live[0];
+        vector<ProofWire> leftovers;
+        map<int, ProofLine> gaps;
+        optional<ProofLine> carried;
+        if (previous_maximum)
+            carried = previous_gaps.at(running.id);
+
+        for (size_t j = 1; j < live.size(); ++j) {
+            auto c = compare(running, live[j], "c");
+            derive_positivity(c.d_lo, {{c.d_lo_ge_a, c.d_a}, {c.d_lo_ge_b, c.d_b}});
+            derive_positivity(c.d_hi, {{c.d_hi_ge_b, c.d_b}, {c.d_hi_ge_a, c.d_a}});
+            result.preserved.push_back(derive_preservation(c));
+            auto gap = derive_gap(c);
+
+            // Every wire the outputs will still be compared against needs a
+            // separation with them: the ones not yet reached in this pass, and
+            // the ones this pass has already put aside.
+            auto still_to_come = vector<ProofWire>{live.begin() + j + 1, live.end()};
+            still_to_come.insert(still_to_come.end(), leftovers.begin(), leftovers.end());
+            for (const auto & other : still_to_come) {
+                transfer(c.lo, other, c, c.lo_le_a, c.lo_ge_a, c.lo_le_b, c.lo_ge_b, c.d_lo_le_a, c.d_lo_le_b);
+                transfer(c.hi, other, c, c.hi_le_a, c.hi_ge_a, c.hi_le_b, c.hi_ge_b, c.d_hi_le_a, c.d_hi_le_b);
+            }
+            separate_from_gap(c.lo, c.hi, gap);
+
+            // The gap rows this pass is accumulating are all against the
+            // running maximum, so when the maximum moves they all move with it.
+            if (j > 1) {
+                auto dominance = derive_dominance(c);
+                for (auto & [wire, row] : gaps) {
+                    PolBuilder builder;
+                    builder.add(row).add(dominance);
+                    row = builder.emit(_logger, _level);
+                }
+            }
+            gaps.emplace(c.lo.id, gap);
+
+            // And the previous pass's maximum has to keep up with this pass's,
+            // which is the link between one pass and the next.
+            if (previous_maximum) {
+                PolBuilder selected;
+                selected.add(previous_gaps.at(live[j].id)).add(c.hi_le_b).add(c.d_hi_le_b);
+                PolBuilder not_selected;
+                not_selected.add(*carried).add(c.hi_le_a).add(c.d_hi_le_a);
+
+                WPBSum goal;
+                add_terms(goal, *previous_maximum, 1_i);
+                add_terms(goal, c.hi, -1_i);
+                add_terms(goal, c.d_hi, -1_i);
+                carried = case_split(move(goal) >= 0_i, {selected.emit(_logger, _level), not_selected.emit(_logger, _level)});
+            }
+
+            // `hi` takes `b` under the selector and `lo` takes `a`, so each
+            // output pairs its selector-guarded record row with THAT input's
+            // bound.
+            _upper.insert_or_assign(c.hi.id, derive_bound(c, c.hi, c.d_hi, c.hi_le_a, c.hi_le_b, c.d_hi_le_a, c.d_hi_le_b));
+            _upper.insert_or_assign(c.lo.id, derive_bound(c, c.lo, c.d_lo, c.lo_le_a, c.lo_le_b, c.d_lo_le_a, c.d_lo_le_b));
+
+            leftovers.push_back(c.lo);
+            running = c.hi;
+        }
+
+        if (previous_maximum)
+            result.chain.push_back(*carried);
+        else
+            first_maximum = running;
+
+        previous_maximum = running;
+        previous_gaps = gaps;
+        live = leftovers;
+    }
+
+    result.chain.push_back(previous_gaps.at(live[0].id));
+    result.top_upper_bound = _upper.at(first_maximum->id);
+    return result;
+}
+
+auto ComparatorNetwork::sum_up(const SortedTasks & sorted) -> ProofLine
+{
+    // Telescope: each chain row is one adjacent gap, so summing them leaves the
+    // largest start minus the smallest, minus every duration but the largest's.
+    // The largest's own upper bound puts the horizon on the other side, and the
+    // preservation rows turn the sorted durations back into the instance's own.
+    // What is left says the horizon covers the total work, over a start that
+    // bit-encoding already makes non-negative.
+    PolBuilder builder;
+    for (const auto & row : sorted.chain)
+        builder.add(row);
+    builder.add(sorted.top_upper_bound);
+    if (! holds_alternative<comparator_network_mutation::DropPreservation>(_mutation))
+        for (const auto & row : sorted.preserved)
+            builder.add(row);
+    return builder.emit(_logger, _level);
 }

--- a/gcs/innards/proofs/comparator_network.hh
+++ b/gcs/innards/proofs/comparator_network.hh
@@ -7,29 +7,116 @@
 #include <gcs/innards/proofs/proof_only_variables.hh>
 #include <gcs/integer.hh>
 
+#include <map>
+#include <optional>
 #include <string>
+#include <utility>
+#include <variant>
 #include <vector>
 
 namespace gcs::innards
 {
     /**
-     * \brief A proof-only bit-encoded integer: `width` fresh flags, read as
+     * \brief Deliberate corruptions of a comparator-network refutation, for
+     * testing only.
+     *
+     * The network's arithmetic is long, and every step of it is *sound* in
+     * isolation: a proof that merely stops early lands on a weaker line rather
+     * than an invalid one. So the corruptions worth having are the ones that
+     * make the endgame's sum come up short, or that ask propagation to do a
+     * step cutting planes had to do explicitly. All but one of these is
+     * rejected by VeriPB, and the one that is not says something worth knowing
+     * about which steps propagation can reach on its own.
+     *
+     * \ingroup Innards
+     */
+    namespace comparator_network_mutation
+    {
+        /// Emit the honest derivation.
+        struct None
+        {
+        };
+
+        /// Leave the earlier task's `duration >= 1` out of the gap lemma. This
+        /// is the fact an equal-duration construction gets for free, the
+        /// duration sitting in the degree as a constant; with the duration
+        /// muxed through the network instead, the degree drops to zero without
+        /// it and a zero-length task can be "before" one it starts level with.
+        struct DropPositivity
+        {
+        };
+
+        /// Cite the *other* input's duration record in each half of the gap
+        /// lemma, so the gap is measured against the wrong task's duration.
+        /// Invisible at equal durations, which is what makes it the mutation
+        /// that says this construction really does unequal ones.
+        struct SwapDurations
+        {
+        };
+
+        /// Ask RUP for the gap lemma rather than deriving it. The interesting
+        /// one: it says the case split over the comparator's selector is
+        /// load-bearing, and that propagation cannot get from the separation
+        /// clause to the gap on its own.
+        struct RupGap
+        {
+        };
+
+        /// Ask RUP for a muxed duration's positivity. Kept although VeriPB
+        /// *accepts* it: while every duration is pinned to a constant,
+        /// propagation gets from the mux clauses to `d_out >= 1` on its own, so
+        /// the case split below is buying predictable cost rather than reach
+        /// --- an unhinted RUP is priced against the whole database, and the
+        /// split is four lines. The day durations become variables the pins go
+        /// and this stops passing, which is the other reason to keep it
+        /// runnable.
+        struct RupPositivity
+        {
+        };
+
+        /// Ask RUP for a comparator's sum-preservation lemma.
+        struct RupPreservation
+        {
+        };
+
+        /// Leave the per-comparator sum-preservation rows out of the endgame.
+        /// If this still refutes, the endgame never needed to know that the
+        /// network permutes the durations rather than losing them.
+        struct DropPreservation
+        {
+        };
+    }
+
+    using ComparatorNetworkMutation = std::variant<comparator_network_mutation::None, comparator_network_mutation::DropPositivity,
+        comparator_network_mutation::SwapDurations, comparator_network_mutation::RupGap, comparator_network_mutation::RupPositivity,
+        comparator_network_mutation::RupPreservation, comparator_network_mutation::DropPreservation>;
+
+    /**
+     * \brief A proof-only bit-encoded integer: `width` flags, read as
      * `sum_t 2^t * bits[t]`.
      *
-     * Nothing in the model mentions a wire. It exists only between the `red`
-     * that introduces its bits and the deletion that removes them, which is
-     * what lets a propagator sort its tasks inside a proof without the OPB
-     * acquiring a sorting network --- or, for that matter, a time index.
+     * A wire is either fresh (ComparatorNetwork::fresh_wire, its bits invented
+     * by redundance) or a reading of flags that already exist
+     * (ComparatorNetwork::wire_over, which is how a model variable's own bit
+     * encoding enters the network). Either way nothing in the model has to
+     * change: a fresh wire exists only between the `red` that introduces its
+     * bits and the deletion that removes them, which is what lets a propagator
+     * sort its tasks inside a proof without the OPB acquiring a sorting network
+     * --- or, for that matter, a time index.
      *
      * Bits rather than ProofModel::create_proof_only_integer_variable_in_proof,
      * which is a *model*-side call and so unavailable to a propagator: a wire
      * introduced during search cannot be a model variable, and does not need to
      * be, every step below being cutting planes over the bits.
      *
+     * `id` is the network's own handle for the wire, and is what its duration,
+     * bounds and separations are filed under.
+     *
      * \ingroup Innards
      */
     struct ProofWire
     {
+        int id;
         std::vector<ProofFlag> bits;
     };
 
@@ -37,23 +124,30 @@ namespace gcs::innards
      * \brief One comparator's outputs, and the rows saying what they are.
      *
      * `selector` is true exactly when `a <= b`, so `lo` takes `a` and `hi`
-     * takes `b`; each output is muxed bitwise on it. The four record rows are
-     * the conditional statements a later lemma consumes --- `lo_ge_a` is
-     * `selector -> lo >= a`, and so on --- each one `pol`, built by multiplying
-     * the bit-`t` mux clause by `2^t` and summing.
+     * takes `b`; each output is muxed bitwise on it, as is each output's
+     * duration --- a comparator permutes whole tasks, not just their starts.
+     * The record rows are the conditional statements the lemmas consume ---
+     * `lo_ge_a` is `selector -> lo >= a`, and so on --- each one a `pol`, built
+     * by multiplying the bit-`t` mux clause by `2^t` and summing.
      *
      * The guard coefficient on a record row comes out at `span` (the largest
      * value a wire of this width can take) and is deliberately left there:
-     * a transfer lemma adds two of them and divides by a separation row's
-     * guard coefficient, which is a clean one only while `2 * span` does not
-     * exceed it.
+     * ComparatorNetwork::transfer adds two of them and divides by a separation
+     * row's guard coefficient, which is a clean one only while `2 * span` does
+     * not exceed it.
      *
      * \ingroup Innards
      */
     struct Comparator
     {
         ProofFlag selector;
-        ProofWire lo, hi;
+
+        /// The inputs, kept so that a lemma can name them without the caller
+        /// having to hold on to them.
+        ProofWire a, b, d_a, d_b;
+
+        /// The outputs: the earlier task and the later one.
+        ProofWire lo, hi, d_lo, d_hi;
 
         /// `selector -> b >= a`, and `~selector -> a >= b + 1`.
         ProofLine forward, reverse;
@@ -61,19 +155,51 @@ namespace gcs::innards
         /// The muxed record rows, `guard -> output (>= or <=) input`.
         ProofLine lo_ge_a, lo_le_a, lo_ge_b, lo_le_b;
         ProofLine hi_ge_b, hi_le_b, hi_ge_a, hi_le_a;
+        ProofLine d_lo_ge_a, d_lo_le_a, d_lo_ge_b, d_lo_le_b;
+        ProofLine d_hi_ge_b, d_hi_le_b, d_hi_ge_a, d_hi_le_a;
+    };
+
+    /**
+     * \brief What sorting the tasks leaves behind, and all the endgame needs.
+     *
+     * \ingroup Innards
+     */
+    struct SortedTasks
+    {
+        /// The telescoping rows, each `upper - lower - duration(lower) >= 0`
+        /// for one adjacent pair of the sorted order. Summing them collapses to
+        /// `largest - smallest - (every duration but the largest's) >= 0`.
+        std::vector<ProofLine> chain;
+
+        /// One sum-preservation row per comparator, `d_lo + d_hi >= d_a + d_b`,
+        /// which is what turns the sorted durations back into the instance's
+        /// own.
+        std::vector<ProofLine> preserved;
+
+        /// `horizon - largest - duration(largest) >= 0`.
+        ProofLine top_upper_bound;
     };
 
     /**
      * \brief Builds proof-only comparator networks over bit-encoded integer
-     * wires.
+     * wires, and sorts tasks with them.
      *
      * The construction is the one issue #730 verified in simulation: wires
      * introduced by redundance, sorted by a network of comparators, with order
      * facts carried across each comparator and telescoped at the end. Its
      * distinguishing property is that it is *duration-magnitude invariant* ---
-     * cost depends on the number of wires and only logarithmically on their
+     * cost depends on the number of tasks and only logarithmically on their
      * range --- which is what makes it the certificate of choice where a
      * time-indexed re-encoding would be too wide.
+     *
+     * There are two layers here. The lower one is generic: wires, pins, and
+     * comparators that mux a key and a payload on one selector. The upper one
+     * sorts *tasks* --- values that are pairwise separated, each by one of the
+     * two durations involved --- because that is the thing a disjunctive
+     * resource has to sort, and because carrying a separation across a
+     * comparator is the whole difficulty. A caller supplies its model's
+     * separation rows through \ref add_separation and never has to know how
+     * they are moved onto the sorted wires.
      *
      * Every step is emitted at the level the network was built with, so a
      * caller that wants the whole thing gone on backtracking asks for
@@ -85,23 +211,84 @@ namespace gcs::innards
     class ComparatorNetwork
     {
     private:
+        /// A separation as the lemmas want it: which row holds when each wire
+        /// goes first, and the clause saying one of them does. Both rows carry
+        /// \ref big as their guard coefficient, whatever they were derived
+        /// from --- which is what \ref add_separation raises a model row to,
+        /// and what lets a transfer lemma divide by a constant it knows.
+        struct Separation
+        {
+            std::map<int, ProofLine> first;
+            ProofLine clause;
+        };
+
         ProofLogger & _logger;
         int _width;
+        Integer _horizon;
         ProofLevel _level;
-        Integer _span, _big;
+        ComparatorNetworkMutation _mutation;
+        Integer _span, _big, _div;
         long long _counter = 0;
+        int _next_wire_id = 0;
+
+        /// Each start wire's duration wire, and each duration wire's `>= 1` row
+        /// and `<= its pinned value` row.
+        std::map<int, ProofWire> _duration;
+        std::map<int, ProofLine> _positivity, _duration_upper;
+
+        /// Each start wire's `horizon - wire - duration(wire) >= 0`.
+        std::map<int, ProofLine> _upper;
+
+        /// Keyed by the pair of wire ids, smaller first.
+        std::map<std::pair<int, int>, Separation> _separations;
 
         [[nodiscard]] auto next_name(const std::string & stem) -> std::string;
+
+        [[nodiscard]] auto separation_between(const ProofWire &, const ProofWire &) const -> const Separation &;
+
+        auto record_separation(const ProofWire &, ProofLine when_first, const ProofWire &, ProofLine when_other_first, ProofLine clause) -> void;
+
+        /// The four `red`s reifying "x runs before y" and "y runs before x" on
+        /// a pair of fresh flags, returning the two forward rows and the two
+        /// reverse ones.
+        struct SeparationFlags
+        {
+            ProofFlag x_first, y_first;
+            ProofLine x_first_row, x_first_reverse, y_first_row, y_first_reverse;
+        };
+
+        [[nodiscard]] auto reify_separation(const ProofWire & x, const ProofWire & y, const std::string & stem) -> SeparationFlags;
+
+        [[nodiscard]] auto case_split(const WPBSumLE & goal, const std::vector<ProofLine> & guarded_halves) -> ProofLine;
+
+        auto derive_positivity(const ProofWire & out, const std::vector<std::pair<ProofLine, ProofWire>> & halves) -> void;
+
+        [[nodiscard]] auto derive_preservation(const Comparator &) -> ProofLine;
+
+        [[nodiscard]] auto derive_gap(const Comparator &) -> ProofLine;
+
+        [[nodiscard]] auto derive_dominance(const Comparator &) -> ProofLine;
+
+        [[nodiscard]] auto derive_bound(const Comparator &, const ProofWire & out, const ProofWire & d_out, ProofLine le_a, ProofLine le_b,
+            ProofLine d_le_a, ProofLine d_le_b) -> ProofLine;
+
+        auto separate_from_gap(const ProofWire & x, const ProofWire & y, ProofLine gap) -> void;
+
+        auto transfer(const ProofWire & out, const ProofWire & other, const Comparator &, ProofLine le_a, ProofLine ge_a, ProofLine le_b,
+            ProofLine ge_b, ProofLine d_le_a, ProofLine d_le_b) -> void;
 
     public:
         /**
          * `width` bits per wire, which must be enough for every value the
-         * caller pins or bounds. `big` is the guard coefficient every
-         * conditional row carries; it has to dominate twice a wire's span, so
-         * that a transfer lemma's division comes out at one, and the caller's
-         * own rows have to be raised to it (see \ref raise_guard).
+         * caller pins or bounds, and `horizon` the upper bound every task's
+         * completion is measured against. The guard coefficient every
+         * conditional row carries is derived from both: it has to dominate
+         * twice a wire's span, so that a transfer lemma's division comes out at
+         * one, and to reach the guard coefficient of the caller's own rows, so
+         * that \ref add_separation can raise them to it.
          */
-        explicit ComparatorNetwork(ProofLogger &, int width, ProofLevel);
+        explicit ComparatorNetwork(
+            ProofLogger &, int width, Integer horizon, ProofLevel, ComparatorNetworkMutation = comparator_network_mutation::None{});
 
         [[nodiscard]] auto width() const -> int;
         [[nodiscard]] auto span() const -> Integer;
@@ -110,6 +297,10 @@ namespace gcs::innards
         /// A fresh wire, its bits unconstrained until something pins or defines
         /// them.
         [[nodiscard]] auto fresh_wire(const std::string & stem) -> ProofWire;
+
+        /// A wire reading flags that already exist --- a model variable's own
+        /// bit encoding, most often. Nothing is emitted.
+        [[nodiscard]] auto wire_over(const std::vector<ProofFlag> & bits) -> ProofWire;
 
         /// `sign * wire` as pseudo-Boolean terms, for building a row about it.
         [[nodiscard]] auto terms(const ProofWire &, Integer sign) const -> WPBSum;
@@ -126,11 +317,67 @@ namespace gcs::innards
         auto pin(const ProofWire &, Integer value) -> void;
 
         /**
-         * Introduce a comparator over two wires already in play: a selector
-         * reifying `a <= b` by two `red`s, four bitwise muxes per output bit,
-         * and the eight conditional record rows those give by `pol`.
+         * Give a wire a duration, pinned to a constant, and derive the
+         * `duration >= 1` the gap lemma needs. A zero-duration task is exactly
+         * the case a non-strict Disjunctive drops from the constraint, so
+         * requiring a positive duration costs no generality.
+         */
+        auto add_task(const ProofWire & start, Integer duration) -> void;
+
+        /**
+         * Record `horizon - start - duration >= 0` for a task, from the model's
+         * own `start <= horizon - duration` row.
+         */
+        auto set_upper_bound(const ProofWire & start, ProofLine model_row) -> void;
+
+        /**
+         * Take a pair of tasks' separation from the model and put it in the
+         * form the lemmas want.
+         *
+         * `x_first_row` is the model's forward reification half for "x runs
+         * before y", `M * ~flag + y - x >= duration(x)`, and `x_first_flag` the
+         * flag it is guarded on; likewise the other way round. `clause` says
+         * one of the two flags holds. `guard_coefficient` is the `M` those rows
+         * carry --- for a row emitted by ProofModel::add_two_way_reified_constraint
+         * that is `-NamesAndIDsTracker::reification_shape(...).reif_coefficient`
+         * --- and must not exceed \ref big.
+         *
+         * The rows are made duration-relative (the pinned duration subtracted,
+         * so the network can carry them across a mux) and raised to the
+         * network's own guard coefficient.
+         */
+        auto add_separation(const ProofWire & x, ProofFlag x_first_flag, ProofLine x_first_row, const ProofWire & y, ProofFlag y_first_flag,
+            ProofLine y_first_row, ProofLine clause, Integer guard_coefficient) -> void;
+
+        /**
+         * Introduce a comparator over two tasks already in play: a selector
+         * reifying `a <= b` by two `red`s, four bitwise muxes per output bit
+         * and per output duration bit, and the conditional record rows those
+         * give by `pol`.
          */
         [[nodiscard]] auto compare(const ProofWire & a, const ProofWire & b, const std::string & stem) -> Comparator;
+
+        /**
+         * Sort the tasks by selection sort, carrying every separation across
+         * every comparator, and return the telescoping chain.
+         *
+         * Every task must have had \ref add_task, \ref set_upper_bound and a
+         * \ref add_separation against each of the others.
+         */
+        [[nodiscard]] auto sort(const std::vector<ProofWire> & tasks) -> SortedTasks;
+
+        /**
+         * The endgame: sum the chain, add the largest task's upper bound, and
+         * turn the sorted durations back into the instance's own.
+         *
+         * The row returned says the horizon is at least the total work, over a
+         * start that bit encoding already makes non-negative --- so if the
+         * tasks do not fit in the window, it is contradictory outright and any
+         * RUP closes. Emitting that contradiction is left to the caller, which
+         * inside a propagator means `ThenRUP::Yes` under a reason rather than a
+         * bare line.
+         */
+        [[nodiscard]] auto sum_up(const SortedTasks &) -> ProofLine;
     };
 }
 

--- a/gcs/innards/proofs/comparator_network_test.cc
+++ b/gcs/innards/proofs/comparator_network_test.cc
@@ -1,26 +1,24 @@
 /* Proof-only comparator networks over bit-encoded integer wires.
  *
- * Nothing here goes near a Disjunctive. The component's whole job is to
- * introduce wires that exist only inside a proof and to say, in cutting
- * planes, what a comparator does to them --- so it is tested on a micro model
- * with no constraints at all, into which two wires are pinned to constants and
- * a comparator is run.
+ * Two tests, at the component's two layers.
  *
- * The model being *satisfiable* is the point, and the trap #656 walked into:
- * against an unsatisfiable one every RUP step is vacuously valid and a
- * corrupted derivation sails through. Here the only way to reach a
- * contradiction is to pin a claim the comparator's own rows refute, which is
- * what each `Claim` below does.
+ * The first goes nowhere near a schedule. A comparator's whole job is to say,
+ * in cutting planes, what muxing two wires on a selector does to them, so it is
+ * tested on a micro model with no constraints at all, into which two wires are
+ * pinned to constants and one comparator is run. The model being *satisfiable*
+ * is the point, and the trap #656 walked into: against an unsatisfiable one
+ * every RUP step is vacuously valid and a corrupted derivation sails through.
+ * Here the only way to reach a contradiction is to pin a claim the comparator's
+ * own rows refute, which is what each `Claim` below does.
  *
- * Three things are checked, for every ordered pair of small values:
- *
- *   1. the wires and the comparator are introduced without VeriPB objecting,
- *      which is a statement about the redundance witnesses rather than about
- *      the arithmetic;
- *   2. `lo` really is the smaller input and `hi` the larger --- claiming
- *      otherwise is refuted;
- *   3. claiming what is *true* of them is not refuted, so the rows are not
- *      simply contradictory.
+ * The second is the whole construction: a disjunctive instance whose tasks
+ * cannot fit in their window, encoded pairwise --- `before` flags and one
+ * separation clause per pair, nothing time-indexed anywhere --- and refuted by
+ * sorting the tasks inside the proof and telescoping. That model *is*
+ * unsatisfiable, so a green run says only that the arithmetic went through; the
+ * mutations are what say it had to. Each corrupts one step and must be
+ * rejected, and one control asks for the same proof over a window the tasks do
+ * fit in, where the endgame has to fail.
  */
 
 #include <gcs/constraints/innards/constraints_test_utils.hh>
@@ -30,9 +28,14 @@
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/proofs/proof_model.hh>
 
+#include <algorithm>
+#include <bit>
 #include <cstdlib>
 #include <iostream>
+#include <map>
 #include <string>
+#include <utility>
+#include <vector>
 #include <version>
 
 #if defined(__cpp_lib_print) && defined(__cpp_lib_format)
@@ -43,9 +46,14 @@
 #endif
 
 using std::cerr;
+using std::map;
 using std::move;
+using std::pair;
 using std::string;
 using std::to_string;
+using std::vector;
+using std::ranges::max;
+using std::ranges::min;
 
 #if defined(__cpp_lib_print) && defined(__cpp_lib_format)
 using std::println;
@@ -80,7 +88,7 @@ namespace
         TheTruth
     };
 
-    auto check(int a_value, int b_value, Claim claim, const string & tag, bool expect_accepted) -> void
+    auto check_comparator(int a_value, int b_value, Claim claim, const string & tag, bool expect_accepted) -> void
     {
         auto proof_name = "comparator_network_" + to_string(a_value) + "_" + to_string(b_value) + "_" + tag;
         ProofOptions proof_options{proof_name};
@@ -96,10 +104,14 @@ namespace
         logger.start_proof(model);
         tracker.emit_delayed_proof_steps();
 
-        ComparatorNetwork network(logger, 4, ProofLevel::Top);
+        ComparatorNetwork network(logger, 4, 15_i, ProofLevel::Top);
         auto a = network.fresh_wire("a"), b = network.fresh_wire("b");
         network.pin(a, Integer{a_value});
         network.pin(b, Integer{b_value});
+        // A comparator permutes whole tasks, so both inputs need a duration
+        // before there is anything to compare. What it is does not matter here.
+        network.add_task(a, 1_i);
+        network.add_task(b, 1_i);
         auto c = network.compare(a, b, "c");
 
         auto smaller = a_value <= b_value ? a : b;
@@ -141,6 +153,146 @@ namespace
                 " where it should have done the opposite");
         dispose_of_proof_files(proof_name);
     }
+
+    /* The pairwise disjunctive encoding, and nothing else: this is the model a
+     * Disjunctive already defines, written out here over plain proof flags so
+     * that the test owns every big-M and the network is exercised against the
+     * shapes it will meet rather than against rows invented to suit it.
+     */
+    struct PairwiseModel
+    {
+        vector<vector<ProofFlag>> start_bits;
+        vector<ProofLine> upper_bounds;
+        map<pair<size_t, size_t>, ProofFlag> before;
+        map<pair<size_t, size_t>, ProofLine> before_rows;
+        map<pair<size_t, size_t>, ProofLine> separation_clauses;
+        Integer big = 0_i;
+        int width = 0;
+    };
+
+    auto build_pairwise_model(ProofModel & model, const vector<int> & durations, int horizon) -> PairwiseModel
+    {
+        auto tasks = durations.size();
+        PairwiseModel built;
+        // Every start gets the same width, which its own bound row then
+        // narrows: a shared width is what lets the network's wires all be read
+        // the same way, and costs nothing but a spare high bit.
+        auto widest_start = horizon - min(durations);
+        auto widest = widest_start > max(durations) ? widest_start : max(durations);
+        built.width = static_cast<int>(std::bit_width(static_cast<unsigned long long>(widest)));
+        built.big = Integer{horizon};
+
+        built.start_bits.resize(tasks);
+        for (size_t i = 0; i < tasks; ++i)
+            for (auto t = 0; t < built.width; ++t)
+                built.start_bits[i].push_back(model.create_proof_flag("x" + to_string(i) + "_" + to_string(t)));
+
+        auto start = [&](size_t i, Integer sign) {
+            WPBSum sum;
+            for (auto t = 0; t < built.width; ++t)
+                sum += (sign * Integer{1LL << t}) * built.start_bits[i][t];
+            return sum;
+        };
+
+        // `start_i <= horizon - duration_i`. Load-bearing in a way it is not
+        // with equal durations: the shared width lets a start range over more
+        // than its own window, and this is the row that says it may not.
+        for (size_t i = 0; i < tasks; ++i)
+            built.upper_bounds.push_back(model.add_labelled_constraint("ub" + to_string(i), start(i, 1_i) <= Integer{horizon - durations[i]}));
+
+        for (size_t i = 0; i < tasks; ++i)
+            for (size_t j = 0; j < tasks; ++j) {
+                if (i == j)
+                    continue;
+                auto name = "b" + to_string(i) + "_" + to_string(j);
+                auto flag = model.create_proof_flag(name);
+                built.before.emplace(pair{i, j}, flag);
+
+                // [r] before_ij -> start_j - start_i >= duration_i
+                auto forward = start(j, 1_i);
+                for (auto & term : start(i, -1_i).terms)
+                    forward += term;
+                forward += built.big * ! flag;
+                built.before_rows.emplace(pair{i, j}, model.add_labelled_constraint(name + "r", move(forward) >= Integer{durations[i]}));
+
+                // [f] ~before_ij -> start_i - start_j >= 1 - duration_i
+                auto reverse = start(i, 1_i);
+                for (auto & term : start(j, -1_i).terms)
+                    reverse += term;
+                reverse += (built.big + 1_i) * flag;
+                model.add_labelled_constraint(name + "f", move(reverse) >= Integer{1 - durations[i]});
+            }
+
+        for (size_t i = 0; i < tasks; ++i)
+            for (size_t j = i + 1; j < tasks; ++j) {
+                WPBSum clause;
+                clause += 1_i * built.before.at(pair{i, j});
+                clause += 1_i * built.before.at(pair{j, i});
+                built.separation_clauses.emplace(
+                    pair{i, j}, model.add_labelled_constraint("sep" + to_string(i) + "_" + to_string(j), move(clause) >= 1_i));
+            }
+
+        return built;
+    }
+
+    auto check_refutation(const vector<int> & durations, int horizon, ComparatorNetworkMutation mutation, const string & tag, bool expect_accepted)
+        -> void
+    {
+        auto proof_name = "comparator_network_refute_" + to_string(durations.size()) + "_" + tag;
+        ProofOptions proof_options{proof_name};
+        NamesAndIDsTracker tracker(proof_options);
+        ProofModel model(proof_options, tracker);
+        auto built = build_pairwise_model(model, durations, horizon);
+        model.finalise();
+
+        ProofLogger logger(proof_options, tracker);
+        tracker.switch_from_model_to_proof(&logger);
+        logger.start_proof(model);
+        tracker.emit_delayed_proof_steps();
+
+        ComparatorNetwork network(logger, built.width, Integer{horizon}, ProofLevel::Top, mutation);
+
+        vector<ProofWire> tasks;
+        for (size_t i = 0; i < durations.size(); ++i)
+            tasks.push_back(network.wire_over(built.start_bits[i]));
+        for (size_t i = 0; i < durations.size(); ++i) {
+            network.add_task(tasks[i], Integer{durations[i]});
+            network.set_upper_bound(tasks[i], built.upper_bounds[i]);
+        }
+        for (size_t i = 0; i < durations.size(); ++i)
+            for (size_t j = i + 1; j < durations.size(); ++j)
+                network.add_separation(tasks[i], built.before.at(pair{i, j}), built.before_rows.at(pair{i, j}), tasks[j], built.before.at(pair{j, i}),
+                    built.before_rows.at(pair{j, i}), built.separation_clauses.at(pair{i, j}), built.big);
+
+        auto sorted = network.sort(tasks);
+        // The window-energy row. It is contradictory exactly when the tasks do
+        // not fit, so concluding is one RUP away --- and when a mutation has
+        // left the sum short, or when the control's window is wide enough, that
+        // RUP is where the proof falls over.
+        (void)network.sum_up(sorted);
+        logger.conclude_unsatisfiable(false);
+        tracker.finalise();
+
+        auto accepted = run_veripb(proof_name + ".opb", proof_name + ".pbp");
+        if (accepted != expect_accepted)
+            fail("refutation of " + to_string(durations.size()) + " tasks in " + to_string(horizon) + " (" + tag + "): veripb " +
+                (accepted ? "accepted" : "rejected") + " where it should have done the opposite");
+        dispose_of_proof_files(proof_name);
+    }
+
+    /// Unequal durations that overload the window by exactly one unit, so the
+    /// instance is unsatisfiable by a margin of one and every separation clause
+    /// matters.
+    auto tight_instance(size_t tasks) -> pair<vector<int>, int>
+    {
+        vector<int> durations;
+        for (size_t i = 0; i < tasks; ++i)
+            durations.push_back(2 + static_cast<int>((i * 5 + 3) % 7));
+        auto total = 0;
+        for (auto d : durations)
+            total += d;
+        return {durations, total - 1};
+    }
 }
 
 auto main(int, char *[]) -> int
@@ -152,15 +304,38 @@ auto main(int, char *[]) -> int
 
     for (auto a = 0; a < 6; ++a)
         for (auto b = 0; b < 6; ++b) {
-            check(a, b, Claim::Nothing, "plain", true);
-            check(a, b, Claim::TheTruth, "truth", true);
+            check_comparator(a, b, Claim::Nothing, "plain", true);
+            check_comparator(a, b, Claim::TheTruth, "truth", true);
             // The two that say the rows have content: claiming the low output
             // is not the smaller input, or the high one not the larger, has to
             // fail --- and does so by the RUP not going through, which is what
             // a false claim against sound rows looks like.
-            check(a, b, Claim::LoIsNotTheSmaller, "lo_wrong", false);
-            check(a, b, Claim::HiIsNotTheLarger, "hi_wrong", false);
+            check_comparator(a, b, Claim::LoIsNotTheSmaller, "lo_wrong", false);
+            check_comparator(a, b, Claim::HiIsNotTheLarger, "hi_wrong", false);
         }
+
+    for (size_t tasks = 3; tasks <= 8; ++tasks) {
+        auto [durations, horizon] = tight_instance(tasks);
+        check_refutation(durations, horizon, comparator_network_mutation::None{}, "honest", true);
+        // Same tasks, one more unit of window: they fit, and the endgame must
+        // not close. This is the control that says the refutation is about the
+        // instance rather than about the scaffolding.
+        check_refutation(durations, horizon + 1, comparator_network_mutation::None{}, "roomy", false);
+    }
+
+    {
+        auto [durations, horizon] = tight_instance(4);
+        check_refutation(durations, horizon, comparator_network_mutation::DropPositivity{}, "drop_positivity", false);
+        check_refutation(durations, horizon, comparator_network_mutation::SwapDurations{}, "swap_durations", false);
+        check_refutation(durations, horizon, comparator_network_mutation::RupGap{}, "rup_gap", false);
+        // Accepted, and expected to be: with every duration pinned, propagation
+        // reaches a muxed duration's positivity without the case split. Asserted
+        // so that it is on the record, and so that it starts failing the day
+        // durations stop being constants.
+        check_refutation(durations, horizon, comparator_network_mutation::RupPositivity{}, "rup_positivity", true);
+        check_refutation(durations, horizon, comparator_network_mutation::RupPreservation{}, "rup_preservation", false);
+        check_refutation(durations, horizon, comparator_network_mutation::DropPreservation{}, "drop_preservation", false);
+    }
 
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Stacked on #737. The comparator network's lemmas, so that #730's above-crossover
certificate exists in the solver and not only in simulation.

#737 landed the machinery — wires by redundance, one comparator, and a micro-model
test. This is the rest of the construction: comparators that mux a duration
alongside a start, the lemmas that carry a gap, a dominance, a sum preservation, a
positivity and an upper bound across one, the transfer that moves a separation onto
an output, a selection-sort driver, and the endgame that telescopes the sorted
order into the window-energy row.

The model does not change, which is the point. `Disjunctive` keeps its pairwise
`before` encoding; the caller hands those rows over and the network makes them
duration-relative and raises them to one guard coefficient. Nothing time-indexed
goes anywhere near the OPB.

**What it is checked against.** The test writes the pairwise encoding itself, over
plain proof flags, so it owns every big-M and meets the shapes a `Disjunctive`
emits rather than rows invented to suit the proof. Three to eight tasks overloading
their window by one unit: all verified. The same tasks given one more unit of
window: all rejected — the control that says the refutation is about the instance
rather than the scaffolding. Six mutations, five rejected.

The sixth is accepted, and is kept for saying so: while every duration is pinned to
a constant, propagation reaches a muxed duration's positivity on its own, so the
case split there is buying predictable cost rather than reach. It starts failing
the day durations become variables. The whole test is 0.35s.

**Two things the simulation did not have to get right.**

Every mux clause is introduced before any record row is built from them. A record
row is a statement about an output's *value*, so a later `red` pinning one of that
output's bits does not preserve it — emit one early and the next bit's clause has a
proofgoal it cannot discharge.

A separation the network *derives* from a gap comes out with a unit clause rather
than the model's two-literal one, and a transfer cancels a clause against one guard
from each of its halves, so handed the unit it lands one literal short: sound, but
not closing. VeriPB's `pbc` hides this by doing a database-wide RUP of its own at
`qed`; a `red` proofgoal does not, and rightly — transfers are the cubic term here
and an unhinted RUP is priced against the whole database. The unit is weakened back
to two literals instead.

**Not in this PR**: emitting the network from `Disjunctive` under a reason, deleting
its scaffolding afterwards, and the crossover parameter that picks between this and
#737's time-indexed certificate. Those need the cost measured with the real
implementation rather than the line-count model, which is the next thing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018FizeTcjBnMJqmqLWZz4qd
