### PR TITLE
cumulative: knapsack-augmented and horizontally elastic overload checking

### DIFF
--- a/dev_docs/cumulative-proof-logging.md
+++ b/dev_docs/cumulative-proof-logging.md
@@ -1429,6 +1429,21 @@ not**: 0.693x of the search, but it closes *fewer* instances than leaving it off
 because its per-time-point scan costs more than the pruning returns --- the same
 verdict not-first / not-last got, and for the same reason.
 
+And on top of the edge-finding family, which is the question that decides
+whether it is worth having at all --- over the 39 instances both arms closed:
+
+| arm | recursions | vs TTEF | propagations | closed | wall |
+|---|---|---|---|---|---|
+| TTEF | 7,250,390 | 1.000x | 74,388,179 | 39 / 95 | 98.2 s |
+| + (KAOC) | 2,342,923 | 0.323x | 29,856,904 | 49 / 95 | 76.0 s |
+
+Fewer recursions on 26 of 39 and more on none, ten more instances closed, and
+**faster in wall time as well** --- so the rule pays for its own O(n^2 * horizon)
+scan and then some. It is not subsumed by the energetic family: edge-finding and
+TTEF move bounds from a window's total energy, and this refutes windows where
+the *shape* of the heights is what does not fit, which no amount of aggregate
+energy reasoning sees.
+
 Soundness: 600 generated instances enumerated exhaustively at sizes 8 and 10,
 zero solution-count differences against the rules off.
 

--- a/dev_docs/cumulative-proof-logging.md
+++ b/dev_docs/cumulative-proof-logging.md
@@ -1343,11 +1343,155 @@ accepts, which fails the lane, so the verdict is veripb's either way.
 lane was corrupting an edge-finding firing on the same instance and reporting a
 rejection that said nothing about not-first / not-last.
 
