### PR TITLE
proofs: sort a window of a model's own variables, not a problem of its own

### DIFF
--- a/gcs/innards/proofs/comparator_network.cc
+++ b/gcs/innards/proofs/comparator_network.cc
@@ -22,14 +22,16 @@ using std::string;
 using std::to_string;
 using std::vector;
 
-ComparatorNetwork::ComparatorNetwork(ProofLogger & logger, int width, Integer horizon, ProofLevel level, ComparatorNetworkMutation mutation) :
-    _logger(logger), _width(width), _horizon(horizon), _level(level), _mutation(mutation), _span((Integer{1LL << width}) - 1_i),
+ComparatorNetwork::ComparatorNetwork(
+    ProofLogger & logger, int width, Integer window_lo, Integer window_hi, ProofLevel level, ComparatorNetworkMutation mutation) :
+    _logger(logger), _width(width), _window_lo(window_lo), _window_hi(window_hi), _level(level), _mutation(mutation),
+    _span((Integer{1LL << width}) - 1_i),
     // Twice a wire's span, so that a transfer lemma --- which adds two record
     // rows and divides by a separation row's guard coefficient --- comes out at
-    // exactly one; and at least the horizon, so that a model row's own guard
-    // coefficient can be raised to it. Larger would still be sound and would
-    // make that division land short.
-    _big(max(2_i * ((Integer{1LL << width}) - 1_i), horizon)),
+    // exactly one; and at least the window's end, so that a model row's own
+    // guard coefficient can be raised to it. Larger would still be sound and
+    // would make that division land short.
+    _big(max(2_i * ((Integer{1LL << width}) - 1_i), window_hi)),
     // Every case split divides by this, which is generous enough for the
     // largest guard coefficient any lemma below accumulates (the gap lemma's
     // `big + 3 * span`). Generous is safe because the negated goal cancels
@@ -64,15 +66,24 @@ auto ComparatorNetwork::fresh_wire(const string & stem) -> ProofWire
     ProofWire wire{.id = _next_wire_id++, .bits = {}};
     auto name = next_name(stem);
     for (auto t = 0; t < _width; ++t)
-        wire.bits.push_back(_logger.create_proof_flag(name + "b" + to_string(t)));
+        wire.bits.push_back(ProofLiteralOrFlag{_logger.create_proof_flag(name + "b" + to_string(t))});
     return wire;
 }
 
-auto ComparatorNetwork::wire_over(const vector<ProofFlag> & bits) -> ProofWire
+auto ComparatorNetwork::wire_over(const vector<ProofLiteralOrFlag> & bits) -> ProofWire
 {
-    if (static_cast<int>(bits.size()) != _width)
-        throw ProofError{"comparator network wire of the wrong width"};
-    return ProofWire{.id = _next_wire_id++, .bits = bits};
+    if (static_cast<int>(bits.size()) > _width)
+        throw ProofError{"comparator network wire wider than the network"};
+
+    // Padding a narrower variable is two wasted mux clauses per padded bit ---
+    // the two that place a constant-zero input into the output are tautologies
+    // --- and the other two are what force the output's high bits to zero, so
+    // the padding is not free but is very nearly so, and it is what lets a
+    // window hold tasks whose starts were encoded to different widths.
+    auto padded = bits;
+    while (static_cast<int>(padded.size()) < _width)
+        padded.push_back(ProofLiteralOrFlag{ProofLiteral{FalseLiteral{}}});
+    return ProofWire{.id = _next_wire_id++, .bits = move(padded)};
 }
 
 auto ComparatorNetwork::terms(const ProofWire & wire, Integer sign) const -> WPBSum
@@ -85,7 +96,7 @@ auto ComparatorNetwork::terms(const ProofWire & wire, Integer sign) const -> WPB
 auto ComparatorNetwork::add_terms(WPBSum & sum, const ProofWire & wire, Integer sign) const -> void
 {
     for (auto t = 0; t < _width; ++t)
-        sum += (sign * Integer{1LL << t}) * wire.bits[t];
+        add_term_to(sum, sign * Integer{1LL << t}, wire.bits[t]);
 }
 
 auto ComparatorNetwork::pin(const ProofWire & wire, Integer value) -> void
@@ -93,10 +104,7 @@ auto ComparatorNetwork::pin(const ProofWire & wire, Integer value) -> void
     for (auto t = 0; t < _width; ++t) {
         auto on = 0 != ((value.raw_value >> t) & 1);
         WPBSum sum;
-        if (on)
-            sum += 1_i * wire.bits[t];
-        else
-            sum += 1_i * ! wire.bits[t];
+        add_term_to(sum, 1_i, on ? wire.bits[t] : ! wire.bits[t]);
         _logger.emit_red_proof_line(
             move(sum) >= 1_i, {{wire.bits[t], on ? ProofLiteralOrFlag{TrueLiteral{}} : ProofLiteralOrFlag{FalseLiteral{}}}}, _level);
     }
@@ -125,37 +133,45 @@ auto ComparatorNetwork::add_task(const ProofWire & start, Integer duration) -> v
     _duration_upper.emplace(wire.id, _logger.emit_rup_proof_line(terms(wire, -1_i) >= -duration, _level));
 }
 
