### PR TITLE
cumulative: certified time-table extended edge-finding (TTEF)

### DIFF
--- a/dev_docs/cumulative-proof-logging.md
+++ b/dev_docs/cumulative-proof-logging.md
@@ -22,12 +22,13 @@ bounds** — over optional tasks and over variable durations, heights and
 capacities.
 
 Also certified, off by default: **edge-finding**, in both directions, under
-`CumulativeRules::edge_finding`. See the section below.
+`CumulativeRules::edge_finding`, and **time-table extended edge-finding**
+(TTEF) under `CumulativeRules::time_table_edge_finding`. See the sections below.
 
-Not here: **not-first / not-last** and **TTEF / KAOC** (#550, #696). Those are
-propagation rules a competitive cumulative solver also runs, so the claim to
-make is "a wide range of commonly used techniques", not completeness. The Open
-follow-ups section at the end says what each would take.
+Not here: **not-first / not-last** and **KAOC** (#550). Those are propagation
+rules a competitive cumulative solver also runs, so the claim to make is "a wide
+range of commonly used techniques", not completeness. The Open follow-ups
+section at the end says what each would take.
 
 ## What's hard about it
 
@@ -1125,6 +1126,81 @@ makes the same push and unit propagation closes the conclusion's RUP whatever
 the derivation above it says, so the fixture measures nothing. Six mutation
 lanes, all rejected.
 
+## TTEF: the same certificate, with the profile added (#696)
+
+Time-table extended edge-finding is to edge-finding what `(TTOC)` is to the
+overload check. The tasks a window does not contain still put their
+mandatory-part load into it, so `rest` is computed against
+
+```
+window_total = energy + (profile_within(a, b) - inside_mandatory)
+```
+
+with the pushed task's own mandatory load taken back out, since its clipped
+energy already covers those time points and each time point has one `C_t` row
+to cancel against. `CumulativeRules::time_table_edge_finding`, off by default.
+
+**The certificate is edge-finding's, plus the pins `(TTOC)` already emits.**
+Same window, same guarded rows, same `pol`; the profile term is the same
+`pin_contributor` line per mandatory `(task, time)` pair that the overload check
+uses. Nothing new was needed, which is the answer to the question #696 asked.
+
+Two things are worth knowing.
+
+- **The pins are read from the live bounds, not from the `mand_load` snapshot
+  the sweep was set up from.** A mandatory part only grows as the sweep pushes
+  bounds around, so the pins claim at least what the firing's arithmetic
+  counted, and a `pol` carrying more energy than it needs closes just the same.
+- **The pins are usually not load-bearing at all.** Without them the `pol`
+  leaves the non-contained tasks' `active` terms uncancelled, and unit
+  propagation assigns those from the reason's own bound literals — so the
+  wrapping RUP closes anyway. Dropping *every* pin is rejected on only 13 of 248
+  searched instances. They are emitted because those 13 exist, not because the
+  common case needs them.
+
+That second point is what makes the fixtures hard. A fixture has to make the
+pins matter *and* land its push somewhere a solution actually sits — where the
+push is merely valid rather than tight, "one too far" is valid too and VeriPB
+verifies the corrupted proof. `cumulative_ttef_test --search` generates random
+instances and keeps the ones satisfying both, `--describe` prints what one does,
+and `--instance=` runs a mutation against a candidate; the two `sharp` fixtures
+came out of that, and the two `profile_push` ones are hand-built to *explain*
+the rule rather than to test it. Seven mutation lanes, all rejected.
+
+`OmitCapacityLine` is not among them: it is accepted on every TTEF fixture
+searched, for the same reason dropping the pins usually is.
+
+**Measured, 175 instances at 60 s** (`data_bl`, `data_pack`, `data_la_x`), over
+the 36 that every arm closed:
+
+| arm | recursions | vs ef | propagations | vs ef |
+|---|---|---|---|---|
+| no edge-finding | 7,227,100 | 3.062x | 72,057,194 | 2.450x |
+| edge-finding | 2,359,885 | 1.000x | 29,411,592 | 1.000x |
+| TTEF | 1,768,271 | **0.749x** | 23,452,325 | 0.797x |
+| energetic | 1,573,267 | **0.667x** | 21,566,293 | 0.733x |
+
+TTEF has fewer recursions on 35 of the 36 and more on none. Do not read the
+wall times from that sweep: the arms differ in per-node cost, and `data_la_x`
+closes nothing at 60 s in any arm.
+
+What it costs: over `data_bl`, 67.1M firings, of which **72.6% are ones
+edge-finding would not make at all**, carrying **2.93 pins per firing** (most 21)
+against 4.54 contained energy rows. So the pins roughly double a firing's proof
+lines. They are also **15,037x reused** — 13,065 distinct `(task, time)` pairs
+across 196M citations — so a guarded, cached pin in the shape of
+`derive_guarded_window_energy` over `[t, t+1)` would amortise them away, exactly
+as the contained rows already are. Not done: the guards of a one-time-point row
+are fixed by `(task, time)` alone, which is why the reuse is so high.
+
+`CumulativeRules::energetic_edge_finding` is the same rule with every task's
+*guaranteed* energy in the window in place of contained-energy-plus-profile.
+That is what `window_energy_bound` computes anyway, so it needs no pins at all,
+and it is stronger. It is **not certified** — `define_proof_model` refuses a
+logger while it is set — and it is in the tree to be measured, not to be used:
+the row above is what it buys, and the propagation cost of recomputing the sum
+per window is not paid for on this family.
+
 ## Open follow-ups
 - **Energetic reasoning.** The window-energy lemma above is the first
   piece of it: horizontally elastic and knapsack-augmented checking
@@ -1132,7 +1208,21 @@ lanes, all rejected.
   presolvers (#549) on the contained one.
 - **Not-first / not-last (#732).** Now cheap: it is edge-finding's certificate
   with a different window and the conclusion on the other bound, and the guarded
-  row already takes its threshold as a parameter.
+  row already takes its threshold as a parameter. Expect the same fixture
+  difficulty TTEF ran into: the conclusion is an existing time point, which is
+  where unit propagation reaches on its own most easily.
+- **Guarded pins for the profile term.** TTEF's pins are reason-backed and
+  re-derived per firing, at 2.93 lines' worth per firing and 15,037x repetition.
+  A one-time-point `derive_guarded_window_energy` row is keyed by `(task, time)`
+  alone, so it would cache the way the contained rows do --- and the same row
+  would amortise `(TTOC)`'s pins, which the merged overload check also
+  re-derives every firing.
+- **Certifying the energetic form.** `energetic_edge_finding` measures better
+  than TTEF and needs *no* pins, since every task's contribution is a guarded
+  window-energy row. What is unresolved is the cache key: a contained task's
+  guards come from the window, a non-contained one's from its current bounds, so
+  the rows would repeat far less. Weakening the guards deliberately, to buy
+  reuse at the price of a looser bound, is the experiment.
 - **Edge-finding's scan (#742).** The rule is certified and its inferences cost
   nothing measurable, but the window x task sweep that finds them is O(n^3) and
   taxes the solve about 1.5x at identical search. Propagation performance, not

--- a/examples/rcpsp/rcpsp.cc
+++ b/examples/rcpsp/rcpsp.cc
@@ -348,6 +348,11 @@ auto main(int argc, char * argv[]) -> int
                 "contain (TTEF). Implies --cumulative-edge-finding. Not certified yet, so a run with "   //
                 "--prove will refuse it",                                                                //
                 cxxopts::value<bool>()->default_value("false"))                                          //
+            ("cumulative-energetic-edge-finding",                                                        //
+                "Strengthen edge-finding with every task's guaranteed energy inside the window, rather " //
+                "than only the contained tasks' whole energy (subsumes TTEF). Implies "                  //
+                "--cumulative-edge-finding. Not certified yet, so a run with --prove will refuse it",    //
+                cxxopts::value<bool>()->default_value("false"))                                          //
             ("mutate-makespan-bound",                                                                    //
                 "Claim a makespan one larger than the inferred constraints' energy supports. For "       //
                 "validating the bound only: VeriPB must reject the resulting proof, and a run that "     //
@@ -631,7 +636,9 @@ auto main(int argc, char * argv[]) -> int
 
     auto cumulative_rules = CumulativeRules{};
     cumulative_rules.time_table_edge_finding = options_vars["cumulative-time-table-edge-finding"].as<bool>();
-    cumulative_rules.edge_finding = options_vars["cumulative-edge-finding"].as<bool>() || cumulative_rules.time_table_edge_finding;
+    cumulative_rules.energetic_edge_finding = options_vars["cumulative-energetic-edge-finding"].as<bool>();
+    cumulative_rules.edge_finding =
+        options_vars["cumulative-edge-finding"].as<bool>() || cumulative_rules.time_table_edge_finding || cumulative_rules.energetic_edge_finding;
 
     vector<IntegerVariableID> machine_order_vars;
     if (machine_variant == "difference" && machine_starts.size() >= 2)

--- a/examples/rcpsp/rcpsp.cc
+++ b/examples/rcpsp/rcpsp.cc
@@ -343,6 +343,11 @@ auto main(int argc, char * argv[]) -> int
                 "Run edge-finding on every posted Cumulative, alongside time-tabling and the overload "  //
                 "check. Certified, but off by default: the sweep that finds the firings is cubic",       //
                 cxxopts::value<bool>()->default_value("false"))                                          //
+            ("cumulative-time-table-edge-finding",                                                       //
+                "Strengthen edge-finding with the mandatory-part load of the tasks the window does not " //
+                "contain (TTEF). Implies --cumulative-edge-finding. Not certified yet, so a run with "   //
+                "--prove will refuse it",                                                                //
+                cxxopts::value<bool>()->default_value("false"))                                          //
             ("mutate-makespan-bound",                                                                    //
                 "Claim a makespan one larger than the inferred constraints' energy supports. For "       //
                 "validating the bound only: VeriPB must reject the resulting proof, and a run that "     //
@@ -625,7 +630,8 @@ auto main(int argc, char * argv[]) -> int
     }
 
     auto cumulative_rules = CumulativeRules{};
-    cumulative_rules.edge_finding = options_vars["cumulative-edge-finding"].as<bool>();
+    cumulative_rules.time_table_edge_finding = options_vars["cumulative-time-table-edge-finding"].as<bool>();
+    cumulative_rules.edge_finding = options_vars["cumulative-edge-finding"].as<bool>() || cumulative_rules.time_table_edge_finding;
 
     vector<IntegerVariableID> machine_order_vars;
     if (machine_variant == "difference" && machine_starts.size() >= 2)

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -277,6 +277,7 @@ if(GCS_BUILD_TESTS)
     add_executable(cumulative_test constraints/cumulative/cumulative_test.cc)
     add_executable(cumulative_overload_test constraints/cumulative/cumulative_overload_test.cc)
     add_executable(cumulative_edge_finding_test constraints/cumulative/cumulative_edge_finding_test.cc)
+    add_executable(cumulative_ttef_test constraints/cumulative/cumulative_ttef_test.cc)
     add_executable(derived_cumulative_test constraints/cumulative/derived_cumulative_test.cc)
     add_executable(cumulative_optional_test constraints/cumulative/cumulative_optional_test.cc)
     add_executable(difference_test constraints/difference/difference_constraints_test.cc)
@@ -330,7 +331,7 @@ if(GCS_BUILD_TESTS)
 
     foreach(test_target
             abs_test all_different_test all_different_except_test all_equal_test among_test at_most_one_test bin_packing_test comparison_test
-            count_test cumulative_test cumulative_overload_test cumulative_edge_finding_test cumulative_optional_test derived_cumulative_test difference_test disjunctive_test disjunctive_optional_test disjunctive_overload_test disjunctive_precedences_test disjunctive_2d_test divide_modulus_test element_test equals_test bounds_global_cardinality_test gac_global_cardinality_test in_test increasing_test inverse_test knapsack_test knapsack_upfront_test lex_test linear_test linear_constant_test
+            count_test cumulative_test cumulative_overload_test cumulative_edge_finding_test cumulative_ttef_test cumulative_optional_test derived_cumulative_test difference_test disjunctive_test disjunctive_optional_test disjunctive_overload_test disjunctive_precedences_test disjunctive_2d_test divide_modulus_test element_test equals_test bounds_global_cardinality_test gac_global_cardinality_test in_test increasing_test inverse_test knapsack_test knapsack_upfront_test lex_test linear_test linear_constant_test
             logical_test mdd_test min_distance_test min_distance_matching_test min_max_test mini_linear_test multiply_test n_value_test nogoods_test parity_test
             plus_minus_test power_test product_bounds_test product_justify_test regular_test regular_bacchus_test regular_legacy_test seq_precede_chain_test smart_table_test sort_test arg_sort_test symmetric_all_different_test
             negative_table_test table_test tabulation_test value_precede_test)
@@ -358,6 +359,12 @@ if(GCS_BUILD_TESTS)
         add_test(NAME cumulative_edge_finding_mutation_${mutation}
             COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_expect_verify_failure.bash
                 --basename cumulative_edge_finding_mutation_${mutation} $<TARGET_FILE:cumulative_edge_finding_test> --mutate=${mutation})
+    endforeach()
+    add_test(NAME cumulative_ttef COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_ttef_test>)
+    foreach(mutation pins pin drop toofar mirror_pins mirror_pin mirror_toofar)
+        add_test(NAME cumulative_ttef_mutation_${mutation}
+            COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_expect_verify_failure.bash
+                --basename cumulative_ttef_mutation_${mutation} $<TARGET_FILE:cumulative_ttef_test> --mutate=${mutation})
     endforeach()
     add_test(NAME derived_cumulative COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:derived_cumulative_test>)
     # Mutation lanes: each writes a deliberately corrupted proof of the

--- a/gcs/constraints/cumulative/cumulative.cc
+++ b/gcs/constraints/cumulative/cumulative.cc
@@ -313,6 +313,12 @@ auto gcs::innards::prepare_cumulative_overload_check(const vector<IntegerVariabl
 
 auto Cumulative::define_proof_model(ProofModel & model, const State &) -> void
 {
+    // The rule is measured before it is certified, and a propagator that
+    // infers what it cannot justify is worse than one that declines: refuse
+    // here rather than emit a proof VeriPB will reject.
+    if (_rules.time_table_edge_finding)
+        throw UnimplementedException{"time-table extended edge-finding is not yet certified"};
+
     // Time-table OPB encoding:
     //   for each task i and each time point t in its possible-active range:
     //     before_{i,t}  ⇔  starts[i] ≤ t
@@ -1044,6 +1050,14 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
                 auto width = slots_within(a, b);
                 auto supply = capacity * width;
 
+                // The mandatory-part load of the tasks that are *not* contained
+                // in the window: what (TTOC) adds to the overload check below,
+                // and what TTEF adds to edge-finding. A contained task's
+                // mandatory part lies inside the window too, so taking I(a, b)'s
+                // off the window's total leaves exactly the rest.
+                auto window_profile = profile_within(a, b) - inside_mandatory;
+                auto ef_profile = rules.time_table_edge_finding ? window_profile : 0_i;
+
                 // Edge-finding. A task j that starts inside [a, b) but is not
                 // contained in it can be pushed when the window has no room
                 // left: if everything contained plus the whole of j cannot fit,
@@ -1064,14 +1078,20 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
                 // Which is why the fire condition below is the certificate's
                 // own inequality and not the textbook detection alone --- what
                 // the propagator asks is exactly what the proof will say.
-                // `energy <= supply` because a window the contained tasks
-                // already overflow is a conflict, not a push: the overload
-                // check below owns it, and edge-finding's arithmetic there
-                // yields a `rest` big enough to put new_lb past the window
-                // entirely, where the pushed task's clipped energy is zero and
-                // there is nothing to certify with.
-                if (rules.edge_finding && ! inside_tasks.empty() && energy <= supply && energy > (capacity - tallest) * width &&
-                    energy + heaviest > supply) {
+                // `energy + ef_profile <= supply` because a window that already
+                // overflows is a conflict, not a push: the overload check below
+                // owns it, and edge-finding's arithmetic there yields a `rest`
+                // big enough to put new_lb past the window entirely, where the
+                // pushed task's clipped energy is zero and there is nothing to
+                // certify with. (Which is why TTEF wants profile_overload on:
+                // with it off, a window only the profile overloads is skipped
+                // here and refuted nowhere. Sound, just weaker.)
+                //
+                // All three tests are profile-inclusive, so they stay necessary
+                // conditions for a firing once j's own mandatory load comes
+                // back out below.
+                if (rules.edge_finding && ! inside_tasks.empty() && energy + ef_profile <= supply &&
+                    energy + ef_profile > (capacity - tallest) * width && energy + ef_profile + heaviest > supply) {
                     // One pass for both directions. They share everything up to
                     // the last test --- the same candidates in the same order,
                     // the same `rest`, the same detection --- and differ only in
@@ -1082,10 +1102,12 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
                         const auto & j = candidates[j_idx];
 
                         // Heights descend, so once one task's `rest` has gone
-                        // non-positive every shorter one's has too.
+                        // non-positive every shorter one's has too. Test the
+                        // profile-inclusive figure here: taking j's own
+                        // mandatory load back out below only lowers `rest`, so
+                        // the early exit stays valid.
                         auto h_j = j.height;
-                        auto rest = energy - (capacity - h_j) * width;
-                        if (rest <= 0_i)
+                        if (energy + ef_profile - (capacity - h_j) * width <= 0_i)
                             break;
 
                         // A task with one end inside the window and one outside.
@@ -1099,11 +1121,24 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
 
                         auto p_j = j.length;
 
-                        // Detection: the contained tasks together with the whole
-                        // of j do not fit. Without it the push can land where
-                        // j's clipped energy is only p_j, which is too little to
-                        // refute.
-                        if (energy + h_j * p_j <= supply)
+                        // j is not contained, so whatever of its own mandatory
+                        // part falls inside the window is in ef_profile --- and
+                        // the clipped energy below covers those same times. Each
+                        // time point has one capacity line to cancel against, so
+                        // counting j twice would leave the pol open. Take it back
+                        // out. lst_j = lct_j − p_j and eet_j = est_j + p_j, which
+                        // is what mand_load was built from.
+                        auto mandatory_inside = rules.time_table_edge_finding ? h_j * max(0_i, min(j.est + p_j, b) - max(j.lct - p_j, a)) : 0_i;
+                        auto other_energy = energy + ef_profile - mandatory_inside;
+                        auto rest = other_energy - (capacity - h_j) * width;
+                        if (rest <= 0_i)
+                            continue;
+
+                        // Detection: everything else in the window together with
+                        // the whole of j does not fit. Without it the push can
+                        // land where j's clipped energy is only p_j, which is too
+                        // little to refute.
+                        if (other_energy + h_j * p_j <= supply)
                             continue;
 
                         // Against the live bound, not the snapshot this sweep
@@ -1129,7 +1164,7 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
 
                         auto clipped = window_energy::window_energy_bound(
                             p_j, per_task_t_lo[j.task], active_flag_count(j.task), a, b, pair{low_guard, high_guard - 1_i});
-                        if (clipped <= 0_i || energy + h_j * clipped <= supply)
+                        if (clipped <= 0_i || other_energy + h_j * clipped <= supply)
                             continue;
 
                         auto one_too_far = std::holds_alternative<cumulative_proof_mutation::PushOneTooFar>(mutation);
@@ -1146,7 +1181,7 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
                     }
                 }
 
-                auto outside_profile = rules.profile_overload ? profile_within(a, b) - inside_mandatory : 0_i;
+                auto outside_profile = rules.profile_overload ? window_profile : 0_i;
                 if (energy + outside_profile <= supply)
                     continue;
 

--- a/gcs/constraints/cumulative/cumulative.cc
+++ b/gcs/constraints/cumulative/cumulative.cc
@@ -313,11 +313,10 @@ auto gcs::innards::prepare_cumulative_overload_check(const vector<IntegerVariabl
 
 auto Cumulative::define_proof_model(ProofModel & model, const State &) -> void
 {
-    // The rules are measured before they are certified, and a propagator that
-    // infers what it cannot justify is worse than one that declines: refuse
-    // here rather than emit a proof VeriPB will reject.
-    if (_rules.time_table_edge_finding || _rules.energetic_edge_finding)
-        throw UnimplementedException{"the strengthened forms of edge-finding are not yet certified"};
+    // A propagator that infers what it cannot justify is worse than one that
+    // declines: refuse here rather than emit a proof VeriPB will reject.
+    if (_rules.energetic_edge_finding)
+        throw UnimplementedException{"energetic edge-finding is not yet certified"};
 
     // Time-table OPB encoding:
     //   for each task i and each time point t in its possible-active range:
@@ -811,6 +810,42 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
                 cite(i, clipped_window_start(i, a), clipped_window_end(i, b) - llb(i) + 1_i, true, true);
             }
 
+            // TTEF: the tasks the window does not contain still put their
+            // mandatory-part load into it, and that load is pinned exactly the
+            // way the overload check's (TTOC) strengthening pins it. A task
+            // whose energy row is already in the pol must not be pinned as well
+            // --- the capacity lines supply each time point once, so a second
+            // claim on the same activity would leave the pol open.
+            //
+            // The bounds read here are the live ones rather than the mand_load
+            // snapshot the sweep was set up from. A mandatory part only grows as
+            // the sweep pushes bounds around, so the pins claim at least what
+            // the firing's arithmetic counted, and a pol carrying more energy
+            // than it needs closes just the same.
+            if (rules.time_table_edge_finding) {
+                vector<bool> contained(starts.size(), false);
+                for (auto i : inside_tasks)
+                    contained[i] = true;
+                auto skip_pin = std::holds_alternative<cumulative_proof_mutation::DropProfilePin>(mutation);
+                auto skip_all_pins = std::holds_alternative<cumulative_proof_mutation::DropProfilePins>(mutation);
+                for (auto i : active_tasks) {
+                    if (i == pushed || contained[i] || ! is_present(i))
+                        continue;
+                    auto lst = state.upper_bound(starts[i]);
+                    auto eet = state.lower_bound(starts[i]) + llb(i);
+                    for (Integer t = max(lst, a); t < min(eet, b); ++t) {
+                        if (skip_all_pins)
+                            continue;
+                        if (skip_pin) {
+                            skip_pin = false;
+                            continue;
+                        }
+                        auto [line, coeff] = pin_contributor(reason, i, t);
+                        pol.add(line, coeff);
+                    }
+                }
+            }
+
             // No mutation lane for citing the pushed task's row at the
             // threshold a *contained* task would use, i.e. for forgetting to
             // clip. That was tried, and it verifies: the un-clipped row claims
@@ -1063,6 +1098,7 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
                 // lemma a certificate would cite, and it is at least the task's
                 // mandatory part in the window --- and for a contained task it
                 // is the whole of its energy.
+                //
                 // A task the window cannot reach has a *negative* bound here,
                 // the lemma's way of saying it has more slack than the window
                 // has room, so clamp before summing.

--- a/gcs/constraints/cumulative/cumulative.cc
+++ b/gcs/constraints/cumulative/cumulative.cc
@@ -313,11 +313,11 @@ auto gcs::innards::prepare_cumulative_overload_check(const vector<IntegerVariabl
 
 auto Cumulative::define_proof_model(ProofModel & model, const State &) -> void
 {
-    // The rule is measured before it is certified, and a propagator that
+    // The rules are measured before they are certified, and a propagator that
     // infers what it cannot justify is worse than one that declines: refuse
     // here rather than emit a proof VeriPB will reject.
-    if (_rules.time_table_edge_finding)
-        throw UnimplementedException{"time-table extended edge-finding is not yet certified"};
+    if (_rules.time_table_edge_finding || _rules.energetic_edge_finding)
+        throw UnimplementedException{"the strengthened forms of edge-finding are not yet certified"};
 
     // Time-table OPB encoding:
     //   for each task i and each time point t in its possible-active range:
@@ -1056,7 +1056,38 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
                 // mandatory part lies inside the window too, so taking I(a, b)'s
                 // off the window's total leaves exactly the rest.
                 auto window_profile = profile_within(a, b) - inside_mandatory;
-                auto ef_profile = rules.time_table_edge_finding ? window_profile : 0_i;
+
+                // A task's *guaranteed* energy inside the window: the least
+                // overlap its execution interval can have with [a, b) over the
+                // starts its bounds still allow. This is one call of the very
+                // lemma a certificate would cite, and it is at least the task's
+                // mandatory part in the window --- and for a contained task it
+                // is the whole of its energy.
+                // A task the window cannot reach has a *negative* bound here,
+                // the lemma's way of saying it has more slack than the window
+                // has room, so clamp before summing.
+                auto guaranteed = [&](const Candidate & c2) {
+                    return c2.height *
+                        max(0_i,
+                            window_energy::window_energy_bound(
+                                c2.length, per_task_t_lo[c2.task], active_flag_count(c2.task), a, b, pair{c2.est, c2.lct - c2.length}));
+                };
+
+                // What the window is charged with, before the task being pushed
+                // is taken back out of it:
+                //
+                //   edge-finding  the contained tasks' whole energy
+                //   TTEF          plus the mandatory-part load of the rest
+                //   energetic     every task's guaranteed energy, which
+                //                 subsumes both
+                Integer window_total = energy;
+                if (rules.energetic_edge_finding) {
+                    window_total = 0_i;
+                    for (const auto & c2 : candidates)
+                        window_total += guaranteed(c2);
+                }
+                else if (rules.time_table_edge_finding)
+                    window_total = energy + window_profile;
 
                 // Edge-finding. A task j that starts inside [a, b) but is not
                 // contained in it can be pushed when the window has no room
@@ -1078,20 +1109,21 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
                 // Which is why the fire condition below is the certificate's
                 // own inequality and not the textbook detection alone --- what
                 // the propagator asks is exactly what the proof will say.
-                // `energy + ef_profile <= supply` because a window that already
+                // `window_total <= supply` because a window that already
                 // overflows is a conflict, not a push: the overload check below
                 // owns it, and edge-finding's arithmetic there yields a `rest`
                 // big enough to put new_lb past the window entirely, where the
                 // pushed task's clipped energy is zero and there is nothing to
-                // certify with. (Which is why TTEF wants profile_overload on:
-                // with it off, a window only the profile overloads is skipped
-                // here and refuted nowhere. Sound, just weaker.)
+                // certify with. (Which is why the strengthened forms want
+                // profile_overload on: with it off, a window only the extra
+                // energy overloads is skipped here and refuted nowhere. Sound,
+                // just weaker.)
                 //
-                // All three tests are profile-inclusive, so they stay necessary
-                // conditions for a firing once j's own mandatory load comes
-                // back out below.
-                if (rules.edge_finding && ! inside_tasks.empty() && energy + ef_profile <= supply &&
-                    energy + ef_profile > (capacity - tallest) * width && energy + ef_profile + heaviest > supply) {
+                // All three tests charge the window in full, so they stay
+                // necessary conditions for a firing once the pushed task's own
+                // contribution comes back out below.
+                if (rules.edge_finding && ! inside_tasks.empty() && window_total <= supply && window_total > (capacity - tallest) * width &&
+                    window_total + heaviest > supply) {
                     // One pass for both directions. They share everything up to
                     // the last test --- the same candidates in the same order,
                     // the same `rest`, the same detection --- and differ only in
@@ -1103,11 +1135,11 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
 
                         // Heights descend, so once one task's `rest` has gone
                         // non-positive every shorter one's has too. Test the
-                        // profile-inclusive figure here: taking j's own
-                        // mandatory load back out below only lowers `rest`, so
-                        // the early exit stays valid.
+                        // figure that charges the window in full here: taking
+                        // j's own contribution back out below only lowers
+                        // `rest`, so the early exit stays valid.
                         auto h_j = j.height;
-                        if (energy + ef_profile - (capacity - h_j) * width <= 0_i)
+                        if (window_total - (capacity - h_j) * width <= 0_i)
                             break;
 
                         // A task with one end inside the window and one outside.
@@ -1121,15 +1153,18 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
 
                         auto p_j = j.length;
 
-                        // j is not contained, so whatever of its own mandatory
-                        // part falls inside the window is in ef_profile --- and
-                        // the clipped energy below covers those same times. Each
-                        // time point has one capacity line to cancel against, so
-                        // counting j twice would leave the pol open. Take it back
-                        // out. lst_j = lct_j − p_j and eet_j = est_j + p_j, which
-                        // is what mand_load was built from.
-                        auto mandatory_inside = rules.time_table_edge_finding ? h_j * max(0_i, min(j.est + p_j, b) - max(j.lct - p_j, a)) : 0_i;
-                        auto other_energy = energy + ef_profile - mandatory_inside;
+                        // j is not contained, so whatever of it the window has
+                        // already been charged with covers the same time points
+                        // as the clipped energy added below under the negated
+                        // conclusion. Each time point has one capacity line to
+                        // cancel against, so counting j twice would leave the
+                        // pol open: take it back out. lst_j = lct_j − p_j and
+                        // eet_j = est_j + p_j, which is what mand_load was built
+                        // from.
+                        auto own = rules.energetic_edge_finding ? guaranteed(j)
+                            : rules.time_table_edge_finding     ? h_j * max(0_i, min(j.est + p_j, b) - max(j.lct - p_j, a))
+                                                                : 0_i;
+                        auto other_energy = window_total - own;
                         auto rest = other_energy - (capacity - h_j) * width;
                         if (rest <= 0_i)
                             continue;

--- a/gcs/constraints/cumulative/cumulative.hh
+++ b/gcs/constraints/cumulative/cumulative.hh
@@ -66,6 +66,24 @@ namespace gcs
         /// \warning Not yet certified. A propagator with this set refuses to
         /// run against a proof logger.
         bool time_table_edge_finding = false;
+
+        /// Count every task's *guaranteed* energy inside the window --- the
+        /// least overlap its execution interval can have with the window, over
+        /// the start positions its bounds still allow --- rather than a
+        /// contained task's whole energy plus a non-contained one's mandatory
+        /// part. This subsumes \ref time_table_edge_finding: a contained task's
+        /// guaranteed energy is its whole energy, and a non-contained one's is
+        /// at least its mandatory part in the window, and usually more. It is
+        /// also exactly what the window-energy lemma derives, so unlike the
+        /// mandatory-part form it needs no per-(task, time) pins.
+        ///
+        /// Only tasks eligible for the overload check contribute, since the
+        /// lemma wants a constant length and height. Takes precedence over
+        /// \ref time_table_edge_finding when both are set.
+        ///
+        /// \warning Not yet certified. A propagator with this set refuses to
+        /// run against a proof logger.
+        bool energetic_edge_finding = false;
     };
 
     /**

--- a/gcs/constraints/cumulative/cumulative.hh
+++ b/gcs/constraints/cumulative/cumulative.hh
@@ -55,6 +55,17 @@ namespace gcs
         /// anything fires (#742); the inferences themselves cost nothing
         /// measurable.
         bool edge_finding = false;
+
+        /// Strengthen edge-finding with the mandatory-part load of the tasks
+        /// that are *not* fully contained in the window, exactly as \ref
+        /// profile_overload does for the overload check: time-table extended
+        /// edge-finding (TTEF). Has no effect unless \ref edge_finding is also
+        /// set, and wants \ref profile_overload set alongside it, since a
+        /// window the profile already overloads is left to the overload check.
+        ///
+        /// \warning Not yet certified. A propagator with this set refuses to
+        /// run against a proof logger.
+        bool time_table_edge_finding = false;
     };
 
     /**

--- a/gcs/constraints/cumulative/cumulative_ttef_test.cc
+++ b/gcs/constraints/cumulative/cumulative_ttef_test.cc
@@ -1,0 +1,436 @@
+#include <gcs/constraints/cumulative.hh>
+#include <gcs/constraints/innards/constraints_test_utils.hh>
+#include <gcs/problem.hh>
+#include <gcs/solve.hh>
+
+#include <algorithm>
+#include <climits>
+#include <cstdlib>
+#include <iostream>
+#include <optional>
+#include <random>
+#include <set>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+#include <version>
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+#include <print>
+#else
+#include <fmt/core.h>
+#include <fmt/ostream.h>
+#include <fmt/ranges.h>
+#endif
+
+using std::cerr;
+using std::flush;
+using std::make_optional;
+using std::max;
+using std::min;
+using std::nullopt;
+using std::optional;
+using std::pair;
+using std::set;
+using std::string;
+using std::tuple;
+using std::vector;
+using std::ranges::any_of;
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+using std::print;
+using std::println;
+#else
+using fmt::print;
+using fmt::println;
+#endif
+
+using namespace gcs;
+using namespace gcs::innards;
+using namespace gcs::test_innards;
+
+namespace
+{
+    struct Instance
+    {
+        vector<pair<int, int>> start_ranges;
+        vector<int> lengths;
+        vector<int> heights;
+        int capacity;
+    };
+
+    auto is_satisfying(const Instance & inst, const vector<int> & starts) -> bool
+    {
+        auto n = inst.start_ranges.size();
+        int t_lo = INT_MAX, t_hi = INT_MIN;
+        for (size_t i = 0; i < n; ++i) {
+            t_lo = min(t_lo, starts[i]);
+            t_hi = max(t_hi, starts[i] + inst.lengths[i] - 1);
+        }
+        for (int t = t_lo; t <= t_hi; ++t) {
+            int load = 0;
+            for (size_t i = 0; i < n; ++i)
+                if (starts[i] <= t && t < starts[i] + inst.lengths[i])
+                    load += inst.heights[i];
+            if (load > inst.capacity)
+                return false;
+        }
+        return true;
+    }
+
+    auto post(Problem & p, const Instance & inst, CumulativeRules rules, CumulativeProofMutation mutation = cumulative_proof_mutation::None{})
+        -> vector<IntegerVariableID>
+    {
+        vector<IntegerVariableID> starts;
+        vector<Integer> lengths, heights;
+        for (size_t i = 0; i < inst.start_ranges.size(); ++i) {
+            starts.push_back(
+                p.create_integer_variable(Integer{inst.start_ranges[i].first}, Integer{inst.start_ranges[i].second}, "start" + std::to_string(i)));
+            lengths.push_back(Integer{inst.lengths[i]});
+            heights.push_back(Integer{inst.heights[i]});
+        }
+        p.post(Cumulative{starts, lengths, heights, Integer{inst.capacity}}.with_rules(rules).with_proof_mutation(mutation));
+        return starts;
+    }
+
+    /// The bounds each start is left with once root propagation has run. TTEF
+    /// moves bounds rather than reporting conflicts, so this is where it has to
+    /// be measured: an enumeration test alone cannot tell whether it fired.
+    auto root_bounds(const Instance & inst, CumulativeRules rules, CumulativeProofMutation mutation, const optional<string> & proof_name)
+        -> optional<vector<pair<int, int>>>
+    {
+        Problem p;
+        auto starts = post(p, inst, rules, mutation);
+
+        optional<vector<pair<int, int>>> bounds;
+        solve_with(p,
+            SolveCallbacks{.solution = [&](const CurrentState & s) -> bool {
+                               if (! bounds) {
+                                   bounds.emplace();
+                                   for (const auto & v : starts)
+                                       bounds->emplace_back(static_cast<int>(s(v).raw_value), static_cast<int>(s(v).raw_value));
+                               }
+                               return false;
+                           },
+                .trace = [&](const CurrentState & s) -> bool {
+                    if (! bounds) {
+                        bounds.emplace();
+                        for (const auto & v : starts)
+                            bounds->emplace_back(static_cast<int>(s.lower_bound(v).raw_value), static_cast<int>(s.upper_bound(v).raw_value));
+                    }
+                    return false;
+                }},
+            proof_name ? make_optional<ProofOptions>(ProofFileNames{*proof_name}) : nullopt);
+        return bounds;
+    }
+
+    auto fail(const string & message) -> void
+    {
+        println(cerr, "cumulative ttef: {}", message);
+        exit(EXIT_FAILURE);
+    }
+
+    /// "starts lo:hi,... / lengths / heights / capacity", so that a fixture
+    /// found by --search can be handed straight back in.
+    auto parse_instance(const string & spec) -> Instance
+    {
+        vector<string> parts;
+        for (size_t at = 0, next; at <= spec.size(); at = next + 1) {
+            next = spec.find('/', at);
+            if (next == string::npos)
+                next = spec.size();
+            parts.push_back(spec.substr(at, next - at));
+            if (next == spec.size())
+                break;
+        }
+        if (parts.size() != 4)
+            fail("instance spec wants four /-separated parts, got " + std::to_string(parts.size()));
+
+        auto split = [](const string & s) {
+            vector<string> out;
+            for (size_t at = 0, next; at <= s.size(); at = next + 1) {
+                next = s.find(',', at);
+                if (next == string::npos)
+                    next = s.size();
+                out.push_back(s.substr(at, next - at));
+                if (next == s.size())
+                    break;
+            }
+            return out;
+        };
+
+        Instance inst{{}, {}, {}, std::stoi(parts[3])};
+        for (const auto & r : split(parts[0])) {
+            auto colon = r.find(':');
+            inst.start_ranges.emplace_back(std::stoi(r.substr(0, colon)), std::stoi(r.substr(colon + 1)));
+        }
+        for (const auto & l : split(parts[1]))
+            inst.lengths.push_back(std::stoi(l));
+        for (const auto & h : split(parts[2]))
+            inst.heights.push_back(std::stoi(h));
+        return inst;
+    }
+
+    auto show_instance(const Instance & inst) -> string
+    {
+        string out;
+        for (size_t i = 0; i < inst.start_ranges.size(); ++i)
+            out += (i ? "," : "") + std::to_string(inst.start_ranges[i].first) + ":" + std::to_string(inst.start_ranges[i].second);
+        out += "/";
+        for (size_t i = 0; i < inst.lengths.size(); ++i)
+            out += (i ? "," : "") + std::to_string(inst.lengths[i]);
+        out += "/";
+        for (size_t i = 0; i < inst.heights.size(); ++i)
+            out += (i ? "," : "") + std::to_string(inst.heights[i]);
+        return out + "/" + std::to_string(inst.capacity);
+    }
+
+    /// A fixture is only a test of the *claim* if the claim is tight: a push to
+    /// v that a solution with the pushed task at v−1 would refute. Where the
+    /// push is merely valid, "one too far" is valid too, and VeriPB verifies the
+    /// corrupted proof --- which is a fact about the fixture, not about the
+    /// rule. So: TTEF must move a bound edge-finding does not, and some solution
+    /// must sit exactly on the bound it moves to.
+    auto search_for_fixture(const CumulativeRules & ef, const CumulativeRules & ttef, unsigned long long seed_from, unsigned long long candidates)
+        -> void
+    {
+        std::mt19937 rand(static_cast<unsigned>(seed_from));
+        for (unsigned long long attempt = 0; attempt < candidates; ++attempt) {
+            auto n = 3 + static_cast<size_t>(rand() % 3);
+            auto capacity = 2 + static_cast<int>(rand() % 3);
+            Instance inst{{}, {}, {}, capacity};
+            for (size_t i = 0; i < n; ++i) {
+                auto len = 1 + static_cast<int>(rand() % 5);
+                auto lo = static_cast<int>(rand() % 6);
+                auto slack = static_cast<int>(rand() % 7);
+                inst.start_ranges.emplace_back(lo, lo + slack);
+                inst.lengths.push_back(len);
+                inst.heights.push_back(1 + static_cast<int>(rand() % capacity));
+            }
+
+            auto without = root_bounds(inst, ef, cumulative_proof_mutation::None{}, nullopt);
+            auto with = root_bounds(inst, ttef, cumulative_proof_mutation::None{}, nullopt);
+            if (! without || ! with)
+                continue;
+
+            set<vector<int>> solutions;
+            build_expected(solutions, [&](const vector<int> & starts) { return is_satisfying(inst, starts); }, inst.start_ranges);
+            if (solutions.empty())
+                continue;
+
+            for (size_t i = 0; i < n; ++i) {
+                auto raises = (*with)[i].first > (*without)[i].first;
+                auto lowers = (*with)[i].second < (*without)[i].second;
+                if (! raises && ! lowers)
+                    continue;
+                auto landed = raises ? (*with)[i].first : (*with)[i].second;
+                auto tight = any_of(solutions, [&](const vector<int> & s) { return s[i] == landed; });
+                if (! tight)
+                    continue;
+                println(cerr, "candidate {} task {} {} -> {} tight, {} solutions", show_instance(inst), i, raises ? "lb" : "ub", landed,
+                    solutions.size());
+                break;
+            }
+        }
+    }
+
+    /// Every rule setting must find exactly the same solutions: TTEF is a
+    /// propagation strength, not a change of constraint. This is the net for an
+    /// over-firing push, which removes solutions.
+    auto check_enumeration(const string & what, const Instance & inst, CumulativeRules rules, const optional<string> & proof_name) -> void
+    {
+        print(cerr, "cumulative ttef {} starts={} lens={} hts={} c={}{}", what, inst.start_ranges, inst.lengths, inst.heights, inst.capacity,
+            proof_name ? " with proofs:" : ":");
+        cerr << flush;
+
+        set<vector<int>> expected, actual;
+        build_expected(expected, [&](const vector<int> & starts) { return is_satisfying(inst, starts); }, inst.start_ranges);
+        println(cerr, " expecting {} solutions", expected.size());
+
+        Problem p;
+        auto starts = post(p, inst, rules);
+        solve_for_tests(p, proof_name, actual, tuple{starts});
+        check_results(proof_name, expected, actual);
+    }
+}
+
+auto main(int argc, char * argv[]) -> int
+{
+    establish_and_announce_seed(argc, argv);
+
+    const CumulativeRules ef{.time_table = true, .overload = true, .profile_overload = true, .edge_finding = true};
+    const CumulativeRules ttef{.time_table = true, .overload = true, .profile_overload = true, .edge_finding = true, .time_table_edge_finding = true};
+
+    auto proofs = can_run_veripb();
+
+    // The fixture, and what it takes to be one. Over [0, 8) at capacity two:
+    //
+    //   * two contained tasks of length four, each with slack enough that its
+    //     mandatory part is EMPTY, so they carry energy but raise no profile;
+    //   * a task whose mandatory part [3, 8) lies inside the window but which
+    //     is not contained by it, so only the profile term counts it;
+    //   * the task to push, which starts inside the window and runs past it.
+    //
+    // 8 units of contained energy against a supply of 16 leaves edge-finding
+    // nothing to say: a length-four unit-height task fits. Add the 5 units of
+    // profile and the window holds only 3 more, so the pushed task cannot start
+    // before 5. The profile is under capacity everywhere, so time-tabling sees
+    // nothing either, and the push is TTEF's alone.
+    const Instance profile_push{{{0, 4}, {0, 4}, {2, 3}, {0, 12}}, {4, 4, 6, 4}, {1, 1, 1, 1}, 2};
+
+    // The same instance reflected about t = 16, so the window is [8, 16) and
+    // the pushed task ENDS inside it but starts before: its upper bound falls
+    // to 7 rather than its lower bound rising to 5. Same energy, same profile,
+    // and the negated conclusion lands on the guarded row's low guard instead
+    // of its high one.
+    const Instance profile_push_mirror{{{8, 12}, {8, 12}, {7, 8}, {0, 12}}, {4, 4, 6, 4}, {1, 1, 1, 1}, 2};
+
+    // The fixture that best *demonstrates* the rule is not the one that makes a
+    // mutation bite, and neither of the two above makes any of them bite. Two
+    // things have to hold at once, and hand-picking gets at most one:
+    //
+    //   * the push must be TIGHT --- some solution must sit exactly on the
+    //     bound it lands on. Where the push is merely valid, "one too far" is
+    //     valid too and VeriPB verifies the corrupted proof, which is a fact
+    //     about the fixture rather than about the rule;
+    //   * the pins must be LOAD-BEARING. They usually are not: the pol leaves
+    //     the non-contained tasks' activity terms uncancelled, unit propagation
+    //     assigns them from the reason's own bound literals, and the wrapping
+    //     RUP closes without them. Dropping every pin is rejected on 13 of 248
+    //     searched instances; dropping one, on fewer still.
+    //
+    // Both were found by --search, which generates random instances and keeps
+    // the ones where TTEF moves a bound edge-finding does not and a solution
+    // sits on it, followed by vetting each candidate against every mutation
+    // with an honest control. --describe prints the numbers written down here.
+    //
+    // Task 2's lower bound moves 5 -> 6, over 30 solutions.
+    const Instance sharp{{{0, 3}, {5, 6}, {5, 7}, {2, 4}}, {3, 1, 3, 5}, {1, 1, 1, 2}, 3};
+
+    // And its mirror, where task 0's upper bound falls 5 -> 4 over 28
+    // solutions, so the negated conclusion lands on the low guard instead.
+    const Instance sharp_mirror{{{1, 5}, {2, 5}, {5, 6}}, {2, 5, 1}, {3, 1, 1}, 4};
+
+    // Describe one instance: what edge-finding leaves, what TTEF leaves, and
+    // whether the bound it moves to is one a solution sits on. This is how a
+    // fixture found by --search gets turned into the numbers written down
+    // beside it below.
+    for (int a = 1; a < argc; ++a)
+        if (string{argv[a]}.starts_with("--describe=")) {
+            string arg = argv[a];
+            auto inst = parse_instance(arg.substr(arg.find('=') + 1));
+            auto without = root_bounds(inst, ef, cumulative_proof_mutation::None{}, nullopt);
+            auto with = root_bounds(inst, ttef, cumulative_proof_mutation::None{}, nullopt);
+            if (! without || ! with)
+                fail("describe: nothing was reached at the root");
+            set<vector<int>> solutions;
+            build_expected(solutions, [&](const vector<int> & starts) { return is_satisfying(inst, starts); }, inst.start_ranges);
+            println(cerr, "{} solutions {}", show_instance(inst), solutions.size());
+            for (size_t i = 0; i < inst.start_ranges.size(); ++i) {
+                auto tight = [&](int v) { return any_of(solutions, [&](const vector<int> & s) { return s[i] == v; }); };
+                println(cerr, "  task {}: ef [{}, {}] ttef [{}, {}]{}{}", i, (*without)[i].first, (*without)[i].second, (*with)[i].first,
+                    (*with)[i].second, (*with)[i].first > (*without)[i].first ? " lb MOVED" : "",
+                    (*with)[i].second < (*without)[i].second ? " ub MOVED" : "");
+                println(cerr, "           lb tight {} ub tight {}", tight((*with)[i].first), tight((*with)[i].second));
+            }
+            return EXIT_SUCCESS;
+        }
+
+    // Fixture search: print instances on which TTEF moves a bound
+    // edge-finding does not, and moves it somewhere a solution actually sits.
+    for (int a = 1; a < argc; ++a)
+        if (string{argv[a]} == "--search") {
+            unsigned long long from = 1, count = 2000;
+            auto number = [&](int at) { return at < argc && argv[at][0] >= '0' && argv[at][0] <= '9'; };
+            if (number(a + 1))
+                from = std::stoull(argv[a + 1]);
+            if (number(a + 2))
+                count = std::stoull(argv[a + 2]);
+            search_for_fixture(ef, ttef, from, count);
+            return EXIT_SUCCESS;
+        }
+
+    // Mutation mode: emit one deliberately corrupted proof and stop, for
+    // run_test_and_expect_verify_failure.bash to hand to veripb.
+    {
+        optional<CumulativeProofMutation> mutation;
+        const Instance * fixture = &sharp;
+        optional<Instance> from_spec;
+        string proof_basename = "cumulative_ttef_mutation";
+        for (int a = 1; a < argc; ++a) {
+            string arg = argv[a];
+            if (arg.starts_with("--instance=")) {
+                from_spec = parse_instance(arg.substr(arg.find('=') + 1));
+                fixture = &*from_spec;
+            }
+            else if (arg == "--mutate=none")
+                mutation = cumulative_proof_mutation::None{};
+            else if (arg == "--mutate=pin")
+                mutation = cumulative_proof_mutation::DropProfilePin{};
+            else if (arg == "--mutate=pins")
+                mutation = cumulative_proof_mutation::DropProfilePins{};
+            else if (arg == "--mutate=drop")
+                mutation = cumulative_proof_mutation::DropContainedTask{};
+            else if (arg == "--mutate=toofar")
+                mutation = cumulative_proof_mutation::PushOneTooFar{};
+            else if (arg == "--mutate=capacity")
+                mutation = cumulative_proof_mutation::OmitCapacityLine{};
+            else if (arg == "--mutate=mirror_pins") {
+                mutation = cumulative_proof_mutation::DropProfilePins{};
+                fixture = &sharp_mirror;
+            }
+            else if (arg == "--mutate=mirror_pin") {
+                mutation = cumulative_proof_mutation::DropProfilePin{};
+                fixture = &sharp_mirror;
+            }
+            else if (arg == "--mutate=mirror_toofar") {
+                mutation = cumulative_proof_mutation::PushOneTooFar{};
+                fixture = &sharp_mirror;
+            }
+            else if (arg == "--proof-files-basename" && a + 1 < argc)
+                proof_basename = argv[++a];
+        }
+
+        if (mutation) {
+            auto bounds = root_bounds(*fixture, ttef, *mutation, make_optional(proof_basename));
+            if (! bounds)
+                fail("mutation mode: nothing was reached, so the proof is empty");
+            println(cerr, "wrote a deliberately corrupted proof to {}.pbp", proof_basename);
+            return EXIT_SUCCESS;
+        }
+    }
+
+    // The rule fires, pushes exactly as far as the energy supports, and does so
+    // where edge-finding on its own does not. `raises` says which bound the
+    // fixture is about, and `task` which task it is about.
+    for (const auto & [name, inst, task, raises, expected] :
+        vector<tuple<string, Instance, size_t, bool, int>>{{"profile_push", profile_push, 3, true, 5},
+            {"profile_push_mirror", profile_push_mirror, 3, false, 7}, {"sharp", sharp, 2, true, 6}, {"sharp_mirror", sharp_mirror, 0, false, 4}}) {
+        auto off = root_bounds(inst, ef, cumulative_proof_mutation::None{}, nullopt);
+        auto on = root_bounds(inst, ttef, cumulative_proof_mutation::None{}, proofs ? make_optional("cumulative_ttef_" + name) : nullopt);
+        if (! off || ! on)
+            fail(name + ": nothing was reached at the root");
+
+        auto pick = [&, task = task, raises = raises](const vector<pair<int, int>> & b) { return raises ? b[task].first : b[task].second; };
+        if (raises ? pick(*off) >= expected : pick(*off) <= expected)
+            fail(name + ": edge-finding alone already reaches the push, so this fixture measures nothing");
+        if (pick(*on) != expected)
+            fail(name + ": expected the pushed task's bound to reach " + std::to_string(expected) + ", got " + std::to_string(pick(*on)));
+        println(cerr, "cumulative ttef {}: task {} {} {} -> {}", name, task, raises ? "lb" : "ub", pick(*off), pick(*on));
+        if (proofs)
+            verify_proof_and_clean_up("cumulative_ttef_" + name);
+    }
+
+    // Soundness, over instances small enough to enumerate: the rule may not
+    // lose a solution, with or without a proof being written.
+    for (const auto & [name, inst] : vector<pair<string, Instance>>{{"profile_push", profile_push}, {"profile_push_mirror", profile_push_mirror},
+             {"sharp", sharp}, {"sharp_mirror", sharp_mirror}, {"tight", Instance{{{0, 3}, {0, 3}, {1, 2}, {0, 5}}, {2, 2, 3, 2}, {1, 1, 1, 1}, 2}},
+             {"mixed_heights", Instance{{{0, 4}, {0, 4}, {1, 2}, {0, 6}}, {3, 2, 4, 2}, {2, 1, 1, 2}, 3}}}) {
+        check_enumeration(name, inst, ttef, nullopt);
+        if (proofs)
+            check_enumeration(name, inst, ttef, make_optional("cumulative_ttef_enum_" + name));
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/gcs/constraints/innards/cumulative_mutations.hh
+++ b/gcs/constraints/innards/cumulative_mutations.hh
@@ -78,11 +78,23 @@ namespace gcs::innards
         struct PushOneTooFar
         {
         };
+
+        /// TTEF: leave the first mandatory (task, time) pin out of the pol, so
+        /// the profile load the push relied on is one unit short.
+        struct DropProfilePin
+        {
+        };
+
+        /// TTEF: leave *every* mandatory (task, time) pin out of the pol, so
+        /// the push is left resting on edge-finding's energy alone.
+        struct DropProfilePins
+        {
+        };
     }
 
-    using CumulativeProofMutation =
-        std::variant<cumulative_proof_mutation::None, cumulative_proof_mutation::OverstateWindowEnergy, cumulative_proof_mutation::OmitCapacityLine,
-            cumulative_proof_mutation::ShrinkLemmaWindow, cumulative_proof_mutation::DropContainedTask, cumulative_proof_mutation::PushOneTooFar>;
+    using CumulativeProofMutation = std::variant<cumulative_proof_mutation::None, cumulative_proof_mutation::OverstateWindowEnergy,
+        cumulative_proof_mutation::OmitCapacityLine, cumulative_proof_mutation::ShrinkLemmaWindow, cumulative_proof_mutation::DropContainedTask,
+        cumulative_proof_mutation::PushOneTooFar, cumulative_proof_mutation::DropProfilePin, cumulative_proof_mutation::DropProfilePins>;
 
     /**
      * \brief Deliberate corruptions of the presence-falsification derivation,


### PR DESCRIPTION
Closes #696. **Stacked on #743** (`cumulative-edge-finding`), which must merge first.

Time-table extended edge-finding is to edge-finding what `(TTOC)` is to the overload check: the tasks a window does not contain still put their mandatory-part load into it, so the window has less room for the task being pushed. `CumulativeRules::time_table_edge_finding`, off by default.

## The answer to what #696 asked

**Nothing new was needed.** The certificate is edge-finding's, unchanged, plus the mandatory `(task, time)` pins that `(TTOC)` already emits for the conflict-only overload check. Same window, same guarded rows, same `pol`. The two halves existed and were certified separately; TTEF is the join of them.

The pins are read from the **live** bounds rather than from the `mand_load` snapshot the sweep was set up from: a mandatory part only grows as the sweep pushes bounds around, so they claim at least what the firing's arithmetic counted, and a `pol` carrying more energy than it needs closes just the same.

## What it buys

175 instances at 60 s (`data_bl`, `data_pack`, `data_la_x`), over the 36 that every arm closed:

| arm | recursions | vs ef | propagations | vs ef |
|---|---|---|---|---|
| no edge-finding | 7,227,100 | 3.062x | 72,057,194 | 2.450x |
| edge-finding | 2,359,885 | 1.000x | 29,411,592 | 1.000x |
| TTEF | 1,768,271 | **0.749x** | 23,452,325 | 0.797x |
| energetic | 1,573,267 | **0.667x** | 21,566,293 | 0.733x |

Fewer recursions on 35 of the 36, more on none, and no arm disagrees about an optimum. `pack021` on its own says −1.5%, which is why it is not quoted as the figure. Do not read wall times from that sweep: the arms differ in per-node cost, and `data_la_x` closes nothing at 60 s in any arm.

What it costs, over `data_bl`: 67.1M firings, **72.6% of them ones edge-finding would not make at all**, carrying 2.93 pins per firing (most 21) against 4.54 contained energy rows — so the pins roughly double a firing's proof lines. They are also **15,037x reused** (13,065 distinct `(task, time)` pairs across 196M citations), so a guarded one-time-point row would amortise them away exactly as the contained rows already are, and would do the same for the merged overload check. Written up as a follow-up rather than done here.

## Two findings, and they are why the test file grew

**The pins are usually not load-bearing.** Without them the `pol` leaves the non-contained tasks' `active` terms uncancelled, unit propagation assigns those from the reason's own bound literals, and the wrapping RUP closes anyway. Dropping *every* pin is rejected on only 13 of 248 searched instances. They are emitted because those 13 exist, not because the common case needs them. The same phenomenon is why `OmitCapacityLine` is accepted on every TTEF fixture searched, and it is not one of the lanes here.

**A push must be tight before "one too far" is a corruption at all.** Where a push is merely valid, one further is valid too, VeriPB verifies the corrupted proof, and that is a fact about the fixture rather than about the rule. Both hand-built fixtures fail that test — three lanes verified when they should have rejected.

So `cumulative_ttef_test` gained `--search` (random instances, keeping those where TTEF moves a bound edge-finding does not *and* a solution sits exactly on it), `--describe` (prints what a candidate does, which is where the numbers written beside each fixture come from) and `--instance=` (run a mutation against a candidate). 13 of 248 candidates made the pins matter; 5 of those made every mutation bite. The two `sharp` fixtures came out of that; the two `profile_push` ones are hand-built and kept only to *explain* the rule.

Seven mutation lanes, all rejected, all on the RUP that follows the `pol`.

## Also here

`CumulativeRules::energetic_edge_finding`, off by default and **refusing a proof logger**: every task's *guaranteed* energy in the window instead of contained-energy-plus-profile. It subsumes TTEF, measures better, and would need no pins at all — it is exactly what `window_energy_bound` computes. It is in the tree to be measured against the literature rule, not to be used; the open question is the cache key, since a non-contained task's guards come from its current bounds rather than from the window.

## Testing

667/667 ctest under GCC with the runtime caps on, and the whole suite again under clang with `GCS_TEST_CAP_DEFAULTS=OFF`. `dev_docs/cumulative-proof-logging.md` has a new section and three new follow-ups.