+## The overload ladder: one certificate, a tighter line per time point (#550)
+
+`(TTOC)` charges a window `capacity x width` in bulk and subtracts the profile.
+Two published rules improve on the same comparison by capping what each
+*individual* time point supplies:
+
+* **(TTHE-OC)**, the time-table horizontally elastic overload check (Kameugne,
+  Fetgo Betmbe, Noulamo & Tayou Djamegni, C&OR 172 (2024); the formulation used
+  here is Cloutier & Quimper's equivalent one, CP 2026 SS2.2.5). A time point no
+  task can reach with more than its own tasks' heights does not supply the whole
+  capacity: resource nobody can use is not available.
+  `CumulativeRules::elastic_overload`.
+* **(KAOC)**, the knapsack-augmented overload check (Cloutier & Quimper, CP
+  2026). The tasks that could run at a time point have integer heights, so what
+  they can between them consume is the largest *subset sum* of those heights
+  fitting under what the profile leaves --- not that figure itself.
+  `CumulativeRules::knapsack_overload`, which implies the rule above and
+  dominates it.
+
+### The three rungs are one comparison
+
+Charge the window each contained task's energy less whatever its compulsory part
+already accounts for, and supply it one time point at a time:
+
+    required = e_Theta - sum_i h_i * |comp_i ^ window|
+    supplied = sum over t in [a, b) of A_t
+
+With `A_t = capacity - f(I, t)` this **is** `(TTOC)`: each contained task's
+compulsory load comes off the required side and goes back on as the supply the
+profile removes, and the two rearrange into `e + F > C(b-a)` term for term. Cap
+`A_t` by the optional heights at `t` and it is (TTHE-OC); cap it by the largest
+total they can reach and it is (KAOC). Nothing else changes --- so this is one
+certificate with a tighter line at some time points, not three certificates.
+
+### The certificate
+
+Per time point, a line saying what the contained tasks can take there:
+
+* where the optional heights **exceed** what the profile leaves, start from the
+  capacity row `C_t`, pin every compulsory contribution off it
+  (`pin_contributor`, which `(TTOC)` already uses) and `weaken` away every term
+  that is not a contained task's optional one. What is left is a statement over
+  exactly the heights the knapsack reasons about, with right hand side
+  `capacity - f(I, t)`. For (KAOC), put it through
+  `derive_subset_sum_strengthening` (#544);
+* where they **do not**, the capacity row is not the binding fact and citing it
+  would supply the window with resource nobody can take. The binding fact is
+  each task's own literal axiom, and their sum is the whole cap --- no capacity
+  row, no pins, and nothing for the knapsack to improve on, since the entire set
+  already fits.
+
+Against those, each contained task's `derive_window_energy` line scaled by its
+height, over the task's **own** `[est, lct)` rather than over the window, with
+its compulsory times weakened back out --- those charged the availability side,
+and counting them twice would leave the pol open.
+
+`weaken` is what makes the item set exact. VeriPB's `w` drops a term and lowers
+the degree by its coefficient, which is precisely "remove this from the left of
+a `<=`"; without it the knapsack would run over the wrong coefficients and the
+cap would be too weak to fire.
+
+### Strengthen only where the conflict needs it
+
+The dynamic programme costs a layer of proof flags per reachable partial sum, at
+every time point it is applied to. The certificate sorts the time points by what
+the cap buys, applies it biggest-gain first, and stops as soon as the comparison
+tips; the marker comment records `strengthened=k/w`. This falls out of the
+per-time-point shape rather than needing machinery, and it means a conflict the
+elastic cap alone can carry pays nothing for the knapsack at all --- which is
+what the `ttheoc` marker means.
+
+### Measured, `data_bl` + `data_pack` at 60 s, over the 36 instances every arm closed
+
+| arm | recursions | vs baseline | propagations | closed |
+|---|---|---|---|---|
+| time-tabling + `(OC')` + `(TTOC)` | 7,227,100 | 1.000x | 72,057,194 | 38 / 95 |
+| + (TTHE-OC) | 5,008,908 | 0.693x | 51,145,525 | 36 / 95 |
+| + (KAOC) | 2,832,478 | 0.392x | 29,227,548 | 48 / 95 |
+
+Fewer recursions on 30 of 36 and more on none, and no arm disagrees about an
+optimum. **The knapsack cap is what pays**: it more than halves the search and
+closes ten more instances at the same wall time. **The elastic cap alone does
+not**: 0.693x of the search, but it closes *fewer* instances than leaving it off,
+because its per-time-point scan costs more than the pruning returns --- the same
+verdict not-first / not-last got, and for the same reason.
+
+Soundness: 600 generated instances enumerated exhaustively at sizes 8 and 10,
+zero solution-count differences against the rules off.
+
+### What the fixtures could not catch
+
+Both bugs found in this rule were the same mistake --- a quantity the check
+computed that the certificate never derived --- and **every fixture verified
+through both of them**. 11 of 60 proofs on generated instances did not.
+
+* The elastic cap was computed and not derived (above). Every published fixture
+  has every task able to run at every time point, so none of them ever reaches
+  the branch where the cap binds.
+* The energy lines ran over the window rather than over the task, leaving a
+  negative coefficient on every `(task, time)` the task cannot reach. Unit
+  propagation finishes that from the reason's bound literals often enough to
+  hide it, and all four fixtures have every task spanning the whole window, so
+  the residue was zero there anyway.
+
+Both are now cross-checked in the justification, which adds up what the pol
+actually charges and throws if it disagrees with what the rule fired on. The two
+figures come from opposite sides of the propagator --- the incremental
+per-time-point arrays against the lines as they are emitted --- so agreeing is
+worth something.
+
+The general lesson is the one #696 recorded from the other side: a fixture built
+to *demonstrate* a rule is symmetric and generous, and the asymmetric cases are
+exactly where a certificate and a check drift apart. Generated instances are not
+an optional extra here.
+
+### Mutations
+
+`claim_one_better` (claim one better than the largest reachable total),
+`strengthen_one_fewer` and `capacity` are rejected on all three fixtures, so the
+integrality argument is load-bearing on both of the strengthening's paths --- the
+divisibility one `cloutier_ex2` takes and the layered programme `dp_path` takes.
+
+There is no lane for the compulsory-time weakening. Leaving it out is a real
+corruption and VeriPB accepts it anyway: the terms it would have cancelled are
+the ones unit propagation assigns from the reason's own bound literals, the same
+way `(TTOC)`'s pins are droppable on 235 of 248 instances. The step stays, since
+it is what makes the pol itself contradictory rather than only close, but nothing
+can test it.
+
+### Restrictions
+
+Constant heights only: a variable height puts bit-linearised contribution terms
+in the capacity row, which neither the knapsack's item list nor the term-dropping
+can read, so v1 declines rather than approximates and the plain rules still run.
+A capacity above 4096 falls back to the elastic cap, since the bitset is
+`capacity + 1` bits at every time point (scheduling capacities are nothing like
+that --- Cloutier & Quimper report `C <= 122` across their benchmarks).
+
+Propagation is `O(n^2 * horizon)` rather than Cloutier & Quimper's `O(Cn^2)`:
+their doubly linked Profile collapses the runs where the profile is constant, and
+this keeps a flat array plus the incremental bitset (their Algorithm 3 shift-or)
+per time point. Same trade as #742 for edge-finding's scan, and the same answer
+--- what is missing is propagation performance, not proof content.
+
 ## Open follow-ups
-- **Energetic reasoning.** The window-energy lemma above is the first
-  piece of it: horizontally elastic and knapsack-augmented checking
-  (#550) build on the clipped form, and the lifted-constraint
-  presolvers (#549) on the contained one.
+- **Cloutier & Quimper's Profile.** The doubly linked list over time points,
+  which collapses the runs where the profile is constant and takes the sweep
+  from `O(n^2 * horizon)` to `O(Cn^2)`. Propagation performance only; the
+  certificate is unchanged.
 - **Guarded pins for the profile term.** TTEF's pins are reason-backed and
   re-derived per firing, at 2.93 lines' worth per firing and 15,037x repetition.
   A one-time-point `derive_guarded_window_energy` row is keyed by `(task, time)`

--- a/examples/rcpsp/rcpsp.cc
+++ b/examples/rcpsp/rcpsp.cc
@@ -339,14 +339,21 @@ auto main(int argc, char * argv[]) -> int
             ("infer-cumulative-lifting-calls",                                                           //
                 "Cap how many lifting subproblems are solved (Sidorov's N_calls)",                       //
                 cxxopts::value<std::size_t>()->default_value("20000"))                                   //
+            ("cumulative-elastic-overload",                                                              //
+                "Cap what the overload check's window supplies at each time point by what the tasks "    //
+                "there could take, rather than charging it capacity x width in bulk (TTHE-OC)",          //
+                cxxopts::value<bool>()->default_value("false"))                                          //
+            ("cumulative-knapsack-overload",                                                             //
+                "Cap the same per-time-point supply by the largest total those heights can actually "    //
+                "reach (KAOC). Implies --cumulative-elastic-overload, which it dominates",               //
+                cxxopts::value<bool>()->default_value("false"))                                          //
             ("cumulative-edge-finding",                                                                  //
                 "Run edge-finding on every posted Cumulative, alongside time-tabling and the overload "  //
                 "check. Certified, but off by default: the sweep that finds the firings is cubic",       //
                 cxxopts::value<bool>()->default_value("false"))                                          //
             ("cumulative-time-table-edge-finding",                                                       //
                 "Strengthen edge-finding with the mandatory-part load of the tasks the window does not " //
-                "contain (TTEF). Implies --cumulative-edge-finding. Not certified yet, so a run with "   //
-                "--prove will refuse it",                                                                //
+                "contain (TTEF). Certified. Implies --cumulative-edge-finding",                          //
                 cxxopts::value<bool>()->default_value("false"))                                          //
             ("cumulative-energetic-edge-finding",                                                        //
                 "Strengthen edge-finding with every task's guaranteed energy inside the window, rather " //
@@ -644,6 +651,8 @@ auto main(int argc, char * argv[]) -> int
     cumulative_rules.not_first_not_last = options_vars["cumulative-not-first-not-last"].as<bool>();
     cumulative_rules.edge_finding = options_vars["cumulative-edge-finding"].as<bool>() || cumulative_rules.time_table_edge_finding ||
         cumulative_rules.energetic_edge_finding || cumulative_rules.not_first_not_last;
+    cumulative_rules.knapsack_overload = options_vars["cumulative-knapsack-overload"].as<bool>();
+    cumulative_rules.elastic_overload = options_vars["cumulative-elastic-overload"].as<bool>() || cumulative_rules.knapsack_overload;
 
     vector<IntegerVariableID> machine_order_vars;
     if (machine_variant == "difference" && machine_starts.size() >= 2)

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -365,6 +365,14 @@ if(GCS_BUILD_TESTS)
     add_test(NAME cumulative_ttef COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_ttef_test>)
     add_test(NAME cumulative_nfnl COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_nfnl_test>)
     add_test(NAME cumulative_kaoc COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_kaoc_test>)
+    foreach(fixture cloutier_ex2 dp_path compulsory)
+        foreach(mutation claim_one_better strengthen_one_fewer capacity)
+            add_test(NAME cumulative_kaoc_mutation_${fixture}_${mutation}
+                COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_expect_verify_failure.bash
+                    --basename cumulative_kaoc_mutation_${fixture}_${mutation} $<TARGET_FILE:cumulative_kaoc_test>
+                    --mutate=${mutation} --fixture=${fixture})
+        endforeach()
+    endforeach()
     foreach(mutation toofar drop roomy_toofar roomy_drop)
         add_test(NAME cumulative_nfnl_mutation_${mutation}
             COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_expect_verify_failure.bash

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -279,6 +279,7 @@ if(GCS_BUILD_TESTS)
     add_executable(cumulative_edge_finding_test constraints/cumulative/cumulative_edge_finding_test.cc)
     add_executable(cumulative_ttef_test constraints/cumulative/cumulative_ttef_test.cc)
     add_executable(cumulative_nfnl_test constraints/cumulative/cumulative_nfnl_test.cc)
+    add_executable(cumulative_kaoc_test constraints/cumulative/cumulative_kaoc_test.cc)
     add_executable(derived_cumulative_test constraints/cumulative/derived_cumulative_test.cc)
     add_executable(cumulative_optional_test constraints/cumulative/cumulative_optional_test.cc)
     add_executable(difference_test constraints/difference/difference_constraints_test.cc)
@@ -332,7 +333,7 @@ if(GCS_BUILD_TESTS)
 
     foreach(test_target
             abs_test all_different_test all_different_except_test all_equal_test among_test at_most_one_test bin_packing_test comparison_test
-            count_test cumulative_test cumulative_overload_test cumulative_edge_finding_test cumulative_ttef_test cumulative_nfnl_test cumulative_optional_test derived_cumulative_test difference_test disjunctive_test disjunctive_optional_test disjunctive_overload_test disjunctive_precedences_test disjunctive_2d_test divide_modulus_test element_test equals_test bounds_global_cardinality_test gac_global_cardinality_test in_test increasing_test inverse_test knapsack_test knapsack_upfront_test lex_test linear_test linear_constant_test
+            count_test cumulative_test cumulative_overload_test cumulative_edge_finding_test cumulative_ttef_test cumulative_nfnl_test cumulative_kaoc_test cumulative_optional_test derived_cumulative_test difference_test disjunctive_test disjunctive_optional_test disjunctive_overload_test disjunctive_precedences_test disjunctive_2d_test divide_modulus_test element_test equals_test bounds_global_cardinality_test gac_global_cardinality_test in_test increasing_test inverse_test knapsack_test knapsack_upfront_test lex_test linear_test linear_constant_test
             logical_test mdd_test min_distance_test min_distance_matching_test min_max_test mini_linear_test multiply_test n_value_test nogoods_test parity_test
             plus_minus_test power_test product_bounds_test product_justify_test regular_test regular_bacchus_test regular_legacy_test seq_precede_chain_test smart_table_test sort_test arg_sort_test symmetric_all_different_test
             negative_table_test table_test tabulation_test value_precede_test)
@@ -363,6 +364,7 @@ if(GCS_BUILD_TESTS)
     endforeach()
     add_test(NAME cumulative_ttef COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_ttef_test>)
     add_test(NAME cumulative_nfnl COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_nfnl_test>)
+    add_test(NAME cumulative_kaoc COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_kaoc_test>)
     foreach(mutation toofar drop roomy_toofar roomy_drop)
         add_test(NAME cumulative_nfnl_mutation_${mutation}
             COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_expect_verify_failure.bash

--- a/gcs/constraints/cumulative/cumulative.cc
+++ b/gcs/constraints/cumulative/cumulative.cc
@@ -1497,6 +1497,7 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
 
                     if (required > supplied) {
                         auto justify = [&, a, b, inside_tasks, strengthen, required, supplied](const ReasonLiterals & reason) -> void {
+                            Integer pol_supply = 0_i, pol_required = 0_i;
                             if (! logger)
                                 return;
                             logger->emit_proof_comment("cumulative overload conflict window=[" + std::to_string(a.raw_value) + "," +
@@ -1529,9 +1530,51 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
                                 if (capacity_line == capacity_lines.end())
                                     continue;
 
+                                auto idx = static_cast<size_t>((t - t_lo).raw_value);
+                                auto left = max(0_i, capacity - mand_load[idx]);
+
+                                // Which of the contained tasks could be running
+                                // here without being obliged to. These are the
+                                // heights the cap is stated over, whichever way
+                                // it is derived.
+                                vector<SubsetSumItem> items;
+                                for (auto j : active_tasks) {
+                                    if (t < per_task_t_lo[j] || t > per_task_t_hi[j] || ! is_inside[j])
+                                        continue;
+                                    auto lst = state.upper_bound(starts[j]), eet = state.lower_bound(starts[j]) + llb(j);
+                                    if (is_present(j) && lst <= t && t < eet)
+                                        continue;
+                                    if (state.lower_bound(starts[j]) <= t && t < state.upper_bound(starts[j]) + llb(j))
+                                        items.push_back(
+                                            SubsetSumItem{hlb(j), active_flags[j][static_cast<size_t>((t - per_task_t_lo[j]).raw_value)]});
+                                }
+
+                                // Where those heights do not add up to what the
+                                // profile leaves, the capacity row is not the
+                                // binding fact and citing it would supply the
+                                // window with resource nobody can take. The
+                                // binding fact is then each task's own literal
+                                // axiom, and their sum is the whole cap --- no
+                                // capacity row, no pins, and nothing for the
+                                // knapsack to improve on, since the entire set
+                                // already fits.
+                                //
+                                // This is the horizontally elastic cap, and
+                                // deriving it rather than only computing it is
+                                // what the first version got wrong: a fixture
+                                // where every task can be at every time point
+                                // never takes this branch, and every published
+                                // one is like that.
+                                if (optional_height[idx] <= left) {
+                                    pol_supply += optional_height[idx];
+                                    for (const auto & item : items)
+                                        pol.add(! logger->names_and_ids_tracker().xliteral_for(std::get<ProofFlag>(item.term)), item.coefficient,
+                                            logger->names_and_ids_tracker());
+                                    continue;
+                                }
+
                                 PolBuilder avail;
                                 avail.add(capacity_line->second);
-                                vector<SubsetSumItem> items;
                                 for (auto j : active_tasks) {
                                     if (t < per_task_t_lo[j] || t > per_task_t_hi[j])
                                         continue;
@@ -1541,20 +1584,24 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
                                         auto [line, coeff] = pin_contributor(reason, j, t);
                                         avail.add(line, coeff);
                                     }
-                                    else if (is_inside[j] && state.lower_bound(starts[j]) <= t && t < state.upper_bound(starts[j]) + llb(j))
-                                        items.push_back(SubsetSumItem{hlb(j), flag});
-                                    else
+                                    else if (! (is_inside[j] && state.lower_bound(starts[j]) <= t && t < state.upper_bound(starts[j]) + llb(j)))
                                         avail.weaken(flag, logger->names_and_ids_tracker());
                                 }
 
-                                auto idx = static_cast<size_t>((t - t_lo).raw_value);
-                                auto left = max(0_i, capacity - mand_load[idx]);
                                 auto line = avail.emit(*logger, ProofLevel::Temporary);
                                 auto strengthen_here = find(strengthen, t) != strengthen.end();
                                 if (strengthen_one_fewer && ! strengthen.empty() && t == strengthen.front())
                                     strengthen_here = false;
                                 if (strengthen_here) {
-                                    auto strengthened = derive_subset_sum_strengthening(*logger, items, line, left, ProofLevel::Temporary,
+                                    // The reason goes in: the availability
+                                    // line was derived under it (its pins
+                                    // carry the negated reason's literals
+                                    // alongside their own terms), so a dead
+                                    // state's "this prefix cannot be
+                                    // completed" only holds where the reason
+                                    // does, and every RUP inside the
+                                    // strengthening has to say so too.
+                                    auto strengthened = derive_subset_sum_strengthening(*logger, items, line, left, ProofLevel::Temporary, reason,
                                         claim_one_better ? SubsetSumMutation{subset_sum_mutation::ClaimOneBetter{}}
                                                          : SubsetSumMutation{subset_sum_mutation::None{}});
                                     if (! claim_one_better && strengthened.bound != elastic_supply_at(t))
@@ -1562,7 +1609,10 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
                                             " reached " + std::to_string(strengthened.bound.raw_value) + ", not the " +
                                             std::to_string(elastic_supply_at(t).raw_value) + " the check counted on"};
                                     line = strengthened.line;
+                                    pol_supply += strengthened.bound;
                                 }
+                                else
+                                    pol_supply += left;
                                 pol.add(line);
                             }
 
@@ -1582,20 +1632,58 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
                             // there is no mutation lane for this step; a
                             // corruption of it is accepted, and rightly.
                             for (auto i : inside_tasks) {
+                                // Over the task's *own* [est, lct), not over
+                                // the whole window. A contained task's span
+                                // sits inside the window either way, so the
+                                // bound is the same p_i --- but the sum's time
+                                // points then line up exactly with the ones the
+                                // availability lines charged for.
+                                //
+                                // Take the window instead and the pol is left
+                                // with a negative coefficient on every
+                                // (task, time) the task cannot reach: the
+                                // availability lines never mention those, and
+                                // nothing cancels them. Unit propagation
+                                // usually finishes it from the reason's bound
+                                // literals, which is why every fixture where
+                                // the tasks all span the window verifies
+                                // anyway, and why this only showed up on
+                                // generated instances.
+                                auto [i_est, i_lst] = state.bounds(starts[i]);
                                 auto energy_line = window_energy::derive_window_energy(*logger, reason,
                                     window_energy::ConstantLengthTask{std::get<SimpleIntegerVariableID>(starts[i]), llb(i), per_task_t_lo[i],
                                         before_flags[i], after_flags[i], active_flags[i]},
-                                    a, b, state.bounds(starts[i]), ProofLevel::Temporary);
+                                    i_est, i_lst + llb(i), state.bounds(starts[i]), ProofLevel::Temporary);
                                 if (! energy_line || energy_line->bound != llb(i))
                                     throw ProofError{"cumulative elastic overload: a contained task's window energy is not its whole length"};
                                 pol.add(energy_line->line, hlb(i));
+                                pol_required += hlb(i) * energy_line->bound;
 
                                 auto lst = state.upper_bound(starts[i]), eet = state.lower_bound(starts[i]) + llb(i);
-                                for (Integer t = max(lst, a); t < min(eet, b); ++t)
+                                for (Integer t = max(lst, a); t < min(eet, b); ++t) {
                                     pol.add(! logger->names_and_ids_tracker().xliteral_for(
                                                 active_flags[i][static_cast<size_t>((t - per_task_t_lo[i]).raw_value)]),
                                         hlb(i), logger->names_and_ids_tracker());
+                                    pol_required -= hlb(i);
+                                }
                             }
+
+                            // What the pol actually adds up to, against what
+                            // the rule decided to fire on. The two are computed
+                            // on opposite sides of the propagator --- one from
+                            // the incremental per-time-point arrays, the other
+                            // from the lines as they are emitted --- so they
+                            // agree only if the certificate is charging the
+                            // window for what the check counted. A mismatch is
+                            // a proof VeriPB will reject, and it reads far
+                            // better here than there. Off under a mutation,
+                            // whose whole purpose is to make the two disagree.
+                            if (std::holds_alternative<cumulative_proof_mutation::None>(mutation) &&
+                                (pol_supply != supplied || pol_required != required))
+                                throw ProofError{"cumulative elastic overload: the pol says " + std::to_string(pol_required.raw_value) + " > " +
+                                    std::to_string(pol_supply.raw_value) + " but the check said " + std::to_string(required.raw_value) + " > " +
+                                    std::to_string(supplied.raw_value) + " over [" + std::to_string(a.raw_value) + "," + std::to_string(b.raw_value) +
+                                    ")"};
 
                             pol.emit(*logger, ProofLevel::Temporary);
                         };

--- a/gcs/constraints/cumulative/cumulative.cc
+++ b/gcs/constraints/cumulative/cumulative.cc
@@ -1490,6 +1490,13 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
                                 std::to_string(b.raw_value) + ") rule=" + (strengthen.empty() ? "ttheoc" : "kaoc") +
                                 " strengthened=" + std::to_string(strengthen.size()) + "/" + std::to_string((b - a).raw_value));
 
+                            // Tests only: each of these breaks one step of what
+                            // follows in a way that must make VeriPB reject.
+                            // See CumulativeProofMutation.
+                            auto claim_one_better = std::holds_alternative<cumulative_proof_mutation::ClaimOneBetterAvailability>(mutation);
+                            auto strengthen_one_fewer = std::holds_alternative<cumulative_proof_mutation::StrengthenOneFewer>(mutation);
+                            auto omit_capacity_line = std::holds_alternative<cumulative_proof_mutation::OmitCapacityLine>(mutation);
+
                             vector<bool> is_inside(starts.size(), false);
                             for (auto i : inside_tasks)
                                 is_inside[i] = true;
@@ -1503,6 +1510,8 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
                             // that what is left is a statement about exactly
                             // the heights the knapsack reasons over.
                             for (Integer t = a; t < b; ++t) {
+                                if (omit_capacity_line && t == b - 1_i)
+                                    continue;
                                 auto capacity_line = capacity_lines.find(t);
                                 if (capacity_line == capacity_lines.end())
                                     continue;
@@ -1528,9 +1537,14 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
                                 auto idx = static_cast<size_t>((t - t_lo).raw_value);
                                 auto left = max(0_i, capacity - mand_load[idx]);
                                 auto line = avail.emit(*logger, ProofLevel::Temporary);
-                                if (find(strengthen, t) != strengthen.end()) {
-                                    auto strengthened = derive_subset_sum_strengthening(*logger, items, line, left, ProofLevel::Temporary);
-                                    if (strengthened.bound != elastic_supply_at(t))
+                                auto strengthen_here = find(strengthen, t) != strengthen.end();
+                                if (strengthen_one_fewer && ! strengthen.empty() && t == strengthen.front())
+                                    strengthen_here = false;
+                                if (strengthen_here) {
+                                    auto strengthened = derive_subset_sum_strengthening(*logger, items, line, left, ProofLevel::Temporary,
+                                        claim_one_better ? SubsetSumMutation{subset_sum_mutation::ClaimOneBetter{}}
+                                                         : SubsetSumMutation{subset_sum_mutation::None{}});
+                                    if (! claim_one_better && strengthened.bound != elastic_supply_at(t))
                                         throw ProofError{"cumulative knapsack overload: the strengthening at time " + std::to_string(t.raw_value) +
                                             " reached " + std::to_string(strengthened.bound.raw_value) + ", not the " +
                                             std::to_string(elastic_supply_at(t).raw_value) + " the check counted on"};
@@ -1544,6 +1558,16 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
                             // sum: those time points charged the availability
                             // side instead, and counting them twice would leave
                             // the pol open.
+                            //
+                            // That weakening is what makes the pol *itself*
+                            // contradictory, and it is deliberately kept even
+                            // though it is not load-bearing: leaving it out
+                            // still verifies, because the terms it would have
+                            // cancelled are ones unit propagation assigns from
+                            // the reason's own bound literals --- the same
+                            // reason (TTOC)'s pins are usually droppable. So
+                            // there is no mutation lane for this step; a
+                            // corruption of it is accepted, and rightly.
                             for (auto i : inside_tasks) {
                                 auto energy_line = window_energy::derive_window_energy(*logger, reason,
                                     window_energy::ConstantLengthTask{std::get<SimpleIntegerVariableID>(starts[i]), llb(i), per_task_t_lo[i],

--- a/gcs/constraints/cumulative/cumulative.cc
+++ b/gcs/constraints/cumulative/cumulative.cc
@@ -11,11 +11,13 @@
 #include <gcs/innards/proofs/proof_error.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/proofs/proof_model.hh>
+#include <gcs/innards/proofs/subset_sum_strengthening.hh>
 #include <gcs/innards/propagators.hh>
 #include <gcs/innards/s_expr.hh>
 #include <gcs/innards/state.hh>
 
 #include <algorithm>
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <sstream>
@@ -44,8 +46,12 @@ using std::pair;
 using std::size_t;
 using std::string;
 using std::stringstream;
+using std::uint64_t;
 using std::unique_ptr;
 using std::vector;
+using std::ranges::fill;
+using std::ranges::find;
+using std::ranges::none_of;
 using std::ranges::sort;
 
 #if defined(__cpp_lib_print) && defined(__cpp_lib_format)
@@ -1067,10 +1073,101 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
             window_starts.push_back(c.est);
         sort(window_starts);
 
+        // (TTHE-OC) and (KAOC) charge the window one time point at a time, so
+        // they need to know what the contained set could take at each of them
+        // separately. Two arrays indexed by t − t_lo carry it: the heights of
+        // the contained tasks that could run at t without being compulsory
+        // there, and — for the knapsack rule — which totals those heights can
+        // actually add up to, as a bitset over 0..capacity.
+        //
+        // Both are grown one task at a time as the window's right edge
+        // advances and reset when the left edge moves, which is Cloutier &
+        // Quimper's incremental Profile (their Algorithm 3 is the shift-or on
+        // the bitset). Their doubly linked list over time points is the part
+        // not reproduced here: it collapses runs where the profile is constant,
+        // and without it this sweep is O(n²·horizon) rather than O(Cn²). That
+        // is the same trade #742 records for edge-finding's scan, and the same
+        // answer — the rule is off by default, and the cost is propagation
+        // performance rather than proof content.
+        //
+        // A variable height would put bit-linearised contribution terms in the
+        // capacity line instead of one `h·active`, which neither the knapsack's
+        // item list nor the term-dropping below can read. v1 declines rather
+        // than approximates: the plain rules above still run.
+        auto elastic_rules = (rules.elastic_overload || rules.knapsack_overload) && none_of(active_tasks, [&](size_t i) { return h_is_var(i); });
+        auto knapsack_words = static_cast<size_t>(capacity.raw_value / 64 + 1);
+        vector<Integer> optional_height(elastic_rules ? static_cast<size_t>(range) : 0, 0_i);
+        vector<uint64_t> reachable(elastic_rules && rules.knapsack_overload ? static_cast<size_t>(range) * knapsack_words : 0, 0);
+
+        // The times this task is optional at: it could be running, but nothing
+        // says it must be. Its compulsory part is charged to the profile
+        // instead, and comes off the *required* side of the comparison rather
+        // than off what the time point supplies --- so counting it here as well
+        // would charge it twice, and the pol would not close.
+        //
+        // A task with no compulsory part at all is optional across the whole of
+        // [est, lct), which is the case to be careful with: `lst` is then at or
+        // past `ect`, and taking the two ends as [est, lst) and [ect, lct)
+        // would silently drop everything between them.
+        auto optional_times = [&](const Candidate & c) {
+            auto lst = c.lct - c.length, ect = c.est + c.length;
+            if (lst < ect)
+                return pair{pair{c.est, lst}, pair{ect, c.lct}};
+            return pair{pair{c.est, c.lct}, pair{c.lct, c.lct}};
+        };
+
+        auto join_elastic = [&](const Candidate & c) {
+            auto [before, after] = optional_times(c);
+            for (auto [from, to] : {before, after})
+                for (Integer t = from; t < to; ++t) {
+                    auto idx = static_cast<size_t>((t - t_lo).raw_value);
+                    optional_height[idx] += c.height;
+                    if (rules.knapsack_overload) {
+                        // bitset |= bitset << height, most significant word
+                        // first so a shift reads only bits it has not written.
+                        auto * bits = reachable.data() + idx * knapsack_words;
+                        auto shift = static_cast<size_t>(c.height.raw_value);
+                        for (size_t k = knapsack_words; k-- > 0;) {
+                            auto word = (shift / 64 > k) ? 0ull : bits[k - shift / 64] << (shift % 64);
+                            if (shift % 64 != 0 && shift / 64 < k)
+                                word |= bits[k - shift / 64 - 1] >> (64 - shift % 64);
+                            bits[k] |= word;
+                        }
+                    }
+                }
+        };
+
+        // What one time point supplies to the contained set: what the profile
+        // leaves of the capacity, capped by what the tasks that could be here
+        // are between them able to take — and, for (KAOC), by the largest total
+        // those heights can actually add up to, since a resource no subset of
+        // them can reach is not available either.
+        auto elastic_supply_at = [&](Integer t) {
+            auto idx = static_cast<size_t>((t - t_lo).raw_value);
+            auto left = max(0_i, capacity - mand_load[idx]);
+            auto cap = min(left, optional_height[idx]);
+            if (rules.knapsack_overload && cap > 0_i) {
+                const auto * bits = reachable.data() + idx * knapsack_words;
+                for (Integer v = cap; v >= 0_i; --v)
+                    if (bits[static_cast<size_t>(v.raw_value) / 64] >> (static_cast<size_t>(v.raw_value) % 64) & 1ull)
+                        return v;
+                return 0_i;
+            }
+            return cap;
+        };
+
         for (size_t w = 0; w < window_starts.size(); ++w) {
             if (w > 0 && window_starts[w] == window_starts[w - 1])
                 continue;
             auto a = window_starts[w];
+
+            if (elastic_rules) {
+                fill(optional_height, 0_i);
+                fill(reachable, 0ull);
+                // Every bitset starts with only the empty subset reachable.
+                for (size_t k = 0; k < reachable.size(); k += knapsack_words)
+                    reachable[k] = 1ull;
+            }
 
             // min_ect and max_lst are not-first / not-last's thresholds, over
             // the same growing contained set the energy accumulates over.
@@ -1082,6 +1179,8 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
                 energy += c.energy;
                 inside_mandatory += c.mandatory;
                 inside_tasks.push_back(c.task);
+                if (elastic_rules)
+                    join_elastic(c);
                 min_ect = inside_tasks.size() == 1 ? c.est + c.length : min(min_ect, c.est + c.length);
                 max_lst = inside_tasks.size() == 1 ? c.lct - c.length : max(max_lst, c.lct - c.length);
 
@@ -1327,6 +1426,149 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
                 }
 
                 auto outside_profile = rules.profile_overload ? window_profile : 0_i;
+
+                // (TTHE-OC) and (KAOC). Both compare the same two quantities,
+                // and differ only in how tightly one of them is capped:
+                //
+                //   required   each contained task's energy, less whatever of
+                //              it its compulsory part already accounts for
+                //   supplied   summed one time point at a time, each capped by
+                //              what the profile leaves, by the heights of the
+                //              tasks that could be there, and (KAOC) by the
+                //              largest total those heights can reach
+                //
+                // With no cap but the profile's this is exactly (TTOC): each
+                // contained task's compulsory load comes off the required side
+                // and goes back on as the supply the profile removes, and the
+                // two rearrange into `e + F > C·(b−a)` term for term. So the
+                // rules form a ladder over one comparison, and the certificate
+                // below is one shape with a tighter line per time point --- not
+                // three certificates.
+                //
+                // Tried only where (TTOC) has already declined, which is sound
+                // because it dominates neither: whatever (TTOC) detects, this
+                // detects too. What that buys is the cheaper certificate
+                // wherever the cheaper rule was enough.
+                if (elastic_rules && ! inside_tasks.empty() && energy + outside_profile <= supply) {
+                    auto required = energy - inside_mandatory;
+
+                    // What each time point supplies with and without the
+                    // knapsack cap. The gap between them is what strengthening
+                    // that point would buy the conflict, and it is worth
+                    // knowing separately: the DP costs a layer of proof flags
+                    // per reachable partial sum, so the certificate pays for it
+                    // only where the contradiction cannot do without.
+                    Integer elastic_total = 0_i;
+                    vector<pair<Integer, Integer>> gain_at;
+                    for (Integer t = a; t < b; ++t) {
+                        auto idx = static_cast<size_t>((t - t_lo).raw_value);
+                        auto uncapped = min(max(0_i, capacity - mand_load[idx]), optional_height[idx]);
+                        elastic_total += uncapped;
+                        if (auto gain = uncapped - elastic_supply_at(t); gain > 0_i)
+                            gain_at.emplace_back(gain, t);
+                    }
+
+                    // Biggest gains first, and stop as soon as the comparison
+                    // tips: `strengthen` is then exactly the set of time points
+                    // the conflict rests on, and every other one keeps the
+                    // cheap line.
+                    sort(gain_at, [](const auto & x, const auto & y) { return x.first > y.first; });
+                    vector<Integer> strengthen;
+                    auto supplied = elastic_total;
+                    for (const auto & [gain, t] : gain_at) {
+                        if (required > supplied)
+                            break;
+                        supplied -= gain;
+                        strengthen.push_back(t);
+                    }
+
+                    if (required > supplied) {
+                        auto justify = [&, a, b, inside_tasks, strengthen, required, supplied](const ReasonLiterals & reason) -> void {
+                            if (! logger)
+                                return;
+                            logger->emit_proof_comment("cumulative overload conflict window=[" + std::to_string(a.raw_value) + "," +
+                                std::to_string(b.raw_value) + ") rule=" + (strengthen.empty() ? "ttheoc" : "kaoc") +
+                                " strengthened=" + std::to_string(strengthen.size()) + "/" + std::to_string((b - a).raw_value));
+
+                            vector<bool> is_inside(starts.size(), false);
+                            for (auto i : inside_tasks)
+                                is_inside[i] = true;
+
+                            PolBuilder pol;
+
+                            // One availability line per time point: the
+                            // capacity row, with every compulsory contribution
+                            // pinned off it and every term that is not a
+                            // contained task's optional one weakened away, so
+                            // that what is left is a statement about exactly
+                            // the heights the knapsack reasons over.
+                            for (Integer t = a; t < b; ++t) {
+                                auto capacity_line = capacity_lines.find(t);
+                                if (capacity_line == capacity_lines.end())
+                                    continue;
+
+                                PolBuilder avail;
+                                avail.add(capacity_line->second);
+                                vector<SubsetSumItem> items;
+                                for (auto j : active_tasks) {
+                                    if (t < per_task_t_lo[j] || t > per_task_t_hi[j])
+                                        continue;
+                                    auto flag = active_flags[j][static_cast<size_t>((t - per_task_t_lo[j]).raw_value)];
+                                    auto lst = state.upper_bound(starts[j]), eet = state.lower_bound(starts[j]) + llb(j);
+                                    if (is_present(j) && lst <= t && t < eet) {
+                                        auto [line, coeff] = pin_contributor(reason, j, t);
+                                        avail.add(line, coeff);
+                                    }
+                                    else if (is_inside[j] && state.lower_bound(starts[j]) <= t && t < state.upper_bound(starts[j]) + llb(j))
+                                        items.push_back(SubsetSumItem{hlb(j), flag});
+                                    else
+                                        avail.weaken(flag, logger->names_and_ids_tracker());
+                                }
+
+                                auto idx = static_cast<size_t>((t - t_lo).raw_value);
+                                auto left = max(0_i, capacity - mand_load[idx]);
+                                auto line = avail.emit(*logger, ProofLevel::Temporary);
+                                if (find(strengthen, t) != strengthen.end()) {
+                                    auto strengthened = derive_subset_sum_strengthening(*logger, items, line, left, ProofLevel::Temporary);
+                                    if (strengthened.bound != elastic_supply_at(t))
+                                        throw ProofError{"cumulative knapsack overload: the strengthening at time " + std::to_string(t.raw_value) +
+                                            " reached " + std::to_string(strengthened.bound.raw_value) + ", not the " +
+                                            std::to_string(elastic_supply_at(t).raw_value) + " the check counted on"};
+                                    line = strengthened.line;
+                                }
+                                pol.add(line);
+                            }
+
+                            // ... against each contained task's energy, with
+                            // its compulsory times weakened back out of the
+                            // sum: those time points charged the availability
+                            // side instead, and counting them twice would leave
+                            // the pol open.
+                            for (auto i : inside_tasks) {
+                                auto energy_line = window_energy::derive_window_energy(*logger, reason,
+                                    window_energy::ConstantLengthTask{std::get<SimpleIntegerVariableID>(starts[i]), llb(i), per_task_t_lo[i],
+                                        before_flags[i], after_flags[i], active_flags[i]},
+                                    a, b, state.bounds(starts[i]), ProofLevel::Temporary);
+                                if (! energy_line || energy_line->bound != llb(i))
+                                    throw ProofError{"cumulative elastic overload: a contained task's window energy is not its whole length"};
+                                pol.add(energy_line->line, hlb(i));
+
+                                auto lst = state.upper_bound(starts[i]), eet = state.lower_bound(starts[i]) + llb(i);
+                                for (Integer t = max(lst, a); t < min(eet, b); ++t)
+                                    pol.add(! logger->names_and_ids_tracker().xliteral_for(
+                                                active_flags[i][static_cast<size_t>((t - per_task_t_lo[i]).raw_value)]),
+                                        hlb(i), logger->names_and_ids_tracker());
+                            }
+
+                            pol.emit(*logger, ProofLevel::Temporary);
+                        };
+
+                        inference.contradiction(
+                            logger, JustifyExplicitly{justify, ThenRUP::Yes, hints::CumulativeOverload{owner}}, reason_with_presence());
+                        return PropagatorState::DisableUntilBacktrack;
+                    }
+                }
+
                 if (energy + outside_profile <= supply)
                     continue;
 

--- a/gcs/constraints/cumulative/cumulative.cc
+++ b/gcs/constraints/cumulative/cumulative.cc
@@ -1095,9 +1095,22 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
         // item list nor the term-dropping below can read. v1 declines rather
         // than approximates: the plain rules above still run.
         auto elastic_rules = (rules.elastic_overload || rules.knapsack_overload) && none_of(active_tasks, [&](size_t i) { return h_is_var(i); });
+
+        // The knapsack cap is pseudo-polynomial in the capacity twice over: a
+        // bitset of `capacity + 1` bits at every time point, and a layer of
+        // proof flags per reachable partial sum in every strengthening it
+        // certifies. Scheduling capacities are small --- Cloutier & Quimper
+        // report C <= 122 across their benchmarks, and the local RCPSP
+        // instances run 5 to 22 --- so this bound is far above anything the
+        // rule is meant for, and exists so that a model with a capacity in the
+        // millions degrades to the horizontally elastic cap instead of asking
+        // for terabytes. Not a silent cap on strength: what it turns off is one
+        // of three rungs, and the two below it still run.
+        constexpr auto max_knapsack_capacity = 4096;
+        auto knapsack_rule = rules.knapsack_overload && capacity <= Integer{max_knapsack_capacity};
         auto knapsack_words = static_cast<size_t>(capacity.raw_value / 64 + 1);
         vector<Integer> optional_height(elastic_rules ? static_cast<size_t>(range) : 0, 0_i);
-        vector<uint64_t> reachable(elastic_rules && rules.knapsack_overload ? static_cast<size_t>(range) * knapsack_words : 0, 0);
+        vector<uint64_t> reachable(elastic_rules && knapsack_rule ? static_cast<size_t>(range) * knapsack_words : 0, 0);
 
         // The times this task is optional at: it could be running, but nothing
         // says it must be. Its compulsory part is charged to the profile
@@ -1122,7 +1135,7 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
                 for (Integer t = from; t < to; ++t) {
                     auto idx = static_cast<size_t>((t - t_lo).raw_value);
                     optional_height[idx] += c.height;
-                    if (rules.knapsack_overload) {
+                    if (knapsack_rule) {
                         // bitset |= bitset << height, most significant word
                         // first so a shift reads only bits it has not written.
                         auto * bits = reachable.data() + idx * knapsack_words;
@@ -1146,7 +1159,7 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
             auto idx = static_cast<size_t>((t - t_lo).raw_value);
             auto left = max(0_i, capacity - mand_load[idx]);
             auto cap = min(left, optional_height[idx]);
-            if (rules.knapsack_overload && cap > 0_i) {
+            if (knapsack_rule && cap > 0_i) {
                 const auto * bits = reachable.data() + idx * knapsack_words;
                 for (Integer v = cap; v >= 0_i; --v)
                     if (bits[static_cast<size_t>(v.raw_value) / 64] >> (static_cast<size_t>(v.raw_value) % 64) & 1ull)

--- a/gcs/constraints/cumulative/cumulative.hh
+++ b/gcs/constraints/cumulative/cumulative.hh
@@ -96,8 +96,8 @@ namespace gcs
         /// set, and wants \ref profile_overload set alongside it, since a
         /// window the profile already overloads is left to the overload check.
         ///
-        /// \warning Not yet certified. A propagator with this set refuses to
-        /// run against a proof logger.
+        /// Certified, by edge-finding's certificate plus the mandatory
+        /// (task, time) pins the overload check already emits.
         bool time_table_edge_finding = false;
 
         /// Count every task's *guaranteed* energy inside the window --- the

--- a/gcs/constraints/cumulative/cumulative.hh
+++ b/gcs/constraints/cumulative/cumulative.hh
@@ -44,6 +44,39 @@ namespace gcs
         /// effect unless \ref overload is also set.
         bool profile_overload = true;
 
+        /// Cap what the window supplies at each individual time point by what
+        /// the tasks there could actually take: the *horizontally elastic*
+        /// overload check, combined with the time table (rule (TTHE-OC),
+        /// Kameugne et al. 2024; the formulation is Cloutier & Quimper's
+        /// equivalent one, CP 2026 §2.2.5).
+        ///
+        /// (TTOC) charges the whole window `capacity · width` and subtracts the
+        /// profile. That over-supplies a time point which no task can reach
+        /// with more than its own tasks' heights: a resource nobody can use is
+        /// not available. Capping each time point separately is what makes this
+        /// rule strictly stronger, and it is why the certificate sums a *line
+        /// per time point* rather than one bulk supply term.
+        ///
+        /// Has no effect unless \ref overload is also set, and wants
+        /// \ref profile_overload alongside it, since the cap is stated against
+        /// what the profile leaves.
+        bool elastic_overload = false;
+
+        /// Cap the same per-time-point supply by *integrality* as well: the
+        /// tasks that could run at a time point have integer heights, so the
+        /// resource they can between them consume is the largest subset sum of
+        /// those heights that fits under what the profile leaves --- not that
+        /// figure itself. This is the knapsack-augmented overload check
+        /// (Cloutier & Quimper, CP 2026), and it dominates \ref
+        /// elastic_overload, which it therefore implies.
+        ///
+        /// The certificate is the same one, with each time point's line put
+        /// through the subset-sum strengthening utility. Off by default: the
+        /// cap has to be recomputed as the window's task set grows, and the
+        /// derivation costs a layer of proof flags per reachable partial sum at
+        /// every time point whose slack the conflict actually needs.
+        bool knapsack_overload = false;
+
         /// Edge-finding: if a window's contained tasks plus one more task with
         /// one end inside it cannot all fit, that task must run past the end it
         /// hangs off, and the bound at that end moves by the energy the window

--- a/gcs/constraints/cumulative/cumulative_kaoc_test.cc
+++ b/gcs/constraints/cumulative/cumulative_kaoc_test.cc
@@ -84,6 +84,11 @@ namespace
         return true;
     }
 
+    // Set from argv, so that a mutation lane runs the same fixtures the honest
+    // lane does and differs only in what the certificate says. Global because
+    // every fixture in the file has to carry it.
+    CumulativeProofMutation the_mutation = cumulative_proof_mutation::None{};
+
     auto post(Problem & p, const Instance & inst, CumulativeRules rules) -> vector<IntegerVariableID>
     {
         vector<IntegerVariableID> starts;
@@ -96,7 +101,7 @@ namespace
         for (auto h : inst.heights)
             heights.push_back(Integer{h});
 
-        p.post(Cumulative{starts, lengths, heights, Integer{inst.capacity}}.with_rules(rules));
+        p.post(Cumulative{starts, lengths, heights, Integer{inst.capacity}}.with_rules(rules).with_proof_mutation(the_mutation));
         return starts;
     }
 
@@ -201,6 +206,42 @@ namespace
     const CumulativeRules elastic{.elastic_overload = true};
     const CumulativeRules knapsack{.elastic_overload = true, .knapsack_overload = true};
 
+    // Cloutier & Quimper, CP 2026, Example 2. Four tasks of height 2 sharing a
+    // resource of capacity 3, each two time units long, all inside [0, 7).
+    // (OC') sees 3 x 7 = 21 units of energy available against the 16 required
+    // and says nothing; so does the horizontally elastic cap, since all four
+    // tasks could be at every time point. But no subset of the heights
+    // {2, 2, 2, 2} sums to 3, so a time point supplies 2 rather than 3, the
+    // window supplies 14, and 16 > 14 is a conflict. The paper calls this the
+    // parity test; here it is the strengthening utility's divisibility fast
+    // path, since every coefficient shares the factor 2.
+    const Instance cloutier_ex2{{{0, 5}, {0, 5}, {0, 5}, {0, 5}}, {2, 2, 2, 2}, {2, 2, 2, 2}, 3};
+
+    // Heights {3, 3, 5, 5} under a capacity of 7, in the window [0, 8). Their
+    // gcd is 1, so the divisibility fast path does not apply and the
+    // strengthening has to run its layered dynamic programme: the reachable
+    // sums are 0, 3, 5, 6, 8, 10, 11, 13, 16, so 6 is the most a time point
+    // can supply, not 7. Over eight time points that is 48 against the 53 the
+    // tasks require --- where (OC') sees 56 available and declines, and so
+    // does the horizontally elastic cap, since between them the four tasks
+    // could take 16 at any time point. No task has a compulsory part, so the
+    // profile says nothing either.
+    const Instance dp_path{{{0, 5}, {0, 5}, {0, 4}, {0, 5}}, {3, 3, 4, 3}, {3, 3, 5, 5}, 7};
+
+    // The same rule again, but on a window where one task has a compulsory
+    // part: the length-four task in [0, 6) must be running throughout [2, 4).
+    // Neither fixture above has one at all, which matters because the
+    // certificate's one asymmetric step --- weakening a contained task's
+    // compulsory times back out of its energy line, since the availability
+    // side was charged for them --- is a no-op without one, and a mutation of
+    // a no-op passes every check there is.
+    //
+    // Over [0, 6) at capacity 7: 33 units required once the compulsory part is
+    // taken off, against 36 the elastic cap allows and 30 the knapsack does,
+    // since {3, 3, 3, 3} reaches only 6 of the 7 free and {3, 3, 3} only 3 of
+    // the 4 the profile leaves at the two compulsory time points.
+    const Instance compulsory{{{0, 2}, {0, 3}, {0, 3}, {0, 3}}, {4, 3, 3, 3}, {3, 3, 3, 3}, 7};
+
     auto has_a_solution(const Instance & inst) -> bool
     {
         set<vector<int>> solutions;
@@ -233,18 +274,37 @@ namespace
     }
 }
 
-auto main(int, char *[]) -> int
+auto main(int argc, char * argv[]) -> int
 {
-    // Cloutier & Quimper, CP 2026, Example 2. Four tasks of height 2 sharing a
-    // resource of capacity 3, each two time units long, all inside [0, 7).
-    // (OC') sees 3 x 7 = 21 units of energy available against the 16 required
-    // and says nothing; so does the horizontally elastic cap, since all four
-    // tasks can be at every time point. But no subset of heights {2,2,2,2}
-    // sums to 3, so a time point supplies 2 rather than 3, the window supplies
-    // 14, and 16 > 14 is a conflict. The paper calls this the parity test; it
-    // is the divisibility fast path in the strengthening utility, since every
-    // coefficient shares the factor 2.
-    check_knapsack_only("cloutier_ex2", Instance{{{0, 5}, {0, 5}, {0, 5}, {0, 5}}, {2, 2, 2, 2}, {2, 2, 2, 2}, 3});
+    // A mutation lane runs one fixture and expects VeriPB to reject it. Which
+    // fixture matters: `cloutier_ex2` takes the strengthening's divisibility
+    // fast path and `dp_path` its layered dynamic programme, and a mutation
+    // that bites on one need not bite on the other.
+    string mutated_fixture, proof_basename = "cumulative_kaoc_mutation";
+    bool mutating = false;
+    for (int a = 1; a < argc; ++a) {
+        string arg = argv[a];
+        if (arg == "--mutate=claim_one_better")
+            the_mutation = cumulative_proof_mutation::ClaimOneBetterAvailability{}, mutating = true;
+        else if (arg == "--mutate=strengthen_one_fewer")
+            the_mutation = cumulative_proof_mutation::StrengthenOneFewer{}, mutating = true;
+        else if (arg == "--mutate=capacity")
+            the_mutation = cumulative_proof_mutation::OmitCapacityLine{}, mutating = true;
+        else if (arg.starts_with("--fixture="))
+            mutated_fixture = arg.substr(arg.find('=') + 1);
+        else if (arg == "--proof-files-basename" && a + 1 < argc)
+            proof_basename = argv[++a];
+    }
+
+    if (mutating) {
+        const auto & inst = mutated_fixture == "dp_path" ? dp_path : mutated_fixture == "compulsory" ? compulsory : cloutier_ex2;
+        if (! solve_root_only(inst, knapsack, make_optional(proof_basename)))
+            fail("mutation mode: the fixture was not refuted, so the proof has no conflict in it");
+        println(cerr, "wrote a deliberately corrupted proof to {}.pbp", proof_basename);
+        return EXIT_SUCCESS;
+    }
+
+    check_knapsack_only("cloutier_ex2", cloutier_ex2);
 
     // The same shape with one more time point to play with, which is exactly
     // enough: 8 units of time for 8 units of work. Nothing may fire.
@@ -254,16 +314,7 @@ auto main(int, char *[]) -> int
             fail("cloutier_ex2 negative twin: refuted a satisfiable instance");
     }
 
-    // Heights {3, 3, 5, 5} under a capacity of 7, in the window [0, 8). Their
-    // gcd is 1, so the divisibility fast path does not apply and the
-    // strengthening has to run its layered dynamic programme: the reachable
-    // sums are 0, 3, 5, 6, 8, 10, 11, 13, 16, so 6 is the most a time point
-    // can supply, not 7. Over eight time points that is 48 against the 53 the
-    // tasks require --- where (OC') sees 56 available and declines, and so
-    // does the horizontally elastic cap, since between them the four tasks
-    // could take 16 at any time point. No task has a compulsory part, so the
-    // profile says nothing either.
-    check_knapsack_only("dp_path", Instance{{{0, 5}, {0, 5}, {0, 4}, {0, 5}}, {3, 3, 4, 3}, {3, 3, 5, 5}, 7});
+    check_knapsack_only("dp_path", dp_path);
 
     // ... and its negative twin, one unit of capacity better off. 8 is now a
     // reachable sum (3 + 5), so the knapsack cap buys nothing at all.
@@ -271,6 +322,17 @@ auto main(int, char *[]) -> int
         auto probe = probe_root(Instance{{{0, 5}, {0, 5}, {0, 4}, {0, 5}}, {3, 3, 4, 3}, {3, 3, 5, 5}, 8}, knapsack, nullopt);
         if (probe.refuted)
             fail("dp_path negative twin: refuted an instance the knapsack cap cannot reach");
+    }
+
+    check_knapsack_only("compulsory", compulsory);
+
+    // ... and its negative twin: give the length-four task one more place to
+    // go and its compulsory part vanishes, which frees the two time points the
+    // conflict was leaning on.
+    {
+        auto probe = probe_root(Instance{{{0, 4}, {0, 3}, {0, 3}, {0, 3}}, {4, 3, 3, 3}, {3, 3, 3, 3}, 7}, knapsack, nullopt);
+        if (probe.refuted)
+            fail("compulsory negative twin: refuted an instance the rule should not reach");
     }
 
     // The soundness net. A conflict-only rule can only ever lose solutions, so

--- a/gcs/constraints/cumulative/cumulative_kaoc_test.cc
+++ b/gcs/constraints/cumulative/cumulative_kaoc_test.cc
@@ -276,6 +276,15 @@ namespace
 
 auto main(int argc, char * argv[]) -> int
 {
+    // Before anything solves. Nothing in this file draws random *data* --- every
+    // fixture is written out --- but the enumeration below branches with
+    // random_branch_with_optional_seed, and without this its order comes from a
+    // random_device: `--seed=N` was silently ignored, no seed was announced, and
+    // cumulative_kaoc_enumeration.pbp differed between two runs of the same
+    // binary. A failing lane could not be re-run, and the proof was useless as
+    // a byte-diff reference.
+    establish_and_announce_seed(argc, argv);
+
     // A mutation lane runs one fixture and expects VeriPB to reject it. Which
     // fixture matters: `cloutier_ex2` takes the strengthening's divisibility
     // fast path and `dp_path` its layered dynamic programme, and a mutation

--- a/gcs/constraints/cumulative/cumulative_kaoc_test.cc
+++ b/gcs/constraints/cumulative/cumulative_kaoc_test.cc
@@ -1,0 +1,283 @@
+#include <gcs/constraints/cumulative.hh>
+#include <gcs/constraints/innards/constraints_test_utils.hh>
+#include <gcs/problem.hh>
+#include <gcs/solve.hh>
+
+#include <algorithm>
+#include <climits>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <optional>
+#include <set>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+#include <version>
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+#include <print>
+#else
+#include <fmt/core.h>
+#include <fmt/ostream.h>
+#include <fmt/ranges.h>
+#endif
+
+using std::cerr;
+using std::flush;
+using std::ifstream;
+using std::make_optional;
+using std::max;
+using std::min;
+using std::nullopt;
+using std::optional;
+using std::pair;
+using std::set;
+using std::string;
+using std::tuple;
+using std::vector;
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+using std::print;
+using std::println;
+#else
+using fmt::print;
+using fmt::println;
+#endif
+
+using namespace gcs;
+using namespace gcs::innards;
+using namespace gcs::test_innards;
+
+namespace
+{
+    // Every fixture here is all-constant: the horizontally elastic rules
+    // decline a variable height outright, and the window-energy lemma the
+    // certificate cites wants a constant length.
+    struct Instance
+    {
+        vector<pair<int, int>> start_ranges;
+        vector<int> lengths;
+        vector<int> heights;
+        int capacity;
+    };
+
+    auto is_satisfying(const Instance & inst, const vector<int> & starts) -> bool
+    {
+        auto n = inst.start_ranges.size();
+        int t_lo = INT_MAX, t_hi = INT_MIN;
+        for (size_t i = 0; i < n; ++i) {
+            if (inst.lengths[i] == 0 || inst.heights[i] == 0)
+                continue;
+            t_lo = min(t_lo, starts[i]);
+            t_hi = max(t_hi, starts[i] + inst.lengths[i] - 1);
+        }
+        for (int t = t_lo; t <= t_hi; ++t) {
+            int load = 0;
+            for (size_t i = 0; i < n; ++i)
+                if (starts[i] <= t && t < starts[i] + inst.lengths[i])
+                    load += inst.heights[i];
+            if (load > inst.capacity)
+                return false;
+        }
+        return true;
+    }
+
+    auto post(Problem & p, const Instance & inst, CumulativeRules rules) -> vector<IntegerVariableID>
+    {
+        vector<IntegerVariableID> starts;
+        for (auto & [lo, hi] : inst.start_ranges)
+            starts.push_back(p.create_integer_variable(Integer{lo}, Integer{hi}));
+
+        vector<Integer> lengths, heights;
+        for (auto l : inst.lengths)
+            lengths.push_back(Integer{l});
+        for (auto h : inst.heights)
+            heights.push_back(Integer{h});
+
+        p.post(Cumulative{starts, lengths, heights, Integer{inst.capacity}}.with_rules(rules));
+        return starts;
+    }
+
+    // Which rung of the overload ladder justified each conflict. The rules
+    // share one certificate shape, so the marker is how a test tells them
+    // apart: `ttheoc` is the shape with no time point strengthened, `kaoc` the
+    // same shape with the knapsack cap on at least one of them.
+    struct MarkerCounts
+    {
+        size_t oc = 0, ttoc = 0, ttheoc = 0, kaoc = 0;
+
+        [[nodiscard]] auto total() const -> size_t
+        {
+            return oc + ttoc + ttheoc + kaoc;
+        }
+    };
+
+    auto count_markers(const string & proof_name) -> MarkerCounts
+    {
+        MarkerCounts counts;
+        ifstream proof{proof_name + ".pbp"};
+        if (! proof) {
+            println(cerr, "could not read {}.pbp to count overload markers", proof_name);
+            std::exit(EXIT_FAILURE);
+        }
+        string line;
+        while (getline(proof, line)) {
+            if (line.find("cumulative overload conflict") == string::npos)
+                continue;
+            if (line.find("rule=ttheoc") != string::npos)
+                ++counts.ttheoc;
+            else if (line.find("rule=kaoc") != string::npos)
+                ++counts.kaoc;
+            else if (line.find("rule=ttoc") != string::npos)
+                ++counts.ttoc;
+            else if (line.find("rule=oc") != string::npos)
+                ++counts.oc;
+        }
+        return counts;
+    }
+
+    struct RootProbe
+    {
+        bool refuted = false;
+        MarkerCounts markers;
+    };
+
+    auto solve_root_only(const Instance & inst, CumulativeRules rules, const optional<string> & proof_name) -> bool
+    {
+        Problem p;
+        post(p, inst, rules);
+
+        bool reached_a_node = false, found_a_solution = false;
+        solve_with(p,
+            SolveCallbacks{.solution = [&](const CurrentState &) -> bool {
+                               found_a_solution = true;
+                               return false;
+                           },
+                .trace = [&](const CurrentState &) -> bool {
+                    reached_a_node = true;
+                    return false;
+                }},
+            proof_name ? make_optional<ProofOptions>(ProofFileNames{*proof_name}) : nullopt);
+        return ! reached_a_node && ! found_a_solution;
+    }
+
+    auto probe_root(const Instance & inst, CumulativeRules rules, const optional<string> & proof_name) -> RootProbe
+    {
+        RootProbe probe;
+        probe.refuted = solve_root_only(inst, rules, proof_name);
+
+        if (proof_name) {
+            probe.markers = count_markers(*proof_name);
+            verify_proof_and_clean_up(*proof_name);
+        }
+        return probe;
+    }
+
+    auto check_enumeration(const string & what, const Instance & inst, CumulativeRules rules, const optional<string> & proof_name) -> void
+    {
+        print(cerr, "cumulative kaoc {} starts={} lens={} hts={} c={}{}", what, inst.start_ranges, inst.lengths, inst.heights, inst.capacity,
+            proof_name ? " with proofs:" : ":");
+        cerr << flush;
+
+        set<vector<int>> expected, actual;
+        build_expected(expected, [&](const vector<int> & starts) { return is_satisfying(inst, starts); }, inst.start_ranges);
+        println(cerr, " expecting {} solutions", expected.size());
+
+        Problem p;
+        auto starts = post(p, inst, rules);
+        solve_for_tests(p, proof_name, actual, tuple{starts});
+        check_results(proof_name, expected, actual);
+    }
+
+    auto fail(const string & message) -> void
+    {
+        println(cerr, "cumulative kaoc test failure: {}", message);
+        std::exit(EXIT_FAILURE);
+    }
+
+    const CumulativeRules plain{};
+    const CumulativeRules elastic{.elastic_overload = true};
+    const CumulativeRules knapsack{.elastic_overload = true, .knapsack_overload = true};
+
+    auto has_a_solution(const Instance & inst) -> bool
+    {
+        set<vector<int>> solutions;
+        build_expected(solutions, [&](const vector<int> & starts) { return is_satisfying(inst, starts); }, inst.start_ranges);
+        return ! solutions.empty();
+    }
+
+    // A fixture the knapsack cap is supposed to refute at the root, and the
+    // rungs below it are supposed to miss. Both halves matter: a rule that
+    // fires everywhere proves nothing, and one that never fires proves less.
+    auto check_knapsack_only(const string & what, const Instance & inst) -> void
+    {
+        println(cerr, "cumulative kaoc {}: knapsack-only differential", what);
+
+        // A conflict rule firing on a satisfiable instance is the failure this
+        // whole file is here to catch, and the rungs below cannot catch it for
+        // us: they decline on this fixture by construction.
+        if (has_a_solution(inst))
+            fail(what + ": the fixture is satisfiable, so refuting it would be a soundness bug");
+        if (probe_root(inst, plain, nullopt).refuted)
+            fail(what + ": (TTOC) already refutes it, so it is not a differential");
+        if (probe_root(inst, elastic, nullopt).refuted)
+            fail(what + ": (TTHE-OC) already refutes it, so it is not a knapsack differential");
+
+        auto probe = probe_root(inst, knapsack, make_optional("cumulative_kaoc_" + what));
+        if (! probe.refuted)
+            fail(what + ": (KAOC) did not refute it");
+        if (probe.markers.kaoc == 0)
+            fail(what + ": refuted, but no conflict carried the kaoc marker");
+    }
+}
+
+auto main(int, char *[]) -> int
+{
+    // Cloutier & Quimper, CP 2026, Example 2. Four tasks of height 2 sharing a
+    // resource of capacity 3, each two time units long, all inside [0, 7).
+    // (OC') sees 3 x 7 = 21 units of energy available against the 16 required
+    // and says nothing; so does the horizontally elastic cap, since all four
+    // tasks can be at every time point. But no subset of heights {2,2,2,2}
+    // sums to 3, so a time point supplies 2 rather than 3, the window supplies
+    // 14, and 16 > 14 is a conflict. The paper calls this the parity test; it
+    // is the divisibility fast path in the strengthening utility, since every
+    // coefficient shares the factor 2.
+    check_knapsack_only("cloutier_ex2", Instance{{{0, 5}, {0, 5}, {0, 5}, {0, 5}}, {2, 2, 2, 2}, {2, 2, 2, 2}, 3});
+
+    // The same shape with one more time point to play with, which is exactly
+    // enough: 8 units of time for 8 units of work. Nothing may fire.
+    {
+        auto probe = probe_root(Instance{{{0, 6}, {0, 6}, {0, 6}, {0, 6}}, {2, 2, 2, 2}, {2, 2, 2, 2}, 3}, knapsack, nullopt);
+        if (probe.refuted)
+            fail("cloutier_ex2 negative twin: refuted a satisfiable instance");
+    }
+
+    // Heights {3, 3, 5, 5} under a capacity of 7, in the window [0, 8). Their
+    // gcd is 1, so the divisibility fast path does not apply and the
+    // strengthening has to run its layered dynamic programme: the reachable
+    // sums are 0, 3, 5, 6, 8, 10, 11, 13, 16, so 6 is the most a time point
+    // can supply, not 7. Over eight time points that is 48 against the 53 the
+    // tasks require --- where (OC') sees 56 available and declines, and so
+    // does the horizontally elastic cap, since between them the four tasks
+    // could take 16 at any time point. No task has a compulsory part, so the
+    // profile says nothing either.
+    check_knapsack_only("dp_path", Instance{{{0, 5}, {0, 5}, {0, 4}, {0, 5}}, {3, 3, 4, 3}, {3, 3, 5, 5}, 7});
+
+    // ... and its negative twin, one unit of capacity better off. 8 is now a
+    // reachable sum (3 + 5), so the knapsack cap buys nothing at all.
+    {
+        auto probe = probe_root(Instance{{{0, 5}, {0, 5}, {0, 4}, {0, 5}}, {3, 3, 4, 3}, {3, 3, 5, 5}, 8}, knapsack, nullopt);
+        if (probe.refuted)
+            fail("dp_path negative twin: refuted an instance the knapsack cap cannot reach");
+    }
+
+    // The soundness net. A conflict-only rule can only ever lose solutions, so
+    // a full enumeration against brute force with the proof verified is what
+    // says the rule is not inventing conflicts.
+    check_enumeration(
+        "small enumeration", Instance{{{0, 4}, {0, 4}, {0, 4}}, {2, 2, 2}, {2, 2, 2}, 3}, knapsack, make_optional("cumulative_kaoc_enumeration"));
+
+    return EXIT_SUCCESS;
+}

--- a/gcs/constraints/innards/cumulative_mutations.hh
+++ b/gcs/constraints/innards/cumulative_mutations.hh
@@ -90,11 +90,29 @@ namespace gcs::innards
         struct DropProfilePins
         {
         };
+
+        /// (KAOC): claim one unit better than the largest total the heights at
+        /// a time point can actually reach. This is the mutation the knapsack
+        /// rule exists for --- it corrupts the *conclusion* of the integrality
+        /// argument rather than the route to it, so a derivation with any slack
+        /// in it verifies anyway and the rule is then resting on nothing.
+        struct ClaimOneBetterAvailability
+        {
+        };
+
+        /// (KAOC): apply the knapsack cap at one fewer time point than the
+        /// conflict needs, which is honest but leaves the window supplying more
+        /// than the comparison was told.
+        struct StrengthenOneFewer
+        {
+        };
+
     }
 
     using CumulativeProofMutation = std::variant<cumulative_proof_mutation::None, cumulative_proof_mutation::OverstateWindowEnergy,
         cumulative_proof_mutation::OmitCapacityLine, cumulative_proof_mutation::ShrinkLemmaWindow, cumulative_proof_mutation::DropContainedTask,
-        cumulative_proof_mutation::PushOneTooFar, cumulative_proof_mutation::DropProfilePin, cumulative_proof_mutation::DropProfilePins>;
+        cumulative_proof_mutation::PushOneTooFar, cumulative_proof_mutation::DropProfilePin, cumulative_proof_mutation::DropProfilePins,
+        cumulative_proof_mutation::ClaimOneBetterAvailability, cumulative_proof_mutation::StrengthenOneFewer>;
 
     /**
      * \brief Deliberate corruptions of the presence-falsification derivation,

--- a/gcs/innards/proofs/subset_sum_strengthening.cc
+++ b/gcs/innards/proofs/subset_sum_strengthening.cc
@@ -122,7 +122,7 @@ auto gcs::innards::largest_subset_sum_at_most(const vector<Integer> & coefficien
 }
 
 auto gcs::innards::derive_subset_sum_strengthening(ProofLogger & logger, const vector<SubsetSumItem> & items, ProofLine source, Integer bound,
-    ProofLevel level, SubsetSumMutation mutation) -> SubsetSumStrengthening
+    ProofLevel level, const ReasonLiterals & reason, SubsetSumMutation mutation) -> SubsetSumStrengthening
 {
     vector<Integer> coefficients;
     coefficients.reserve(items.size());
@@ -191,7 +191,7 @@ auto gcs::innards::derive_subset_sum_strengthening(ProofLogger & logger, const v
     // is a one-line RUP. Every later layer's at-least-one is a RUP against the
     // previous one, which is why they are emitted rather than kept: unit
     // propagation finds them in the database.
-    logger.emit_rup_proof_line(WPBSum{} + 1_i * layers.back().at(0_i).exactly >= 1_i, level);
+    logger.emit_rup_proof_line_under_reason(reason, WPBSum{} + 1_i * layers.back().at(0_i).exactly >= 1_i, level);
 
     for (size_t k = 0; k < items.size(); ++k) {
         const auto & item = items[k];
@@ -235,7 +235,7 @@ auto gcs::innards::derive_subset_sum_strengthening(ProofLogger & logger, const v
             stays += 1_i * ! state.exactly;
             add_term_to(stays, 1_i, item.term);
             stays += 1_i * stay.exactly;
-            auto stay_transition = logger.emit_rup_proof_line(move(stays) >= 1_i, level);
+            auto stay_transition = logger.emit_rup_proof_line_under_reason(reason, move(stays) >= 1_i, level);
 
             if (advanced <= bound) {
                 const auto & step = after.at(advanced);
@@ -258,7 +258,7 @@ auto gcs::innards::derive_subset_sum_strengthening(ProofLogger & logger, const v
                 steps += 1_i * ! state.exactly;
                 add_term_to(steps, 1_i, ! item.term);
                 steps += 1_i * step.exactly;
-                auto step_transition = logger.emit_rup_proof_line(move(steps) >= 1_i, level);
+                auto step_transition = logger.emit_rup_proof_line_under_reason(reason, move(steps) >= 1_i, level);
 
                 // Either way the layer moves to one of the two states:
                 // resolving the two transitions on the item literal.
@@ -282,7 +282,7 @@ auto gcs::innards::derive_subset_sum_strengthening(ProofLogger & logger, const v
                 WPBSum out;
                 out += 1_i * ! state.exactly;
                 add_term_to(out, 1_i, ! item.term);
-                auto item_is_out = logger.emit_rup_proof_line(move(out) >= 1_i, level);
+                auto item_is_out = logger.emit_rup_proof_line_under_reason(reason, move(out) >= 1_i, level);
 
                 if (! skip_this_layer) {
                     PolBuilder resolve;
@@ -298,7 +298,7 @@ auto gcs::innards::derive_subset_sum_strengthening(ProofLogger & logger, const v
         WPBSum at_least_one;
         for (const auto & [value, state] : after)
             at_least_one += 1_i * state.exactly;
-        logger.emit_rup_proof_line(move(at_least_one) >= 1_i, level);
+        logger.emit_rup_proof_line_under_reason(reason, move(at_least_one) >= 1_i, level);
 
         layers.push_back(move(after));
         prefix = move(after_prefix);
@@ -312,10 +312,10 @@ auto gcs::innards::derive_subset_sum_strengthening(ProofLogger & logger, const v
         PolBuilder dominated;
         dominated.add(state.at_most_forward).add(under_reverse).saturate();
         dominated.emit(logger, level);
-        logger.emit_rup_proof_line(WPBSum{} + 1_i * ! state.exactly + 1_i * under >= 1_i, level);
+        logger.emit_rup_proof_line_under_reason(reason, WPBSum{} + 1_i * ! state.exactly + 1_i * under >= 1_i, level);
     }
 
-    auto under_holds = logger.emit_rup_proof_line(WPBSum{} + 1_i * under >= 1_i, level);
+    auto under_holds = logger.emit_rup_proof_line_under_reason(reason, WPBSum{} + 1_i * under >= 1_i, level);
 
     // Discharge the flag: its forward half is the strengthened line, weakened
     // by the reification coefficient, and the unit above pays exactly that

--- a/gcs/innards/proofs/subset_sum_strengthening.hh
+++ b/gcs/innards/proofs/subset_sum_strengthening.hh
@@ -4,6 +4,7 @@
 #include <gcs/innards/proofs/proof_line.hh>
 #include <gcs/innards/proofs/proof_logger-fwd.hh>
 #include <gcs/innards/proofs/proof_only_variables.hh>
+#include <gcs/innards/reason.hh>
 #include <gcs/integer.hh>
 
 #include <variant>
@@ -127,6 +128,15 @@ namespace gcs::innards
      * cannot add to the OPB even by mistake. `level` selects where they land
      * --- `Temporary` inside a conflict justification, `Top` for a presolver.
      *
+     * `reason` must be the one the *source line* was derived under, and an
+     * empty one says the source is a fact about the model. This matters: a
+     * reason-backed source carries the negated reason's literals alongside its
+     * own terms, so a dead state's "this prefix cannot be completed" is only
+     * true where the reason holds, and every RUP below has to say so too.
+     * Getting this wrong does not produce a wrong answer --- it produces a
+     * proof VeriPB rejects, on the first instance whose conflict happens below
+     * the root.
+     *
      * Degenerate cases: an empty item list gives a bound of zero; a bound that
      * is already reachable returns the source line unchanged; a bound at least
      * the sum of every coefficient gives that sum.
@@ -134,7 +144,8 @@ namespace gcs::innards
      * \ingroup Innards
      */
     [[nodiscard]] auto derive_subset_sum_strengthening(ProofLogger &, const std::vector<SubsetSumItem> & items, ProofLine source, Integer bound,
-        ProofLevel level, SubsetSumMutation mutation = subset_sum_mutation::None{}) -> SubsetSumStrengthening;
+        ProofLevel level, const ReasonLiterals & reason = ReasonLiterals{}, SubsetSumMutation mutation = subset_sum_mutation::None{})
+        -> SubsetSumStrengthening;
 }
 
 #endif

--- a/gcs/innards/proofs/subset_sum_strengthening_test.cc
+++ b/gcs/innards/proofs/subset_sum_strengthening_test.cc
@@ -129,7 +129,7 @@ namespace
         logger.start_proof(model);
         tracker.emit_delayed_proof_steps();
 
-        auto strengthening = derive_subset_sum_strengthening(logger, items, source, fixture.bound, ProofLevel::Top, mutation);
+        auto strengthening = derive_subset_sum_strengthening(logger, items, source, fixture.bound, ProofLevel::Top, ReasonLiterals{}, mutation);
 
         if (std::holds_alternative<subset_sum_mutation::None>(mutation)) {
             if (strengthening.bound != fixture.expected)

--- a/gcs/presolvers/cumulative_strengthening/cumulative_strengthening.cc
+++ b/gcs/presolvers/cumulative_strengthening/cumulative_strengthening.cc
@@ -555,8 +555,8 @@ auto CumulativeStrengthening::run(Problem & problem, Propagators & propagators, 
                 auto donor_row = *reduced_row;
 
                 auto strengthen_to_kappa = [&](ProofLine source) -> ProofLine {
-                    auto strengthened =
-                        derive_subset_sum_strengthening(recipe_logger, items, source, capacity, ProofLevel::Temporary, subset_sum_corruption);
+                    auto strengthened = derive_subset_sum_strengthening(
+                        recipe_logger, items, source, capacity, ProofLevel::Temporary, ReasonLiterals{}, subset_sum_corruption);
                     // After the call rather than before it, and off what came
                     // back rather than off the assessment's prediction: the
                     // marker and the counter then agree with each other and


### PR DESCRIPTION
Closes the last commonly-run cumulative rule that was uncovered: the time-table
horizontally elastic overload check (TTHE-OC, Kameugne et al., C&OR 172 (2024))
and Cloutier & Quimper's knapsack-augmented one (KAOC, CP 2026). Issue #550.

Stacked on #745, which merges first.

## The three rungs are one certificate

`(TTOC)`, `(TTHE-OC)` and `(KAOC)` turn out to be one comparison with a
different cap on one side of it. Charge the window each contained task's energy
less whatever its compulsory part already accounts for, and supply it **one time
point at a time**:

```
required = e_Θ − Σ h_i·|comp_i ∩ window|
supplied = Σ_{t ∈ [a,b)} A_t

A_t = capacity − f(I,t)              → rearranges term for term into (TTOC)
A_t = min(that, optional heights)    → (TTHE-OC)
A_t = knapsack(heights, that)        → (KAOC)
```

So the pol shape never changes; only the line at some time points gets tighter.
Each availability line is the capacity row with every compulsory contribution
pinned off it (`pin_contributor`, which `(TTOC)` already uses) and every term
that is not a contained task's optional one `weaken`ed away — which leaves a
statement over exactly the heights the knapsack reasons about. `(KAOC)` then
puts it through `derive_subset_sum_strengthening`, the utility #544 added for
exactly this and which until now only a presolver had used.

Against those, each contained task's `derive_window_energy` line scaled by its
height, over the task's own `[est, lct)`, with its compulsory times weakened
back out.

**The knapsack DP is applied biggest-gain-first and stopped as soon as the
comparison tips**, so a conflict the elastic cap can carry pays nothing for it;
the marker records `strengthened=k/w`.

## Measured — `data_bl` + `data_pack` at 60 s, over the 36 instances every arm closed

| arm | recursions | vs baseline | propagations | closed |
|---|---|---|---|---|
| time-tabling + (OC') + (TTOC) | 7,227,100 | 1.000× | 72,057,194 | 38 / 95 |
| + (TTHE-OC) | 5,008,908 | 0.693× | 51,145,525 | 36 / 95 |
| + (KAOC) | 2,832,478 | **0.392×** | 29,227,548 | **48 / 95** |

Fewer recursions on 30 of 36 and more on none; no arm disagrees about an
optimum. **The knapsack cap is what pays** — it more than halves the search and
closes ten more instances at the same wall time. **The elastic cap alone does
not**: 0.693× of the search, but it closes *fewer* instances than leaving it
off, because its per-time-point scan costs more than the pruning returns. Same
verdict not-first / not-last got, and for the same reason.

That baseline is the identical figure to #744's "no edge-finding" row, so the
two families are directly comparable: edge-finding alone is 2,359,885.

## ... and on top of the edge-finding family, which is the question that matters

(TTOC) is not what anyone runs. Over the 39 instances both arms closed:

| arm | recursions | vs TTEF | propagations | closed | wall |
|---|---|---|---|---|---|
| TTEF | 7,250,390 | 1.000× | 74,388,179 | 39 / 95 | 98.2 s |
| + (KAOC) | 2,342,923 | **0.323×** | 29,856,904 | **49 / 95** | **76.0 s** |

Fewer recursions on 26 of 39 and more on none, ten more instances closed, and
faster in wall time as well — so the rule pays for its own `O(n²·horizon)` scan
and then some.

Which also settles that it is **not subsumed by the energetic family**.
Edge-finding and TTEF move bounds from a window's total energy; this refutes
windows where the *shape* of the heights is what does not fit, and no amount of
aggregate energy reasoning sees that.

## What the fixtures could not catch

Worth reading even if the rest is skimmed. **Every hand-built fixture verified
through two real certificate bugs**; 11 of 60 proofs on *generated* instances
did not. Both were the same mistake — a quantity the check computed that the
certificate never derived:

- **The elastic cap was computed and not derived.** Where the optional heights
  fall *below* what the profile leaves, the check charged
  `min(left, heights)` while the pol cited the capacity row, whose right hand
  side is `left`. The binding fact there is not the capacity row at all — it is
  each task's own literal axiom.
- **The energy lines ran over the window rather than over the task**, leaving a
  negative coefficient on every `(task, time)` the task cannot reach.

Both were hidden by the same property: a fixture built to *demonstrate* a rule
is symmetric and generous. Every task can run at every time point (so the
elastic cap never binds) and every task spans the whole window (so the energy
residue is zero). Cloutier & Quimper's own Example 2 has both.

This is the other half of #744's lesson — that one said a demonstration fixture
will not make a *mutation* bite; this says it will not make a *bug* show either.

Both are now cross-checked structurally: the justification adds up what the pol
actually charges and throws if it disagrees with what the rule fired on, with
the two figures computed from opposite sides of the propagator.

## One change outside the constraint

`derive_subset_sum_strengthening` now takes the reason its source line was
derived under. A reason-backed source carries the negated reason's literals
alongside its own terms, so a dead state's "this prefix cannot be completed"
holds only where the reason does, and the transition RUPs have to say so. Its
two existing callers are presolve-time, pass an empty one, and emit exactly what
they emitted before.

Also two stale doc claims corrected, both saying TTEF is not certified and
refuses a proof logger. Neither has been true since #744 certified it; only
`energetic_edge_finding` throws. They belong further down the stack, but moving
a two-line doc fix would mean rebasing.

## Testing

- `cumulative_kaoc_test`: three KAOC-only differentials with negative twins —
  `cloutier_ex2` (the paper's parity example, which takes the strengthening's
  divisibility fast path), `dp_path` (gcd 1, so the layered programme runs), and
  `compulsory` (added because neither published fixture has a task with a
  compulsory part, so the certificate's one asymmetric step was a no-op on both).
  Each asserts brute force finds no solution, that `(TTOC)` and `(TTHE-OC)` both
  decline, and that the conflict carries the `kaoc` marker.
- Nine mutation lanes: `claim_one_better`, `strengthen_one_fewer` and `capacity`
  on each fixture, all rejected. There is deliberately **no** lane for the
  compulsory-time weakening: corrupting it is accepted, because unit propagation
  assigns the terms it would have cancelled from the reason's own bound
  literals, the same way `(TTOC)`'s pins are droppable on 235 of 248 instances.
- Enumeration against brute force with the proof verified, caps on and off.
- 600 generated instances enumerated exhaustively at sizes 8 and 10, zero
  solution-count differences.
- 60 of 60 generated proofs verify on both arms.
- 53 of 53 cumulative and subset-sum ctest entries pass. OPB byte-identical.

## Restrictions

Constant heights only — a variable height puts bit-linearised contribution terms
in the capacity row, which neither the knapsack's item list nor the term-dropping
can read, so v1 declines rather than approximates and the plain rules still run.
A capacity above 4096 falls back to the elastic cap, since the bitset is
`capacity + 1` bits per time point (Cloutier & Quimper report `C ≤ 122` across
their benchmarks; the local instances run 5 to 22).

Propagation is `O(n²·horizon)` rather than their `O(Cn²)`: their doubly linked
Profile collapses the runs where the profile is constant, and this keeps a flat
array plus the incremental bitset (their Algorithm 3 shift-or) per time point.
Same trade as #742 for edge-finding's scan, and the same answer — what is
missing is propagation performance, not proof content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