-auto ComparatorNetwork::set_upper_bound(const ProofWire & start, ProofLine model_row) -> void
+auto ComparatorNetwork::set_upper_bound(const ProofWire & start, ProofLine row) -> void
 {
     PolBuilder builder;
-    builder.add(model_row).add(_duration_upper.at(_duration.at(start.id).id));
+    builder.add(row).add(_duration_upper.at(_duration.at(start.id).id));
     _upper.insert_or_assign(start.id, builder.emit(_logger, _level));
 }
 
-auto ComparatorNetwork::add_separation(const ProofWire & x, ProofFlag x_first_flag, ProofLine x_first_row, const ProofWire & y,
-    ProofFlag y_first_flag, ProofLine y_first_row, ProofLine clause, Integer guard_coefficient) -> void
+auto ComparatorNetwork::set_lower_bound(const ProofWire & start, ProofLine row) -> void
 {
-    if (guard_coefficient > _big)
-        throw ProofError{"comparator network guard coefficient is too small for the model's rows"};
+    _lower.insert_or_assign(start.id, row);
+}
 
-    auto adopt = [&](const ProofWire & first, ProofFlag flag, ProofLine row) -> ProofLine {
+auto ComparatorNetwork::add_separation(
+    const ProofWire & x, const ModelSeparation & x_first, const ProofWire & y, const ModelSeparation & y_first, ProofLine clause) -> void
+{
+    auto adopt = [&](const ProofWire & first, const ModelSeparation & direction) -> ProofLine {
+        if (direction.guard_coefficient > _big)
+            throw ProofError{"comparator network guard coefficient is too small for the model's rows"};
+
         // Subtract the pinned duration, putting the model's `y - x >= p_x` in
         // the duration-relative form the network maintains across a mux.
         PolBuilder relative;
-        relative.add(row).add(_duration_upper.at(_duration.at(first.id).id));
+        relative.add(direction.row).add(_duration_upper.at(_duration.at(first.id).id));
         auto result = relative.emit(_logger, _level);
 
         // Then raise the row's own big-M to the network's, using the literal
         // axiom `~flag >= 0`, so that separation rows all carry the same guard
         // coefficient whether they came from the model or from a comparator.
-        if (guard_coefficient == _big)
+        // Per direction, since the two halves of a pair rarely agree.
+        if (direction.guard_coefficient == _big)
             return result;
         PolBuilder raised;
-        raised.add(! _logger.names_and_ids_tracker().xliteral_for(flag), _big - guard_coefficient, _logger.names_and_ids_tracker()).add(result);
+        raised
+            .add(! _logger.names_and_ids_tracker().xliteral_for(direction.flag), _big - direction.guard_coefficient, _logger.names_and_ids_tracker())
+            .add(result);
         return raised.emit(_logger, _level);
     };
 
-    record_separation(x, adopt(x, x_first_flag, x_first_row), y, adopt(y, y_first_flag, y_first_row), clause);
+    record_separation(x, adopt(x, x_first), y, adopt(y, y_first), clause);
 }
 
 auto ComparatorNetwork::record_separation(
@@ -213,10 +229,10 @@ auto ComparatorNetwork::compare(const ProofWire & a, const ProofWire & b, const 
             for (auto which = 0; which < 4; ++which) {
                 WPBSum clause;
                 switch (which) {
-                case 0: clause += 1_i * ! selector, clause += 1_i * ! on_t, clause += 1_i * out_bit; break;
-                case 1: clause += 1_i * selector, clause += 1_i * ! on_f, clause += 1_i * out_bit; break;
-                case 2: clause += 1_i * ! selector, clause += 1_i * on_t, clause += 1_i * ! out_bit; break;
-                default: clause += 1_i * selector, clause += 1_i * on_f, clause += 1_i * ! out_bit; break;
+                case 0: clause += 1_i * ! selector, add_term_to(clause, 1_i, ! on_t), add_term_to(clause, 1_i, out_bit); break;
+                case 1: clause += 1_i * selector, add_term_to(clause, 1_i, ! on_f), add_term_to(clause, 1_i, out_bit); break;
+                case 2: clause += 1_i * ! selector, add_term_to(clause, 1_i, on_t), add_term_to(clause, 1_i, ! out_bit); break;
+                default: clause += 1_i * selector, add_term_to(clause, 1_i, on_f), add_term_to(clause, 1_i, ! out_bit); break;
                 }
                 auto witness = (which < 2) ? ProofLiteralOrFlag{TrueLiteral{}} : ProofLiteralOrFlag{FalseLiteral{}};
                 per_bit.push_back(_logger.emit_red_proof_line(move(clause) >= 1_i, {{out_bit, witness}}, _level));
@@ -430,7 +446,22 @@ auto ComparatorNetwork::derive_bound(const Comparator & c, const ProofWire & out
     WPBSum goal;
     add_terms(goal, out, -1_i);
     add_terms(goal, d_out, -1_i);
-    return case_split(move(goal) >= -_horizon, {from_a.emit(_logger, _level), from_b.emit(_logger, _level)});
+    return case_split(move(goal) >= -_window_hi, {from_a.emit(_logger, _level), from_b.emit(_logger, _level)});
+}
+
+auto ComparatorNetwork::derive_lower_bound(const Comparator & c, const ProofWire & out, ProofLine ge_a, ProofLine ge_b) -> ProofLine
+{
+    // `out - window_lo >= 0`, carried through the mux from the inputs'. Free at
+    // a window starting from zero, where a bit vector cannot be negative in the
+    // first place --- but the endgame telescopes down to the earliest task's
+    // start, and over a real window what makes that a refutation is that the
+    // earliest start is not earlier than the window it was selected for.
+    PolBuilder from_a;
+    from_a.add(_lower.at(c.a.id)).add(ge_a);
+    PolBuilder from_b;
+    from_b.add(_lower.at(c.b.id)).add(ge_b);
+
+    return case_split(terms(out, 1_i) >= _window_lo, {from_a.emit(_logger, _level), from_b.emit(_logger, _level)});
 }
 
 auto ComparatorNetwork::reify_separation(const ProofWire & x, const ProofWire & y, const string & stem) -> SeparationFlags
@@ -579,7 +610,7 @@ auto ComparatorNetwork::sort(const vector<ProofWire> & tasks) -> SortedTasks
     if (tasks.size() < 2)
         throw ProofError{"a comparator network needs at least two tasks to sort"};
 
-    SortedTasks result{.chain = {}, .preserved = {}, .top_upper_bound = {}};
+    SortedTasks result{.chain = {}, .preserved = {}, .top_upper_bound = {}, .bottom_lower_bound = {}};
 
     auto live = tasks;
     optional<ProofWire> previous_maximum, first_maximum;
@@ -643,6 +674,8 @@ auto ComparatorNetwork::sort(const vector<ProofWire> & tasks) -> SortedTasks
             // bound.
             _upper.insert_or_assign(c.hi.id, derive_bound(c, c.hi, c.d_hi, c.hi_le_a, c.hi_le_b, c.d_hi_le_a, c.d_hi_le_b));
             _upper.insert_or_assign(c.lo.id, derive_bound(c, c.lo, c.d_lo, c.lo_le_a, c.lo_le_b, c.d_lo_le_a, c.d_lo_le_b));
+            _lower.insert_or_assign(c.hi.id, derive_lower_bound(c, c.hi, c.hi_ge_a, c.hi_ge_b));
+            _lower.insert_or_assign(c.lo.id, derive_lower_bound(c, c.lo, c.lo_ge_a, c.lo_ge_b));
 
             leftovers.push_back(c.lo);
             running = c.hi;
@@ -660,6 +693,7 @@ auto ComparatorNetwork::sort(const vector<ProofWire> & tasks) -> SortedTasks
 
     result.chain.push_back(previous_gaps.at(live[0].id));
     result.top_upper_bound = _upper.at(first_maximum->id);
+    result.bottom_lower_bound = _lower.at(live[0].id);
     return result;
 }
 
@@ -667,14 +701,15 @@ auto ComparatorNetwork::sum_up(const SortedTasks & sorted) -> ProofLine
 {
     // Telescope: each chain row is one adjacent gap, so summing them leaves the
     // largest start minus the smallest, minus every duration but the largest's.
-    // The largest's own upper bound puts the horizon on the other side, and the
-    // preservation rows turn the sorted durations back into the instance's own.
-    // What is left says the horizon covers the total work, over a start that
-    // bit-encoding already makes non-negative.
+    // The largest's upper bound and the smallest's lower bound then replace the
+    // two ends by the window they were selected for, and the preservation rows
+    // turn the sorted durations back into the instance's own. What is left says
+    // the window is as wide as the work inside it.
     PolBuilder builder;
     for (const auto & row : sorted.chain)
         builder.add(row);
     builder.add(sorted.top_upper_bound);
+    builder.add(sorted.bottom_lower_bound);
     if (! holds_alternative<comparator_network_mutation::DropPreservation>(_mutation))
         for (const auto & row : sorted.preserved)
             builder.add(row);

--- a/gcs/innards/proofs/comparator_network.hh
+++ b/gcs/innards/proofs/comparator_network.hh
@@ -109,6 +109,11 @@ namespace gcs::innards
      * introduced during search cannot be a model variable, and does not need to
      * be, every step below being cutting planes over the bits.
      *
+     * A bit is anything a proof can name: a fresh flag, one bit of a model
+     * variable's own encoding (which is how a propagator's tasks enter, without
+     * a copy layer and without the model gaining anything), or a constant, which
+     * is how a variable narrower than the network is padded up to it.
+     *
      * `id` is the network's own handle for the wire, and is what its duration,
      * bounds and separations are filed under.
      *
@@ -117,7 +122,7 @@ namespace gcs::innards
     struct ProofWire
     {
         int id;
-        std::vector<ProofFlag> bits;
+        std::vector<ProofLiteralOrFlag> bits;
     };
 
     /**
@@ -160,6 +165,32 @@ namespace gcs::innards
     };
 
     /**
+     * \brief One direction of a pair's separation, as the model states it.
+     *
+     * `flag` is the model's "x runs before y" flag, `row` the forward half of
+     * its reification (`M * ~flag + y - x >= duration(x)`), and
+     * `guard_coefficient` the `M` that row carries --- which for a row emitted
+     * by ProofModel::add_two_way_reified_constraint is
+     * `-NamesAndIDsTracker::reification_shape(...).reif_coefficient`.
+     *
+     * The coefficient is per direction, not per pair, and asking for it rather
+     * than assuming is not ceremony: a reifier sizes the constant from the
+     * inequality it is given, so `before_{i,j}` and `before_{j,i}` differ
+     * whenever the two tasks' durations or encoding widths do. Raising both by
+     * the same amount leaves one of them short of the network's guard
+     * coefficient, and every later division by it then rounds instead of
+     * cancelling.
+     *
+     * \ingroup Innards
+     */
+    struct ModelSeparation
+    {
+        ProofFlag flag;
+        ProofLine row;
+        Integer guard_coefficient;
+    };
+
+    /**
      * \brief What sorting the tasks leaves behind, and all the endgame needs.
      *
      * \ingroup Innards
@@ -176,8 +207,11 @@ namespace gcs::innards
         /// own.
         std::vector<ProofLine> preserved;
 
-        /// `horizon - largest - duration(largest) >= 0`.
+        /// `window_hi - largest - duration(largest) >= 0`.
         ProofLine top_upper_bound;
+
+        /// `smallest - window_lo >= 0`.
+        ProofLine bottom_lower_bound;
     };
 
     /**
@@ -224,7 +258,7 @@ namespace gcs::innards
 
         ProofLogger & _logger;
         int _width;
-        Integer _horizon;
+        Integer _window_lo, _window_hi;
         ProofLevel _level;
         ComparatorNetworkMutation _mutation;
         Integer _span, _big, _div;
@@ -236,8 +270,9 @@ namespace gcs::innards
         std::map<int, ProofWire> _duration;
         std::map<int, ProofLine> _positivity, _duration_upper;
 
-        /// Each start wire's `horizon - wire - duration(wire) >= 0`.
-        std::map<int, ProofLine> _upper;
+        /// Each start wire's `window_hi - wire - duration(wire) >= 0` and
+        /// `wire - window_lo >= 0`.
+        std::map<int, ProofLine> _upper, _lower;
 
         /// Keyed by the pair of wire ids, smaller first.
         std::map<std::pair<int, int>, Separation> _separations;
@@ -272,6 +307,8 @@ namespace gcs::innards
         [[nodiscard]] auto derive_bound(const Comparator &, const ProofWire & out, const ProofWire & d_out, ProofLine le_a, ProofLine le_b,
             ProofLine d_le_a, ProofLine d_le_b) -> ProofLine;
 
+        [[nodiscard]] auto derive_lower_bound(const Comparator &, const ProofWire & out, ProofLine ge_a, ProofLine ge_b) -> ProofLine;
+
         auto separate_from_gap(const ProofWire & x, const ProofWire & y, ProofLine gap) -> void;
 
         auto transfer(const ProofWire & out, const ProofWire & other, const Comparator &, ProofLine le_a, ProofLine ge_a, ProofLine le_b,
@@ -280,15 +317,18 @@ namespace gcs::innards
     public:
         /**
          * `width` bits per wire, which must be enough for every value the
-         * caller pins or bounds, and `horizon` the upper bound every task's
-         * completion is measured against. The guard coefficient every
-         * conditional row carries is derived from both: it has to dominate
-         * twice a wire's span, so that a transfer lemma's division comes out at
-         * one, and to reach the guard coefficient of the caller's own rows, so
-         * that \ref add_separation can raise them to it.
+         * caller pins or bounds, and `[window_lo, window_hi)` the window whose
+         * tasks are being sorted --- for a whole-problem refutation that is
+         * `[0, horizon)`, and for a propagator it is the overloaded window.
+         *
+         * The guard coefficient every conditional row carries is derived from
+         * the width and the window: it has to dominate twice a wire's span, so
+         * that a transfer lemma's division comes out at one, and to reach the
+         * guard coefficient of the caller's own rows, so that \ref
+         * add_separation can raise them to it.
          */
-        explicit ComparatorNetwork(
-            ProofLogger &, int width, Integer horizon, ProofLevel, ComparatorNetworkMutation = comparator_network_mutation::None{});
+        explicit ComparatorNetwork(ProofLogger &, int width, Integer window_lo, Integer window_hi, ProofLevel,
+            ComparatorNetworkMutation = comparator_network_mutation::None{});
 
         [[nodiscard]] auto width() const -> int;
         [[nodiscard]] auto span() const -> Integer;
@@ -298,9 +338,24 @@ namespace gcs::innards
         /// them.
         [[nodiscard]] auto fresh_wire(const std::string & stem) -> ProofWire;
 
-        /// A wire reading flags that already exist --- a model variable's own
-        /// bit encoding, most often. Nothing is emitted.
-        [[nodiscard]] auto wire_over(const std::vector<ProofFlag> & bits) -> ProofWire;
+        /**
+         * A wire reading bits that already exist --- a model variable's own
+         * encoding, most often. Nothing is emitted.
+         *
+         * Fewer bits than the network's width are padded with constant zeroes,
+         * so a window's tasks can have been encoded to different widths and
+         * still be compared. More is an error: the network's guard coefficients
+         * are sized from its width, and a wire that overflows them would make
+         * every guarded row it appears in unsound.
+         *
+         * The bits must read as an unsigned magnitude, least significant first.
+         * A two's-complement encoding's sign bit is not that, and a comparator
+         * muxing one into an unsigned output would land on the wrong value, so
+         * a caller with a possibly-negative variable has to say so some other
+         * way --- which for the disjunctive overload check means a window whose
+         * tasks all start at or after zero.
+         */
+        [[nodiscard]] auto wire_over(const std::vector<ProofLiteralOrFlag> & bits) -> ProofWire;
 
         /// `sign * wire` as pseudo-Boolean terms, for building a row about it.
         [[nodiscard]] auto terms(const ProofWire &, Integer sign) const -> WPBSum;
@@ -325,29 +380,33 @@ namespace gcs::innards
         auto add_task(const ProofWire & start, Integer duration) -> void;
 
         /**
-         * Record `horizon - start - duration >= 0` for a task, from the model's
-         * own `start <= horizon - duration` row.
+         * Record `window_hi - start - duration >= 0` for a task, from a
+         * `start <= window_hi - duration` row the caller supplies --- the
+         * model's own bound row for a refutation, or a reason-backed RUP for a
+         * propagator's window.
          */
-        auto set_upper_bound(const ProofWire & start, ProofLine model_row) -> void;
+        auto set_upper_bound(const ProofWire & start, ProofLine row) -> void;
+
+        /**
+         * And `start - window_lo >= 0`, likewise. Free when the window starts
+         * at zero and the wire is a bit vector, load-bearing otherwise: the
+         * endgame telescopes down to the *earliest* task's start, and what
+         * makes that a refutation is that it cannot be earlier than the window
+         * it was selected for.
+         */
+        auto set_lower_bound(const ProofWire & start, ProofLine row) -> void;
 
         /**
          * Take a pair of tasks' separation from the model and put it in the
-         * form the lemmas want.
-         *
-         * `x_first_row` is the model's forward reification half for "x runs
-         * before y", `M * ~flag + y - x >= duration(x)`, and `x_first_flag` the
-         * flag it is guarded on; likewise the other way round. `clause` says
-         * one of the two flags holds. `guard_coefficient` is the `M` those rows
-         * carry --- for a row emitted by ProofModel::add_two_way_reified_constraint
-         * that is `-NamesAndIDsTracker::reification_shape(...).reif_coefficient`
-         * --- and must not exceed \ref big.
+         * form the lemmas want: `x_first` says x runs before y, `y_first` the
+         * other way round, and `clause` says one of them does.
          *
          * The rows are made duration-relative (the pinned duration subtracted,
          * so the network can carry them across a mux) and raised to the
-         * network's own guard coefficient.
+         * network's own guard coefficient, which neither may exceed.
          */
-        auto add_separation(const ProofWire & x, ProofFlag x_first_flag, ProofLine x_first_row, const ProofWire & y, ProofFlag y_first_flag,
-            ProofLine y_first_row, ProofLine clause, Integer guard_coefficient) -> void;
+        auto add_separation(
+            const ProofWire & x, const ModelSeparation & x_first, const ProofWire & y, const ModelSeparation & y_first, ProofLine clause) -> void;
 
         /**
          * Introduce a comparator over two tasks already in play: a selector
@@ -370,10 +429,9 @@ namespace gcs::innards
          * The endgame: sum the chain, add the largest task's upper bound, and
          * turn the sorted durations back into the instance's own.
          *
-         * The row returned says the horizon is at least the total work, over a
-         * start that bit encoding already makes non-negative --- so if the
-         * tasks do not fit in the window, it is contradictory outright and any
-         * RUP closes. Emitting that contradiction is left to the caller, which
+         * The row returned says the window is at least as wide as the total
+         * work in it --- so if the tasks do not fit, it is contradictory
+         * outright and any RUP closes. Emitting that contradiction is left to the caller, which
          * inside a propagator means `ThenRUP::Yes` under a reason rather than a
          * bare line.
          */

--- a/gcs/innards/proofs/comparator_network_test.cc
+++ b/gcs/innards/proofs/comparator_network_test.cc
@@ -104,7 +104,7 @@ namespace
         logger.start_proof(model);
         tracker.emit_delayed_proof_steps();
 
-        ComparatorNetwork network(logger, 4, 15_i, ProofLevel::Top);
+        ComparatorNetwork network(logger, 4, 0_i, 15_i, ProofLevel::Top);
         auto a = network.fresh_wire("a"), b = network.fresh_wire("b");
         network.pin(a, Integer{a_value});
         network.pin(b, Integer{b_value});
@@ -155,72 +155,54 @@ namespace
     }
 
     /* The pairwise disjunctive encoding, and nothing else: this is the model a
-     * Disjunctive already defines, written out here over plain proof flags so
-     * that the test owns every big-M and the network is exercised against the
-     * shapes it will meet rather than against rows invented to suit it.
+     * Disjunctive already defines, written out here over *real* integer
+     * variables so that the network meets the shapes it will meet in a
+     * propagator --- bits it does not own, widths that differ from task to
+     * task, and a reification big-M chosen by the model rather than by the
+     * proof.
      */
     struct PairwiseModel
     {
-        vector<vector<ProofFlag>> start_bits;
-        vector<ProofLine> upper_bounds;
+        vector<SimpleIntegerVariableID> starts;
         map<pair<size_t, size_t>, ProofFlag> before;
         map<pair<size_t, size_t>, ProofLine> before_rows;
         map<pair<size_t, size_t>, ProofLine> separation_clauses;
-        Integer big = 0_i;
+        map<pair<size_t, size_t>, Integer> guard_coefficients;
         int width = 0;
     };
 
-    auto build_pairwise_model(ProofModel & model, const vector<int> & durations, int horizon) -> PairwiseModel
+    auto build_pairwise_model(ProofModel & model, NamesAndIDsTracker & tracker, const vector<int> & durations, int window_lo, int window_hi)
+        -> PairwiseModel
     {
         auto tasks = durations.size();
         PairwiseModel built;
-        // Every start gets the same width, which its own bound row then
-        // narrows: a shared width is what lets the network's wires all be read
-        // the same way, and costs nothing but a spare high bit.
-        auto widest_start = horizon - min(durations);
-        auto widest = widest_start > max(durations) ? widest_start : max(durations);
-        built.width = static_cast<int>(std::bit_width(static_cast<unsigned long long>(widest)));
-        built.big = Integer{horizon};
 
-        built.start_bits.resize(tasks);
-        for (size_t i = 0; i < tasks; ++i)
-            for (auto t = 0; t < built.width; ++t)
-                built.start_bits[i].push_back(model.create_proof_flag("x" + to_string(i) + "_" + to_string(t)));
-
-        auto start = [&](size_t i, Integer sign) {
-            WPBSum sum;
-            for (auto t = 0; t < built.width; ++t)
-                sum += (sign * Integer{1LL << t}) * built.start_bits[i][t];
-            return sum;
-        };
-
-        // `start_i <= horizon - duration_i`. Load-bearing in a way it is not
-        // with equal durations: the shared width lets a start range over more
-        // than its own window, and this is the row that says it may not.
-        for (size_t i = 0; i < tasks; ++i)
-            built.upper_bounds.push_back(model.add_labelled_constraint("ub" + to_string(i), start(i, 1_i) <= Integer{horizon - durations[i]}));
+        // Each start is encoded to its own width, from its own domain: a task
+        // that must finish by the window's end cannot start after
+        // `window_hi - duration`, so a long task gets a narrower encoding than
+        // a short one, and the network has to pad.
+        for (size_t i = 0; i < tasks; ++i) {
+            SimpleIntegerVariableID start{i};
+            model.set_up_integer_variable(start, Integer{window_lo}, Integer{window_hi - durations[i]}, "s" + to_string(i), std::nullopt);
+            built.starts.push_back(start);
+        }
+        built.width = static_cast<int>(std::bit_width(static_cast<unsigned long long>(window_hi)));
 
         for (size_t i = 0; i < tasks; ++i)
             for (size_t j = 0; j < tasks; ++j) {
                 if (i == j)
                     continue;
-                auto name = "b" + to_string(i) + "_" + to_string(j);
-                auto flag = model.create_proof_flag(name);
+                auto flag = model.create_proof_flag("b" + to_string(i) + "_" + to_string(j));
                 built.before.emplace(pair{i, j}, flag);
 
-                // [r] before_ij -> start_j - start_i >= duration_i
-                auto forward = start(j, 1_i);
-                for (auto & term : start(i, -1_i).terms)
-                    forward += term;
-                forward += built.big * ! flag;
-                built.before_rows.emplace(pair{i, j}, model.add_labelled_constraint(name + "r", move(forward) >= Integer{durations[i]}));
-
-                // [f] ~before_ij -> start_i - start_j >= 1 - duration_i
-                auto reverse = start(i, 1_i);
-                for (auto & term : start(j, -1_i).terms)
-                    reverse += term;
-                reverse += (built.big + 1_i) * flag;
-                model.add_labelled_constraint(name + "f", move(reverse) >= Integer{1 - durations[i]});
+                // before_ij <-> start_i + duration_i <= start_j, exactly as
+                // Disjunctive::define_proof_model writes it. The [r] half is
+                // what the network consumes, and its big-M is whatever the
+                // reifier picked --- which the network then has to raise to its
+                // own, so ask rather than assume.
+                auto ineq = WPBSum{} + 1_i * built.starts[i] + -1_i * built.starts[j] <= Integer{-durations[i]};
+                built.guard_coefficients.emplace(pair{i, j}, -tracker.reification_shape(ineq, HalfReifyOnConjunctionOf{{flag}}).reif_coefficient);
+                built.before_rows.emplace(pair{i, j}, model.add_two_way_reified_constraint(ineq, flag).first);
             }
 
         for (size_t i = 0; i < tasks; ++i)
@@ -235,14 +217,14 @@ namespace
         return built;
     }
 
-    auto check_refutation(const vector<int> & durations, int horizon, ComparatorNetworkMutation mutation, const string & tag, bool expect_accepted)
-        -> void
+    auto check_refutation(const vector<int> & durations, int window_lo, int window_hi, ComparatorNetworkMutation mutation, const string & tag,
+        bool expect_accepted) -> void
     {
         auto proof_name = "comparator_network_refute_" + to_string(durations.size()) + "_" + tag;
         ProofOptions proof_options{proof_name};
         NamesAndIDsTracker tracker(proof_options);
         ProofModel model(proof_options, tracker);
-        auto built = build_pairwise_model(model, durations, horizon);
+        auto built = build_pairwise_model(model, tracker, durations, window_lo, window_hi);
         model.finalise();
 
         ProofLogger logger(proof_options, tracker);
@@ -250,19 +232,35 @@ namespace
         logger.start_proof(model);
         tracker.emit_delayed_proof_steps();
 
-        ComparatorNetwork network(logger, built.width, Integer{horizon}, ProofLevel::Top, mutation);
+        ComparatorNetwork network(logger, built.width, Integer{window_lo}, Integer{window_hi}, ProofLevel::Top, mutation);
 
         vector<ProofWire> tasks;
-        for (size_t i = 0; i < durations.size(); ++i)
-            tasks.push_back(network.wire_over(built.start_bits[i]));
+        for (size_t i = 0; i < durations.size(); ++i) {
+            // A wire straight over the model variable's own bits. Nothing is
+            // copied and nothing is emitted: the network reads the encoding
+            // that is already there, and pads the narrow ones itself.
+            vector<ProofLiteralOrFlag> bits;
+            for (Integer b = 0_i; b < tracker.num_bits(built.starts[i]); ++b)
+                bits.push_back(ProofBitVariable{built.starts[i], b, true});
+            tasks.push_back(network.wire_over(bits));
+        }
+
         for (size_t i = 0; i < durations.size(); ++i) {
             network.add_task(tasks[i], Integer{durations[i]});
-            network.set_upper_bound(tasks[i], built.upper_bounds[i]);
+            // The window's own bounds, as a propagator would have them: not
+            // model rows but facts about the state, which here RUP straight
+            // from the variables' domains.
+            network.set_upper_bound(
+                tasks[i], logger.emit_rup_proof_line(WPBSum{} + 1_i * built.starts[i] <= Integer{window_hi - durations[i]}, ProofLevel::Top));
+            network.set_lower_bound(tasks[i], logger.emit_rup_proof_line(WPBSum{} + 1_i * built.starts[i] >= Integer{window_lo}, ProofLevel::Top));
         }
+
+        auto direction = [&](size_t i, size_t j) {
+            return ModelSeparation{built.before.at(pair{i, j}), built.before_rows.at(pair{i, j}), built.guard_coefficients.at(pair{i, j})};
+        };
         for (size_t i = 0; i < durations.size(); ++i)
             for (size_t j = i + 1; j < durations.size(); ++j)
-                network.add_separation(tasks[i], built.before.at(pair{i, j}), built.before_rows.at(pair{i, j}), tasks[j], built.before.at(pair{j, i}),
-                    built.before_rows.at(pair{j, i}), built.separation_clauses.at(pair{i, j}), built.big);
+                network.add_separation(tasks[i], direction(i, j), tasks[j], direction(j, i), built.separation_clauses.at(pair{i, j}));
 
         auto sorted = network.sort(tasks);
         // The window-energy row. It is contradictory exactly when the tasks do
@@ -275,14 +273,14 @@ namespace
 
         auto accepted = run_veripb(proof_name + ".opb", proof_name + ".pbp");
         if (accepted != expect_accepted)
-            fail("refutation of " + to_string(durations.size()) + " tasks in " + to_string(horizon) + " (" + tag + "): veripb " +
-                (accepted ? "accepted" : "rejected") + " where it should have done the opposite");
+            fail("refutation of " + to_string(durations.size()) + " tasks in [" + to_string(window_lo) + ", " + to_string(window_hi) + ") (" + tag +
+                "): veripb " + (accepted ? "accepted" : "rejected") + " where it should have done the opposite");
         dispose_of_proof_files(proof_name);
     }
 
-    /// Unequal durations that overload the window by exactly one unit, so the
-    /// instance is unsatisfiable by a margin of one and every separation clause
-    /// matters.
+    /// Unequal durations, and the total work they carry: a window one unit
+    /// narrower than that is unsatisfiable by a margin of one, so every
+    /// separation clause matters.
     auto tight_instance(size_t tasks) -> pair<vector<int>, int>
     {
         vector<int> durations;
@@ -291,7 +289,7 @@ namespace
         auto total = 0;
         for (auto d : durations)
             total += d;
-        return {durations, total - 1};
+        return {durations, total};
     }
 }
 
@@ -314,27 +312,35 @@ auto main(int, char *[]) -> int
             check_comparator(a, b, Claim::HiIsNotTheLarger, "hi_wrong", false);
         }
 
