### PR TITLE
disjunctive: two overload certificates over one encoding, and a crossover

### DIFF
--- a/gcs/constraints/disjunctive/disjunctive.cc
+++ b/gcs/constraints/disjunctive/disjunctive.cc
@@ -4,6 +4,7 @@
 #include <gcs/exception.hh>
 #include <gcs/innards/inference_tracker.hh>
 #include <gcs/innards/proofs/am1_from_pairs.hh>
+#include <gcs/innards/proofs/comparator_network.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
 #include <gcs/innards/proofs/pol_builder.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
@@ -13,6 +14,7 @@
 #include <gcs/innards/state.hh>
 
 #include <algorithm>
+#include <bit>
 #include <cstdlib>
 #include <iostream>
 #include <map>
@@ -68,7 +70,7 @@ namespace
      */
     struct OverloadInstrumentation
     {
-        unsigned long long calls = 0, windows_examined = 0, firings = 0, declined = 0;
+        unsigned long long calls = 0, windows_examined = 0, firings = 0, declined = 0, sorted = 0;
         std::map<size_t, unsigned long long> window_sizes, candidate_counts, declined_sizes;
 
         ~OverloadInstrumentation()
@@ -86,6 +88,7 @@ namespace
             println(std::cerr, "disjunctive_overload_calls: {}", calls);
             println(std::cerr, "disjunctive_overload_firings: {}", firings);
             println(std::cerr, "disjunctive_overload_declined: {}", declined);
+            println(std::cerr, "disjunctive_overload_sorted: {}", sorted);
             println(std::cerr, "disjunctive_overload_windows_examined: {}", windows_examined);
             println(std::cerr, "disjunctive_overload_window_sizes: {}", histogram(window_sizes));
             println(std::cerr, "disjunctive_overload_declined_sizes: {}", histogram(declined_sizes));
@@ -291,8 +294,13 @@ auto Disjunctive::define_proof_model(ProofModel & model, const State &) -> void
         auto flag = model.create_proof_flag(_constraint_id, vector<long long>{static_cast<long long>(i), static_cast<long long>(j)}, "bf");
         auto ineq = is_constant_variable(_lengths[i]) ? (WPBSum{} + 1_i * _starts[i] + -1_i * _starts[j] <= -_length_vals[i])
                                                       : (WPBSum{} + 1_i * _starts[i] + 1_i * _lengths[i] + -1_i * _starts[j] <= 0_i);
+        // Ask what big-M the reifier is about to choose, rather than assuming:
+        // the sorting-network certificate raises this row to its own guard
+        // coefficient, and the two directions of a pair get different constants
+        // whenever their durations or encoding widths differ.
+        auto guard = -model.names_and_ids_tracker().reification_shape(ineq, HalfReifyOnConjunctionOf{{flag}}).reif_coefficient;
         auto [fwd, rev] = model.add_two_way_reified_constraint(ineq, flag);
-        return BeforeFlagData{flag, fwd, rev};
+        return BeforeFlagData{flag, fwd, rev, guard};
     };
     for (size_t a = 0; a < _active_tasks.size(); ++a) {
         auto i = _active_tasks[a];
@@ -517,6 +525,96 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                 for (Integer v = hi - min_len(i) + 1_i; v <= hi; ++v)
                     pol.add(logger->emit_rup_proof_line_under_reason(reason, WPBSum{} + 1_i * (starts[i] < v) >= 1_i, ProofLevel::Temporary));
                 return pol.emit(*logger, ProofLevel::Temporary);
+            };
+
+            // --- the overload certificate as a sorting network -----------------
+            //
+            // The other way to certify the same conflict: rather than
+            // re-encoding time, sort the window's tasks inside the proof and
+            // telescope the sorted order. Costs O(w^3) and is flat in the
+            // window's span but for the wires' widths, where the time-indexed
+            // route is O(w^2) per time point --- so which is cheaper is a
+            // property of the window's shape, and neither dominates.
+            //
+            // Not every window can take it. A wire reads a start variable's own
+            // bit encoding, which has to be a simple variable's and has to read
+            // as an unsigned magnitude, and the durations have to be constants
+            // for the separation rows to be duration-relative. A window failing
+            // any of that falls back rather than declining the conflict.
+            auto sorting_network_bits = [&](size_t i) -> optional<vector<ProofLiteralOrFlag>> {
+                if (is_var_len(i))
+                    return nullopt;
+                const auto * simple = std::get_if<SimpleIntegerVariableID>(&starts[i]);
+                if (! simple)
+                    return nullopt;
+                auto & tracker = logger->names_and_ids_tracker();
+                auto bits = tracker.num_bits(*simple);
+                // A negative bit sits at index zero and carries -2^(k+1), so a
+                // wire reading the vector as an unsigned magnitude would be
+                // reading a different number.
+                if (bits > 0_i && tracker.get_bit(*simple, 0_i).first != 1_i)
+                    return nullopt;
+                vector<ProofLiteralOrFlag> result;
+                for (Integer b = 0_i; b < bits; ++b)
+                    result.push_back(ProofBitVariable{*simple, b, true});
+                return result;
+            };
+
+            auto sorting_certificate_width = [&](const vector<size_t> & tasks, Integer hi) -> optional<int> {
+                auto width = static_cast<int>(std::bit_width(static_cast<unsigned long long>(hi.raw_value)));
+                for (auto i : tasks) {
+                    auto bits = sorting_network_bits(i);
+                    if (! bits)
+                        return nullopt;
+                    width = max(width, static_cast<int>(bits->size()));
+                }
+                // The network's guard coefficients are 2^width sized, so a
+                // variable declared over half the Integer range --- which is
+                // what an unbounded FlatZinc int gets --- would overflow them
+                // long before the proof got expensive enough to care.
+                return width <= 40 ? optional<int>{width} : nullopt;
+            };
+
+            auto emit_sorting_certificate = [&](const vector<size_t> & tasks, Integer lo, Integer hi, int width,
+                                                const ReasonLiterals & reason) -> void {
+                // Everything here is Temporary: unlike the time-indexed
+                // certificate's activity flags, whose definitions say nothing
+                // about the search state and so can be kept, a window's wires
+                // are about the window, and backtracking is what deletes them.
+                logger->emit_proof_comment("disjunctive overload by sorting network");
+                ComparatorNetwork network(*logger, width, lo, hi, ProofLevel::Temporary);
+
+                // The window is a fact about the state rather than the model,
+                // so every bound the network derives from it is guarded by the
+                // inference's reason, at the network's own coefficient.
+                WPBSum guard;
+                for (const auto & lit : reason)
+                    add_term_to(guard, network.big(), ! lit);
+                network.assume(guard);
+
+                vector<ProofWire> wires;
+                for (auto i : tasks)
+                    wires.push_back(network.wire_over(*sorting_network_bits(i)));
+                for (size_t k = 0; k < tasks.size(); ++k) {
+                    network.add_task(wires[k], min_len(tasks[k]));
+                    network.set_bounds(wires[k]);
+                }
+
+                auto direction = [&](size_t x, size_t y) -> ModelSeparation {
+                    const auto & data = before_flags.at(make_pair(x, y));
+                    return ModelSeparation{data.flag, data.forward_line, data.forward_guard_coefficient};
+                };
+                for (size_t a = 0; a < tasks.size(); ++a)
+                    for (size_t b = a + 1; b < tasks.size(); ++b) {
+                        auto i = tasks[a], j = tasks[b];
+                        network.add_separation(
+                            wires[a], direction(i, j), wires[b], direction(j, i), clause_lines.at(make_pair(min(i, j), max(i, j))));
+                    }
+
+                // The row this lands on says the window is at least as wide as
+                // the work inside it, which the firing says it is not, so the
+                // framework's closing RUP has nothing left to do.
+                (void)network.sum_up(network.sort(wires));
             };
 
             auto pin_escapes = [&](const ReasonLiterals & reason, const vector<size_t> & tasks) -> void {
@@ -1221,6 +1319,33 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                                     return;
 
                                 pin_escapes(reason, tasks);
+
+                                // Two certificates over the one unchanged
+                                // encoding, and a crossover between them. The
+                                // network is flat in the window's span where
+                                // re-encoding time is linear in it, so a wide
+                                // window is where it pays; a window the network
+                                // cannot take falls back rather than declining
+                                // the conflict, since a certificate that is
+                                // merely more expensive is not a reason to lose
+                                // an inference.
+                                auto width = sorting_certificate_width(tasks, hi);
+                                auto sort_it = false;
+                                switch (rules.overload_certificate) {
+                                    using enum DisjunctiveOverloadCertificate;
+                                case TimeIndexed: break;
+                                case SortingNetwork: sort_it = width.has_value(); break;
+                                case Cheaper:
+                                    sort_it =
+                                        width.has_value() && (hi - lo) > Integer{static_cast<long long>(rules.overload_crossover * tasks.size())};
+                                    break;
+                                }
+
+                                if (sort_it) {
+                                    ++overload_instrumentation.sorted;
+                                    emit_sorting_certificate(tasks, lo, hi, *width, reason);
+                                    return;
+                                }
 
                                 // A Temporary vocabulary does not outlive the
                                 // firing that made it, so what the cache holds

--- a/gcs/constraints/disjunctive/disjunctive.hh
+++ b/gcs/constraints/disjunctive/disjunctive.hh
@@ -17,6 +17,34 @@
 namespace gcs
 {
     /**
+     * \brief Which certificate the overload check emits, over the one
+     * unchanged pairwise OPB.
+     *
+     * Both re-encode the window inside the proof and neither touches the model,
+     * so this selects a proof *strategy* rather than a formulation: the
+     * statement being verified is the same whichever is chosen.
+     *
+     * \ingroup Constraints
+     */
+    enum class DisjunctiveOverloadCertificate
+    {
+        /// Re-encode time: an activity flag per (task, time), a pol per ordered
+        /// pair and time bridging the pairwise rows to a per-time at-most-one,
+        /// and the energies telescoped against it. Costs O(w^2) per time point,
+        /// so it grows with the window's span.
+        TimeIndexed,
+
+        /// Sort the window's tasks with a proof-only comparator network over
+        /// bit-encoded wires, and telescope the sorted order. Costs O(w^3) and
+        /// is flat in the span but for the wires' widths, so it wins once the
+        /// window is wide.
+        SortingNetwork,
+
+        /// Whichever of the two the window's own geometry says is cheaper.
+        Cheaper
+    };
+
+    /**
      * \brief Which of Disjunctive's propagation rules are enabled.
      *
      * Both are on by default. Turning one off weakens propagation but never
@@ -75,6 +103,35 @@ namespace gcs
         /// default. The switch stays so the measurement can be repeated
         /// in-solver rather than believed.
         innards::ProofLevel overload_vocabulary_at = innards::ProofLevel::Top;
+
+        /// Which overload certificate to emit. The default picks per firing.
+        DisjunctiveOverloadCertificate overload_certificate = DisjunctiveOverloadCertificate::Cheaper;
+
+        /// The crossover \ref DisjunctiveOverloadCertificate::Cheaper uses: the
+        /// sorting network is emitted once the window's span exceeds this many
+        /// times the number of tasks in it.
+        ///
+        /// Seven, measured in-solver over both certificates on identical
+        /// instances --- windows of `w` tasks of equal duration overloading by
+        /// one unit, so that only this rule fires, with the duration varied to
+        /// move the span independently of `w`. The time-indexed certificate is
+        /// linear in the span and the network is flat in it but for its wires'
+        /// widths, so they cross once; where they cross, in units of `w`:
+        ///
+        ///     w      3    4    5    6    7    8   10   12
+        ///     span/w 4.7  5.7  6.1  6.4  6.6  6.6  6.7  6.8
+        ///
+        /// which is rising and flattening, so seven fits the wide windows ---
+        /// the expensive ones, and the ones where being wrong costs most ---
+        /// and is at worst a little conservative at three or four tasks. The
+        /// simulation this rule came from said nine (#730), over models without
+        /// a window offset or a reason to carry.
+        ///
+        /// Counted in proof lines, on this machine, with both certificates
+        /// emitted at the same level. Checking time tracks lines here but is
+        /// not the same measurement, and a RUP's cost depends on the database
+        /// it runs against.
+        std::size_t overload_crossover = 7;
     };
 
     /**
@@ -167,6 +224,12 @@ namespace gcs
             innards::ProofFlag flag;
             innards::ProofLine forward_line;
             innards::ProofLine reverse_line;
+
+            /// The big-M the forward half carries, which the sorting-network
+            /// certificate has to raise to its own. Recorded here because it is
+            /// the reifier's choice and differs between the two directions of a
+            /// pair whenever their durations or encoding widths do.
+            Integer forward_guard_coefficient;
         };
         std::map<std::pair<std::size_t, std::size_t>, BeforeFlagData> _before_flags;
         std::map<std::pair<std::size_t, std::size_t>, innards::ProofLine> _clause_lines;

--- a/gcs/constraints/disjunctive/disjunctive_overload_test.cc
+++ b/gcs/constraints/disjunctive/disjunctive_overload_test.cc
@@ -99,15 +99,29 @@ namespace
         int markers = 0;
     };
 
-    auto count_overload_markers(const string & basename) -> int
+    auto count_markers(const string & basename, const string & marker) -> int
     {
         ifstream f{basename + ".pbp"};
         string line;
         auto count = 0;
         while (getline(f, line))
-            if (line.find("disjunctive overload w=") != string::npos)
+            if (line.find(marker) != string::npos)
                 ++count;
         return count;
+    }
+
+    auto count_overload_markers(const string & basename) -> int
+    {
+        return count_markers(basename, "disjunctive overload w=");
+    }
+
+    /// How many of those were certified by sorting the window rather than by
+    /// re-encoding time. The two are alternative arguments over one unchanged
+    /// encoding, so which was taken is not visible in the answer --- only in
+    /// the proof.
+    auto count_sorted_markers(const string & basename) -> int
+    {
+        return count_markers(basename, "disjunctive overload by sorting network");
     }
 
     auto probe(const Instance & inst, DisjunctiveRules rules, const optional<string> & proof_name,
@@ -231,6 +245,61 @@ auto main(int argc, char * argv[]) -> int
             if (! gcs::test_innards::run_veripb(name + ".opb", name + ".pbp"))
                 fail(name + ": veripb rejected the certificate");
         }
+
+    // The same refutation, certified by sorting the window instead. Both
+    // arguments run over the one unchanged pairwise encoding, so a difference
+    // here is a bug in one of them rather than a fact about the instance.
+    if (proofs) {
+        DisjunctiveRules rules{.overload = true};
+        rules.overload_certificate = DisjunctiveOverloadCertificate::SortingNetwork;
+        auto result = probe(sharp, rules, make_optional("disjunctive_overload_sorted"));
+        if (! result.refuted_at_root)
+            fail("sorted: the root did not close");
+        if (result.markers != 1)
+            fail("sorted: expected exactly one overload marker, got " + std::to_string(result.markers));
+        if (count_sorted_markers("disjunctive_overload_sorted") != 1)
+            fail("sorted: the sorting-network certificate was asked for and not emitted");
+        if (! gcs::test_innards::run_veripb("disjunctive_overload_sorted.opb", "disjunctive_overload_sorted.pbp"))
+            fail("sorted: veripb rejected the sorting-network certificate");
+    }
+
+    // A window wide enough that the crossover picks the network on its own:
+    // three tasks of ten whose starts lie in [0, 19], so thirty units of work
+    // have to fit in a window twenty-nine wide. Certified both ways, and the
+    // default has to choose the network without being told.
+    {
+        const Instance wide{{{0, 19}, {0, 19}, {0, 19}}, {10, 10, 10}};
+
+        auto by_default = probe(wide, all_rules, proofs ? make_optional("disjunctive_overload_wide") : nullopt);
+        if (by_default.satisfiable)
+            fail("wide: a solution was reported, but thirty units do not fit in twenty-nine");
+        if (! by_default.refuted_at_root)
+            fail("wide: the rule did not close the root");
+        if (proofs) {
+            if (count_sorted_markers("disjunctive_overload_wide") != by_default.markers)
+                fail("wide: the crossover did not pick the network on a window twenty-nine wide with three tasks");
+            if (! gcs::test_innards::run_veripb("disjunctive_overload_wide.opb", "disjunctive_overload_wide.pbp"))
+                fail("wide: veripb rejected the certificate the crossover picked");
+        }
+
+        auto without_rule = probe(wide, no_overload, nullopt);
+        if (without_rule.refuted_at_root)
+            fail("wide: the root closed with the rule off, so the fixture says nothing about the rule");
+
+        // And the other certificate on the same window, which is what says the
+        // crossover is choosing between two things that both work.
+        if (proofs) {
+            DisjunctiveRules rules{.overload = true};
+            rules.overload_certificate = DisjunctiveOverloadCertificate::TimeIndexed;
+            auto result = probe(wide, rules, make_optional("disjunctive_overload_wide_time_indexed"));
+            if (! result.refuted_at_root)
+                fail("wide_time_indexed: the root did not close");
+            if (count_sorted_markers("disjunctive_overload_wide_time_indexed") != 0)
+                fail("wide_time_indexed: a sorting network was emitted where time indexing was asked for");
+            if (! gcs::test_innards::run_veripb("disjunctive_overload_wide_time_indexed.opb", "disjunctive_overload_wide_time_indexed.pbp"))
+                fail("wide_time_indexed: veripb rejected the time-indexed certificate");
+        }
+    }
 
     // A window the rule must not touch: two tasks that genuinely fit, where a
     // sloppy sweep would still find "a" window if it counted a task whose lct

--- a/gcs/innards/proofs/comparator_network.cc
+++ b/gcs/innards/proofs/comparator_network.cc
@@ -133,16 +133,25 @@ auto ComparatorNetwork::add_task(const ProofWire & start, Integer duration) -> v
     _duration_upper.emplace(wire.id, _logger.emit_rup_proof_line(terms(wire, -1_i) >= -duration, _level));
 }
 
-auto ComparatorNetwork::set_upper_bound(const ProofWire & start, ProofLine row) -> void
+auto ComparatorNetwork::assume(const WPBSum & guard) -> void
 {
-    PolBuilder builder;
-    builder.add(row).add(_duration_upper.at(_duration.at(start.id).id));
-    _upper.insert_or_assign(start.id, builder.emit(_logger, _level));
+    _guard = guard;
 }
 
-auto ComparatorNetwork::set_lower_bound(const ProofWire & start, ProofLine row) -> void
+auto ComparatorNetwork::set_bounds(const ProofWire & start) -> void
 {
-    _lower.insert_or_assign(start.id, row);
+    auto guarded = [&](WPBSum sum) {
+        for (const auto & term : _guard.terms)
+            sum += term;
+        return sum;
+    };
+
+    WPBSum fits;
+    add_terms(fits, start, -1_i);
+    add_terms(fits, _duration.at(start.id), -1_i);
+    _upper.insert_or_assign(start.id, _logger.emit_rup_proof_line(guarded(move(fits)) >= -_window_hi, _level));
+
+    _lower.insert_or_assign(start.id, _logger.emit_rup_proof_line(guarded(terms(start, 1_i)) >= _window_lo, _level));
 }
 
 auto ComparatorNetwork::add_separation(
@@ -446,6 +455,8 @@ auto ComparatorNetwork::derive_bound(const Comparator & c, const ProofWire & out
     WPBSum goal;
     add_terms(goal, out, -1_i);
     add_terms(goal, d_out, -1_i);
+    for (const auto & term : _guard.terms)
+        goal += term;
     return case_split(move(goal) >= -_window_hi, {from_a.emit(_logger, _level), from_b.emit(_logger, _level)});
 }
 
@@ -461,7 +472,10 @@ auto ComparatorNetwork::derive_lower_bound(const Comparator & c, const ProofWire
     PolBuilder from_b;
     from_b.add(_lower.at(c.b.id)).add(ge_b);
 
-    return case_split(terms(out, 1_i) >= _window_lo, {from_a.emit(_logger, _level), from_b.emit(_logger, _level)});
+    auto goal = terms(out, 1_i);
+    for (const auto & term : _guard.terms)
+        goal += term;
+    return case_split(move(goal) >= _window_lo, {from_a.emit(_logger, _level), from_b.emit(_logger, _level)});
 }
 
 auto ComparatorNetwork::reify_separation(const ProofWire & x, const ProofWire & y, const string & stem) -> SeparationFlags

--- a/gcs/innards/proofs/comparator_network.hh
+++ b/gcs/innards/proofs/comparator_network.hh
@@ -270,6 +270,9 @@ namespace gcs::innards
         std::map<int, ProofWire> _duration;
         std::map<int, ProofLine> _positivity, _duration_upper;
 
+        /// What makes a state-dependent row vacuous; see \ref assume.
+        WPBSum _guard;
+
         /// Each start wire's `window_hi - wire - duration(wire) >= 0` and
         /// `wire - window_lo >= 0`.
         std::map<int, ProofLine> _upper, _lower;
@@ -380,21 +383,44 @@ namespace gcs::innards
         auto add_task(const ProofWire & start, Integer duration) -> void;
 
         /**
-         * Record `window_hi - start - duration >= 0` for a task, from a
-         * `start <= window_hi - duration` row the caller supplies --- the
-         * model's own bound row for a refutation, or a reason-backed RUP for a
-         * propagator's window.
+         * State that every bound below holds only where `guard` is zero.
+         *
+         * A propagator's window is a fact about the search state, not about the
+         * model, so the rows saying a task fits inside it have to be guarded by
+         * the inference's reason. That guard cannot simply ride along: the
+         * bounds are carried across each comparator by a case split, and a case
+         * split works by adding the negated goal to each half and dividing, so
+         * a term the halves carry and the goal does not survives the division
+         * and the split lands on something sound but not closing.
+         *
+         * So the guard is declared once and the network puts it on both sides:
+         * on the rows it emits for the bounds, and on every goal derived from
+         * them. `guard` is a sum of `big() * ~literal`, one per reason literal
+         * --- a uniform coefficient, since two rows guarded by the *same*
+         * reason at *different* coefficients cancel no better than two rows
+         * guarded by different reasons.
+         *
+         * Left empty (the default) for a whole-problem refutation, where the
+         * bounds come from the model and hold outright.
          */
-        auto set_upper_bound(const ProofWire & start, ProofLine row) -> void;
+        auto assume(const WPBSum & guard) -> void;
 
         /**
-         * And `start - window_lo >= 0`, likewise. Free when the window starts
-         * at zero and the wire is a bit vector, load-bearing otherwise: the
-         * endgame telescopes down to the *earliest* task's start, and what
-         * makes that a refutation is that it cannot be earlier than the window
-         * it was selected for.
+         * Emit the window's bounds for a task: `start + duration <= window_hi`
+         * and `start >= window_lo`, each as one RUP carrying \ref assume's
+         * guard.
+         *
+         * The network emits these rather than taking them, so that the guard on
+         * a bound and the guard on the goals derived from it cannot drift
+         * apart. Both close by propagation --- from the model's own bound rows
+         * for a refutation, and from the reason's order atoms for a propagator.
+         *
+         * The lower bound is free when the window starts at zero and the wire
+         * is a bit vector, and load-bearing otherwise: the endgame telescopes
+         * down to the *earliest* task's start, and what makes that a refutation
+         * is that it cannot be earlier than the window it was selected for.
          */
-        auto set_lower_bound(const ProofWire & start, ProofLine row) -> void;
+        auto set_bounds(const ProofWire & start) -> void;
 
         /**
          * Take a pair of tasks' separation from the model and put it in the

--- a/gcs/innards/proofs/comparator_network_test.cc
+++ b/gcs/innards/proofs/comparator_network_test.cc
@@ -247,12 +247,10 @@ namespace
 
         for (size_t i = 0; i < durations.size(); ++i) {
             network.add_task(tasks[i], Integer{durations[i]});
-            // The window's own bounds, as a propagator would have them: not
-            // model rows but facts about the state, which here RUP straight
-            // from the variables' domains.
-            network.set_upper_bound(
-                tasks[i], logger.emit_rup_proof_line(WPBSum{} + 1_i * built.starts[i] <= Integer{window_hi - durations[i]}, ProofLevel::Top));
-            network.set_lower_bound(tasks[i], logger.emit_rup_proof_line(WPBSum{} + 1_i * built.starts[i] >= Integer{window_lo}, ProofLevel::Top));
+            // Unguarded: here the window is the whole problem, so a task
+            // fitting inside it is the variable's own domain saying so, and
+            // holds outright.
+            network.set_bounds(tasks[i]);
         }
 
         auto direction = [&](size_t i, size_t j) {


### PR DESCRIPTION
Stacked on #739. Both of #730's certificates are now in the solver, and the overload
check picks between them per firing from the window's own geometry. The OPB is
untouched either way — this selects a proof *strategy*, not a formulation, so the
statement being verified is the same whichever is chosen.

## Neither dominates

Same instance, same encoding, only the window's shape differing:

| window | tasks | time-indexed | sorting network |
|---|---|---|---|
| span 8 | 3 | 374 lines | 648 lines |
| span 29 | 3 | 1,319 lines | 699 lines |

The predicted shape: the time-indexed certificate is linear in the span, the network
flat in it but for its wires' widths (648 → 699 over a 3.6× wider window is the log).

## The crossover is measured, not taken from the simulation

Windows of `w` tasks of equal duration overloading by one unit, so only this rule
fires, with the duration varied to move the span independently of `w`. Where they
cross, in units of `w`:

| w | 3 | 4 | 5 | 6 | 7 | 8 | 10 | 12 |
|---|---|---|---|---|---|---|---|---|
| span/w | 4.7 | 5.7 | 6.1 | 6.4 | 6.6 | 6.6 | 6.7 | 6.8 |

Rising and flattening, so the default is **7** — fits the wide windows, which are the
expensive ones and where being wrong costs most, and is at worst a little conservative
at three or four tasks. The simulation said nine, over models with no window offset and
no reason to carry.

Counted in proof lines. Checking time tracks lines here but is not the same
measurement, and a RUP's cost depends on the database it runs against, so #730's
artefact still has something to say.

## The part that is not plumbing

The network's window bounds are facts about the *search state*, so the rows saying a
task fits inside the window have to be guarded by the inference's reason — and that
guard cannot simply ride along. The bounds are carried across each comparator by a case
split, which adds the negated goal to each half and divides; a term the halves carry and
the goal does not survives the division, and the split lands on something sound but not
closing. So `ComparatorNetwork::assume` takes the guard once at a uniform coefficient and
puts it on both sides: on the bound rows it now emits itself, and on every goal derived
from them. Two rows guarded by the same reason at different coefficients cancel no better
than two guarded by different reasons — which is why the network emits those rows rather
than taking them.

Everything the network emits is `Temporary`, so backtracking deletes it. That is the
difference from the time-indexed certificate's activity flags, which say nothing about
the search state and so can live at `Top` and be cited again: a window's wires are about
the window.

## Falling back

The network reads a start's own bit encoding, so the start must be a simple variable
whose encoding is an unsigned magnitude, and durations must be constants for the
separation rows to be duration-relative. A window failing any of that falls back to time
indexing rather than declining the conflict — a certificate that is merely more expensive
is not a reason to lose an inference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018FizeTcjBnMJqmqLWZz4qd
