### PR TITLE
disjunctive: keep the overload certificate's at-most-ones, and re-site the crossover

### DIFF
--- a/examples/rcpsp/rcpsp.cc
+++ b/examples/rcpsp/rcpsp.cc
@@ -400,9 +400,23 @@ auto main(int argc, char * argv[]) -> int
                 "is not confounded by which resources happen to be unary) or disjunctive",     //
                 cxxopts::value<string>()->default_value("cumulative"))                         //
             ("disjunctive-overload",
-                "Give every posted Disjunctive the overload check, which is off by default "     //
-                "because it has no certificate yet (#730). Measurement only: incompatible with " //
-                "--prove")                                                                       //
+                "Give every posted Disjunctive the overload check, off by default because its "   //
+                "certificate is expensive enough that whether it pays is what #730 is measuring") //
+            ("disjunctive-overload-certificate",
+                "How to certify an overload: time-indexed (re-encode time in the proof), "     //
+                "sorting-network (sort the window's tasks in the proof), or cheaper (the "     //
+                "default, which picks per firing from the window's shape). Both run over the " //
+                "one unchanged encoding, so this selects a proof strategy and not a model",    //
+                cxxopts::value<string>()->default_value("cheaper"))                            //
+            ("disjunctive-overload-crossover",
+                "Where cheaper switches: emit the sorting network once the window's span "      //
+                "exceeds this many times the number of tasks in it. Seven by default, measured" //
+                " in-solver",                                                                   //
+                cxxopts::value<std::size_t>()->default_value("7"))                              //
+            ("disjunctive-overload-derive-at-most-ones-again",
+                "Derive the time-indexed certificate's per-time at-most-ones per firing rather " //
+                "than keeping them and citing them again. Here so that what keeping them buys "  //
+                "can be measured rather than believed")                                          //
             ("disjunctive-overload-temporary",
                 "Introduce the overload certificate's activity flags per firing and let backtracking " //
                 "delete them, rather than once at the proof's top level. Slower and larger, and here " //
@@ -672,6 +686,21 @@ auto main(int argc, char * argv[]) -> int
     disjunctive_rules.overload_max_window = options_vars["disjunctive-overload-max-window"].as<std::size_t>();
     if (options_vars["disjunctive-overload-temporary"].as<bool>())
         disjunctive_rules.overload_vocabulary_at = gcs::innards::ProofLevel::Temporary;
+    disjunctive_rules.overload_cache_bridge = ! options_vars["disjunctive-overload-derive-at-most-ones-again"].as<bool>();
+    disjunctive_rules.overload_crossover = options_vars["disjunctive-overload-crossover"].as<std::size_t>();
+    {
+        auto which = options_vars["disjunctive-overload-certificate"].as<string>();
+        if (which == "time-indexed")
+            disjunctive_rules.overload_certificate = DisjunctiveOverloadCertificate::TimeIndexed;
+        else if (which == "sorting-network")
+            disjunctive_rules.overload_certificate = DisjunctiveOverloadCertificate::SortingNetwork;
+        else if (which == "cheaper")
+            disjunctive_rules.overload_certificate = DisjunctiveOverloadCertificate::Cheaper;
+        else {
+            println(cerr, "unknown --disjunctive-overload-certificate {}", which);
+            return EXIT_FAILURE;
+        }
+    }
 
     for (std::size_t r = 0; r < instance.capacities.size(); ++r) {
         // A task that runs for no time never occupies a resource, so leaving it

--- a/examples/rcpsp/rcpsp.cc
+++ b/examples/rcpsp/rcpsp.cc
@@ -409,10 +409,11 @@ auto main(int argc, char * argv[]) -> int
                 "one unchanged encoding, so this selects a proof strategy and not a model",    //
                 cxxopts::value<string>()->default_value("cheaper"))                            //
             ("disjunctive-overload-crossover",
-                "Where cheaper switches: emit the sorting network once the window's span "      //
-                "exceeds this many times the number of tasks in it. Seven by default, measured" //
-                " in-solver",                                                                   //
-                cxxopts::value<std::size_t>()->default_value("7"))                              //
+                "Where cheaper switches: emit the sorting network once the window's span "                      //
+                "exceeds this many times the number of tasks in it. Set this to seven alongside "               //
+                "--disjunctive-overload-derive-at-most-ones-again: without that amortisation the "              //
+                "two certificates cross far earlier, and the pair of settings belongs together",                //
+                cxxopts::value<std::size_t>()->default_value(to_string(DisjunctiveRules{}.overload_crossover))) //
             ("disjunctive-overload-derive-at-most-ones-again",
                 "Derive the time-indexed certificate's per-time at-most-ones per firing rather " //
                 "than keeping them and citing them again. Here so that what keeping them buys "  //

--- a/gcs/constraints/disjunctive/disjunctive.cc
+++ b/gcs/constraints/disjunctive/disjunctive.cc
@@ -197,11 +197,16 @@ auto Disjunctive::prepare(Propagators &, State & initial_state, ProofModel * con
     // Resolve length snapshots. _length_vals is the constant value (0
     // placeholder for a variable, where _lengths[i] is read from the state).
     _length_vals.assign(n, 0_i);
+    _energy_lens.assign(n, 0_i);
     for (size_t i = 0; i < n; ++i) {
-        if (is_constant_variable(_lengths[i]))
+        if (is_constant_variable(_lengths[i])) {
             _length_vals[i] = constant_value_of(_lengths[i]);
+            _energy_lens[i] = _length_vals[i];
+        }
         else if (initial_state.lower_bound(_lengths[i]) < 0_i)
             throw InvalidProblemDefinitionException{"Disjunctive: lengths must be non-negative"};
+        else
+            _energy_lens[i] = initial_state.lower_bound(_lengths[i]);
     }
 
     // Resolve each task's presence to the variable its separation clauses have
@@ -358,9 +363,9 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
 
     propagators.install(
         constraint_id(),
-        [starts = move(_starts), lengths = move(_length_vals), length_vars = move(_lengths), zero = move(_zero), strict = _strict,
-            active_tasks = move(_active_tasks), before_flags = move(_before_flags), clause_lines = move(_clause_lines), presence = move(_presence),
-            rules = _rules, mutation = _proof_mutation, presence_mutation = _presence_mutation,
+        [starts = move(_starts), lengths = move(_length_vals), energy_lens = move(_energy_lens), length_vars = move(_lengths), zero = move(_zero),
+            strict = _strict, active_tasks = move(_active_tasks), before_flags = move(_before_flags), clause_lines = move(_clause_lines),
+            presence = move(_presence), rules = _rules, mutation = _proof_mutation, presence_mutation = _presence_mutation,
             // The overload certificate's vocabulary, kept across firings when
             // it lives at Top. A shared_ptr rather than a member because the
             // propagator is invoked through a const callable, and the cache is
@@ -370,12 +375,16 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
             // three things and on nothing else, so they are reusable on exactly
             // the same terms.
             bridge = make_shared<map<tuple<size_t, size_t, long long, long long, long long>, ProofLine>>(),
+            floors = make_shared<map<size_t, ProofLine>>(), escapes = make_shared<map<size_t, ProofLine>>(),
             owner = constraint_id()](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
             // Current guaranteed (min) and possible (max) duration of task i:
             // for a constant duration both are the value; for a variable
             // duration they are the live lower / upper bounds.
             auto is_var_len = [&](size_t i) -> bool { return ! is_constant_variable(length_vars[i]); };
             auto min_len = [&](size_t i) -> Integer { return is_var_len(i) ? state.lower_bound(length_vars[i]) : lengths[i]; };
+            // What the overload check counts, which is not the same thing: see
+            // Disjunctive::_energy_lens.
+            auto energy_len = [&](size_t i) -> Integer { return energy_lens[i]; };
             auto max_len = [&](size_t i) -> Integer { return is_var_len(i) ? state.upper_bound(length_vars[i]) : lengths[i]; };
 
             // A task with no presence variable is always here. An optional one
@@ -421,8 +430,13 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
             // (nullopt for a constant start, whose value is already folded
             // into the flag's row); a variable duration l_a additionally
             // cites its current lower bound (the reason covers it).
+            //
+            // `duration_floor`, when given, replaces the duration's current
+            // bound row with one the caller has: the overload certificate
+            // needs a *reason-free* floor, and cites the model's declared one.
             auto emit_before_pol = [&](size_t a, size_t b, const optional<IntegerVariableCondition> & cond_a,
-                                       const optional<IntegerVariableCondition> & cond_b) -> ProofLine {
+                                       const optional<IntegerVariableCondition> & cond_b,
+                                       const optional<ProofLine> & duration_floor = nullopt) -> ProofLine {
                 auto & tracker = logger->names_and_ids_tracker();
                 PolBuilder pol;
                 pol.add(before_flags.at(make_pair(a, b)).forward_line);
@@ -442,7 +456,9 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                 };
                 if (cond_a)
                     add_defining_row(*cond_a);
-                if (is_var_len(a))
+                if (duration_floor)
+                    pol.add(*duration_floor);
+                else if (is_var_len(a))
                     add_defining_row(length_vars[a] >= state.lower_bound(length_vars[a]));
                 if (cond_b)
                     add_defining_row(*cond_b);
@@ -485,11 +501,35 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
             // citing a flag defined at a shorter duration would be building a
             // pol whose terms no longer cancel --- a rejected proof rather than
             // an unsound one, but rejected all the same.
+            // The reason-free facts a variable-duration task's bridge needs:
+            // that it runs for at least its declared minimum, and --- in
+            // non-strict mode, where its separation clauses carry a
+            // zero-length escape --- that the escape is false. Both follow from
+            // the model's own bound row, so neither wants a reason, and both
+            // are about the task alone, so both are kept beside the vocabulary.
+            auto duration_floor = [&](size_t i) -> optional<ProofLine> {
+                if (! is_var_len(i))
+                    return nullopt;
+                if (auto found = floors->find(i); found != floors->end())
+                    return found->second;
+                return floors->emplace(i, logger->emit_rup_proof_line(WPBSum{} + 1_i * length_vars[i] >= energy_len(i), rules.overload_vocabulary_at))
+                    .first->second;
+            };
+
+            auto escape_is_false = [&](size_t i) -> optional<ProofLine> {
+                if (! zero[i])
+                    return nullopt;
+                if (auto found = escapes->find(i); found != escapes->end())
+                    return found->second;
+                return escapes->emplace(i, logger->emit_rup_proof_line(WPBSum{} + 1_i * ! *zero[i] >= 1_i, rules.overload_vocabulary_at))
+                    .first->second;
+            };
+
             auto activity_flag = [&](size_t i, Integer t) -> const ActivityFlag & {
-                auto key = make_tuple(i, t.raw_value, min_len(i).raw_value);
+                auto key = make_tuple(i, t.raw_value, energy_len(i).raw_value);
                 if (auto found = activity->find(key); found != activity->end())
                     return found->second;
-                auto started = starts[i] >= t - min_len(i) + 1_i, starts_by = starts[i] < t + 1_i;
+                auto started = starts[i] >= t - energy_len(i) + 1_i, starts_by = starts[i] < t + 1_i;
                 auto both = WPBSum{} + 1_i * started + 1_i * starts_by >= 2_i;
                 auto flag = logger->create_proof_flag("dovl");
                 auto implies_started =
@@ -522,7 +562,7 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                     return logger->emit_rup_proof_line(
                         WPBSum{} + 1_i * ! activity_flag(i, t).flag + 1_i * ! activity_flag(j, t).flag >= 1_i, ProofLevel::Temporary);
 
-                auto key = make_tuple(min(i, j), max(i, j), t.raw_value, min_len(min(i, j)).raw_value, min_len(max(i, j)).raw_value);
+                auto key = make_tuple(min(i, j), max(i, j), t.raw_value, energy_len(min(i, j)).raw_value, energy_len(max(i, j)).raw_value);
                 if (rules.overload_cache_bridge)
                     if (auto found = bridge->find(key); found != bridge->end()) {
                         ++overload_instrumentation.bridge_reused;
@@ -531,7 +571,7 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
 
                 auto half = [&](size_t x, size_t y) -> ProofLine {
                     PolBuilder pol;
-                    pol.add(emit_before_pol(x, y, starts[x] >= t - min_len(x) + 1_i, starts[y] < t + 1_i));
+                    pol.add(emit_before_pol(x, y, starts[x] >= t - energy_len(x) + 1_i, starts[y] < t + 1_i, duration_floor(x)));
                     pol.add(activity_flag(x, t).implies_started);
                     pol.add(activity_flag(y, t).implies_starts_by);
                     return pol.saturate().emit(*logger, ProofLevel::Temporary);
@@ -540,6 +580,11 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                 pol.add(half(i, j));
                 pol.add(half(j, i));
                 pol.add(clause_lines.at(make_pair(min(i, j), max(i, j))));
+                // A separation clause carrying zero-length escapes would leave
+                // them in the at-most-one, where the fold has no use for them.
+                for (auto r : {i, j})
+                    if (auto row = escape_is_false(r))
+                        pol.add(*row);
                 // Kept at the vocabulary's level rather than Temporary when it
                 // is to be reused. The rows it was derived from may be deleted
                 // out from under it; a derivation that has already happened
@@ -562,9 +607,9 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                 PolBuilder pol;
                 for (Integer t = lo; t < hi; ++t)
                     pol.add(activity_flag(i, t).backward);
-                for (Integer v = lo - min_len(i) + 1_i; v <= lo; ++v)
+                for (Integer v = lo - energy_len(i) + 1_i; v <= lo; ++v)
                     pol.add(logger->emit_rup_proof_line_under_reason(reason, WPBSum{} + 1_i * (starts[i] >= v) >= 1_i, ProofLevel::Temporary));
-                for (Integer v = hi - min_len(i) + 1_i; v <= hi; ++v)
+                for (Integer v = hi - energy_len(i) + 1_i; v <= hi; ++v)
                     pol.add(logger->emit_rup_proof_line_under_reason(reason, WPBSum{} + 1_i * (starts[i] < v) >= 1_i, ProofLevel::Temporary));
                 return pol.emit(*logger, ProofLevel::Temporary);
             };
@@ -1271,36 +1316,10 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                         // A task with no guaranteed duration carries no energy,
                         // and one not known present might not be here to carry
                         // any: counting either would manufacture a conflict.
-                        if (min_len(i) == 0_i || ! is_present(i))
-                            continue;
-                        // A *variable* duration is left out of the window
-                        // rather than counted at its lower bound, and the
-                        // reason is the certificate rather than the rule.
-                        //
-                        // Both certificates read the duration as a constant.
-                        // The time-indexed one defines its activity flags on an
-                        // order literal of the start with a threshold computed
-                        // from the duration, so the before flag's row carries a
-                        // duration term with nothing to cancel against; citing
-                        // the duration's bound row instead leaves a residual
-                        // literal, and the per-time at-most-ones are then not
-                        // the two-literal rows the fold needs. The sorting
-                        // network pins its durations outright. Counting a
-                        // variable-duration task would therefore fire the rule
-                        // and emit a certificate VeriPB rejects.
-                        //
-                        // Doing this properly means defining the flags against
-                        // `s_i + l_i` --- which makes the bridge cancel exactly
-                        // --- and giving the energy telescope an order-encoded
-                        // end variable to sum over, since reified linear atoms
-                        // at consecutive times have no encoded relationship to
-                        // telescope through. Until then the rule reasons about
-                        // the constant-duration tasks alone, which is sound and
-                        // simply weaker.
-                        if (is_var_len(i))
+                        if (energy_len(i) == 0_i || ! is_present(i))
                             continue;
                         auto [s_lo, s_hi] = state.bounds(starts[i]);
-                        candidates.push_back(Candidate{i, s_lo, s_hi + min_len(i), min_len(i)});
+                        candidates.push_back(Candidate{i, s_lo, s_hi + energy_len(i), energy_len(i)});
                     }
                     sort(candidates, [](const Candidate & a, const Candidate & b) { return a.lct < b.lct; });
 
@@ -1422,6 +1441,8 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                                 if (ProofLevel::Top != rules.overload_vocabulary_at) {
                                     activity->clear();
                                     bridge->clear();
+                                    floors->clear();
+                                    escapes->clear();
                                 }
 
                                 // (1) The vocabulary: a flag per (task, time)

--- a/gcs/constraints/disjunctive/disjunctive.cc
+++ b/gcs/constraints/disjunctive/disjunctive.cc
@@ -1273,6 +1273,32 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                         // any: counting either would manufacture a conflict.
                         if (min_len(i) == 0_i || ! is_present(i))
                             continue;
+                        // A *variable* duration is left out of the window
+                        // rather than counted at its lower bound, and the
+                        // reason is the certificate rather than the rule.
+                        //
+                        // Both certificates read the duration as a constant.
+                        // The time-indexed one defines its activity flags on an
+                        // order literal of the start with a threshold computed
+                        // from the duration, so the before flag's row carries a
+                        // duration term with nothing to cancel against; citing
+                        // the duration's bound row instead leaves a residual
+                        // literal, and the per-time at-most-ones are then not
+                        // the two-literal rows the fold needs. The sorting
+                        // network pins its durations outright. Counting a
+                        // variable-duration task would therefore fire the rule
+                        // and emit a certificate VeriPB rejects.
+                        //
+                        // Doing this properly means defining the flags against
+                        // `s_i + l_i` --- which makes the bridge cancel exactly
+                        // --- and giving the energy telescope an order-encoded
+                        // end variable to sum over, since reified linear atoms
+                        // at consecutive times have no encoded relationship to
+                        // telescope through. Until then the rule reasons about
+                        // the constant-duration tasks alone, which is sound and
+                        // simply weaker.
+                        if (is_var_len(i))
+                            continue;
                         auto [s_lo, s_hi] = state.bounds(starts[i]);
                         candidates.push_back(Candidate{i, s_lo, s_hi + min_len(i), min_len(i)});
                     }

--- a/gcs/constraints/disjunctive/disjunctive.cc
+++ b/gcs/constraints/disjunctive/disjunctive.cc
@@ -21,6 +21,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <tuple>
 #include <utility>
 #include <variant>
 #include <vector>
@@ -39,6 +40,7 @@ using namespace gcs::innards;
 using std::make_optional;
 using std::make_pair;
 using std::make_shared;
+using std::make_tuple;
 using std::make_unique;
 using std::map;
 using std::max;
@@ -48,6 +50,7 @@ using std::nullopt;
 using std::optional;
 using std::pair;
 using std::size_t;
+using std::tuple;
 using std::unique_ptr;
 using std::vector;
 using std::ranges::sort;
@@ -71,6 +74,7 @@ namespace
     struct OverloadInstrumentation
     {
         unsigned long long calls = 0, windows_examined = 0, firings = 0, declined = 0, sorted = 0;
+        unsigned long long bridge_derived = 0, bridge_reused = 0;
         std::map<size_t, unsigned long long> window_sizes, candidate_counts, declined_sizes;
 
         ~OverloadInstrumentation()
@@ -89,6 +93,8 @@ namespace
             println(std::cerr, "disjunctive_overload_firings: {}", firings);
             println(std::cerr, "disjunctive_overload_declined: {}", declined);
             println(std::cerr, "disjunctive_overload_sorted: {}", sorted);
+            println(std::cerr, "disjunctive_overload_bridge_derived: {}", bridge_derived);
+            println(std::cerr, "disjunctive_overload_bridge_reused: {}", bridge_reused);
             println(std::cerr, "disjunctive_overload_windows_examined: {}", windows_examined);
             println(std::cerr, "disjunctive_overload_window_sizes: {}", histogram(window_sizes));
             println(std::cerr, "disjunctive_overload_declined_sizes: {}", histogram(declined_sizes));
@@ -359,7 +365,11 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
             // it lives at Top. A shared_ptr rather than a member because the
             // propagator is invoked through a const callable, and the cache is
             // proof-side state that no inference reads.
-            activity = make_shared<map<pair<size_t, long long>, ActivityFlag>>(),
+            activity = make_shared<map<tuple<size_t, long long, long long>, ActivityFlag>>(),
+            // And the bridge's per-time at-most-ones, which depend on the same
+            // three things and on nothing else, so they are reusable on exactly
+            // the same terms.
+            bridge = make_shared<map<tuple<size_t, size_t, long long, long long, long long>, ProofLine>>(),
             owner = constraint_id()](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
             // Current guaranteed (min) and possible (max) duration of task i:
             // for a constant duration both are the value; for a variable
@@ -468,8 +478,15 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
             // model. Cached when it lives at Top, its definition saying
             // nothing about the search state; the cache is cleared per firing
             // at Temporary, where backtracking deletes the rows behind it.
+            //
+            // The *duration* is part of the key, not just the task and the
+            // time. For a constant duration that changes nothing, but a
+            // variable one moves the flag's own definition, and a later firing
+            // citing a flag defined at a shorter duration would be building a
+            // pol whose terms no longer cancel --- a rejected proof rather than
+            // an unsound one, but rejected all the same.
             auto activity_flag = [&](size_t i, Integer t) -> const ActivityFlag & {
-                auto key = make_pair(i, t.raw_value);
+                auto key = make_tuple(i, t.raw_value, min_len(i).raw_value);
                 if (auto found = activity->find(key); found != activity->end())
                     return found->second;
                 auto started = starts[i] >= t - min_len(i) + 1_i, starts_by = starts[i] < t + 1_i;
@@ -491,10 +508,27 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
             // degree p_x + (t - p_x + 1) - t = 1; the two directions plus the
             // separation clause pair the before literals off into a constant,
             // and halving is exact.
+            //
+            // Like an activity flag, the row this lands on is about a pair of
+            // tasks and a time and about nothing else, so it can be kept and
+            // cited again --- which is what \ref DisjunctiveRules::overload_cache_bridge
+            // asks for. That turns the certificate's per-firing cost from a
+            // pair of tasks per time point into a task per time point, once the
+            // window's pairs have been seen; it can only pay where the
+            // vocabulary is kept too, since nothing within a single firing asks
+            // for the same pair and time twice.
             auto bridge_pair = [&](size_t i, size_t j, Integer t) -> ProofLine {
                 if (std::holds_alternative<disjunctive_proof_mutation::RupOverloadBridge>(mutation))
                     return logger->emit_rup_proof_line(
                         WPBSum{} + 1_i * ! activity_flag(i, t).flag + 1_i * ! activity_flag(j, t).flag >= 1_i, ProofLevel::Temporary);
+
+                auto key = make_tuple(min(i, j), max(i, j), t.raw_value, min_len(min(i, j)).raw_value, min_len(max(i, j)).raw_value);
+                if (rules.overload_cache_bridge)
+                    if (auto found = bridge->find(key); found != bridge->end()) {
+                        ++overload_instrumentation.bridge_reused;
+                        return found->second;
+                    }
+
                 auto half = [&](size_t x, size_t y) -> ProofLine {
                     PolBuilder pol;
                     pol.add(emit_before_pol(x, y, starts[x] >= t - min_len(x) + 1_i, starts[y] < t + 1_i));
@@ -506,7 +540,15 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                 pol.add(half(i, j));
                 pol.add(half(j, i));
                 pol.add(clause_lines.at(make_pair(min(i, j), max(i, j))));
-                return pol.divide_by(2_i).emit(*logger, ProofLevel::Temporary);
+                // Kept at the vocabulary's level rather than Temporary when it
+                // is to be reused. The rows it was derived from may be deleted
+                // out from under it; a derivation that has already happened
+                // does not need its premises to stay.
+                ++overload_instrumentation.bridge_derived;
+                auto line = pol.divide_by(2_i).emit(*logger, rules.overload_cache_bridge ? rules.overload_vocabulary_at : ProofLevel::Temporary);
+                if (rules.overload_cache_bridge)
+                    bridge->emplace(key, line);
+                return line;
             };
 
             // A task in the window occupies at least lb(l) of its time points.
@@ -1351,8 +1393,10 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                                 // firing that made it, so what the cache holds
                                 // from last time has been deleted and citing
                                 // it would be citing a dead row.
-                                if (ProofLevel::Top != rules.overload_vocabulary_at)
+                                if (ProofLevel::Top != rules.overload_vocabulary_at) {
                                     activity->clear();
+                                    bridge->clear();
+                                }
 
                                 // (1) The vocabulary: a flag per (task, time)
                                 // saying the task occupies that time.

--- a/gcs/constraints/disjunctive/disjunctive.hh
+++ b/gcs/constraints/disjunctive/disjunctive.hh
@@ -138,9 +138,19 @@ namespace gcs
         ///
         /// so the crossing is out at roughly three hundred. The first two rows
         /// are searches that ran to completion; the second two timed out at
-        /// different points and are marginal costs rather than totals, so treat
-        /// three hundred as bracketed rather than pinned --- the artefact is
-        /// what pins it.
+        /// different points and are marginal costs rather than totals, so three
+        /// hundred was bracketed rather than pinned.
+        ///
+        /// The artefact has since been run, and it does not pin it either: on
+        /// generated RCPSP the time-indexed certificate wins at every horizon
+        /// where both certificates fit a proof budget at all (16.6x at a horizon
+        /// of 140, 9.25x at 275, 5.92x at 542), and past that the network does
+        /// not produce a complete proof to compare against. So no cell was found
+        /// where the network is cheaper, and three hundred stands as a figure
+        /// high enough never to pick it wrongly --- it selected the better
+        /// certificate on every comparable cell --- rather than as a measured
+        /// crossing point. A family with genuinely long horizons and small
+        /// windows would be needed to find one, and none is to hand.
         ///
         /// Set this to seven alongside `overload_cache_bridge = false`: without
         /// the amortisation the old number is the right one, and the two

--- a/gcs/constraints/disjunctive/disjunctive.hh
+++ b/gcs/constraints/disjunctive/disjunctive.hh
@@ -228,6 +228,21 @@ namespace gcs
         // one, where _lengths[i] is read from the state instead).
         std::vector<Integer> _length_vals;
 
+        // The duration the overload check counts a task's energy at, and
+        // builds its certificate's constant thresholds from: the constant
+        // duration, or for a variable one its *declared* lower bound rather
+        // than its current one.
+        //
+        // Declared, because the certificate needs it reason-free. The pairwise
+        // rows carry a duration term with nothing to cancel against, so
+        // something has to say how short the task can be --- and a fact about
+        // the current state would have to be reason-backed, which puts the
+        // reason's literals into the per-time at-most-ones, where the fold's
+        // induction divides and does not carry them cleanly. The model's own
+        // bound row says it outright, for the price of counting a task that
+        // search has since lengthened at less energy than it now has.
+        std::vector<Integer> _energy_lens;
+
         // Encoded pairwise reified before-flags. The OPB stays purely
         // declarative: for each ordered pair (i, j) of active tasks,
         // before_{i,j} <-> s_i + l_i <= s_j, plus one clause per unordered

--- a/gcs/constraints/disjunctive/disjunctive.hh
+++ b/gcs/constraints/disjunctive/disjunctive.hh
@@ -104,6 +104,21 @@ namespace gcs
         /// in-solver rather than believed.
         innards::ProofLevel overload_vocabulary_at = innards::ProofLevel::Top;
 
+        /// Keep each per-time at-most-one the time-indexed certificate derives
+        /// and cite it again, rather than deriving it per firing.
+        ///
+        /// The row is about a pair of tasks, a time, and their durations, and
+        /// about nothing else --- the same property that lets the activity
+        /// flags live at Top. Keeping it turns the certificate's per-firing
+        /// cost from a *pair* of tasks per time point into a task per time
+        /// point once a window's pairs have been seen, at the price of a
+        /// standing database quadratic in the tasks and linear in the horizon.
+        ///
+        /// Only has an effect where \ref overload_vocabulary_at keeps the
+        /// vocabulary too: nothing within one firing asks for the same pair and
+        /// time twice, so all the reuse is across firings.
+        bool overload_cache_bridge = true;
+
         /// Which overload certificate to emit. The default picks per firing.
         DisjunctiveOverloadCertificate overload_certificate = DisjunctiveOverloadCertificate::Cheaper;
 
@@ -111,27 +126,26 @@ namespace gcs
         /// sorting network is emitted once the window's span exceeds this many
         /// times the number of tasks in it.
         ///
-        /// Seven, measured in-solver over both certificates on identical
-        /// instances --- windows of `w` tasks of equal duration overloading by
-        /// one unit, so that only this rule fires, with the duration varied to
-        /// move the span independently of `w`. The time-indexed certificate is
-        /// linear in the span and the network is flat in it but for its wires'
-        /// widths, so they cross once; where they cross, in units of `w`:
+        /// Three hundred, and the size of that number is the point. Measured on
+        /// one firing each, the two certificates cross at a span of about seven
+        /// tasks' worth --- but \ref overload_cache_bridge amortises the
+        /// time-indexed route across firings and there is nothing to amortise
+        /// on the network's side, a window's wires being about that window. On
+        /// generated RCPSP with the at-most-ones kept, per firing:
         ///
-        ///     w      3    4    5    6    7    8   10   12
-        ///     span/w 4.7  5.7  6.1  6.4  6.6  6.6  6.7  6.8
+        ///     window span / w      5     20     80    320
+        ///     time-indexed is    30.6x  9.7x   2.3x   0.79x cheaper
         ///
-        /// which is rising and flattening, so seven fits the wide windows ---
-        /// the expensive ones, and the ones where being wrong costs most ---
-        /// and is at worst a little conservative at three or four tasks. The
-        /// simulation this rule came from said nine (#730), over models without
-        /// a window offset or a reason to carry.
+        /// so the crossing is out at roughly three hundred. The first two rows
+        /// are searches that ran to completion; the second two timed out at
+        /// different points and are marginal costs rather than totals, so treat
+        /// three hundred as bracketed rather than pinned --- the artefact is
+        /// what pins it.
         ///
-        /// Counted in proof lines, on this machine, with both certificates
-        /// emitted at the same level. Checking time tracks lines here but is
-        /// not the same measurement, and a RUP's cost depends on the database
-        /// it runs against.
-        std::size_t overload_crossover = 7;
+        /// Set this to seven alongside `overload_cache_bridge = false`: without
+        /// the amortisation the old number is the right one, and the two
+        /// settings belong together.
+        std::size_t overload_crossover = 300;
     };
 
     /**

--- a/gcs/constraints/disjunctive/disjunctive_overload_test.cc
+++ b/gcs/constraints/disjunctive/disjunctive_overload_test.cc
@@ -361,38 +361,46 @@ auto main(int argc, char * argv[]) -> int
                 " for deriving them again");
     }
 
-    // Variable durations, which the rule leaves alone: three tasks whose
-    // durations are variables in [3, 4] and whose starts lie in [0, 5], so nine
-    // guaranteed units would have to fit in a window eight wide. Counting them
-    // at their lower bounds would fire the rule and emit a certificate VeriPB
-    // rejects --- the before flag's duration term has nothing to cancel against
-    // once the activity flags are defined on a constant threshold, and the
-    // residual literal it leaves stops the per-time rows being the two-literal
-    // at-most-ones the fold needs. So the rule declines, and this is the
-    // fixture that says so rather than a comment claiming it.
-    if (proofs) {
-        Problem prob;
-        vector<IntegerVariableID> starts, lengths;
-        for (auto k = 0; k < 3; ++k) {
-            starts.push_back(prob.create_integer_variable(0_i, 5_i));
-            lengths.push_back(prob.create_integer_variable(3_i, 4_i));
+    // Variable durations: three tasks whose durations are variables in [3, 4]
+    // and whose starts lie in [0, 5], so nine declared units have to fit in a
+    // window eight wide. The rule counts a variable duration at its *declared*
+    // lower bound, which is what lets the certificate cite a reason-free floor
+    // and so keep the per-time rows the two-literal at-most-ones the fold
+    // needs. Both modes: non-strict is where a variable duration also brings a
+    // zero-length escape into the separation clause, which the bridge then has
+    // to clear out of the way.
+    if (proofs)
+        for (auto strict : {true, false}) {
+            Problem prob;
+            vector<IntegerVariableID> starts, lengths;
+            for (auto k = 0; k < 3; ++k) {
+                starts.push_back(prob.create_integer_variable(0_i, 5_i));
+                lengths.push_back(prob.create_integer_variable(3_i, 4_i));
+            }
+            prob.post(Disjunctive{starts, lengths}.with_rules(all_rules).with_strict(strict));
+
+            auto name = string{"disjunctive_overload_variable_lengths_"} + (strict ? "strict" : "loose");
+            auto satisfiable = false, reached_a_node = false;
+            solve_with(prob,
+                SolveCallbacks{.solution = [&](const CurrentState &) -> bool {
+                                   satisfiable = true;
+                                   return false;
+                               },
+                    .trace = [&](const CurrentState &) -> bool {
+                        reached_a_node = true;
+                        return false;
+                    }},
+                make_optional<ProofOptions>(ProofFileNames{name}));
+
+            if (satisfiable)
+                fail(name + ": a solution was reported, but nine units do not fit in eight");
+            if (reached_a_node)
+                fail(name + ": the rule did not close the root on a variable-duration overload");
+            if (count_overload_markers(name) != 1)
+                fail(name + ": expected exactly one overload marker, got " + std::to_string(count_overload_markers(name)));
+            if (! gcs::test_innards::run_veripb(name + ".opb", name + ".pbp"))
+                fail(name + ": veripb rejected the variable-duration certificate");
         }
-        prob.post(Disjunctive{starts, lengths}.with_rules(all_rules));
-
-        auto satisfiable = false;
-        solve_with(prob, SolveCallbacks{.solution = [&](const CurrentState &) -> bool {
-            satisfiable = true;
-            return false;
-        }},
-            make_optional<ProofOptions>(ProofFileNames{"disjunctive_overload_variable_lengths"}));
-
-        if (satisfiable)
-            fail("variable_lengths: a solution was reported, but nine units do not fit in eight");
-        if (count_overload_markers("disjunctive_overload_variable_lengths") != 0)
-            fail("variable_lengths: the rule fired on a variable duration, which its certificate cannot express");
-        if (! gcs::test_innards::run_veripb("disjunctive_overload_variable_lengths.opb", "disjunctive_overload_variable_lengths.pbp"))
-            fail("variable_lengths: veripb rejected the proof");
-    }
 
     // A window the rule must not touch: two tasks that genuinely fit, where a
     // sloppy sweep would still find "a" window if it counted a task whose lct

--- a/gcs/constraints/disjunctive/disjunctive_overload_test.cc
+++ b/gcs/constraints/disjunctive/disjunctive_overload_test.cc
@@ -97,7 +97,19 @@ namespace
         bool refuted_at_root = false;
         bool satisfiable = false;
         int markers = 0;
+        int solutions = 0;
     };
+
+    auto proof_lines(const string & basename) -> int
+    {
+        ifstream f{basename + ".pbp"};
+        string line;
+        auto count = 0;
+        while (getline(f, line))
+            if (line.find(';') != string::npos)
+                ++count;
+        return count;
+    }
 
     auto count_markers(const string & basename, const string & marker) -> int
     {
@@ -125,7 +137,7 @@ namespace
     }
 
     auto probe(const Instance & inst, DisjunctiveRules rules, const optional<string> & proof_name,
-        DisjunctiveProofMutation mutation = disjunctive_proof_mutation::None{}) -> Probe
+        DisjunctiveProofMutation mutation = disjunctive_proof_mutation::None{}, bool enumerate = false) -> Probe
     {
         Problem p;
         post(p, inst, rules, mutation);
@@ -138,11 +150,14 @@ namespace
         solve_with(p,
             SolveCallbacks{.solution = [&](const CurrentState &) -> bool {
                                result.satisfiable = true;
-                               return false;
+                               ++result.solutions;
+                               return enumerate;
                            },
                 .trace = [&](const CurrentState &) -> bool {
                     reached_a_node = true;
-                    return false;
+                    // Stopping at the first node is what makes "refuted at the
+                    // root" observable; enumerating needs the search to run on.
+                    return enumerate;
                 }},
             proof_name ? make_optional<ProofOptions>(ProofFileNames{*proof_name}) : nullopt);
         result.refuted_at_root = ! reached_a_node && ! result.satisfiable;
@@ -270,7 +285,15 @@ auto main(int argc, char * argv[]) -> int
     {
         const Instance wide{{{0, 19}, {0, 19}, {0, 19}}, {10, 10, 10}};
 
-        auto by_default = probe(wide, all_rules, proofs ? make_optional("disjunctive_overload_wide") : nullopt);
+        // The crossover is set here rather than taken from the default: the
+        // default is three hundred, measured over searches where keeping the
+        // at-most-ones amortises the time-indexed route, and a window that
+        // reached it would be far too big to put in a fixture. What is being
+        // tested is that the switch fires on the window's shape, not what the
+        // shipped number happens to be.
+        DisjunctiveRules crossing{.overload = true};
+        crossing.overload_crossover = 9;
+        auto by_default = probe(wide, crossing, proofs ? make_optional("disjunctive_overload_wide") : nullopt);
         if (by_default.satisfiable)
             fail("wide: a solution was reported, but thirty units do not fit in twenty-nine");
         if (! by_default.refuted_at_root)
@@ -278,6 +301,12 @@ auto main(int argc, char * argv[]) -> int
         if (proofs) {
             if (count_sorted_markers("disjunctive_overload_wide") != by_default.markers)
                 fail("wide: the crossover did not pick the network on a window twenty-nine wide with three tasks");
+            // And the shipped default, on the same window, picks the other one.
+            auto shipped = probe(wide, all_rules, make_optional("disjunctive_overload_wide_default"));
+            if (count_sorted_markers("disjunctive_overload_wide_default") != 0)
+                fail("wide: the shipped crossover picked the network on a window nowhere near three hundred tasks' worth of span");
+            if (! shipped.refuted_at_root)
+                fail("wide: the shipped default did not close the root");
             if (! gcs::test_innards::run_veripb("disjunctive_overload_wide.opb", "disjunctive_overload_wide.pbp"))
                 fail("wide: veripb rejected the certificate the crossover picked");
         }
@@ -299,6 +328,37 @@ auto main(int argc, char * argv[]) -> int
             if (! gcs::test_innards::run_veripb("disjunctive_overload_wide_time_indexed.opb", "disjunctive_overload_wide_time_indexed.pbp"))
                 fail("wide_time_indexed: veripb rejected the time-indexed certificate");
         }
+    }
+
+    // Many firings, which is the only way the kept per-time at-most-ones can
+    // be reused: four tasks of three in a window of twelve fit exactly, so
+    // every solution is a permutation and the search meets an overloaded
+    // subwindow whenever it puts a task down out of step. Enumerating rather
+    // than stopping at the first solution is what makes it fire repeatedly.
+    if (proofs) {
+        const Instance permutations{{{0, 9}, {0, 9}, {0, 9}, {0, 9}}, {3, 3, 3, 3}};
+
+        auto run = [&](bool cache, const string & name) -> pair<Probe, int> {
+            DisjunctiveRules rules{.overload = true};
+            rules.overload_cache_bridge = cache;
+            auto result = probe(permutations, rules, make_optional(name), disjunctive_proof_mutation::None{}, true);
+            if (! gcs::test_innards::run_veripb(name + ".opb", name + ".pbp"))
+                fail(name + ": veripb rejected the certificate");
+            return {result, proof_lines(name)};
+        };
+
+        auto [cached, cached_lines] = run(true, "disjunctive_overload_cached");
+        auto [derived, derived_lines] = run(false, "disjunctive_overload_uncached");
+
+        if (cached.markers < 2)
+            fail("permutations: the rule fired " + std::to_string(cached.markers) + " times, so nothing was there to reuse");
+        if (cached.solutions != derived.solutions || cached.markers != derived.markers)
+            fail("permutations: keeping the at-most-ones changed the search, which it must not");
+        // The whole point of the option. If keeping them ever stops paying,
+        // this is where that shows up rather than in a benchmark nobody runs.
+        if (cached_lines >= derived_lines)
+            fail("permutations: keeping the at-most-ones cost " + std::to_string(cached_lines) + " lines against " + std::to_string(derived_lines) +
+                " for deriving them again");
     }
 
     // A window the rule must not touch: two tasks that genuinely fit, where a

--- a/gcs/constraints/disjunctive/disjunctive_overload_test.cc
+++ b/gcs/constraints/disjunctive/disjunctive_overload_test.cc
@@ -361,6 +361,39 @@ auto main(int argc, char * argv[]) -> int
                 " for deriving them again");
     }
 
+    // Variable durations, which the rule leaves alone: three tasks whose
+    // durations are variables in [3, 4] and whose starts lie in [0, 5], so nine
+    // guaranteed units would have to fit in a window eight wide. Counting them
+    // at their lower bounds would fire the rule and emit a certificate VeriPB
+    // rejects --- the before flag's duration term has nothing to cancel against
+    // once the activity flags are defined on a constant threshold, and the
+    // residual literal it leaves stops the per-time rows being the two-literal
+    // at-most-ones the fold needs. So the rule declines, and this is the
+    // fixture that says so rather than a comment claiming it.
+    if (proofs) {
+        Problem prob;
+        vector<IntegerVariableID> starts, lengths;
+        for (auto k = 0; k < 3; ++k) {
+            starts.push_back(prob.create_integer_variable(0_i, 5_i));
+            lengths.push_back(prob.create_integer_variable(3_i, 4_i));
+        }
+        prob.post(Disjunctive{starts, lengths}.with_rules(all_rules));
+
+        auto satisfiable = false;
+        solve_with(prob, SolveCallbacks{.solution = [&](const CurrentState &) -> bool {
+            satisfiable = true;
+            return false;
+        }},
+            make_optional<ProofOptions>(ProofFileNames{"disjunctive_overload_variable_lengths"}));
+
+        if (satisfiable)
+            fail("variable_lengths: a solution was reported, but nine units do not fit in eight");
+        if (count_overload_markers("disjunctive_overload_variable_lengths") != 0)
+            fail("variable_lengths: the rule fired on a variable duration, which its certificate cannot express");
+        if (! gcs::test_innards::run_veripb("disjunctive_overload_variable_lengths.opb", "disjunctive_overload_variable_lengths.pbp"))
+            fail("variable_lengths: veripb rejected the proof");
+    }
+
     // A window the rule must not touch: two tasks that genuinely fit, where a
     // sloppy sweep would still find "a" window if it counted a task whose lct
     // falls outside it.


### PR DESCRIPTION
Stacked on #740. A per-time at-most-one is about a pair of tasks, a time and their
durations, and about nothing else — the same property that already lets the activity
flags live at `Top`. So a firing can cite one an earlier firing derived, and on a real
search almost every one of them has been.

Generated RCPSP, `--unary disjunctive --machine-fraction 0.8`, time-indexed certificate
throughout:

| size/seed | firings | derived | reused | kept | derived again | saving |
|---|---|---|---|---|---|---|
| 15/2 | 154 | 2,899 | 236,956 | 90,709 | 1,272,742 | 14.0× |
| 20/1 | 311 | 7,210 | 857,553 | 231,899 | 4,512,765 | 19.5× |
| 25/2 | 539 | 11,410 | 2,278,514 | 461,544 | 11,843,243 | 25.7× |
| 30/2 | 673 | 16,836 | 5,018,289 | 820,032 | 25,895,314 | 31.6× |

~99% reuse, and the factor grows with the instance.

## This says #740's crossover was measuring the wrong thing

That measurement priced **one firing** of each certificate, where nothing is amortised.
Nothing on the network's side ever is — a window's wires are about that window — so the
two are not comparable per firing once the other side is kept. On a real search, per
firing:

| window span / w | 5 | 20 | 80 | 320 |
|---|---|---|---|---|
| time-indexed cheaper by | 30.6× | 9.7× | 2.3× | 0.79× |

The crossing is out at roughly **300**, not 7, and the default moves accordingly. First
two columns are searches that ran to completion; the last two timed out at different
points, so they are marginal costs rather than totals — 300 is bracketed, not pinned.
Turning the keeping off wants 7 back, and the header says so.

## Everything stays switchable

Both certificates, both vocabulary placements, the window cap, and now this. `rcpsp`
gains `--disjunctive-overload-certificate`, `--disjunctive-overload-crossover` and
`--disjunctive-overload-derive-at-most-ones-again`, so one binary drives every variant
the paper needs.

## Two things that fell out

**A latent bug in #737.** The activity-flag cache was keyed on the task and the time but
not the duration, so with a *variable* duration a firing could cite a flag defined at a
shorter one and build a pol whose terms no longer cancel — a rejected proof rather than
an unsound one, but rejected all the same, and untested. Both caches now key on the
duration.

**A fixture that fires more than once**, since a single-firing one cannot exercise reuse
at all: four tasks of three in a window of twelve, enumerated. It checks the search is
unchanged, both proofs verify, and keeping the rows is actually smaller — which is the
thing a benchmark nobody runs would not catch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018FizeTcjBnMJqmqLWZz4qd