+    // A window that starts where the time line does, and one slid along it.
+    // The offset one is what a propagator's window actually looks like, and is
+    // where the earliest task's lower bound stops being free: from zero a bit
+    // vector cannot be negative and the endgame gets that end for nothing.
+    const auto offset = 7;
     for (size_t tasks = 3; tasks <= 8; ++tasks) {
-        auto [durations, horizon] = tight_instance(tasks);
-        check_refutation(durations, horizon, comparator_network_mutation::None{}, "honest", true);
-        // Same tasks, one more unit of window: they fit, and the endgame must
-        // not close. This is the control that says the refutation is about the
-        // instance rather than about the scaffolding.
-        check_refutation(durations, horizon + 1, comparator_network_mutation::None{}, "roomy", false);
+        auto [durations, work] = tight_instance(tasks);
+        check_refutation(durations, 0, work - 1, comparator_network_mutation::None{}, "honest", true);
+        check_refutation(durations, offset, offset + work - 1, comparator_network_mutation::None{}, "offset", true);
+        // The same tasks with one more unit of window: they fit, and the
+        // endgame must not close. This is the control that says the refutation
+        // is about the instance rather than about the scaffolding.
+        check_refutation(durations, 0, work, comparator_network_mutation::None{}, "roomy", false);
+        check_refutation(durations, offset, offset + work, comparator_network_mutation::None{}, "offset_roomy", false);
     }
 
     {
-        auto [durations, horizon] = tight_instance(4);
-        check_refutation(durations, horizon, comparator_network_mutation::DropPositivity{}, "drop_positivity", false);
-        check_refutation(durations, horizon, comparator_network_mutation::SwapDurations{}, "swap_durations", false);
-        check_refutation(durations, horizon, comparator_network_mutation::RupGap{}, "rup_gap", false);
+        auto [durations, work] = tight_instance(4);
+        auto lo = offset, hi = offset + work - 1;
+        check_refutation(durations, lo, hi, comparator_network_mutation::DropPositivity{}, "drop_positivity", false);
+        check_refutation(durations, lo, hi, comparator_network_mutation::SwapDurations{}, "swap_durations", false);
+        check_refutation(durations, lo, hi, comparator_network_mutation::RupGap{}, "rup_gap", false);
         // Accepted, and expected to be: with every duration pinned, propagation
         // reaches a muxed duration's positivity without the case split. Asserted
         // so that it is on the record, and so that it starts failing the day
         // durations stop being constants.
-        check_refutation(durations, horizon, comparator_network_mutation::RupPositivity{}, "rup_positivity", true);
-        check_refutation(durations, horizon, comparator_network_mutation::RupPreservation{}, "rup_preservation", false);
-        check_refutation(durations, horizon, comparator_network_mutation::DropPreservation{}, "drop_preservation", false);
+        check_refutation(durations, lo, hi, comparator_network_mutation::RupPositivity{}, "rup_positivity", true);
+        check_refutation(durations, lo, hi, comparator_network_mutation::RupPreservation{}, "rup_preservation", false);
+        check_refutation(durations, lo, hi, comparator_network_mutation::DropPreservation{}, "drop_preservation", false);
     }
 
     return EXIT_SUCCESS;


