### PR TITLE
cumulative: certified not-first / not-last

### DIFF
--- a/dev_docs/cumulative-proof-logging.md
+++ b/dev_docs/cumulative-proof-logging.md
@@ -22,13 +22,13 @@ bounds** — over optional tasks and over variable durations, heights and
 capacities.
 
 Also certified, off by default: **edge-finding**, in both directions, under
-`CumulativeRules::edge_finding`, and **time-table extended edge-finding**
-(TTEF) under `CumulativeRules::time_table_edge_finding`. See the sections below.
+`CumulativeRules::edge_finding`, **time-table extended edge-finding** (TTEF)
+under `CumulativeRules::time_table_edge_finding`, and **not-first / not-last**
+under `CumulativeRules::not_first_not_last`. See the sections below.
 
-Not here: **not-first / not-last** and **KAOC** (#550). Those are propagation
-rules a competitive cumulative solver also runs, so the claim to make is "a wide
-range of commonly used techniques", not completeness. The Open follow-ups
-section at the end says what each would take.
+Not here: **KAOC** (#550), and energetic reasoning in general. The claim to make
+is "a wide range of commonly used techniques", not completeness. The Open
+follow-ups section at the end says what each would take.
 
 ## What's hard about it
 
@@ -1201,16 +1201,79 @@ logger while it is set — and it is in the tree to be measured, not to be used:
 the row above is what it buys, and the propagation cost of recomputing the sum
 per window is not paid for on this family.
 
+## Not-first / not-last: the same certificate, different thresholds (#732)
+
+A task that cannot start before every task the window contains has ended must
+start after the earliest of those ends; and a task that cannot end after every
+one of them has started must end before the latest of those starts. So the
+thresholds are the contained set's own `min ect` and `max lst`, not a figure
+computed from the leftover energy --- which is what makes this a different rule
+rather than a weaker edge-finding.
+`CumulativeRules::not_first_not_last`, off by default.
+
+**The certificate is edge-finding's, unchanged.** Same window, same guarded
+rows, same `pol`; what differs is the threshold and which guard carries the
+negated conclusion, and `derive_guarded_window_energy` already takes both as
+parameters. Nothing was added to the proof vocabulary, and the first proof
+generated verified.
+
+**What is new is which tasks it can speak about.** Where a task has one end
+inside the window, edge-finding's threshold is the furthest an energy argument
+over that window can reach --- `step = ceil(rest / h_j)` is exactly the largest
+`v` for which `energy + h_j * minoverlap(a, b, est_j, v-1) > supply` --- so its
+push subsumes this rule's and the live-bound test drops the duplicate. Measured
+over `data_bl`, **every one of 6,316,773 firings is on a task that SPANS the
+window**, which is the case the edge-finding section documents as one where
+nothing can be said. A spanning task's guaranteed energy is a hump in its start:
+it rises until the task is fully inside the window and falls after, so no
+closed form pushes it, and restricting the start to one side of a threshold is
+what makes the hump's *minimum* say something.
+
+One wrinkle in the guards. A spanning task's lower bound is to the left of the
+window, so the low guard cannot be `clipped_window_start`, which would not be
+dischargeable. It is `min(lb(s_j), clipped_window_start(j, a))`: any guard at or
+past the window's start already discharges every survivor the ladder has, so
+where the bound is inside the window the window's own start does just as well
+--- and being a fact about the window rather than about the search, the row it
+derives is the one edge-finding already keeps, rather than one keyed on a bound
+that moves.
+
+**Measured, `data_bl` + `data_pack` at 60 s**, over the 37 instances every arm
+closed:
+
+| arm | recursions | vs baseline | propagations |
+|---|---|---|---|
+| edge-finding | 3,852,140 | 1.000x | 45,917,542 |
+| + not-first / not-last | 3,846,036 | 0.998x | 45,847,449 |
+| TTEF | 2,244,499 | 1.000x | 30,271,109 |
+| + not-first / not-last | 2,238,267 | 0.997x | 30,071,983 |
+
+It changes the search on 5 of 37 over edge-finding and 8 of 37 over TTEF, never
+for the worse, and no arm disagrees about an optimum. But it fires in the
+millions to buy that 0.3%, and at 60 s it **closes fewer instances than leaving
+it off** (37 against 39, and 38 against 39 alongside TTEF) --- the scan costs
+more than the pruning returns. Hence off by default, and hence the honest
+summary: certifiable for nothing, and worth nearly nothing.
+
+Testing is `cumulative_nfnl_test`, whose fixtures were searched the same way
+TTEF's were and against the same two conditions --- the rule must move a bound
+that time-tabling, the overload check, edge-finding and TTEF together do not,
+and the bound must be one a solution sits on. Its mutation harness differs in
+one way from the other two, and deliberately: it does **not** insist the root
+was reached. A push corrupted one step too far can empty a domain outright,
+leaving no root to report, and the proof of that emptying is exactly the
+corrupted step. Where a mutation is a no-op the root *is* reached and veripb
+accepts, which fails the lane, so the verdict is veripb's either way.
+
+`PushOneTooFar` had to be wired into this rule's own pushes. Until it was, the
+lane was corrupting an edge-finding firing on the same instance and reporting a
+rejection that said nothing about not-first / not-last.
+
 ## Open follow-ups
 - **Energetic reasoning.** The window-energy lemma above is the first
   piece of it: horizontally elastic and knapsack-augmented checking
   (#550) build on the clipped form, and the lifted-constraint
   presolvers (#549) on the contained one.
-- **Not-first / not-last (#732).** Now cheap: it is edge-finding's certificate
-  with a different window and the conclusion on the other bound, and the guarded
-  row already takes its threshold as a parameter. Expect the same fixture
-  difficulty TTEF ran into: the conclusion is an existing time point, which is
-  where unit propagation reaches on its own most easily.
 - **Guarded pins for the profile term.** TTEF's pins are reason-backed and
   re-derived per firing, at 2.93 lines' worth per firing and 15,037x repetition.
   A one-time-point `derive_guarded_window_energy` row is keyed by `(task, time)`

--- a/dev_docs/cumulative-proof-logging.md
+++ b/dev_docs/cumulative-proof-logging.md
@@ -1,70 +1,101 @@
-# Proof logging for `Cumulative`
+#Proof logging for `Cumulative`
 
-This document explains how the `Cumulative` propagator's three inferences
-are backed by VeriPB proofs. The technique generalises beyond cumulative
-to any constraint whose propagator reasons about a *load profile* over a
-set of integer variables with constant coefficients (binPacking,
-disjunctive, energetic-time-table extensions).
+This document explains how the `Cumulative` propagator's three inferences are backed by VeriPB proofs
+    .The technique generalises beyond cumulative to any constraint whose propagator reasons about a *load profile *
+        over a set of integer variables with constant
+        coefficients(binPacking, disjunctive, energetic - time - table extensions)
+    .
 
-For the constraint itself — the basic case, the OPB encoding, the
-time-table algorithm — read `gcs/constraints/cumulative/cumulative.{hh,cc}`. For
-the broader proof-logging framework (justifications, the OPB scaffold,
-`emit_rup_proof_line_under_reason`), read [`constraints.md`](constraints.md).
+    For the constraint itself — the basic case,
+    the OPB encoding,
+    the time - table algorithm — read `gcs / constraints / cumulative / cumulative.{hh, cc}`.For the broader proof
+    - logging framework(justifications, the OPB scaffold,
+`emit_rup_proof_line_under_reason`),
+    read[`constraints.md`](constraints.md)
+        .
 
-## What is and is not covered
+    ##What is and is not covered
 
-Worth stating plainly, because "we can certify cumulative scheduling" is an
-easy thing to write and a wrong thing to claim. Certified here: **time-tabling**
-(the overflow check and both bound pushes), the **overload check** and the
-window-energy lemma under it, **derived-constraint inference** (capacity
-strengthening, conflict cliques, lifted cover cuts), and **makespan lower
-bounds** — over optional tasks and over variable durations, heights and
-capacities.
+    Worth stating plainly,
+    because "we can certify cumulative scheduling" is an easy thing to write and a wrong thing to claim.Certified here:
+**time - tabling **(the overflow check and both bound pushes), the ** overload check **and the window - energy lemma under it,
+    **derived - constraint inference **(capacity strengthening, conflict cliques, lifted cover cuts),
+    and**makespan lower bounds ** — over optional tasks and over variable durations,
+    heights and capacities.
 
-Also certified, off by default: **edge-finding**, in both directions, under
-`CumulativeRules::edge_finding`, **time-table extended edge-finding** (TTEF)
-under `CumulativeRules::time_table_edge_finding`, and **not-first / not-last**
-under `CumulativeRules::not_first_not_last`. See the sections below.
+    Also certified,
+    off by default : **edge - finding **
+    , in both directions
+    , under
+`CumulativeRules::edge_finding`
+    , **time - table extended edge - finding **(TTEF)under `CumulativeRules::time_table_edge_finding`
+    , and**not -first / not -last *
+    *under `CumulativeRules::not_first_not_last`.See the sections below.
 
-Not here: **KAOC** (#550), and energetic reasoning in general. The claim to make
-is "a wide range of commonly used techniques", not completeness. The Open
-follow-ups section at the end says what each would take.
+     Not here : **KAOC
+    * *(#550)
+    , and energetic reasoning in general.The claim to make is "a wide range of commonly used techniques"
+    , not completeness.The Open follow -
+        ups section at the end says what each would take
+            .
 
-## What's hard about it
+        ##What's hard about it
 
-The TT propagator on its own is textbook. The proof-logging is not: the
-inference "task `j` cannot start at any `s ∈ [cur_lb, new_lb−1]`" hinges
-on a *disjunctive* fact
+        The TT propagator on its own is textbook.The proof
+        -
+        logging is not
+    : the inference "task `j` cannot start at any `s ∈ [cur_lb, new_lb−1]`" hinges on a
+      *
+      disjunctive *
+      fact
 
 ```
-∀ blocked t.    s_j > t   ∨   s_j ≤ t − l_j
+∀ blocked t.s_j
+    > t   ∨ s_j ≤ t − l_j
 ```
 
-— and that disjunction is exactly the shape memory flags as a hazard
-(`X ∉ [a, b]` as one Boolean breaks RUP-closure under backtrack-from-guess).
-So we can't reify the blocked-time fact as a single flag.
+— and that disjunction is exactly the shape memory flags as a hazard(`X ∉ [a, b]` as one Boolean breaks RUP - closure under backtrack - from - guess)
+          .So we can't reify the blocked-time fact as a single flag.
 
-The way out is *chained bound pushes under extended reason*: at each
-blocked time `t_i` in turn, we use the lower-bound work the previous
-chain step did to close the disjunction's lower branch, leaving only
-the upper branch `s_j > t_i` to derive.
+      The way out is * chained bound pushes under extended reason * : at each blocked time `t_i` in turn
+    , we use the lower - bound work the previous chain step did to close the disjunction's lower branch, leaving only the upper branch `s_j
+    > t_i` to derive.
 
-## The OPB scaffolding (recap)
+      ##The OPB scaffolding(recap)
 
-For every task `i` and every time `t` in its possible-active window,
-`define_proof_model` emits three fully-reified flags:
+For every task `i` and every time `t` in its possible - active window,
+`define_proof_model` emits three fully - reified flags :
 
-| Flag                  | Reification                                                  |
-|-----------------------|--------------------------------------------------------------|
-| `before_{i,t}`        | `s_i ≤ t`                                                    |
-| `after_{i,t}`         | `s_i ≥ t − l_i + 1`                                          |
-| `active_{i,t}`        | `before_{i,t} ∧ after_{i,t}` (AND-gate over the two)         |
+    | Flag | Reification | | -- -- -- -- -- -- -- -- -- -- -- -|
+    -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --| | `before_
+{
+    i, t
+}
+` | `s_i ≤ t` | | `after_
+{
+    i, t
+}
+` | `s_i ≥ t − l_i + 1` | | `active_
+{
+    i, t
+}
+` | `before_
+{
+    i, t
+}
+∧ after_
+{
+    i, t
+}` (AND-gate over the two)         |
 
 and, for each `t` in the union of possible-active windows, a single
 time-table constraint
 
 ```
-C_t :    Σ_i  h_i · active_{i,t}   ≤   capacity .
+C_t :    Σ_i  h_i · active_
+{
+    i, t
+}   ≤   capacity .
 ```
 
 All three inferences below cite these flags and `C_t` lines by handle —
@@ -79,7 +110,8 @@ can capture them in the propagator closure.
 For each task `i`, the *mandatory part* is the half-open interval
 `[lst_i, eet_i) = [ub(s_i), lb(s_i) + l_i)`. It's non-empty iff
 `l_i > ub(s_i) − lb(s_i)`. Any feasible `s_i` puts the task active
-at every `t ∈ [lst_i, eet_i)`, so `active_{i,t}` is forced to 1 by
+at every `t ∈ [lst_i, eet_i)`, so `active_{
+    i, t}` is forced to 1 by
 unit propagation from the bound literals `s_i ≥ lb(s_i)` and
 `s_i ≤ ub(s_i)`.
 
@@ -88,7 +120,8 @@ can't be satisfied: the mandatory tasks alone already overflow.
 
 ### Proof emission
 
-In the `JustifyExplicitly{…, ThenRUP::Yes}` emit callback:
+In the `JustifyExplicitly{
+    …, ThenRUP::Yes}` emit callback:
 
 1. For each task `i` mandatory at `t`, emit three RUPs under the
    bounds reason:
@@ -142,14 +175,19 @@ Both branches are needed; neither alone gets us anywhere generic.
 ### The chain idea
 
 Walk the bound one blocked-time at a time. At step `i`, we hold a
-*running bound* `B_{i−1}` already established by previous steps
+*running bound* `B_{
+    i−1}` already established by previous steps
 (initially the original bound from the reason). For the step's `t_i`:
 
-- If `t_i − l_j + 1 ≤ B_{i−1}` (the *precondition*), then the lower
-  branch `s_j ≤ t_i − l_j` is incompatible with `s_j ≥ B_{i−1}`,
+- If `t_i − l_j + 1 ≤ B_{
+    i−1}` (the *precondition*), then the lower
+  branch `s_j ≤ t_i − l_j` is incompatible with `s_j ≥ B_{
+    i−1}`,
   closing it. The remaining branch gives `s_j ≥ t_i + 1`.
-- Symmetrically for `ub`-push, with `B_{i−1}` an upper bound and the
-  precondition `t_i ≥ B_{i−1}` closing the *upper* branch
+- Symmetrically for `ub`-push, with `B_{
+    i−1}` an upper bound and the
+  precondition `t_i ≥ B_{
+    i−1}` closing the *upper* branch
   `s_j ≥ t_i + 1`, leaving the lower one `s_j ≤ t_i − l_j`.
 
 So the proof advances the bound exactly one blocked-time per step,
@@ -178,7 +216,8 @@ sub-pieces below, parameterised by `j`, `t`, the contributing tasks,
 **(a) Mandatory tasks at `t` (other than `j`):** the same three RUPs
 as inference 1, under the bounds reason. Each pins `active_{i,t} = 1`.
 
-**(b) Task `j` itself, under the EXTENDED reason `{bounds ∪ ¬ext_lit}`:**
+**(b) Task `j` itself, under the EXTENDED reason `{
+    bounds ∪ ¬ext_lit}`:**
 three RUPs of the same shape, but each line has `ext_lit` appended as
 an extra disjunct:
 
@@ -256,7 +295,8 @@ mentions `j`; no aliasing in the pol.
 Two reusable ideas crystallise out of the above:
 
 1. **`pol` over `active = 1` reified flags.** When a constraint
-   ships a per-time-point sum `Σ h_i · active_{i,t} ≤ capacity` and
+   ships a per-time-point sum `Σ h_i · active_{
+    i, t} ≤ capacity` and
    the propagator detects "the load already exceeds capacity here",
    the proof is a `pol` summing scaled unit-active lines into the
    time-table constraint. VeriPB cannot do this via RUP alone:
@@ -297,18 +337,21 @@ non-constant `d`/`r`/`b` joins the reason. Each extension touches the OPB
 and the pol differently:
 
 - **Variable capacity** is nearly free: `C_t` becomes
-  `Σ h_i·active_{i,t} − capacity ≤ 0` (the bound moves left as a single
+  `Σ h_i·active_{
+    i, t} − capacity ≤ 0` (the bound moves left as a single
   linear term). The existing pol closes unchanged because the wrapping
   RUP now has `capacity ≤ ub(capacity)` in the reason.
 
-- **Variable heights** linearise the nonlinear product `h_i·active_{i,t}`
+- **Variable heights** linearise the nonlinear product `h_i·active_{
+    i, t}`
   over `cake_pb_cp`'s per-bit contribution flags `cc_k = v[id][i_t_k][cc]`
   (weight `2^k`): `contrib_{i,t} = Σ 2^k·cc_k`, half-reified
   `active ⇒ contrib = h_i` and `¬active ⇒ contrib = 0` (the flags carry no
   domain bound of their own — `cle`/`cz` constrain them, exactly as cake
   does). `C_t` sums `contrib` for variable heights (and `h_i·active` for
   constant ones, so the all-constant proof is byte-identical). The pol pins
-  `contrib_{i,t} ≥ lb(h_i)` (coeff 1) instead of an `active = 1` line
+  `contrib_{
+    i, t} ≥ lb(h_i)` (coeff 1) instead of an `active = 1` line
   scaled by the constant height; for the pushed task it deposits
   `contrib_j + lb(h_j)·ext_lit ≥ lb(h_j)`. This is **variable × Boolean**,
   which is linear — *not* the multiplication frontier. Because the `cc`
@@ -316,7 +359,8 @@ and the pol differently:
   ordinary Booleans, just as the solver's were), the variable-height load
   reasoning **chain-verifies** (`scp_chain_cumulative_var_height_sat`).
 
-- **Variable durations** rewrite `after_{i,t} ⇔ s_i + l_i ≥ t+1`. The
+- **Variable durations** rewrite `after_{
+    i, t} ⇔ s_i + l_i ≥ t+1`. The
   pinning `after = 1` then needs the *cross-variable* fact
   `s_i + l_i ≥ B`, which RUP cannot derive from the operands' bounds
   alone (the VeriPB linear-combination limit). `after` stays reified on
@@ -327,7 +371,8 @@ and the pol differently:
   no OPB encoding: `cake_pb_cp` has no such variable, so keeping it out
   of the OPB is what makes the proof chain-portable) by the install
   initialiser, which also emits, per `(i,t)`, the **bridge lemma**
-  `end_i ≥ t+1 → after_{i,t}`:
+  `end_i ≥ t+1 → after_{
+    i, t}`:
 
   ```
   pol  @v[id][i_t][ca][f]  ( ¬after → s+l ≤ t )  +  end_le ( end ≤ s+l )
@@ -415,7 +460,8 @@ The proof needs, for each `i ∈ I(a, b)`, a derived line saying task `i`
 really does spend `p_i` time active inside the window:
 
 ```
-    Σ_{t ∈ [a,b)} active_{i,t}  ≥  p_i .
+    Σ_{t ∈ [a,b)} active_{
+    i, t}  ≥  p_i .
 ```
 
 That is `derive_window_energy` in
@@ -427,9 +473,12 @@ general bound rather than just the contained case.
 Per time point `t`, three `pol` lines:
 
 ```
-    before_{i,t} \/ [s_i ≥ t+1]                  @v[..][cb][f]  +  Def([s_i < t+1])   , saturate
-    after_{i,t}  \/ ~[s_i ≥ t-p+1]               @v[..][ca][f]  +  Def([s_i ≥ t-p+1]) , saturate
-    active_{i,t} \/ [s_i ≥ t+1] \/ ~[s_i ≥ t-p+1]        @v[..][cact][f]  +  the two above
+    before_{
+    i, t} \/ [s_i ≥ t+1]                  @v[..][cb][f]  +  Def([s_i < t+1])   , saturate
+    after_{
+    i, t}  \/ ~[s_i ≥ t-p+1]               @v[..][ca][f]  +  Def([s_i ≥ t-p+1]) , saturate
+    active_{
+    i, t} \/ [s_i ≥ t+1] \/ ~[s_i ≥ t-p+1]        @v[..][cact][f]  +  the two above
 ```
 
 The first two are order bridges of exactly the shape
@@ -517,7 +566,8 @@ tracker says whether it is there:
 
 | what | published as | resolved by |
 |---|---|---|
-| `Σ h_i·active_{i,t} ≤ C` for a time `t` | `ConstraintProofModelData<Cumulative>::capacity_row_role(t)` | `NamesAndIDsTracker::constraint_row_label` |
+| `Σ h_i·active_{
+    i, t} ≤ C` for a time `t` | `ConstraintProofModelData<Cumulative>::capacity_row_role(t)` | `NamesAndIDsTracker::constraint_row_label` |
 | the `before` / `after` / `active` flags for `(i, t)` | `...::before_flag_key(i, t)` and friends | `NamesAndIDsTracker::find_proof_flag_values` |
 
 The flag half is new. A flag's name is a pure function of
@@ -642,7 +692,10 @@ sanctioned change to the OPB in the whole #541 plan, and it is a single
 extra conjunct:
 
 ```
-active_{i,t}  ⇔  before_{i,t} ∧ after_{i,t} ∧ (presences[i] = 1)
+active_{
+    i, t}  ⇔  before_{
+    i, t} ∧ after_{
+    i, t} ∧ (presences[i] = 1)
 ```
 
 `C_t` keeps its shape. A `{0, 1}` variable is direct-only encoded as one
@@ -681,7 +734,8 @@ to the (at most two) disjuncts this needs.
 
 The last step drops the start-side disjunct. Its blocked time is at or
 beyond `ub(s_j)` — that is what makes it the last, since the chain stops
-when the running bound passes `ub(s_j)` — so `before_{j,t}` follows from
+when the running bound passes `ub(s_j)` — so `before_{
+    j, t}` follows from
 the task's own upper bound in the reason, and the proof never asks for an
 order literal above the domain, which need not exist.
 
@@ -755,7 +809,8 @@ profile, is issue 09's extension and is not here.
 ### Deriving over a donor that is not all constants
 
 Everything a derived constraint's recipe does is an argument about rows of the
-form `Σ h_i·active_{i,t} ≤ C`, and a donor only writes those when its arguments
+form `Σ h_i·active_{
+    i, t} ≤ C`, and a donor only writes those when its arguments
 are constants. `CumulativeDonorView`
 ([`donor_view.hh`](../gcs/constraints/cumulative/donor_view.hh)) is what reduces
 a donor to the part of itself that is, and the reduction is per **task**: one
@@ -825,7 +880,8 @@ them.
 
 Nothing in a capacity row mentions a length, so a derived constraint over such a
 task derives exactly the row it would otherwise. What breaks is the pin.
-`after_{i,t}` for a constant length is `s_i ≥ t − l + 1`, single-variable and
+`after_{
+    i, t}` for a constant length is `s_i ≥ t − l + 1`, single-variable and
 RUP-closable from the start's bounds; for a variable one it is reified on
 `s_i + l_i ≥ t+1`, which no RUP reaches from the operands' bounds separately —
 the VeriPB linear-combination limit.
@@ -897,7 +953,8 @@ not contain `height × active` for such a task; it contains the bits of a
 linearised contribution:
 
 ```
-C_t :   Σ_{i const} h_i·active_{i,t}  +  Σ_{i var} Σ_k 2^k·cc_{i,t,k}   ≤   capacity
+C_t :   Σ_{i const} h_i·active_{i,t}  +  Σ_{i var} Σ_k 2^k·cc_{
+    i, t, k}   ≤   capacity
 ```
 
 so a subset sum of the heights is not a subset sum of the row's coefficients,
@@ -923,12 +980,14 @@ rup  Σ_k 2^k·cc_{i,t,k} + L·¬active_{i,t} >= L   :  @c[id][<i>_<t>_cge]  <th
 ```
 
 added to the capacity row with coefficient one, so the bits cancel exactly and
-what is left on that task is `L·active_{i,t}`.
+what is left on that task is `L·active_{
+    i, t}`.
 
 It closes for a reason, which is worth writing down because the alternative is
 believing a pass rate. Negating the target forces `¬active` to zero — its
 coefficient `L` exceeds the slack `L−1` — leaving
-`{Σ2^k·cc_k ≤ L−1, Σ2^k·cc_k ≥ Σ2^j·hb_j, Σ2^j·hb_j ≥ L}` over two
+`{
+    Σ2 ^ k·cc_k ≤ L−1, Σ2 ^ k·cc_k ≥ Σ2 ^ j·hb_j, Σ2 ^ j·hb_j ≥ L}` over two
 power-of-two bit counters. Induct on the top bit `2^s`: if `L ≤ 2^s` the negated
 target zeroes `cc_s`, the `cge` row then zeroes `hb_s`, and the same system
 recurs one bit narrower; if `L > 2^s` the bound row forces `hb_s = 1`, `cge`
@@ -988,7 +1047,8 @@ conversion (claiming one more than the demand, and using `ub(h)` in place of
 A *derived* Cumulative (issue 04) works over an optional donor, and the
 striking thing is how little it takes. The rows are the argument, and an
 optional task's presence is a conjunct *inside* its activity flag rather
-than a term beside it, so `Σ h_i·active_{i,t} ≤ C` is the same row either
+than a term beside it, so `Σ h_i·active_{
+    i, t} ≤ C` is the same row either
 way. Every recipe built on one — subset sums, at-most-ones, coefficient
 raising, cover cuts — reads it identically, and none of them changes at
 all.
@@ -1255,6 +1315,20 @@ it off** (37 against 39, and 38 against 39 alongside TTEF) --- the scan costs
 more than the pruning returns. Hence off by default, and hence the honest
 summary: certifiable for nothing, and worth nearly nothing.
 
+**What is certified here is a weakening of the published rule (#746).** The
+conclusions are the published ones, and the propagator reproduces Schutt &
+Wolf's (CP 2010) worked example number for number. Their *detection* condition,
+and Kameugne et al.'s (CPAIOR 2018), take the pushed task's overlap at **one
+end** of the negated conclusion's start range; this takes `window_energy_bound`
+over the whole range, i.e. the minimum over both, because that is exactly what
+`derive_guarded_window_energy` can derive and the certificate then cites. Where
+each paper's setting makes the overlap monotone across that range the two
+coincide; where it does not, we fire less --- 3535 published-only firings
+against 7 of ours on one seed. #746 has the measurements and the open question,
+which is whether the divergence is a standing assumption on the task set that
+the transcription drops, or a genuine argument the window-energy lemma cannot
+make.
+
 Testing is `cumulative_nfnl_test`, whose fixtures were searched the same way
 TTEF's were and against the same two conditions --- the rule must move a bound
 that time-tabling, the overload check, edge-finding and TTEF together do not,
@@ -1297,7 +1371,7 @@ rejection that said nothing about not-first / not-last.
   filter as a constant and passes, which
   `cumulative_strengthening_all_var_heights` demonstrates by refuting at
   the root through the energy check. The **length** one still binds, since
-  #685 passes a length through as the variable it was posted with — so a
+# 685 passes a length through as the variable it was posted with — so a
   multi-mode RCPSP task gets its demand counted and its energy discarded,
   and it is the duration that discards it. Loosening it is not free: the
   lemma telescopes order literals over ranges fixed by a constant length,

--- a/examples/rcpsp/rcpsp.cc
+++ b/examples/rcpsp/rcpsp.cc
@@ -353,6 +353,10 @@ auto main(int argc, char * argv[]) -> int
                 "than only the contained tasks' whole energy (subsumes TTEF). Implies "                  //
                 "--cumulative-edge-finding. Not certified yet, so a run with --prove will refuse it",    //
                 cxxopts::value<bool>()->default_value("false"))                                          //
+            ("cumulative-not-first-not-last",                                                            //
+                "Run not-first / not-last on every posted Cumulative, alongside edge-finding. Implies "  //
+                "--cumulative-edge-finding",                                                             //
+                cxxopts::value<bool>()->default_value("false"))                                          //
             ("mutate-makespan-bound",                                                                    //
                 "Claim a makespan one larger than the inferred constraints' energy supports. For "       //
                 "validating the bound only: VeriPB must reject the resulting proof, and a run that "     //
@@ -637,8 +641,9 @@ auto main(int argc, char * argv[]) -> int
     auto cumulative_rules = CumulativeRules{};
     cumulative_rules.time_table_edge_finding = options_vars["cumulative-time-table-edge-finding"].as<bool>();
     cumulative_rules.energetic_edge_finding = options_vars["cumulative-energetic-edge-finding"].as<bool>();
-    cumulative_rules.edge_finding =
-        options_vars["cumulative-edge-finding"].as<bool>() || cumulative_rules.time_table_edge_finding || cumulative_rules.energetic_edge_finding;
+    cumulative_rules.not_first_not_last = options_vars["cumulative-not-first-not-last"].as<bool>();
+    cumulative_rules.edge_finding = options_vars["cumulative-edge-finding"].as<bool>() || cumulative_rules.time_table_edge_finding ||
+        cumulative_rules.energetic_edge_finding || cumulative_rules.not_first_not_last;
 
     vector<IntegerVariableID> machine_order_vars;
     if (machine_variant == "difference" && machine_starts.size() >= 2)

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -278,6 +278,7 @@ if(GCS_BUILD_TESTS)
     add_executable(cumulative_overload_test constraints/cumulative/cumulative_overload_test.cc)
     add_executable(cumulative_edge_finding_test constraints/cumulative/cumulative_edge_finding_test.cc)
     add_executable(cumulative_ttef_test constraints/cumulative/cumulative_ttef_test.cc)
+    add_executable(cumulative_nfnl_test constraints/cumulative/cumulative_nfnl_test.cc)
     add_executable(derived_cumulative_test constraints/cumulative/derived_cumulative_test.cc)
     add_executable(cumulative_optional_test constraints/cumulative/cumulative_optional_test.cc)
     add_executable(difference_test constraints/difference/difference_constraints_test.cc)
@@ -331,7 +332,7 @@ if(GCS_BUILD_TESTS)
 
     foreach(test_target
             abs_test all_different_test all_different_except_test all_equal_test among_test at_most_one_test bin_packing_test comparison_test
-            count_test cumulative_test cumulative_overload_test cumulative_edge_finding_test cumulative_ttef_test cumulative_optional_test derived_cumulative_test difference_test disjunctive_test disjunctive_optional_test disjunctive_overload_test disjunctive_precedences_test disjunctive_2d_test divide_modulus_test element_test equals_test bounds_global_cardinality_test gac_global_cardinality_test in_test increasing_test inverse_test knapsack_test knapsack_upfront_test lex_test linear_test linear_constant_test
+            count_test cumulative_test cumulative_overload_test cumulative_edge_finding_test cumulative_ttef_test cumulative_nfnl_test cumulative_optional_test derived_cumulative_test difference_test disjunctive_test disjunctive_optional_test disjunctive_overload_test disjunctive_precedences_test disjunctive_2d_test divide_modulus_test element_test equals_test bounds_global_cardinality_test gac_global_cardinality_test in_test increasing_test inverse_test knapsack_test knapsack_upfront_test lex_test linear_test linear_constant_test
             logical_test mdd_test min_distance_test min_distance_matching_test min_max_test mini_linear_test multiply_test n_value_test nogoods_test parity_test
             plus_minus_test power_test product_bounds_test product_justify_test regular_test regular_bacchus_test regular_legacy_test seq_precede_chain_test smart_table_test sort_test arg_sort_test symmetric_all_different_test
             negative_table_test table_test tabulation_test value_precede_test)
@@ -361,6 +362,12 @@ if(GCS_BUILD_TESTS)
                 --basename cumulative_edge_finding_mutation_${mutation} $<TARGET_FILE:cumulative_edge_finding_test> --mutate=${mutation})
     endforeach()
     add_test(NAME cumulative_ttef COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_ttef_test>)
+    add_test(NAME cumulative_nfnl COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_nfnl_test>)
+    foreach(mutation toofar drop roomy_toofar roomy_drop)
+        add_test(NAME cumulative_nfnl_mutation_${mutation}
+            COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_expect_verify_failure.bash
+                --basename cumulative_nfnl_mutation_${mutation} $<TARGET_FILE:cumulative_nfnl_test> --mutate=${mutation})
+    endforeach()
     foreach(mutation pins pin drop toofar mirror_pins mirror_pin mirror_toofar)
         add_test(NAME cumulative_ttef_mutation_${mutation}
             COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_expect_verify_failure.bash

--- a/gcs/constraints/cumulative/cumulative.cc
+++ b/gcs/constraints/cumulative/cumulative.cc
@@ -1072,7 +1072,9 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
                 continue;
             auto a = window_starts[w];
 
-            Integer energy = 0_i, inside_mandatory = 0_i;
+            // min_ect and max_lst are not-first / not-last's thresholds, over
+            // the same growing contained set the energy accumulates over.
+            Integer energy = 0_i, inside_mandatory = 0_i, min_ect = 0_i, max_lst = 0_i;
             vector<size_t> inside_tasks;
             for (const auto & c : candidates) {
                 if (c.est < a)
@@ -1080,6 +1082,8 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
                 energy += c.energy;
                 inside_mandatory += c.mandatory;
                 inside_tasks.push_back(c.task);
+                min_ect = inside_tasks.size() == 1 ? c.est + c.length : min(min_ect, c.est + c.length);
+                max_lst = inside_tasks.size() == 1 ? c.lct - c.length : max(max_lst, c.lct - c.length);
 
                 auto b = c.lct;
                 auto width = slots_within(a, b);
@@ -1124,6 +1128,19 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
                 }
                 else if (rules.time_table_edge_finding)
                     window_total = energy + window_profile;
+
+                // Whatever of a task the window has already been charged with.
+                // A push adds that task's clipped energy under the negated
+                // conclusion, covering the same time points, and each time
+                // point has one capacity line to cancel against --- so this
+                // comes back out first, or the pol would be left open.
+                // lst = lct − p and eet = est + p, which is what mand_load was
+                // built from.
+                auto own_contribution = [&](const Candidate & c2) {
+                    return rules.energetic_edge_finding ? guaranteed(c2)
+                        : rules.time_table_edge_finding ? c2.height * max(0_i, min(c2.est + c2.length, b) - max(c2.lct - c2.length, a))
+                                                        : 0_i;
+                };
 
                 // Edge-finding. A task j that starts inside [a, b) but is not
                 // contained in it can be pushed when the window has no room
@@ -1180,27 +1197,17 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
 
                         // A task with one end inside the window and one outside.
                         // Both ends in means it is contained, and already
-                        // counted; neither means it spans the window, and
-                        // nothing can be said. Which end is in decides which
-                        // bound moves.
+                        // counted; neither means it spans the window, where the
+                        // closed form below does not apply --- that case is what
+                        // not-first / not-last is for. Which end is in decides
+                        // which bound moves.
                         auto starts_inside = j.est >= a, ends_inside = j.lct <= b;
                         if (starts_inside == ends_inside)
                             continue;
 
                         auto p_j = j.length;
 
-                        // j is not contained, so whatever of it the window has
-                        // already been charged with covers the same time points
-                        // as the clipped energy added below under the negated
-                        // conclusion. Each time point has one capacity line to
-                        // cancel against, so counting j twice would leave the
-                        // pol open: take it back out. lst_j = lct_j − p_j and
-                        // eet_j = est_j + p_j, which is what mand_load was built
-                        // from.
-                        auto own = rules.energetic_edge_finding ? guaranteed(j)
-                            : rules.time_table_edge_finding     ? h_j * max(0_i, min(j.est + p_j, b) - max(j.lct - p_j, a))
-                                                                : 0_i;
-                        auto other_energy = window_total - own;
+                        auto other_energy = window_total - own_contribution(j);
                         auto rest = other_energy - (capacity - h_j) * width;
                         if (rest <= 0_i)
                             continue;
@@ -1248,6 +1255,73 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
                         else {
                             inference.infer_less_than(logger, starts[j.task], one_too_far ? low_guard - 1_i : low_guard,
                                 JustifyExplicitly{justify, ThenRUP::Yes, hints::Cumulative{owner}}, reason_with_presence());
+                        }
+                    }
+                }
+
+                // Not-first / not-last. Edge-finding asks how far a task can be
+                // pushed and answers with a closed form; this asks a different
+                // question --- can j start before every task the window
+                // contains has finished, or end after every one of them has
+                // started --- and takes its thresholds from the contained set
+                // rather than from the leftover energy.
+                //
+                // Where j has one end inside the window the two overlap, and
+                // edge-finding's threshold is the furthest an energy argument
+                // over this window can reach, so its push subsumes this one and
+                // the live-bound tests below drop the duplicate. What is new is
+                // a j that SPANS the window: its guaranteed energy is a hump in
+                // its start, edge-finding's closed form assumes a task crossing
+                // one edge and so does not apply, and the rule above skips it.
+                // Restricting the start to one side of a threshold is exactly
+                // what makes the hump's minimum say something.
+                if (rules.not_first_not_last && ! inside_tasks.empty() && window_total <= supply) {
+                    for (const auto & j : candidates) {
+                        if (j.est >= a && j.lct <= b)
+                            continue;
+
+                        auto h_j = j.height, p_j = j.length;
+                        auto other_energy = window_total - own_contribution(j);
+                        auto [s_lo, s_hi] = state.bounds(starts[j.task]);
+
+                        // Not-first: refute "j starts before every contained
+                        // task has ended". The guarded row's low guard is what
+                        // the reason discharges and its high guard is the
+                        // threshold, which is the negated conclusion.
+                        //
+                        // Any low guard at or past the window's start discharges
+                        // every survivor the ladder has, so where j's own lower
+                        // bound is inside the window the window's start does
+                        // just as well --- and it is a fact about the window
+                        // rather than about the search, so the row it derives is
+                        // shared with edge-finding's rather than keyed on a
+                        // bound that moves.
+                        if (min_ect > s_lo) {
+                            auto low_guard = min(s_lo, clipped_window_start(j.task, a));
+                            auto clipped = window_energy::window_energy_bound(
+                                p_j, per_task_t_lo[j.task], active_flag_count(j.task), a, b, pair{low_guard, min_ect - 1_i});
+                            if (clipped > 0_i && other_energy + h_j * clipped > supply) {
+                                auto one_too_far = std::holds_alternative<cumulative_proof_mutation::PushOneTooFar>(mutation);
+                                auto justify = edge_finding_justification(a, b, inside_tasks, j.task, low_guard, min_ect, GuardToDischarge::Low);
+                                inference.infer_greater_than_or_equal(logger, starts[j.task], one_too_far ? min_ect + 1_i : min_ect,
+                                    JustifyExplicitly{justify, ThenRUP::Yes, hints::Cumulative{owner}}, reason_with_presence());
+                            }
+                        }
+
+                        // Not-last: the mirror. Refute "j ends after every
+                        // contained task has started", so the negated conclusion
+                        // lands on the low guard and j's own upper bound is what
+                        // the reason discharges.
+                        if (max_lst - p_j < s_hi) {
+                            auto low_guard = max_lst - p_j + 1_i;
+                            auto clipped = window_energy::window_energy_bound(
+                                p_j, per_task_t_lo[j.task], active_flag_count(j.task), a, b, pair{low_guard, s_hi});
+                            if (clipped > 0_i && other_energy + h_j * clipped > supply) {
+                                auto one_too_far = std::holds_alternative<cumulative_proof_mutation::PushOneTooFar>(mutation);
+                                auto justify = edge_finding_justification(a, b, inside_tasks, j.task, low_guard, s_hi + 1_i, GuardToDischarge::High);
+                                inference.infer_less_than(logger, starts[j.task], one_too_far ? low_guard - 1_i : low_guard,
+                                    JustifyExplicitly{justify, ThenRUP::Yes, hints::Cumulative{owner}}, reason_with_presence());
+                            }
                         }
                     }
                 }

--- a/gcs/constraints/cumulative/cumulative.hh
+++ b/gcs/constraints/cumulative/cumulative.hh
@@ -84,6 +84,26 @@ namespace gcs
         /// \warning Not yet certified. A propagator with this set refuses to
         /// run against a proof logger.
         bool energetic_edge_finding = false;
+
+        /// Not-first / not-last: a task that cannot start before every task the
+        /// window contains has ended must start after the earliest of those
+        /// ends, and a task that cannot end after every one of them has started
+        /// must end before the latest of those starts.
+        ///
+        /// The thresholds are the set's own `min ect` and `max lst` rather than
+        /// a figure computed from the leftover energy, which is what makes this
+        /// a different rule from edge-finding rather than a weaker one: it can
+        /// fire on a task that *spans* the window, where edge-finding's closed
+        /// form does not apply and which \ref edge_finding therefore skips.
+        /// Where a task has one end inside the window, edge-finding pushes at
+        /// least as far, and the live-bound check drops the duplicate: measured
+        /// over the benchmark set, *every* firing is on a spanning task.
+        ///
+        /// Certified, by edge-finding's certificate unchanged. Off by default
+        /// because it is not worth its scan: it fires in the millions and buys
+        /// 0.3% of the search, and at a 60 s timeout it closes fewer instances
+        /// than leaving it off.
+        bool not_first_not_last = false;
     };
 
     /**

--- a/gcs/constraints/cumulative/cumulative.hh
+++ b/gcs/constraints/cumulative/cumulative.hh
@@ -103,6 +103,12 @@ namespace gcs
         /// because it is not worth its scan: it fires in the millions and buys
         /// 0.3% of the search, and at a 60 s timeout it closes fewer instances
         /// than leaving it off.
+        ///
+        /// The detection is what the window-energy lemma can *derive* --- the
+        /// least overlap the pushed task can have with the window over the
+        /// negated conclusion's whole start range --- where the published rules
+        /// take the overlap at one end of that range. So this is a weakening of
+        /// them, sound and certified but firing less often. See #746.
         bool not_first_not_last = false;
     };
 

--- a/gcs/constraints/cumulative/cumulative_nfnl_test.cc
+++ b/gcs/constraints/cumulative/cumulative_nfnl_test.cc
@@ -1,0 +1,429 @@
+#include <gcs/constraints/cumulative.hh>
+#include <gcs/constraints/innards/constraints_test_utils.hh>
+#include <gcs/problem.hh>
+#include <gcs/solve.hh>
+
+#include <algorithm>
+#include <climits>
+#include <cstdlib>
+#include <iostream>
+#include <optional>
+#include <random>
+#include <set>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+#include <version>
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+#include <print>
+#else
+#include <fmt/core.h>
+#include <fmt/ostream.h>
+#include <fmt/ranges.h>
+#endif
+
+using std::cerr;
+using std::flush;
+using std::make_optional;
+using std::max;
+using std::min;
+using std::nullopt;
+using std::optional;
+using std::pair;
+using std::set;
+using std::string;
+using std::tuple;
+using std::vector;
+using std::ranges::any_of;
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+using std::print;
+using std::println;
+#else
+using fmt::print;
+using fmt::println;
+#endif
+
+using namespace gcs;
+using namespace gcs::innards;
+using namespace gcs::test_innards;
+
+namespace
+{
+    struct Instance
+    {
+        vector<pair<int, int>> start_ranges;
+        vector<int> lengths;
+        vector<int> heights;
+        int capacity;
+    };
+
+    auto is_satisfying(const Instance & inst, const vector<int> & starts) -> bool
+    {
+        auto n = inst.start_ranges.size();
+        int t_lo = INT_MAX, t_hi = INT_MIN;
+        for (size_t i = 0; i < n; ++i) {
+            t_lo = min(t_lo, starts[i]);
+            t_hi = max(t_hi, starts[i] + inst.lengths[i] - 1);
+        }
+        for (int t = t_lo; t <= t_hi; ++t) {
+            int load = 0;
+            for (size_t i = 0; i < n; ++i)
+                if (starts[i] <= t && t < starts[i] + inst.lengths[i])
+                    load += inst.heights[i];
+            if (load > inst.capacity)
+                return false;
+        }
+        return true;
+    }
+
+    auto post(Problem & p, const Instance & inst, CumulativeRules rules, CumulativeProofMutation mutation = cumulative_proof_mutation::None{})
+        -> vector<IntegerVariableID>
+    {
+        vector<IntegerVariableID> starts;
+        vector<Integer> lengths, heights;
+        for (size_t i = 0; i < inst.start_ranges.size(); ++i) {
+            starts.push_back(
+                p.create_integer_variable(Integer{inst.start_ranges[i].first}, Integer{inst.start_ranges[i].second}, "start" + std::to_string(i)));
+            lengths.push_back(Integer{inst.lengths[i]});
+            heights.push_back(Integer{inst.heights[i]});
+        }
+        p.post(Cumulative{starts, lengths, heights, Integer{inst.capacity}}.with_rules(rules).with_proof_mutation(mutation));
+        return starts;
+    }
+
+    /// The bounds each start is left with once root propagation has run. TTEF
+    /// moves bounds rather than reporting conflicts, so this is where it has to
+    /// be measured: an enumeration test alone cannot tell whether it fired.
+    auto root_bounds(const Instance & inst, CumulativeRules rules, CumulativeProofMutation mutation, const optional<string> & proof_name)
+        -> optional<vector<pair<int, int>>>
+    {
+        Problem p;
+        auto starts = post(p, inst, rules, mutation);
+
+        optional<vector<pair<int, int>>> bounds;
+        solve_with(p,
+            SolveCallbacks{.solution = [&](const CurrentState & s) -> bool {
+                               if (! bounds) {
+                                   bounds.emplace();
+                                   for (const auto & v : starts)
+                                       bounds->emplace_back(static_cast<int>(s(v).raw_value), static_cast<int>(s(v).raw_value));
+                               }
+                               return false;
+                           },
+                .trace = [&](const CurrentState & s) -> bool {
+                    if (! bounds) {
+                        bounds.emplace();
+                        for (const auto & v : starts)
+                            bounds->emplace_back(static_cast<int>(s.lower_bound(v).raw_value), static_cast<int>(s.upper_bound(v).raw_value));
+                    }
+                    return false;
+                }},
+            proof_name ? make_optional<ProofOptions>(ProofFileNames{*proof_name}) : nullopt);
+        return bounds;
+    }
+
+    auto fail(const string & message) -> void
+    {
+        println(cerr, "cumulative nfnl: {}", message);
+        exit(EXIT_FAILURE);
+    }
+
+    /// "starts lo:hi,... / lengths / heights / capacity", so that a fixture
+    /// found by --search can be handed straight back in.
+    auto parse_instance(const string & spec) -> Instance
+    {
+        vector<string> parts;
+        for (size_t at = 0, next; at <= spec.size(); at = next + 1) {
+            next = spec.find('/', at);
+            if (next == string::npos)
+                next = spec.size();
+            parts.push_back(spec.substr(at, next - at));
+            if (next == spec.size())
+                break;
+        }
+        if (parts.size() != 4)
+            fail("instance spec wants four /-separated parts, got " + std::to_string(parts.size()));
+
+        auto split = [](const string & s) {
+            vector<string> out;
+            for (size_t at = 0, next; at <= s.size(); at = next + 1) {
+                next = s.find(',', at);
+                if (next == string::npos)
+                    next = s.size();
+                out.push_back(s.substr(at, next - at));
+                if (next == s.size())
+                    break;
+            }
+            return out;
+        };
+
+        Instance inst{{}, {}, {}, std::stoi(parts[3])};
+        for (const auto & r : split(parts[0])) {
+            auto colon = r.find(':');
+            inst.start_ranges.emplace_back(std::stoi(r.substr(0, colon)), std::stoi(r.substr(colon + 1)));
+        }
+        for (const auto & l : split(parts[1]))
+            inst.lengths.push_back(std::stoi(l));
+        for (const auto & h : split(parts[2]))
+            inst.heights.push_back(std::stoi(h));
+        return inst;
+    }
+
+    auto show_instance(const Instance & inst) -> string
+    {
+        string out;
+        for (size_t i = 0; i < inst.start_ranges.size(); ++i)
+            out += (i ? "," : "") + std::to_string(inst.start_ranges[i].first) + ":" + std::to_string(inst.start_ranges[i].second);
+        out += "/";
+        for (size_t i = 0; i < inst.lengths.size(); ++i)
+            out += (i ? "," : "") + std::to_string(inst.lengths[i]);
+        out += "/";
+        for (size_t i = 0; i < inst.heights.size(); ++i)
+            out += (i ? "," : "") + std::to_string(inst.heights[i]);
+        return out + "/" + std::to_string(inst.capacity);
+    }
+
+    /// A fixture is only a test of the *claim* if the claim is tight: a push to
+    /// v that a solution with the pushed task at v−1 would refute. Where the
+    /// push is merely valid, "one too far" is valid too, and VeriPB verifies the
+    /// corrupted proof --- which is a fact about the fixture, not about the
+    /// rule. So: TTEF must move a bound edge-finding does not, and some solution
+    /// must sit exactly on the bound it moves to.
+    auto search_for_fixture(
+        const CumulativeRules & without_rule, const CumulativeRules & with_rule, unsigned long long seed_from, unsigned long long candidates) -> void
+    {
+        std::mt19937 rand(static_cast<unsigned>(seed_from));
+        for (unsigned long long attempt = 0; attempt < candidates; ++attempt) {
+            auto n = 3 + static_cast<size_t>(rand() % 3);
+            auto capacity = 2 + static_cast<int>(rand() % 3);
+            Instance inst{{}, {}, {}, capacity};
+            for (size_t i = 0; i < n; ++i) {
+                auto len = 1 + static_cast<int>(rand() % 5);
+                auto lo = static_cast<int>(rand() % 6);
+                auto slack = static_cast<int>(rand() % 7);
+                inst.start_ranges.emplace_back(lo, lo + slack);
+                inst.lengths.push_back(len);
+                inst.heights.push_back(1 + static_cast<int>(rand() % capacity));
+            }
+
+            auto without = root_bounds(inst, without_rule, cumulative_proof_mutation::None{}, nullopt);
+            auto with = root_bounds(inst, with_rule, cumulative_proof_mutation::None{}, nullopt);
+            if (! without || ! with)
+                continue;
+
+            set<vector<int>> solutions;
+            build_expected(solutions, [&](const vector<int> & starts) { return is_satisfying(inst, starts); }, inst.start_ranges);
+            if (solutions.empty())
+                continue;
+
+            for (size_t i = 0; i < n; ++i) {
+                auto raises = (*with)[i].first > (*without)[i].first;
+                auto lowers = (*with)[i].second < (*without)[i].second;
+                if (! raises && ! lowers)
+                    continue;
+                auto landed = raises ? (*with)[i].first : (*with)[i].second;
+                auto tight = any_of(solutions, [&](const vector<int> & s) { return s[i] == landed; });
+                if (! tight)
+                    continue;
+                println(cerr, "candidate {} task {} {} -> {} tight, {} solutions", show_instance(inst), i, raises ? "lb" : "ub", landed,
+                    solutions.size());
+                break;
+            }
+        }
+    }
+
+    /// Every rule setting must find exactly the same solutions: TTEF is a
+    /// propagation strength, not a change of constraint. This is the net for an
+    /// over-firing push, which removes solutions.
+    auto check_enumeration(const string & what, const Instance & inst, CumulativeRules rules, const optional<string> & proof_name) -> void
+    {
+        print(cerr, "cumulative nfnl {} starts={} lens={} hts={} c={}{}", what, inst.start_ranges, inst.lengths, inst.heights, inst.capacity,
+            proof_name ? " with proofs:" : ":");
+        cerr << flush;
+
+        set<vector<int>> expected, actual;
+        build_expected(expected, [&](const vector<int> & starts) { return is_satisfying(inst, starts); }, inst.start_ranges);
+        println(cerr, " expecting {} solutions", expected.size());
+
+        Problem p;
+        auto starts = post(p, inst, rules);
+        solve_for_tests(p, proof_name, actual, tuple{starts});
+        check_results(proof_name, expected, actual);
+    }
+}
+
+auto main(int argc, char * argv[]) -> int
+{
+    establish_and_announce_seed(argc, argv);
+
+    // The baseline is everything else that is certified, so a fixture here has
+    // to show not-first / not-last inferring something time-tabling, the
+    // overload check, edge-finding and TTEF together do not.
+    const CumulativeRules without_rule{
+        .time_table = true, .overload = true, .profile_overload = true, .edge_finding = true, .time_table_edge_finding = true};
+    const CumulativeRules with_rule{.time_table = true,
+        .overload = true,
+        .profile_overload = true,
+        .edge_finding = true,
+        .time_table_edge_finding = true,
+        .not_first_not_last = true};
+
+    auto proofs = can_run_veripb();
+
+    // What a fixture here has to do, and why hand-building one does not work.
+    //
+    // Not-first / not-last only ever adds an inference on a task that SPANS the
+    // window: where a task has one end inside, edge-finding's threshold is the
+    // furthest an energy argument over that window can reach, so its push
+    // subsumes this rule's and the live-bound test drops the duplicate. A
+    // fixture therefore needs a spanning task whose guaranteed energy, once its
+    // start is restricted to one side of the contained set's `min ect` or
+    // `max lst`, is enough to overflow a window that does not otherwise
+    // overflow --- while the contained tasks keep mandatory parts small enough
+    // that time-tabling sees nothing. Two hand-built attempts had time-tabling
+    // making the same push on its own.
+    //
+    // And the push has to be TIGHT --- some solution must sit exactly on the
+    // bound --- or "one too far" is valid too and VeriPB verifies the corrupted
+    // proof. Both were found by --search, which keeps random instances where
+    // the rule moves a bound the other rules do not and a solution sits on it,
+    // then vetted against every mutation with an honest control. --describe
+    // prints the numbers written down here.
+    //
+    // Capacity four, three tasks. Task 0's lower bound rises 5 -> 6 (not-first)
+    // and task 2's upper bound falls 5 -> 3 (not-last), over 2 solutions.
+    const Instance sharp{{{5, 6}, {0, 3}, {0, 5}}, {1, 3, 3}, {1, 4, 4}, 4};
+
+    // A roomier one, 18 solutions, where the two directions land on different
+    // tasks: task 0's lower bound rises 6 -> 7 and task 3's upper bound falls
+    // 4 -> 0.
+    const Instance roomy{{{5, 11}, {3, 4}, {5, 7}, {0, 4}, {2, 5}}, {3, 4, 1, 5, 1}, {2, 1, 2, 2, 2}, 3};
+
+    // Describe one instance: what edge-finding leaves, what TTEF leaves, and
+    // whether the bound it moves to is one a solution sits on. This is how a
+    // fixture found by --search gets turned into the numbers written down
+    // beside it below.
+    for (int a = 1; a < argc; ++a)
+        if (string{argv[a]}.starts_with("--describe=")) {
+            string arg = argv[a];
+            auto inst = parse_instance(arg.substr(arg.find('=') + 1));
+            auto without = root_bounds(inst, without_rule, cumulative_proof_mutation::None{}, nullopt);
+            auto with = root_bounds(inst, with_rule, cumulative_proof_mutation::None{}, nullopt);
+            if (! without || ! with)
+                fail("describe: nothing was reached at the root");
+            set<vector<int>> solutions;
+            build_expected(solutions, [&](const vector<int> & starts) { return is_satisfying(inst, starts); }, inst.start_ranges);
+            println(cerr, "{} solutions {}", show_instance(inst), solutions.size());
+            for (size_t i = 0; i < inst.start_ranges.size(); ++i) {
+                auto tight = [&](int v) { return any_of(solutions, [&](const vector<int> & s) { return s[i] == v; }); };
+                println(cerr, "  task {}: without_rule [{}, {}] with_rule [{}, {}]{}{}", i, (*without)[i].first, (*without)[i].second,
+                    (*with)[i].first, (*with)[i].second, (*with)[i].first > (*without)[i].first ? " lb MOVED" : "",
+                    (*with)[i].second < (*without)[i].second ? " ub MOVED" : "");
+                println(cerr, "           lb tight {} ub tight {}", tight((*with)[i].first), tight((*with)[i].second));
+            }
+            return EXIT_SUCCESS;
+        }
+
+    // Fixture search: print instances on which TTEF moves a bound
+    // edge-finding does not, and moves it somewhere a solution actually sits.
+    for (int a = 1; a < argc; ++a)
+        if (string{argv[a]} == "--search") {
+            unsigned long long from = 1, count = 2000;
+            auto number = [&](int at) { return at < argc && argv[at][0] >= '0' && argv[at][0] <= '9'; };
+            if (number(a + 1))
+                from = std::stoull(argv[a + 1]);
+            if (number(a + 2))
+                count = std::stoull(argv[a + 2]);
+            search_for_fixture(without_rule, with_rule, from, count);
+            return EXIT_SUCCESS;
+        }
+
+    // Mutation mode: emit one deliberately corrupted proof and stop, for
+    // run_test_and_expect_verify_failure.bash to hand to veripb.
+    {
+        optional<CumulativeProofMutation> mutation;
+        const Instance * fixture = &sharp;
+        optional<Instance> from_spec;
+        string proof_basename = "cumulative_nfnl_mutation";
+        for (int a = 1; a < argc; ++a) {
+            string arg = argv[a];
+            if (arg.starts_with("--instance=")) {
+                from_spec = parse_instance(arg.substr(arg.find('=') + 1));
+                fixture = &*from_spec;
+            }
+            else if (arg == "--mutate=none")
+                mutation = cumulative_proof_mutation::None{};
+            else if (arg == "--mutate=pin")
+                mutation = cumulative_proof_mutation::DropProfilePin{};
+            else if (arg == "--mutate=pins")
+                mutation = cumulative_proof_mutation::DropProfilePins{};
+            else if (arg == "--mutate=drop")
+                mutation = cumulative_proof_mutation::DropContainedTask{};
+            else if (arg == "--mutate=toofar")
+                mutation = cumulative_proof_mutation::PushOneTooFar{};
+            else if (arg == "--mutate=capacity")
+                mutation = cumulative_proof_mutation::OmitCapacityLine{};
+            else if (arg == "--mutate=roomy_toofar") {
+                mutation = cumulative_proof_mutation::PushOneTooFar{};
+                fixture = &roomy;
+            }
+            else if (arg == "--mutate=roomy_drop") {
+                mutation = cumulative_proof_mutation::DropContainedTask{};
+                fixture = &roomy;
+            }
+            else if (arg == "--proof-files-basename" && a + 1 < argc)
+                proof_basename = argv[++a];
+        }
+
+        if (mutation) {
+            auto bounds = root_bounds(*fixture, with_rule, *mutation, make_optional(proof_basename));
+            // Unlike the other two mutation harnesses, this one does not insist
+            // that the root was reached. A push corrupted one step too far can
+            // empty a domain outright, and then there is no root to report ---
+            // but the proof of that emptying is exactly the corrupted step, and
+            // veripb is the thing that judges it. Where a mutation is instead a
+            // no-op, the root *is* reached, veripb accepts, and the lane fails,
+            // which is the verdict wanted either way.
+            if (! bounds)
+                println(cerr, "the corrupted inference left nothing at the root, which is itself the corruption");
+            println(cerr, "wrote a deliberately corrupted proof to {}.pbp", proof_basename);
+            return EXIT_SUCCESS;
+        }
+    }
+
+    // The rule fires, pushes exactly as far as the energy supports, and does so
+    // where edge-finding on its own does not. `raises` says which bound the
+    // fixture is about, and `task` which task it is about.
+    for (const auto & [name, inst, task, raises, expected] :
+        vector<tuple<string, Instance, size_t, bool, int>>{{"sharp_not_first", sharp, 0, true, 6}, {"sharp_not_last", sharp, 2, false, 3},
+            {"roomy_not_first", roomy, 0, true, 7}, {"roomy_not_last", roomy, 3, false, 0}}) {
+        auto off = root_bounds(inst, without_rule, cumulative_proof_mutation::None{}, nullopt);
+        auto on = root_bounds(inst, with_rule, cumulative_proof_mutation::None{}, proofs ? make_optional("cumulative_nfnl_" + name) : nullopt);
+        if (! off || ! on)
+            fail(name + ": nothing was reached at the root");
+
+        auto pick = [&, task = task, raises = raises](const vector<pair<int, int>> & b) { return raises ? b[task].first : b[task].second; };
+        if (raises ? pick(*off) >= expected : pick(*off) <= expected)
+            fail(name + ": edge-finding alone already reaches the push, so this fixture measures nothing");
+        if (pick(*on) != expected)
+            fail(name + ": expected the pushed task's bound to reach " + std::to_string(expected) + ", got " + std::to_string(pick(*on)));
+        println(cerr, "cumulative nfnl {}: task {} {} {} -> {}", name, task, raises ? "lb" : "ub", pick(*off), pick(*on));
+        if (proofs)
+            verify_proof_and_clean_up("cumulative_nfnl_" + name);
+    }
+
+    // Soundness, over instances small enough to enumerate: the rule may not
+    // lose a solution, with or without a proof being written.
+    for (const auto & [name, inst] : vector<pair<string, Instance>>{{"sharp", sharp}, {"roomy", roomy},
+             {"tight", Instance{{{0, 3}, {0, 3}, {1, 2}, {0, 5}}, {2, 2, 3, 2}, {1, 1, 1, 1}, 2}},
+             {"mixed_heights", Instance{{{0, 4}, {0, 4}, {1, 2}, {0, 6}}, {3, 2, 4, 2}, {2, 1, 1, 2}, 3}}}) {
+        check_enumeration(name, inst, with_rule, nullopt);
+        if (proofs)
+            check_enumeration(name, inst, with_rule, make_optional("cumulative_nfnl_enum_" + name));
+    }
+
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Closes #732 for `Cumulative`. **Stacked on #744**, which is stacked on #743.

A task that cannot start before every task the window contains has ended must start after the earliest of those ends; and a task that cannot end after every one of them has started must end before the latest of those starts. The thresholds come from the contained set's own `min ect` and `max lst` rather than from the leftover energy, which is what makes this a different rule rather than a weaker edge-finding. `CumulativeRules::not_first_not_last`, off by default.

## It is a weakening of the published rule (#746)

Checked against Schutt & Wolf (CP 2010) and Kameugne et al. (CPAIOR 2018) after this was first written. The **conclusions** match both exactly, and the propagator reproduces Schutt & Wolf's worked Example 1 number for number — window [5,10), `|Ω|` = 3, `e_Ω` = 6, supply 10, task term 5, detection 11 > 10, push `UB[i] = 9`.

The **detection** does not match. Both papers take the pushed task's overlap at *one end* of the negated conclusion's start range; this takes `window_energy_bound` over the whole range, i.e. the minimum over both ends, because that is exactly what the certificate can derive. Measured: 3535 published-only firings against 7 of ours on one seed. The published condition, used as the firing rule, removes no solutions over 399 exhaustively enumerated instances while firing in the thousands — so it is stronger, and what is certified here fires less.

Nothing about the certificate or the soundness of this PR changes. #746 carries the measurements, a side-by-side reproduction under `GCS_NFNL_COMPARE`, and the open question of whether the divergence is a standing assumption on Ω that the transcription drops.

## The certificate is edge-finding's, unchanged

Same window, same guarded rows, same `pol`. What differs is the threshold and which guard carries the negated conclusion, and `derive_guarded_window_energy` already takes both as parameters. Nothing was added to the proof vocabulary and the first proof generated verified.

One wrinkle in the guards: a spanning task's lower bound is to the left of the window, so the low guard cannot be `clipped_window_start`, which would not be dischargeable. It is `min(lb, clipped_window_start)` — the window's own start wherever that is dischargeable, since any guard at or past it discharges every survivor the ladder has, so the row stays the one edge-finding already keeps rather than one keyed on a bound that moves.

## What is new is which tasks it can speak about

Where a task has one end inside the window, edge-finding's `step = ceil(rest / h_j)` is exactly the largest `v` for which the energy argument closes, so its push subsumes this rule's and the live-bound test drops the duplicate. **Every one of 6,316,773 firings measured over `data_bl` is on a task that SPANS the window** — the case the edge-finding section documents as one where nothing can be said. A spanning task's guaranteed energy is a hump in its start, so no closed form pushes it, and restricting the start to one side of a threshold is what makes the hump's minimum say something.

## What it is worth: nearly nothing

`data_bl` + `data_pack` at 60 s, over the 37 instances every arm closed:

| arm | recursions | vs baseline | propagations |
|---|---|---|---|
| edge-finding | 3,852,140 | 1.000x | 45,917,542 |
| + not-first / not-last | 3,846,036 | 0.998x | 45,847,449 |
| TTEF | 2,244,499 | 1.000x | 30,271,109 |
| + not-first / not-last | 2,238,267 | 0.997x | 30,071,983 |

It changes the search on 5 of 37 over edge-finding and 8 of 37 over TTEF, never for the worse, and no arm disagrees about an optimum. But it fires in the millions to buy 0.3%, and at 60 s it **closes fewer instances than leaving it off** — 37 against 39, and 38 against 39 alongside TTEF. The scan costs more than the pruning returns. Hence off by default, and hence the honest summary: certifiable for nothing, worth nearly nothing. That is a result worth having in the table rather than a gap.

## Testing

Fixtures searched against the same two conditions as TTEF's — the rule must move a bound the other four rules together do not, and the bound must be one a solution sits on. Two hand-built attempts were thrown away, both because time-tabling made the same push on its own.

Two things about the harness the reviewer should look at:

- **`PushOneTooFar` had to be wired into this rule's own pushes.** Until it was, the lane was corrupting an edge-finding firing on the same instance and reporting a rejection that said nothing about not-first / not-last. A mutation lane green for the wrong reason.
- **This mutation harness does not insist the root was reached**, unlike the other two. A push corrupted one step too far can empty a domain outright, leaving no root to report — and the proof of that emptying is exactly the corrupted step. Where a mutation is instead a no-op, the root *is* reached, veripb accepts, and the lane fails, so the verdict is veripb's either way.

Four lanes, all rejected on the RUP that follows the `pol`. 672/672 ctest under GCC; the cumulative tests also built and run under clang with `GCS_TEST_CAP_DEFAULTS=OFF`. 249 random instances enumerated with and without the rule agree exactly.