### PR DESCRIPTION
Stacked on #738. What stood between the comparator network and a `Disjunctive`
propagator — three things, all of them about being handed a real model rather
than one written to suit the proof.

**A wire is now anything a proof can name.** Its bits were fresh flags; they are
`ProofLiteralOrFlag`, so a wire reads a model variable's own encoding directly. No
copy layer — that would need two reds per bit plus a rewrite of every model row
mentioning the variable, and buys nothing, since the per-bit access a mux needs is
unavoidable either way. Constant bits pad a variable narrower than the network, so
one window can hold tasks encoded to different widths.

Restriction: the bits must read as an unsigned magnitude, since muxing a
two's-complement sign bit into an unsigned output lands on the wrong value. For the
overload check that means a window whose tasks all start at or after zero.

**The window need not start at zero.** The endgame telescopes down to the earliest
task's start, and what makes that a refutation is that it cannot be earlier than the
window it was selected for. At zero that was free — a bit vector cannot be negative —
and the endgame quietly relied on it. Each wire now carries a lower bound as well as
an upper one, muxed across each comparator by the same case split.

**A reification's big-M is per direction, not per pair.** `before_{i,j}` and
`before_{j,i}` get different constants whenever the two tasks' durations or encoding
widths differ. `add_separation` took one coefficient for the pair and raised both rows
by it, leaving one short of the network's guard coefficient — after which every
division by that coefficient rounds instead of cancelling, and the gap lemma's case
split lands on something sound but not closing. It now takes a `ModelSeparation` per
direction.

That last one is why the test no longer builds its model out of proof flags. Over real
integer variables it gets the widths, bounds and big-Ms the model actually chooses, and
the bug showed up on the first run; over flags the test owned every constant and could
not have. Windows are exercised both from zero and slid along the time line.

**Next**, and not in this PR: emitting the network from `Disjunctive` over a Θ-tree
window under a reason, deleting its scaffolding, and the crossover parameter that picks
between this and #737's time-indexed certificate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018FizeTcjBnMJqmqLWZz4qd
