### PR TITLE
cumulative: count a variable duration's guaranteed energy

### DIFF
--- a/dev_docs/cumulative-proof-logging.md
+++ b/dev_docs/cumulative-proof-logging.md
@@ -525,17 +525,58 @@ against its terms in the capacity lines, and what is left is a
 constraint with nothing but negative coefficients on the left and a
 positive right hand side. The framework's wrapping RUP closes it.
 
+### A variable duration, counted at what it guarantees
+
+A task whose length is a decision variable is in the energy set too, and
+counted at `lb(l)` — the duration it will run for whatever the search
+does with the rest of it. `[start, start + lb(l))` is inside the real
+execution interval, so activity established for the short one is
+activity all the same, and `shape_of` and the telescoping are the
+constant-length ones with `p = lb(l)`.
+
+What changes is the `after` bridge, and only it. For a constant length
+`after_{i,t}` is reified on the single variable `s ≥ t − l + 1` and the
+bridge is a two-line `pol`; for a variable one it is reified on
+`s + l ≥ t + 1`, and the bridge adds the length's own order literal to
+cancel the `l` bits:
+
+    pol( @…[ca][f] : ¬after → s + l ≤ t )
+       + ( [s ≥ t−p+1] → s ≥ t−p+1 )
+       + ( [l ≥ p]     → l ≥ p     )   s
+    = after_t ∨ ¬[s ≥ t−p+1] ∨ ¬[l ≥ p]
+
+which is the whole of the idea: `s ≥ t−p+1` and `l ≥ p` together give
+`s + l ≥ t+1`. The saturation is what makes `¬[l ≥ p]` worth one unit
+rather than whatever the length's encoding gave it, so a unit saying
+`[l ≥ p]` cancels it outright.
+
+Where that unit comes from is what decides whether the derivation is
+reason-free. At the length's **declared** lower bound it is the boundary
+pin `need_gevar` already wrote at the top of the proof — a model fact —
+so the row is as reusable as a constant-length one. Above it the fact is
+still permanent for the subtree but nothing has written it down, so
+`derive_window_energy` emits a unit RUP under the reason (which is why
+every variable length is in `reason_vars`). `derive_guarded_window_energy`
+cannot do either, its rows outliving the node that wanted them: it keeps
+`¬[l ≥ p]` as a **third guard**, one copy per time point summed, and the
+citing `pol` discharges it alongside the two start guards. The length is
+part of that cache's key for the same reason.
+
+`window_energy::Task::length_variable` is the switch, and is set exactly
+when `after` was reified the two-variable way. Everything else in
+`window_energy.cc` is shared between the two kinds.
+
 ### Restrictions, and why they are only weakenings
 
-The energy set takes only tasks with a constant length and height (a
-variable height enters `C_t` as the bit-linearised `contrib`, not as
-`h·active`, so the cancellation would not be exact) and a start that is
-a plain variable with an order encoding (the bridges need order
-literals; a `{0,1}` domain is direct-only encoded, and a view's atoms
-would need deview-mode arithmetic). The whole check is skipped when the
-capacity is a variable: a `(b−a)·capacity` term would survive into the
-conflict line for the wrapping RUP to dispose of over the capacity's
-bits, which it cannot do in general.
+The energy set takes only tasks with a constant height (a variable
+height enters `C_t` as the bit-linearised `contrib`, not as `h·active`,
+so the cancellation would not be exact) and a start — and a variable
+length — that is a plain variable with an order encoding (the bridges
+need order literals; a `{0,1}` domain is direct-only encoded, and a
+view's atoms would need deview-mode arithmetic). The whole check is
+skipped when the capacity is a variable: a `(b−a)·capacity` term would
+survive into the conflict line for the wrapping RUP to dispose of over
+the capacity's bits, which it cannot do in general.
 
 None of these lose soundness or solutions: a task the energy set will
 not take still counts through `F(a, b)`, and a check not made is a
@@ -927,16 +968,21 @@ it otherwise. It asks "can this task load the resource at all?" *first*: a task
 the donor gave no window — a zero height on this resource — published no proxy
 either, and would otherwise be counted as set aside for the wrong reason.
 
-The energy rules need no thought. `prepare_cumulative_overload_check` keeps only
-constant-length tasks, a window-energy lemma needing a task's energy to be a
-number, so a variable-duration task takes part in the rows and the time-tabling
-and stays out of the lemma. Where it *does* earn its place in a presolver that
-runs the energy rules alone is the (TTOC) profile term, which counts a task's
-mandatory part whether or not the lemma can speak for it — and those pins are the
-ones that go through the proxy. `cumulative_strengthening_var_length` is that
-case: four tasks of energy six fill a window of four at the strengthened capacity
-exactly, and one compulsory time point of a fifth, variable-duration task is the
-whole of the overshoot.
+The energy rules take such a task as well, at the duration it guarantees (see
+"A variable duration, counted at what it guarantees" above), and the proxy is
+not what they go through: the window-energy bridge cancels the length against
+its own order literal rather than materialising the sum. The proxy is still what
+the **pins** need, so a presolver running the energy rules gets both — the (TTOC)
+profile term counts a variable-duration task's mandatory part through the proxy,
+and the lemma counts its `lb(l)·h` through the bridge.
+`cumulative_strengthening_var_length` is the profile case: four tasks of energy
+six fill a window of four at the strengthened capacity exactly, and one
+compulsory time point of a fifth, variable-duration task is the whole of the
+overshoot.
+
+The **makespan** bound is the one energy rule that still declines a variable
+duration, and `install_derived_cumulative` re-checks rather than assuming: its
+rows are built once at the root off a length that has to be a number.
 
 **A tripwire.** No fixture in the tree catches the *wrong* line being published.
 Publish `end ≤ s + l` in place of `end ≥ s + l` and every proof still verifies:
@@ -1523,19 +1569,17 @@ per time point. Same trade as #742 for edge-finding's scan, and the same answer
   nothing measurable, but the window x task sweep that finds them is O(n^3) and
   taxes the solve about 1.5x at identical search. Propagation performance, not
   proof logging.
-- **A variable duration in the energy set (#689).** The window-energy
-  lemma's eligibility filter turns away a task whose length or height is
-  not a constant, and those two halves are now in different states. The
-  **height** one has resolved itself: a task #686 converted arrives at the
-  filter as a constant and passes, which
-  `cumulative_strengthening_all_var_heights` demonstrates by refuting at
-  the root through the energy check. The **length** one still binds, since
-# 685 passes a length through as the variable it was posted with — so a
-  multi-mode RCPSP task gets its demand counted and its energy discarded,
-  and it is the duration that discards it. Loosening it is not free: the
-  lemma telescopes order literals over ranges fixed by a constant length,
-  and a variable-duration task's `after` is reified on `start + length`
-  instead. #689 has the sketch. The rest of #542's staging is unchanged.
+- **A posted constraint's variable height in the energy set (#689's other
+  half).** The length half is done: a variable-duration task is counted at
+  `lb(l)`. The height half is done for a *derived* constraint by accident of
+  composition — a task #686 converted arrives at the filter as a constant and
+  passes, which `cumulative_strengthening_all_var_heights` demonstrates by
+  refuting at the root through the energy check — but a **posted** constraint's
+  variable-height task is still turned away, and need not be: #686's conversion
+  RUP is not specific to derived constraints, and the same line would let the
+  energy set count such a task at `lb(h)`. What it would cost is the
+  cancellation in the conflict `pol`, since a variable height enters `C_t` as
+  the bit-linearised `contrib` rather than as `h·active`.
 - **Conditional bounds for optional tasks.** An undecided task's start
   bounds are never pruned, because there is no conditional-bounds store
   and an unconditional prune would be unsound if the task turns out

--- a/gcs/constraints/cumulative/cumulative.cc
+++ b/gcs/constraints/cumulative/cumulative.cc
@@ -246,21 +246,31 @@ auto gcs::innards::prepare_cumulative_overload_check(const vector<IntegerVariabl
     const vector<Integer> & per_task_t_hi, const State & initial_state) -> CumulativeOverloadData
 {
     CumulativeOverloadData result;
-    // Which tasks the window-energy lemma can speak about: a constant length
-    // and height (so the task's energy is a constant, and its load in C_t is
-    // h·active rather than the bit-linearised contrib), and a start that is a
-    // plain variable with an order encoding, since the lemma bridges the
-    // before/after flags to the start's order literals. A task that is not
-    // eligible is not lost to the check: whatever it must occupy still counts,
-    // through the profile term of the (TTOC) strengthening.
+    // Which tasks the window-energy lemma can speak about: a constant height
+    // (so the task's load in C_t is h·active rather than the bit-linearised
+    // contrib), and a start that is a plain variable with an order encoding,
+    // since the lemma bridges the before/after flags to the start's order
+    // literals. A task that is not eligible is not lost to the check: whatever
+    // it must occupy still counts, through the profile term of the (TTOC)
+    // strengthening.
     //
     // The height half is looser than it reads. A *derived* Cumulative's tasks
     // carry constant heights by construction, so one whose donor height was a
     // variable arrives here already converted to the demand it guarantees and
     // passes --- which is how an all-variable-height donor's energy gets
     // counted at all. A posted constraint's variable height is still turned
-    // away, and need not be: the same conversion would serve. The length half
-    // is the one that genuinely binds, and #689 is what it would take.
+    // away, and need not be: the same conversion would serve, and #689's
+    // remaining half is what it would take.
+    //
+    // A *variable* length is admitted (#689), at the length it is guaranteed to
+    // reach rather than at the one it might: the lemma counts the task over
+    // [start, start + lb(length)), which its execution interval contains, by
+    // bridging its `after` flags back onto the start's order literals through
+    // the length's own. What that needs from here is a length whose order
+    // literals exist to be bridged with, so a plain variable, and one that can
+    // be positive at all --- a task whose length can only be zero is not an
+    // active task in the first place. Whether the bound it reaches is worth
+    // anything is asked at every node, in the candidate sweep, and not here.
     //
     // Presence is not among the tests, and deliberately so. What is asked here
     // is whether the lemma could *ever* speak about a task, which is a question
@@ -270,18 +280,26 @@ auto gcs::innards::prepare_cumulative_overload_check(const vector<IntegerVariabl
     // presence literals of the ones it did use into the reason. A task that can
     // never be present at all is gone before this is called, `active_tasks`
     // having dropped it.
+    // A variable whose domain is exactly {0, 1} is direct-only encoded, so it
+    // has no order literals for the lemma's bridges to cancel against. Asked of
+    // a variable length as well as of the start: both are bridged through.
+    auto direct_only_encoded = [&](const IntegerVariableID & v) {
+        auto [lo, hi] = initial_state.bounds(v);
+        return lo == 0_i && hi == 1_i;
+    };
+
     result.overload_tasks.clear();
     for (auto i : active_tasks) {
-        if (! is_constant_variable(lengths[i]) || ! is_constant_variable(heights[i]))
+        if (! is_constant_variable(heights[i]) || constant_value_of(heights[i]) <= 0_i)
             continue;
-        if (constant_value_of(lengths[i]) <= 0_i || constant_value_of(heights[i]) <= 0_i)
+        if (! std::holds_alternative<SimpleIntegerVariableID>(starts[i]) || direct_only_encoded(starts[i]))
             continue;
-        if (! std::holds_alternative<SimpleIntegerVariableID>(starts[i]))
-            continue;
-        // A start whose domain is exactly {0, 1} is direct-only encoded, so it
-        // has no order literals for the lemma's bridges to cancel against.
-        auto [s_lo, s_hi] = initial_state.bounds(starts[i]);
-        if (s_lo == 0_i && s_hi == 1_i)
+        if (is_constant_variable(lengths[i])) {
+            if (constant_value_of(lengths[i]) <= 0_i)
+                continue;
+        }
+        else if (! std::holds_alternative<SimpleIntegerVariableID>(lengths[i]) || initial_state.upper_bound(lengths[i]) <= 0_i ||
+            direct_only_encoded(lengths[i]))
             continue;
         result.overload_tasks.push_back(i);
     }
@@ -580,7 +598,8 @@ auto Cumulative::install_propagators(Propagators & propagators) -> void
         .overload_tasks = move(_overload_tasks),
         .time_slot_prefix = move(_time_slot_prefix),
         .time_slot_lo = _time_slot_lo,
-        .guarded_energy = std::make_shared<std::map<std::tuple<size_t, Integer, Integer, Integer, Integer>, window_energy::GuardedWindowEnergy>>()};
+        .guarded_energy =
+            std::make_shared<std::map<std::tuple<size_t, Integer, Integer, Integer, Integer, Integer>, window_energy::GuardedWindowEnergy>>()};
 
     propagators.install(
         constraint_id(),
@@ -640,6 +659,18 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
     auto lub = [&](size_t i) { return state.upper_bound(lengths_var[i]); };
     auto l_is_var = [&](size_t i) { return ! is_constant_variable(lengths_var[i]); };
     auto s_is_var = [&](size_t i) { return ! is_constant_variable(starts[i]); };
+
+    // The task as the window-energy lemma sees it. Only ever called for a task
+    // prepare_cumulative_overload_check kept, so the start --- and a variable
+    // length --- really are plain variables. A variable length goes along with
+    // lb(l_i) rather than instead of it: the flags it has to bridge through are
+    // reified on the two-variable s_i + l_i, and the lemma needs to know that to
+    // read them, while what it counts the task at is still the length the task
+    // is guaranteed to run for.
+    auto lemma_task = [&](size_t i) {
+        return window_energy::Task{std::get<SimpleIntegerVariableID>(starts[i]), llb(i), per_task_t_lo[i], before_flags[i], after_flags[i],
+            active_flags[i], l_is_var(i) ? make_optional(std::get<SimpleIntegerVariableID>(lengths_var[i])) : optional<SimpleIntegerVariableID>{}};
+    };
 
     // A task with no presence variable is always here. An optional one is here
     // only once its presence is fixed to 1: until then it contributes nothing
@@ -742,14 +773,16 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
     // is a fact about the model --- the bounds a firing would have resolved its
     // leftover order literals against are carried as guard literals instead ---
     // so it lives at Top and outlives the search state that first wanted it.
+    //
+    // The length a variable-duration task is counted at is part of the key, and
+    // has to be: it is the live lower bound, so the same task over the same
+    // window is a different row once the search has tightened it. It is a guard
+    // on the row too, which is what keeps the row itself a model fact.
     auto guarded_energy = [&](size_t i, Integer lo, Integer hi, Integer low_guard, Integer high_guard) -> const window_energy::GuardedWindowEnergy & {
-        auto key = std::tuple{i, lo, hi, low_guard, high_guard};
+        auto key = std::tuple{i, lo, hi, low_guard, high_guard, llb(i)};
         if (auto found = inputs.guarded_energy->find(key); found != inputs.guarded_energy->end())
             return found->second;
-        auto derived = window_energy::derive_guarded_window_energy(*logger,
-            window_energy::ConstantLengthTask{
-                std::get<SimpleIntegerVariableID>(starts[i]), llb(i), per_task_t_lo[i], before_flags[i], after_flags[i], active_flags[i]},
-            lo, hi, low_guard, high_guard, ProofLevel::Top);
+        auto derived = window_energy::derive_guarded_window_energy(*logger, lemma_task(i), lo, hi, low_guard, high_guard, ProofLevel::Top);
         if (! derived)
             throw ProofError{"cumulative edge-finding: task " + std::to_string(i) + " has no derivable window energy over [" +
                 std::to_string(lo.raw_value) + "," + std::to_string(hi.raw_value) + ") guarded by [" + std::to_string(low_guard.raw_value) + "," +
@@ -801,6 +834,16 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
                     pol.add(
                         logger->emit_rup_proof_line_under_reason(reason, WPBSum{} + 1_i * (starts[i] < row.high_guard) >= 1_i, ProofLevel::Temporary),
                         hlb(i) * row.bound);
+                // The length guard, which unlike the other two is discharged
+                // whichever way the push goes: it says nothing about the
+                // conclusion, only that the task really does run for as long as
+                // the row counted it at. The reason carries every variable
+                // length's bounds, so this closes on the same literals the row
+                // was derived under.
+                if (row.length_coeff > 0_i)
+                    pol.add(logger->emit_rup_proof_line_under_reason(
+                                reason, WPBSum{} + 1_i * (lengths_var[i] >= row.length_guard) >= 1_i, ProofLevel::Temporary),
+                        hlb(i) * row.length_coeff);
             };
 
             // A contained task is inside the window whichever way the push
@@ -1034,6 +1077,14 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
             // there. Its presence literal is already in the reason, put there
             // with every other known-present task's.
             if (! is_present(i))
+                continue;
+            // A task guaranteed no duration at all carries no guaranteed
+            // energy, so there is nothing for the lemma to establish and
+            // nothing for the window to be charged. Only reachable for a
+            // variable length --- a constant one this small was turned away at
+            // prepare time --- and it can stop being true further down the
+            // search, which is why it is asked here and not there.
+            if (llb(i) <= 0_i)
                 continue;
             auto [s_lo, s_hi] = state.bounds(starts[i]);
             auto p = llb(i), h = hlb(i);
@@ -1650,10 +1701,8 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
                                 // anyway, and why this only showed up on
                                 // generated instances.
                                 auto [i_est, i_lst] = state.bounds(starts[i]);
-                                auto energy_line = window_energy::derive_window_energy(*logger, reason,
-                                    window_energy::ConstantLengthTask{std::get<SimpleIntegerVariableID>(starts[i]), llb(i), per_task_t_lo[i],
-                                        before_flags[i], after_flags[i], active_flags[i]},
-                                    i_est, i_lst + llb(i), state.bounds(starts[i]), ProofLevel::Temporary);
+                                auto energy_line = window_energy::derive_window_energy(
+                                    *logger, reason, lemma_task(i), i_est, i_lst + llb(i), state.bounds(starts[i]), ProofLevel::Temporary);
                                 if (! energy_line || energy_line->bound != llb(i))
                                     throw ProofError{"cumulative elastic overload: a contained task's window energy is not its whole length"};
                                 pol.add(energy_line->line, hlb(i));
@@ -1757,10 +1806,8 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
                     }
 
                     for (auto i : inside_tasks) {
-                        auto energy_line = window_energy::derive_window_energy(*logger, reason,
-                            window_energy::ConstantLengthTask{std::get<SimpleIntegerVariableID>(starts[i]), llb(i), per_task_t_lo[i], before_flags[i],
-                                after_flags[i], active_flags[i]},
-                            a, shrink_lemma_window ? b - 1_i : b, state.bounds(starts[i]), ProofLevel::Temporary);
+                        auto energy_line = window_energy::derive_window_energy(
+                            *logger, reason, lemma_task(i), a, shrink_lemma_window ? b - 1_i : b, state.bounds(starts[i]), ProofLevel::Temporary);
                         if (! energy_line) {
                             // Only reachable under the shrunk-window
                             // mutation, where a task can be left with

--- a/gcs/constraints/cumulative/cumulative_edge_finding_test.cc
+++ b/gcs/constraints/cumulative/cumulative_edge_finding_test.cc
@@ -49,26 +49,50 @@ using namespace gcs::test_innards;
 
 namespace
 {
+    // A length is a range: `{p, p}` is a constant, and `{p, q}` with p < q a
+    // decision variable, which the rule counts at `p` --- the duration the task
+    // guarantees, and the one its energy rows carry a guard for (#689).
     struct Instance
     {
         vector<pair<int, int>> start_ranges;
-        vector<int> lengths;
+        vector<pair<int, int>> lengths;
         vector<int> heights;
         int capacity;
     };
 
-    auto is_satisfying(const Instance & inst, const vector<int> & starts) -> bool
+    auto length_is_var(const Instance & inst, size_t i) -> bool
+    {
+        return inst.lengths[i].first != inst.lengths[i].second;
+    }
+
+    // Every variable an assignment has to fix, in the order the solutions carry
+    // them: the starts, then the variable lengths in task order.
+    auto all_ranges(const Instance & inst) -> vector<pair<int, int>>
+    {
+        auto ranges = inst.start_ranges;
+        for (size_t i = 0; i < inst.lengths.size(); ++i)
+            if (length_is_var(inst, i))
+                ranges.push_back(inst.lengths[i]);
+        return ranges;
+    }
+
+    auto is_satisfying(const Instance & inst, const vector<int> & vals) -> bool
     {
         auto n = inst.start_ranges.size();
+        vector<int> l(n);
+        size_t k = n;
+        for (size_t i = 0; i < n; ++i)
+            l[i] = length_is_var(inst, i) ? vals.at(k++) : inst.lengths[i].first;
+
         int t_lo = INT_MAX, t_hi = INT_MIN;
         for (size_t i = 0; i < n; ++i) {
-            t_lo = min(t_lo, starts[i]);
-            t_hi = max(t_hi, starts[i] + inst.lengths[i] - 1);
+            t_lo = min(t_lo, vals[i]);
+            t_hi = max(t_hi, vals[i] + l[i] - 1);
         }
         for (int t = t_lo; t <= t_hi; ++t) {
             int load = 0;
             for (size_t i = 0; i < n; ++i)
-                if (starts[i] <= t && t < starts[i] + inst.lengths[i])
+                if (vals[i] <= t && t < vals[i] + l[i])
                     load += inst.heights[i];
             if (load > inst.capacity)
                 return false;
@@ -76,19 +100,37 @@ namespace
         return true;
     }
 
-    auto post(Problem & p, const Instance & inst, CumulativeRules rules, CumulativeProofMutation mutation = cumulative_proof_mutation::None{})
-        -> vector<IntegerVariableID>
+    /// What posting an instance created: the starts, which is what the bound
+    /// measurements read, and every decision variable, which is what an
+    /// enumeration has to be told about.
+    struct Posted
     {
-        vector<IntegerVariableID> starts;
-        vector<Integer> lengths, heights;
+        vector<IntegerVariableID> starts, all_vars;
+    };
+
+    auto post(Problem & p, const Instance & inst, CumulativeRules rules, CumulativeProofMutation mutation = cumulative_proof_mutation::None{})
+        -> Posted
+    {
+        Posted posted;
+        vector<IntegerVariableID> lengths, heights;
         for (size_t i = 0; i < inst.start_ranges.size(); ++i) {
-            starts.push_back(
+            posted.starts.push_back(
                 p.create_integer_variable(Integer{inst.start_ranges[i].first}, Integer{inst.start_ranges[i].second}, "start" + std::to_string(i)));
-            lengths.push_back(Integer{inst.lengths[i]});
-            heights.push_back(Integer{inst.heights[i]});
+            posted.all_vars.push_back(posted.starts.back());
+            heights.push_back(constant_variable(Integer{inst.heights[i]}));
         }
-        p.post(Cumulative{starts, lengths, heights, Integer{inst.capacity}}.with_rules(rules).with_proof_mutation(mutation));
-        return starts;
+        for (size_t i = 0; i < inst.lengths.size(); ++i) {
+            if (! length_is_var(inst, i))
+                lengths.push_back(constant_variable(Integer{inst.lengths[i].first}));
+            else {
+                lengths.push_back(
+                    p.create_integer_variable(Integer{inst.lengths[i].first}, Integer{inst.lengths[i].second}, "length" + std::to_string(i)));
+                posted.all_vars.push_back(lengths.back());
+            }
+        }
+        p.post(
+            Cumulative{posted.starts, lengths, heights, constant_variable(Integer{inst.capacity})}.with_rules(rules).with_proof_mutation(mutation));
+        return posted;
     }
 
     /// The lower bound each start is left with once root propagation has run,
@@ -99,7 +141,7 @@ namespace
         -> optional<vector<pair<int, int>>>
     {
         Problem p;
-        auto starts = post(p, inst, rules, mutation);
+        auto starts = post(p, inst, rules, mutation).starts;
 
         optional<vector<pair<int, int>>> bounds;
         solve_with(p,
@@ -139,12 +181,12 @@ namespace
         cerr << flush;
 
         set<vector<int>> expected, actual;
-        build_expected(expected, [&](const vector<int> & starts) { return is_satisfying(inst, starts); }, inst.start_ranges);
+        build_expected(expected, [&](const vector<int> & vals) { return is_satisfying(inst, vals); }, all_ranges(inst));
         println(cerr, " expecting {} solutions", expected.size());
 
         Problem p;
-        auto starts = post(p, inst, rules);
-        solve_for_tests(p, proof_name, actual, tuple{starts});
+        auto all_vars = post(p, inst, rules).all_vars;
+        solve_for_tests(p, proof_name, actual, tuple{all_vars});
         check_results(proof_name, expected, actual);
     }
 }
@@ -169,12 +211,12 @@ auto main(int argc, char * argv[]) -> int
     // and unit propagation over the time-table encoding closes the conclusion's
     // RUP whatever the derivation above it says. 301 randomly generated firings
     // were all of that kind before this family was found.
-    const Instance packed{{{0, 4}, {0, 4}, {0, 4}, {0, 4}, {0, 12}}, {4, 4, 4, 4, 4}, {1, 1, 1, 1, 1}, 2};
+    const Instance packed{{{0, 4}, {0, 4}, {0, 4}, {0, 4}, {0, 12}}, {{4, 4}, {4, 4}, {4, 4}, {4, 4}, {4, 4}}, {1, 1, 1, 1, 1}, 2};
 
     // The same, over a window that does not start where the tasks' domains do,
     // so the derivation's lower guard is a real order literal rather than a
     // constant and the citing pol has to discharge it.
-    const Instance packed_offset{{{2, 6}, {2, 6}, {2, 6}, {2, 6}, {2, 20}}, {4, 4, 4, 4, 4}, {1, 1, 1, 1, 1}, 2};
+    const Instance packed_offset{{{2, 6}, {2, 6}, {2, 6}, {2, 6}, {2, 20}}, {{4, 4}, {4, 4}, {4, 4}, {4, 4}, {4, 4}}, {1, 1, 1, 1, 1}, 2};
 
     // The mirror image: [4, 12) is full, and the fifth task ENDS inside it but
     // starts before, so it is its upper bound that has to fall --- to 2, the
@@ -185,7 +227,20 @@ auto main(int argc, char * argv[]) -> int
     // The pushed task is shorter than the rest on purpose. At length four the
     // push would pin it to its own lower bound, and then the one-too-far
     // mutation empties the domain rather than corrupting a proof.
-    const Instance packed_mirror{{{4, 8}, {4, 8}, {4, 8}, {4, 8}, {0, 8}}, {4, 4, 4, 4, 2}, {1, 1, 1, 1, 1}, 2};
+    const Instance packed_mirror{{{4, 8}, {4, 8}, {4, 8}, {4, 8}, {0, 8}}, {{4, 4}, {4, 4}, {4, 4}, {4, 4}, {2, 2}}, {1, 1, 1, 1, 1}, 2};
+
+    // `packed` with one of the four contained tasks given a variable duration.
+    // It guarantees the same four units of energy, so the window is as full as
+    // before and the push is to the same place --- but the row saying so is now
+    // a statement about a length the model does not fix, and carries a guard
+    // for it that the citing pol has to discharge (#689).
+    const Instance packed_var{{{0, 4}, {0, 4}, {0, 4}, {0, 4}, {0, 12}}, {{4, 5}, {4, 4}, {4, 4}, {4, 4}, {4, 4}}, {1, 1, 1, 1, 1}, 2};
+
+    // The other place a length guard turns up: on the *pushed* task's own row,
+    // which is cited at the threshold rather than for containment. Its clipped
+    // energy is measured at lb(l) like everything else, so the push is again to
+    // eight, and it is the length it might have that has to not matter.
+    const Instance packed_var_pushed{{{0, 4}, {0, 4}, {0, 4}, {0, 4}, {0, 12}}, {{4, 4}, {4, 4}, {4, 4}, {4, 4}, {4, 6}}, {1, 1, 1, 1, 1}, 2};
 
     // Mutation mode: emit one deliberately corrupted proof and stop, for
     // run_test_and_expect_verify_failure.bash to hand to veripb.
@@ -224,8 +279,9 @@ auto main(int argc, char * argv[]) -> int
 
     // The rule fires, and pushes exactly as far as the energy supports --- in
     // both directions. `raises` says which bound the fixture is about.
-    for (const auto & [name, inst, raises, expected] : vector<tuple<string, Instance, bool, int>>{
-             {"packed", packed, true, 8}, {"packed_offset", packed_offset, true, 10}, {"packed_mirror", packed_mirror, false, 2}}) {
+    for (const auto & [name, inst, raises, expected] :
+        vector<tuple<string, Instance, bool, int>>{{"packed", packed, true, 8}, {"packed_offset", packed_offset, true, 10},
+            {"packed_mirror", packed_mirror, false, 2}, {"packed_var", packed_var, true, 8}, {"packed_var_pushed", packed_var_pushed, true, 8}}) {
         auto off = root_bounds(inst, without, cumulative_proof_mutation::None{}, nullopt);
         auto on = root_bounds(inst, with, cumulative_proof_mutation::None{}, proofs ? make_optional("cumulative_edge_finding_" + name) : nullopt);
         if (! off || ! on)
@@ -244,9 +300,10 @@ auto main(int argc, char * argv[]) -> int
     // Soundness, over instances small enough to enumerate: the rule may not
     // lose a solution, with or without a proof being written.
     for (const auto & [name, inst] :
-        vector<pair<string, Instance>>{{"packed", packed}, {"tight", Instance{{{0, 3}, {0, 3}, {0, 5}}, {2, 2, 3}, {1, 1, 1}, 2}},
-            {"mixed_heights", Instance{{{0, 4}, {0, 4}, {0, 6}}, {3, 2, 2}, {2, 1, 2}, 3}},
-            {"unit_lengths", Instance{{{0, 3}, {0, 3}, {0, 3}, {0, 5}}, {1, 1, 1, 2}, {1, 1, 1, 1}, 2}}}) {
+        vector<pair<string, Instance>>{{"packed", packed}, {"tight", Instance{{{0, 3}, {0, 3}, {0, 5}}, {{2, 2}, {2, 2}, {3, 3}}, {1, 1, 1}, 2}},
+            {"mixed_heights", Instance{{{0, 4}, {0, 4}, {0, 6}}, {{3, 3}, {2, 2}, {2, 2}}, {2, 1, 2}, 3}},
+            {"unit_lengths", Instance{{{0, 3}, {0, 3}, {0, 3}, {0, 5}}, {{1, 1}, {1, 1}, {1, 1}, {2, 2}}, {1, 1, 1, 1}, 2}},
+            {"var_contained", packed_var}, {"var_pushed", packed_var_pushed}}) {
         check_enumeration(name, inst, with, nullopt);
         if (proofs)
             check_enumeration(name, inst, with, make_optional("cumulative_edge_finding_enum_" + name));

--- a/gcs/constraints/cumulative/cumulative_overload_test.cc
+++ b/gcs/constraints/cumulative/cumulative_overload_test.cc
@@ -54,30 +54,54 @@ using namespace gcs::test_innards;
 
 namespace
 {
-    // Every fixture in this file is an all-constant instance: the overload
-    // check only speaks about tasks whose length and height are constants.
+    // Every height in this file is a constant, which is what the overload
+    // check's energy set still requires. A length is a range: `{p, p}` is the
+    // constant most fixtures use, and `{p, q}` with p < q a decision variable,
+    // which the check counts at `p` --- the duration the task is guaranteed to
+    // run for, whatever the search does with the rest of it (#689).
     struct Instance
     {
         vector<pair<int, int>> start_ranges;
-        vector<int> lengths;
+        vector<pair<int, int>> lengths;
         vector<int> heights;
         int capacity;
     };
 
-    auto is_satisfying(const Instance & inst, const vector<int> & starts) -> bool
+    auto length_is_var(const Instance & inst, size_t i) -> bool
+    {
+        return inst.lengths[i].first != inst.lengths[i].second;
+    }
+
+    // Every variable an assignment has to fix, in the order the solutions carry
+    // them: the starts, then the variable lengths in task order.
+    auto all_ranges(const Instance & inst) -> vector<pair<int, int>>
+    {
+        auto ranges = inst.start_ranges;
+        for (size_t i = 0; i < inst.lengths.size(); ++i)
+            if (length_is_var(inst, i))
+                ranges.push_back(inst.lengths[i]);
+        return ranges;
+    }
+
+    auto is_satisfying(const Instance & inst, const vector<int> & vals) -> bool
     {
         auto n = inst.start_ranges.size();
+        vector<int> l(n);
+        size_t k = n;
+        for (size_t i = 0; i < n; ++i)
+            l[i] = length_is_var(inst, i) ? vals.at(k++) : inst.lengths[i].first;
+
         int t_lo = INT_MAX, t_hi = INT_MIN;
         for (size_t i = 0; i < n; ++i) {
-            if (inst.lengths[i] == 0 || inst.heights[i] == 0)
+            if (l[i] == 0 || inst.heights[i] == 0)
                 continue;
-            t_lo = min(t_lo, starts[i]);
-            t_hi = max(t_hi, starts[i] + inst.lengths[i] - 1);
+            t_lo = min(t_lo, vals[i]);
+            t_hi = max(t_hi, vals[i] + l[i] - 1);
         }
         for (int t = t_lo; t <= t_hi; ++t) {
             int load = 0;
             for (size_t i = 0; i < n; ++i)
-                if (starts[i] <= t && t < starts[i] + inst.lengths[i])
+                if (vals[i] <= t && t < vals[i] + l[i])
                     load += inst.heights[i];
             if (load > inst.capacity)
                 return false;
@@ -88,18 +112,27 @@ namespace
     auto post(Problem & p, const Instance & inst, CumulativeRules rules, CumulativeProofMutation mutation = cumulative_proof_mutation::None{})
         -> vector<IntegerVariableID>
     {
-        vector<IntegerVariableID> starts;
-        for (auto & [lo, hi] : inst.start_ranges)
+        vector<IntegerVariableID> starts, all_vars;
+        for (auto & [lo, hi] : inst.start_ranges) {
             starts.push_back(p.create_integer_variable(Integer{lo}, Integer{hi}));
+            all_vars.push_back(starts.back());
+        }
 
-        vector<Integer> lengths, heights;
-        for (auto l : inst.lengths)
-            lengths.push_back(Integer{l});
+        vector<IntegerVariableID> lengths, heights;
+        for (size_t i = 0; i < inst.lengths.size(); ++i) {
+            auto [lo, hi] = inst.lengths[i];
+            if (! length_is_var(inst, i))
+                lengths.push_back(constant_variable(Integer{lo}));
+            else {
+                lengths.push_back(p.create_integer_variable(Integer{lo}, Integer{hi}));
+                all_vars.push_back(lengths.back());
+            }
+        }
         for (auto h : inst.heights)
-            heights.push_back(Integer{h});
+            heights.push_back(constant_variable(Integer{h}));
 
-        p.post(Cumulative{starts, lengths, heights, Integer{inst.capacity}}.with_rules(rules).with_proof_mutation(mutation));
-        return starts;
+        p.post(Cumulative{starts, lengths, heights, constant_variable(Integer{inst.capacity})}.with_rules(rules).with_proof_mutation(mutation));
+        return all_vars;
     }
 
     // How many times each overload rule left its marker in a proof file. The
@@ -193,12 +226,12 @@ namespace
         cerr << flush;
 
         set<vector<int>> expected, actual;
-        build_expected(expected, [&](const vector<int> & starts) { return is_satisfying(inst, starts); }, inst.start_ranges);
+        build_expected(expected, [&](const vector<int> & vals) { return is_satisfying(inst, vals); }, all_ranges(inst));
         println(cerr, " expecting {} solutions", expected.size());
 
         Problem p;
-        auto starts = post(p, inst, rules);
-        solve_for_tests(p, proof_name, actual, tuple{starts});
+        auto all_vars = post(p, inst, rules);
+        solve_for_tests(p, proof_name, actual, tuple{all_vars});
         check_results(proof_name, expected, actual);
     }
 
@@ -245,18 +278,31 @@ namespace
     }
 
     // A task raises the load profile at all --- what prepare() calls an active
-    // task.
+    // task. Its length only has to be able to be positive.
     auto is_active(const Instance & inst, size_t i) -> bool
     {
-        return inst.lengths[i] > 0 && inst.heights[i] > 0;
+        return inst.lengths[i].second > 0 && inst.heights[i] > 0;
     }
 
     // A task the window-energy lemma can speak about, so a task the energy set
-    // may contain. Mirrors prepare_overload_check: everything here is a
-    // constant already, so all that is left is the start's encoding.
+    // may contain. Mirrors prepare_overload_check: the heights are constants
+    // already, which leaves the encodings of the start and of a variable length
+    // --- a domain of exactly {0, 1} is direct-only encoded, so it has no order
+    // literals for the lemma's bridges to cancel against.
     auto is_eligible(const Instance & inst, size_t i) -> bool
     {
-        return is_active(inst, i) && ! (inst.start_ranges[i].first == 0 && inst.start_ranges[i].second == 1);
+        if (! is_active(inst, i) || (inst.start_ranges[i].first == 0 && inst.start_ranges[i].second == 1))
+            return false;
+        return ! (length_is_var(inst, i) && inst.lengths[i].first == 0 && inst.lengths[i].second == 1);
+    }
+
+    // A task the energy set actually counts: one whose guaranteed duration is
+    // positive, so that there is energy to count. A constant-length task this
+    // short was turned away at prepare time; a variable-length one is skipped by
+    // the candidate sweep instead, and both are then nothing but profile.
+    auto counts_energy(const Instance & inst, size_t i) -> bool
+    {
+        return is_eligible(inst, i) && inst.lengths[i].first > 0;
     }
 
     // The two rules, written out from their definitions over a plain double
@@ -275,15 +321,20 @@ namespace
     auto oracle_says_overloaded(const Instance & inst, bool with_profile) -> bool
     {
         auto n = inst.start_ranges.size();
+        // A task's guaranteed duration, which is what both its energy and its
+        // mandatory part are measured in. Its *possible* duration is the
+        // range's other end, and only the possibly-active range below uses it.
+        auto p_of = [&](size_t i) { return inst.lengths[i].first; };
+
         for (size_t wa = 0; wa < n; ++wa) {
-            if (! is_eligible(inst, wa))
+            if (! counts_energy(inst, wa))
                 continue;
             auto a = inst.start_ranges[wa].first;
 
             for (size_t wb = 0; wb < n; ++wb) {
-                if (! is_eligible(inst, wb) || inst.start_ranges[wb].first < a)
+                if (! counts_energy(inst, wb) || inst.start_ranges[wb].first < a)
                     continue;
-                auto b = inst.start_ranges[wb].second + inst.lengths[wb];
+                auto b = inst.start_ranges[wb].second + p_of(wb);
                 if (b <= a)
                     continue;
 
@@ -291,26 +342,28 @@ namespace
                 for (size_t i = 0; i < n; ++i) {
                     if (! is_active(inst, i))
                         continue;
-                    auto est = inst.start_ranges[i].first, lct = inst.start_ranges[i].second + inst.lengths[i];
-                    if (is_eligible(inst, i) && est >= a && lct <= b) {
-                        energy += static_cast<long long>(inst.lengths[i]) * inst.heights[i];
+                    auto est = inst.start_ranges[i].first, lct = inst.start_ranges[i].second + p_of(i);
+                    if (counts_energy(inst, i) && est >= a && lct <= b) {
+                        energy += static_cast<long long>(p_of(i)) * inst.heights[i];
                         continue;
                     }
                     if (! with_profile)
                         continue;
                     // the part of task i's mandatory part [lst, eet) =
                     // [ub(s), lb(s) + p) that lies inside the window
-                    auto lst = inst.start_ranges[i].second, eet = inst.start_ranges[i].first + inst.lengths[i];
+                    auto lst = inst.start_ranges[i].second, eet = inst.start_ranges[i].first + p_of(i);
                     for (auto t = max(lst, a); t < min(eet, b); ++t)
                         profile += inst.heights[i];
                 }
 
                 // Time points no task can occupy supply nothing to the window,
-                // and the propagator does not count them either.
+                // and the propagator does not count them either. What a task
+                // could occupy runs to its *longest* duration, which is where
+                // the flags it would be pinned through were laid down.
                 long long slots = 0;
                 for (auto t = a; t < b; ++t)
                     for (size_t i = 0; i < n; ++i)
-                        if (is_active(inst, i) && t >= inst.start_ranges[i].first && t <= inst.start_ranges[i].second + inst.lengths[i] - 1) {
+                        if (is_active(inst, i) && t >= inst.start_ranges[i].first && t <= inst.start_ranges[i].second + inst.lengths[i].second - 1) {
                             ++slots;
                             break;
                         }
@@ -370,7 +423,7 @@ namespace
             }();
             if (length > horizon)
                 return nullopt;
-            inst.lengths.push_back(length);
+            inst.lengths.emplace_back(length, length);
             inst.heights.push_back(height);
             inst.start_ranges.emplace_back(0, horizon - length);
             energy += static_cast<long long>(length) * height;
@@ -413,7 +466,7 @@ auto main(int argc, char * argv[]) -> int
     // of exactly one is what makes every step of the derivation load-bearing:
     // one capacity line fewer, or one unit less energy from one task, and the
     // contradiction is gone.
-    const Instance sharp{{{0, 7}, {0, 6}, {0, 7}, {0, 11}}, {5, 6, 5, 1}, {4, 3, 2, 1}, 4};
+    const Instance sharp{{{0, 7}, {0, 6}, {0, 7}, {0, 11}}, {{5, 5}, {6, 6}, {5, 5}, {1, 1}}, {4, 3, 2, 1}, 4};
 
     // Mutation mode: emit one deliberately corrupted proof of `sharp` and
     // stop, for run_test_and_expect_verify_failure.bash to hand to veripb.
@@ -446,12 +499,12 @@ auto main(int argc, char * argv[]) -> int
     // a resource of capacity one. Every mandatory part is empty (lst = 2 is
     // not before eet = 2), so time-tabling sees nothing at all; but the window
     // [0, 4) must hold 3 x 2 = 6 units of energy and supplies 1 x 4 = 4.
-    const Instance f1{{{0, 2}, {0, 2}, {0, 2}}, {2, 2, 2}, {1, 1, 1}, 1};
+    const Instance f1{{{0, 2}, {0, 2}, {0, 2}}, {{2, 2}, {2, 2}, {2, 2}}, {1, 1, 1}, 1};
 
     // F1's negative twin: the same tasks with room to spread out. The widest
     // window [0, 8) now supplies exactly the 6 units the tasks need, so
     // nothing is overloaded and the rule must stay silent at the root.
-    const Instance f1_twin{{{0, 6}, {0, 6}, {0, 6}}, {2, 2, 2}, {1, 1, 1}, 1};
+    const Instance f1_twin{{{0, 6}, {0, 6}, {0, 6}}, {{2, 2}, {2, 2}, {2, 2}}, {1, 1, 1}, 1};
 
     {
         auto with_rule = probe_root(f1, all_rules, proofs ? make_optional("cumulative_overload_f1") : nullopt);
@@ -485,12 +538,12 @@ auto main(int argc, char * argv[]) -> int
     // Time-tabling can say nothing here: no task in the window has a mandatory
     // part, and the fifth task's one unit of load never blocks a height-one
     // task under a capacity of two, so no bound moves either.
-    const Instance f2{{{0, 2}, {0, 2}, {0, 2}, {0, 2}, {1, 2}}, {2, 2, 2, 2, 4}, {1, 1, 1, 1, 1}, 2};
+    const Instance f2{{{0, 2}, {0, 2}, {0, 2}, {0, 2}, {1, 2}}, {{2, 2}, {2, 2}, {2, 2}, {2, 2}, {4, 4}}, {1, 1, 1, 1, 1}, 2};
 
     // F2's negative twin: the same, with the straddling task moved past the
     // window, so its mandatory part [5, 8) contributes nothing to [0, 4) and
     // the window's demand is back to exactly its supply.
-    const Instance f2_twin{{{0, 2}, {0, 2}, {0, 2}, {0, 2}, {4, 5}}, {2, 2, 2, 2, 4}, {1, 1, 1, 1, 1}, 2};
+    const Instance f2_twin{{{0, 2}, {0, 2}, {0, 2}, {0, 2}, {4, 5}}, {{2, 2}, {2, 2}, {2, 2}, {2, 2}, {4, 4}}, {1, 1, 1, 1, 1}, 2};
 
     {
         auto with_rule = probe_root(f2, all_rules, proofs ? make_optional("cumulative_overload_f2") : nullopt);
@@ -514,6 +567,47 @@ auto main(int argc, char * argv[]) -> int
             fail("F2 twin: refuted at the root, but it is satisfiable");
         if (proofs && with_rule.markers.total() != 0)
             fail("F2 twin: the overload check claimed a conflict at the root");
+    }
+
+    // F3: a variable duration, which is what #689 is about. Two unit-height
+    // tasks of length two and one whose length is a decision variable in
+    // [1, 3], all free in [0, 2] against a capacity of one. The window [0, 4)
+    // supplies four units and the two constant tasks want four of them, so the
+    // conflict is exactly the one unit the variable-duration task is guaranteed
+    // to occupy somewhere inside it.
+    //
+    // Nothing else in the propagator can find that unit. The task's mandatory
+    // part is [lst, eet) = [2, 1), which is empty --- so the (TTOC) profile
+    // term, which is where a variable duration used to end up in full, has
+    // nothing to contribute, and neither has time-tabling. The energy set
+    // counting the task at lb(l) is the whole of the difference.
+    const Instance f3{{{0, 2}, {0, 2}, {0, 2}}, {{2, 2}, {2, 2}, {1, 3}}, {1, 1, 1}, 1};
+
+    // F3's negative twin: the same instance with the variable duration allowed
+    // to be zero, so the task guarantees nothing and the window is back to
+    // wanting exactly what it supplies. It is satisfiable --- the two constant
+    // tasks tile [0, 4) and the third takes no time at all --- so this also
+    // says that counting a task at anything above lb(l) would lose solutions.
+    const Instance f3_twin{{{0, 2}, {0, 2}, {0, 2}}, {{2, 2}, {2, 2}, {0, 3}}, {1, 1, 1}, 1};
+
+    {
+        auto with_rule = probe_root(f3, all_rules, proofs ? make_optional("cumulative_overload_f3") : nullopt);
+        if (! with_rule.refuted)
+            fail("F3: the overload check did not count the variable-duration task's guaranteed energy");
+        if (proofs && with_rule.markers.oc != 1)
+            fail("F3: expected exactly one (OC') marker, got " + std::to_string(with_rule.markers.oc));
+
+        auto without_rule = probe_root(f3, no_overload, nullopt);
+        if (without_rule.refuted)
+            fail("F3: time-tabling alone refuted at the root, so the fixture proves nothing");
+    }
+
+    {
+        auto with_rule = probe_root(f3_twin, all_rules, proofs ? make_optional("cumulative_overload_f3_twin") : nullopt);
+        if (with_rule.refuted)
+            fail("F3 twin: refuted at the root, but it is satisfiable");
+        if (proofs && with_rule.markers.total() != 0)
+            fail("F3 twin: the overload check claimed a conflict at the root");
     }
 
     // The sharp-margin fixture itself, with time-tabling out of the way so
@@ -548,7 +642,7 @@ auto main(int argc, char * argv[]) -> int
 
                 auto name = "cumulative_overload_sharp_" + string{label} + "_" + std::to_string(found);
                 println(cerr, "cumulative overload sharp margin {} lens={} hts={} c={} horizon={}", label, inst->lengths, inst->heights,
-                    inst->capacity, inst->start_ranges[0].second + inst->lengths[0]);
+                    inst->capacity, inst->start_ranges[0].second + inst->lengths[0].first);
                 auto probe = probe_root(*inst, only_overload, proofs ? make_optional(name) : nullopt);
                 if (! probe.refuted)
                     fail("sharp margin: the overload check did not refute at the root");
@@ -569,19 +663,29 @@ auto main(int argc, char * argv[]) -> int
         // Start domains reach below zero: a window then runs over negative
         // time points, where the order literals the lemma bridges to are on a
         // signed bit encoding (issue #553's shape).
-        std::uniform_int_distribution<> n_dist(2, 4), lo_dist(-3, 4), span_dist(0, 4), len_dist(0, 3), ht_dist(0, 3), cap_dist(0, 4);
+        // At most one task per instance gets a variable duration, and by a
+        // narrow spread: every extra value multiplies the brute-force
+        // enumeration each of these instances is also checked against, and what
+        // is wanted here is 300 instances rather than one wide one.
+        std::uniform_int_distribution<> n_dist(2, 4), lo_dist(-3, 4), span_dist(0, 4), len_dist(0, 3), ht_dist(0, 3), cap_dist(0, 4),
+            spread_dist(0, 2);
 
-        size_t fired = 0, verified = 0;
+        size_t fired = 0, verified = 0, with_var_length = 0;
         for (int k = 0; k < 300; ++k) {
             Instance inst;
             auto n = n_dist(rand);
+            auto var_task = std::uniform_int_distribution<>(0, n - 1)(rand);
+            auto spread = spread_dist(rand);
             for (int i = 0; i < n; ++i) {
                 auto lo = lo_dist(rand), span = span_dist(rand);
                 inst.start_ranges.emplace_back(lo, lo + span);
-                inst.lengths.push_back(len_dist(rand));
+                auto len = len_dist(rand);
+                inst.lengths.emplace_back(len, len + (i == var_task ? spread : 0));
                 inst.heights.push_back(ht_dist(rand));
             }
             inst.capacity = cap_dist(rand);
+            if (spread > 0)
+                ++with_var_length;
 
             auto oracle = oracle_says_overloaded(inst, true);
             // Verify a proof for the first few conflicts, rather than all of
@@ -609,7 +713,9 @@ auto main(int argc, char * argv[]) -> int
 
         if (fired == 0)
             fail("oracle cross-check: no instance in the corpus overloaded, so nothing was compared");
-        println(cerr, "oracle cross-check: {} of 300 instances overloaded at the root", fired);
+        if (with_var_length == 0)
+            fail("oracle cross-check: no instance in the corpus had a variable duration");
+        println(cerr, "oracle cross-check: {} of 300 instances overloaded at the root, {} of them with a variable duration", fired, with_var_length);
     }
 
     // Two tasks sharing one start variable. Each still has its own per-time
@@ -652,16 +758,19 @@ auto main(int argc, char * argv[]) -> int
         check_opb_unaffected("f1", f1);
         check_opb_unaffected("f2", f2);
         check_opb_unaffected("sharp", sharp);
+        check_opb_unaffected("f3", f3);
 
         std::mt19937 rand(*get_seed());
-        std::uniform_int_distribution<> n_dist(2, 4), lo_dist(-2, 4), span_dist(0, 4), len_dist(0, 3), ht_dist(0, 3), cap_dist(0, 4);
+        std::uniform_int_distribution<> n_dist(2, 4), lo_dist(-2, 4), span_dist(0, 4), len_dist(0, 3), ht_dist(0, 3), cap_dist(0, 4),
+            spread_dist(0, 3);
         for (int k = 0; k < 20; ++k) {
             Instance inst;
             auto n = n_dist(rand);
             for (int i = 0; i < n; ++i) {
                 auto lo = lo_dist(rand), span = span_dist(rand);
                 inst.start_ranges.emplace_back(lo, lo + span);
-                inst.lengths.push_back(len_dist(rand));
+                auto len = len_dist(rand);
+                inst.lengths.emplace_back(len, len + spread_dist(rand));
                 inst.heights.push_back(ht_dist(rand));
             }
             inst.capacity = cap_dist(rand);
@@ -675,6 +784,12 @@ auto main(int argc, char * argv[]) -> int
     check_enumeration("f1_twin", f1_twin, all_rules, proofs ? make_optional("cumulative_overload_enum_f1_twin") : nullopt);
     check_enumeration("f2", f2, all_rules, proofs ? make_optional("cumulative_overload_enum_f2") : nullopt);
     check_enumeration("f2_twin", f2_twin, all_rules, proofs ? make_optional("cumulative_overload_enum_f2_twin") : nullopt);
+    // F3's pair, where the search is what makes them worth running: branching
+    // on the length variable raises lb(l) below the root, so the energy rows
+    // here are ones whose length bound is not the declared one --- the case the
+    // boundary pin cannot pay for and a unit RUP has to.
+    check_enumeration("f3", f3, all_rules, proofs ? make_optional("cumulative_overload_enum_f3") : nullopt);
+    check_enumeration("f3_twin", f3_twin, all_rules, proofs ? make_optional("cumulative_overload_enum_f3_twin") : nullopt);
 
     return EXIT_SUCCESS;
 }

--- a/gcs/constraints/cumulative/derived_cumulative.cc
+++ b/gcs/constraints/cumulative/derived_cumulative.cc
@@ -116,7 +116,8 @@ auto gcs::innards::install_derived_cumulative(
     // A derived Cumulative's own cache. Not the donor's: the rows are about
     // this constraint's window and this constraint's capacity lines, so sharing
     // one would have a firing cite a line derived against different rows.
-    inputs->guarded_energy = make_shared<std::map<std::tuple<std::size_t, Integer, Integer, Integer, Integer>, window_energy::GuardedWindowEnergy>>();
+    inputs->guarded_energy =
+        make_shared<std::map<std::tuple<std::size_t, Integer, Integer, Integer, Integer, Integer>, window_energy::GuardedWindowEnergy>>();
 
     // The donors' rows, to derive from. Resolved before anything is installed:
     // a derived constraint that cannot cite what it needs must not be installed
@@ -259,16 +260,17 @@ auto gcs::innards::install_derived_cumulative(
         vector<makespan_energy::EnergyTask> energy_tasks;
         vector<std::optional<IntegerVariableID>> energy_presences;
         for (auto i : inputs->overload_tasks) {
-            // A plain variable and a constant, and by construction:
-            // prepare_cumulative_overload_check keeps only such tasks, the
-            // window-energy lemma needing a task's energy to be a number before
-            // it can count it. So a variable-duration task takes part in the
-            // time-tabling and in the rows, and stays out of the energy
-            // argument.
+            // A plain variable and a constant. The start is by construction ---
+            // prepare_cumulative_overload_check keeps only such tasks --- but
+            // the length is not: that filter admits a variable one and counts it
+            // at the duration it guarantees (#689), which the makespan bound
+            // cannot do, its rows being built once at the root off a length that
+            // has to be a number. So a variable-duration task takes part in the
+            // time-tabling, in the rows and in the overload check's energy, and
+            // stays out of the makespan argument alone.
             //
             // Checked rather than assumed, because the invariant lives in
-            // another file and loosening that filter is a thing somebody will
-            // want to do: what would arrive here otherwise is a
+            // another file: what would arrive here otherwise is a
             // std::bad_variant_access from inside an install initialiser, and
             // what should arrive is nothing at all.
             if (! std::holds_alternative<SimpleIntegerVariableID>(spec.tasks[i].start) || ! is_constant_variable(spec.tasks[i].length))

--- a/gcs/constraints/cumulative/propagate.hh
+++ b/gcs/constraints/cumulative/propagate.hh
@@ -98,7 +98,8 @@ namespace gcs::innards
         Integer time_slot_lo = 0_i;
 
         /// Edge-finding's window-energy rows, keyed on (task, window lo, window
-        /// hi, low guard, high guard). They are facts about the model rather than about the
+        /// hi, low guard, high guard, the length the task was counted at). They
+        /// are facts about the model rather than about the
         /// search state, so they live at ProofLevel::Top and every later firing
         /// over the same window cites the same line. Shared, and mutable
         /// through the shared_ptr, because the propagator closure holds these
@@ -109,7 +110,8 @@ namespace gcs::innards
         /// because a window is a pair of an earliest start and a latest
         /// completion time and those repeat constantly. Re-deriving per firing
         /// costs about a hundred times more.
-        std::shared_ptr<std::map<std::tuple<std::size_t, Integer, Integer, Integer, Integer>, window_energy::GuardedWindowEnergy>> guarded_energy;
+        std::shared_ptr<std::map<std::tuple<std::size_t, Integer, Integer, Integer, Integer, Integer>, window_energy::GuardedWindowEnergy>>
+            guarded_energy;
     };
 
     /**

--- a/gcs/constraints/innards/makespan_energy.cc
+++ b/gcs/constraints/innards/makespan_energy.cc
@@ -159,7 +159,7 @@ auto gcs::innards::makespan_energy::derive_makespan_bound(ProofLogger & logger, 
             confine.emit(logger, level);
         }
 
-        window_energy::ConstantLengthTask lemma_task{task.start, task.length, task.t_lo, *task.before, *task.after, *task.active};
+        window_energy::Task lemma_task{task.start, task.length, task.t_lo, *task.before, *task.after, *task.active};
         auto energy = window_energy::derive_window_energy(
             logger, forget_deadline ? reason : deadline, lemma_task, bound.lo, hi, start_bounds_within(task, hi), level);
 

--- a/gcs/constraints/innards/makespan_energy.hh
+++ b/gcs/constraints/innards/makespan_energy.hh
@@ -146,7 +146,7 @@ namespace gcs::innards::makespan_energy
         /// task's own length.
         std::optional<MakespanLink> link = std::nullopt;
 
-        /// The task's per-time flags, as window_energy::ConstantLengthTask
+        /// The task's per-time flags, as window_energy::Task
         /// describes them, or null with proofs off.
         const std::vector<ProofFlag> * before = nullptr;
         const std::vector<ProofFlag> * after = nullptr;

--- a/gcs/constraints/innards/window_energy.cc
+++ b/gcs/constraints/innards/window_energy.cc
@@ -87,7 +87,19 @@ namespace
     // two-literal clause after saturation. The third adds active's [f] half,
     // the AND-gate clause active \/ ~before \/ ~after, whose before and after
     // terms then cancel against the two bridges.
-    auto emit_per_time_bridges(ProofLogger & logger, const ConstantLengthTask & task, const Shape & shape, ProofLevel level) -> vector<ProofLine>
+    //
+    // A variable-length task's `after` is reified on `s + l >= t + 1` instead,
+    // so its bridge cancels two variables rather than one: the length's own
+    // order literal `[l >= p]` takes the l bits away, and what is left after
+    // saturation is
+    //     after_t  \/  ~[s >= t - p + 1]  \/  ~[l >= p]
+    // --- the whole content of the move, since `s >= t - p + 1` and `l >= p`
+    // together give `s + l >= t + 1`. `length_holds`, where the caller has a
+    // line saying `[l >= p]`, pays the third literal off here and leaves the
+    // clause the shape the constant-length case has; where it does not, the
+    // literal stays and rides through the sum as a guard.
+    auto emit_per_time_bridges(ProofLogger & logger, const Task & task, const Shape & shape, optional<ProofLine> length_holds, ProofLevel level)
+        -> vector<ProofLine>
     {
         auto & tracker = logger.names_and_ids_tracker();
         IntegerVariableID start = task.start;
@@ -106,7 +118,23 @@ namespace
             PolBuilder after_bridge;
             after_bridge.add(ProofLineLabel{tracker.name_of(task.after[idx]) + "[f]"});
             after_bridge.add_for_literal(tracker, start >= t - shape.p + 1_i);
-            after_bridge.saturate();
+            if (task.length_variable) {
+                after_bridge.add_for_literal(tracker, *task.length_variable >= shape.p);
+                // Saturating here and not only at the end, which the PolBuilder
+                // docs warn off, is what makes the length unit worth one: the
+                // three rows leave a clause whose ~[l >= p] carries whatever
+                // coefficient the length's encoding gave it, and adding the unit
+                // to *that* would have to match it. Saturating first makes every
+                // coefficient one, so the unit cancels the literal outright.
+                after_bridge.saturate();
+                // And no second saturation after it: `~[l >= p] + [l >= p]` is
+                // the constant one, so what the addition leaves is the clause
+                // this saturation already made of everything else.
+                if (length_holds)
+                    after_bridge.add(*length_holds);
+            }
+            else
+                after_bridge.saturate();
             auto after_clause = after_bridge.emit(logger, level);
 
             PolBuilder step;
@@ -116,6 +144,26 @@ namespace
             per_time.push_back(step.emit(logger, level));
         }
         return per_time;
+    }
+
+    // The line saying a variable-length task really does run for at least the
+    // length the lemma is counting it at. At the length's declared lower bound
+    // that is the boundary pin need_gevar wrote down at the top of the proof,
+    // which is a model fact and costs nothing to cite; above it the fact is
+    // still permanent for the subtree but nothing has written it down, so a
+    // unit RUP under the reason does --- which is why the reason has to entail
+    // the length bound. Requesting the defining item first is what makes the
+    // pin exist to be found: need_gevar writes it when it creates the atom.
+    auto length_holds_line(ProofLogger & logger, const ReasonLiterals & reason, const Task & task, ProofLevel level) -> optional<ProofLine>
+    {
+        if (! task.length_variable)
+            return nullopt;
+        auto & tracker = logger.names_and_ids_tracker();
+        auto at_least = *task.length_variable >= task.length;
+        static_cast<void>(tracker.need_pol_item_defining_literal(at_least));
+        if (auto pin = tracker.boundary_pin_line(*task.length_variable, task.length))
+            return pin;
+        return logger.emit_rup_proof_line_under_reason(reason, WPBSum{} + 1_i * at_least >= 1_i, level);
     }
 
     // `[s >= weaker] \/ ~[s >= stronger]`, for weaker <= stronger: a fact about
@@ -140,8 +188,8 @@ auto gcs::innards::window_energy::window_energy_bound(
     return shape_of(length, flags_t_lo, flags_size, lo, hi, start_bounds).bound;
 }
 
-auto gcs::innards::window_energy::derive_window_energy(ProofLogger & logger, const ReasonLiterals & reason, const ConstantLengthTask & task,
-    Integer lo, Integer hi, pair<Integer, Integer> start_bounds, ProofLevel level) -> optional<WindowEnergy>
+auto gcs::innards::window_energy::derive_window_energy(ProofLogger & logger, const ReasonLiterals & reason, const Task & task, Integer lo, Integer hi,
+    pair<Integer, Integer> start_bounds, ProofLevel level) -> optional<WindowEnergy>
 {
     auto shape = shape_of(task.length, task.flags_t_lo, task.active.size(), lo, hi, start_bounds);
     if (shape.empty() || shape.bound <= 0_i)
@@ -150,7 +198,7 @@ auto gcs::innards::window_energy::derive_window_energy(ProofLogger & logger, con
     auto & tracker = logger.names_and_ids_tracker();
     IntegerVariableID start = task.start;
 
-    auto per_time = emit_per_time_bridges(logger, task, shape, level);
+    auto per_time = emit_per_time_bridges(logger, task, shape, length_holds_line(logger, reason, task, level), level);
 
     // Step 2, one pol summing them, into which the order literals telescope.
     PolBuilder sum;
@@ -191,8 +239,8 @@ auto gcs::innards::window_energy::derive_window_energy(ProofLogger & logger, con
     return WindowEnergy{sum.emit(logger, level), shape.bound, shape.a, shape.b};
 }
 
-auto gcs::innards::window_energy::derive_guarded_window_energy(ProofLogger & logger, const ConstantLengthTask & task, Integer lo, Integer hi,
-    Integer low_guard, Integer high_guard, ProofLevel level) -> optional<GuardedWindowEnergy>
+auto gcs::innards::window_energy::derive_guarded_window_energy(ProofLogger & logger, const Task & task, Integer lo, Integer hi, Integer low_guard,
+    Integer high_guard, ProofLevel level) -> optional<GuardedWindowEnergy>
 {
     // The guards stand in for the bounds a firing would have had, so the shape,
     // and the bound it predicts, are the reason-backed ones for those bounds.
@@ -203,7 +251,12 @@ auto gcs::innards::window_energy::derive_guarded_window_energy(ProofLogger & log
     auto & tracker = logger.names_and_ids_tracker();
     IntegerVariableID start = task.start;
 
-    auto per_time = emit_per_time_bridges(logger, task, shape, level);
+    // No length line, so a variable length's `~[l >= p]` stays in every per-time
+    // clause and the sum below carries one copy per time point. That is more
+    // than the bound, and the citer pays for all of them; making it exactly the
+    // bound would need the sum divided, which the leftover order literals do
+    // not survive.
+    auto per_time = emit_per_time_bridges(logger, task, shape, nullopt, level);
 
     PolBuilder sum;
     for (const auto & line : per_time)
@@ -248,5 +301,6 @@ auto gcs::innards::window_energy::derive_guarded_window_energy(ProofLogger & log
     if (kept_u - lost_v != shape.bound)
         throw ProofError{"guarded window energy derivation and its predicted bound disagree"};
 
-    return GuardedWindowEnergy{sum.emit(logger, level), shape.bound, shape.a, shape.b, low_guard, low_coeff, high_guard};
+    auto length_coeff = task.length_variable ? shape.b - shape.a : 0_i;
+    return GuardedWindowEnergy{sum.emit(logger, level), shape.bound, shape.a, shape.b, low_guard, low_coeff, high_guard, task.length, length_coeff};
 }

--- a/gcs/constraints/innards/window_energy.hh
+++ b/gcs/constraints/innards/window_energy.hh
@@ -15,9 +15,9 @@
 namespace gcs::innards::window_energy
 {
     /**
-     * \brief A task, as the window-energy lemma sees it: a start variable with a
-     * constant duration, plus the per-time proof flags a time-table encoding
-     * gives it.
+     * \brief A task, as the window-energy lemma sees it: a start variable and a
+     * length it is guaranteed to run for, plus the per-time proof flags a
+     * time-table encoding gives it.
      *
      * The three flag vectors are indexed by <code>t - flags_t_lo</code>, and
      * must be fully reified (so that both their <code>[r]</code> and
@@ -25,19 +25,31 @@ namespace gcs::innards::window_energy
      *
      * <ul>
      * <li><code>before[t] &hArr; start &le; t</code></li>
-     * <li><code>after[t] &hArr; start &ge; t - length + 1</code></li>
+     * <li><code>after[t] &hArr; start &ge; t - length + 1</code>, or, when
+     * <code>length_variable</code> is set,
+     * <code>after[t] &hArr; start + length_variable &ge; t + 1</code></li>
      * <li><code>active[t] &hArr; before[t] &and; after[t]</code></li>
      * </ul>
      *
-     * which is exactly what <code>Cumulative::define_proof_model</code> emits.
+     * which is exactly what <code>Cumulative::define_proof_model</code> emits
+     * for a constant-length and for a variable-length task respectively.
+     *
+     * For a variable-length task, <code>length</code> is a value the length is
+     * known to be at least, and the lemma counts the task at that: the
+     * execution interval <code>[start, start + length_variable)</code> contains
+     * <code>[start, start + length)</code>, so activity established for the
+     * shorter one is activity all the same. Every derivation is then reason-free
+     * in the length exactly when <code>length</code> is its *declared* lower
+     * bound; taking a tightened one instead costs a guard (see
+     * \ref GuardedWindowEnergy) or a unit RUP (see \ref derive_window_energy).
      *
      * The flag range must cover every time at which the task can be active
-     * (i.e. <code>[lb(start), ub(start) + length - 1]</code> at the time the
+     * (i.e. <code>[lb(start), ub(start) + ub(length) - 1]</code> at the time the
      * flags were created): the lemma clips its window to the flag range, and
      * that clipping is only energy-preserving because the task is inactive
      * outside it.
      */
-    struct ConstantLengthTask
+    struct Task
     {
         SimpleIntegerVariableID start;
         Integer length;
@@ -45,6 +57,12 @@ namespace gcs::innards::window_energy
         const std::vector<ProofFlag> & before;
         const std::vector<ProofFlag> & after;
         const std::vector<ProofFlag> & active;
+        /// Set iff <code>after</code> is reified on the two-variable
+        /// <code>start + length_variable</code>, in which case
+        /// <code>length</code> is what the lemma counts the task at and
+        /// <code>length_variable &ge; length</code> is what it needs to bridge
+        /// back onto <code>start</code>'s order literals.
+        std::optional<SimpleIntegerVariableID> length_variable = std::nullopt;
     };
 
     /**
@@ -92,11 +110,20 @@ namespace gcs::innards::window_energy
      * telescope: the sum's <code>start</code> terms cancel exactly, in the
      * same way the <code>end</code> bridge lemma's operand bits do.
      *
+     * A variable-length task's <code>after</code> bridge takes one more line
+     * (the length's own order literal, which cancels the length out of the
+     * flag's reification) and one more term, <code>~[length_variable &ge;
+     * length]</code>. That term is discharged once for the whole derivation
+     * rather than per time point: at the declared lower bound by the boundary
+     * pin need_gevar already wrote down, and anywhere above it by a unit RUP
+     * under the reason --- which is why the reason must entail the length bound
+     * as well as <code>start_bounds</code>.
+     *
      * Returns nullopt when the window is empty after clipping, or when the
      * bound would be zero or less (there is nothing to say, and callers must
      * not cite a line that was never emitted).
      */
-    [[nodiscard]] auto derive_window_energy(ProofLogger &, const ReasonLiterals &, const ConstantLengthTask &, Integer lo, Integer hi,
+    [[nodiscard]] auto derive_window_energy(ProofLogger &, const ReasonLiterals &, const Task &, Integer lo, Integer hi,
         std::pair<Integer, Integer> start_bounds, ProofLevel) -> std::optional<WindowEnergy>;
 
     /**
@@ -108,16 +135,19 @@ namespace gcs::innards::window_energy
      * sum of <code>active[t]</code> over the window
      * + <code>low_coeff</code>&middot;<code>~[start &ge; low_guard]</code>
      * + <code>bound</code>&middot;<code>[start &ge; high_guard]</code>
+     * + <code>length_coeff</code>&middot;<code>~[length_variable &ge; length]</code>
      * &ge; <code>bound</code>
      * </blockquote>
      *
-     * so a citer has to discharge both guards. The first holds for any task the
-     * window contains, the second is the negation of a bound push's conclusion.
+     * so a citer has to discharge every guard. The first holds for any task the
+     * window contains, the second is the negation of a bound push's conclusion,
+     * and the third is absent (<code>length_coeff</code> zero) unless the task's
+     * length is a variable.
      */
     struct GuardedWindowEnergy
     {
         ProofLine line;
-        /// The activity the line establishes once both guards are discharged.
+        /// The activity the line establishes once every guard is discharged.
         Integer bound;
         /// The window the sum runs over: the requested one clipped to the flag range.
         Integer lo, hi;
@@ -128,6 +158,13 @@ namespace gcs::innards::window_energy
         /// ... and <code>bound</code> copies of <code>[start &ge; high_guard]</code>,
         /// which is the requested threshold.
         Integer high_guard;
+        /// ... and, for a variable-length task, <code>length_coeff</code> copies
+        /// of <code>~[length_variable &ge; length_guard]</code>, one per time
+        /// point summed. Zero for a constant-length task, whose line has no such
+        /// term. A citer whose reason entails the length bound discharges them;
+        /// at the declared lower bound the boundary pin does it with no reason
+        /// at all.
+        Integer length_guard, length_coeff;
     };
 
     /**
@@ -158,14 +195,22 @@ namespace gcs::innards::window_energy
      * and the ones it cannot reach are discharged by their own literal axioms
      * at a unit of the bound each.
      *
+     * A variable length is weakened onto a guard of its own for the same
+     * reason, and only when it has to be: at the declared lower bound the
+     * length term would be paid off by a boundary pin, which is a model fact,
+     * but the row is kept across nodes and the caller may well be counting the
+     * task at a bound the search has tightened. Carrying the term instead
+     * leaves one row that is right at either, and costs its citer one more
+     * unit RUP.
+     *
      * Costs two more pol lines per surviving order literal than the
      * reason-backed form, all of them inside the part that gets kept.
      *
      * Returns nullopt on an empty clipped window, or when the bound would be
      * zero or less.
      */
-    [[nodiscard]] auto derive_guarded_window_energy(ProofLogger &, const ConstantLengthTask &, Integer lo, Integer hi, Integer low_guard,
-        Integer high_guard, ProofLevel) -> std::optional<GuardedWindowEnergy>;
+    [[nodiscard]] auto derive_guarded_window_energy(
+        ProofLogger &, const Task &, Integer lo, Integer hi, Integer low_guard, Integer high_guard, ProofLevel) -> std::optional<GuardedWindowEnergy>;
 }
 
 #endif


### PR DESCRIPTION
Closes #689's length half. Stacked on #747 (`cumulative-kaoc`); review that first.

## What it does

The window-energy lemma turned away a task whose length was a decision
variable, so a multi-mode RCPSP task got its demand counted (#686) and its
energy discarded — and it was the duration that discarded it. It is now
counted at `lb(l)`: `[start, start + lb(l))` is inside the execution interval,
so activity established for the short one is activity all the same, and
`shape_of` and the telescoping are the constant-length ones with `p = lb(l)`.

## The proof move, which is one `pol` and no new vocabulary

A constant length reifies `after_{i,t}` on the single variable `s ≥ t − l + 1`,
and the bridge is a two-line `pol`. A variable one reifies it on
`s + l ≥ t + 1`, so the bridge adds the length's own order literal to cancel
the `l` bits and lands on

    after_t  ∨  ¬[s ≥ t − p + 1]  ∨  ¬[l ≥ p]

which is the whole of the idea: `s ≥ t−p+1` and `l ≥ p` together give
`s + l ≥ t+1`. Saturating *before* paying the length literal off is what makes
it worth one unit rather than whatever the encoding gave it, so a unit saying
`[l ≥ p]` cancels it outright.

Where that unit comes from decides how reusable the row is:

- at the length's **declared** lower bound it is the boundary pin `need_gevar`
  already wrote at the top of the proof — a model fact, so the row is as
  reusable as a constant-length one;
- above it `derive_window_energy` emits a unit RUP under the reason (every
  variable length is already in `reason_vars`);
- `derive_guarded_window_energy` can do neither, its rows outliving the node
  that wanted them, so it keeps `¬[l ≥ p]` as a **third guard** — one copy per
  time point summed — and the citing `pol` discharges it beside the two start
  guards. The length joins that cache's key for the same reason.

Everything else in `window_energy.cc` is shared between the two kinds;
`ConstantLengthTask` is renamed `Task` and gains an optional `length_variable`.

## Evidence

- **F3** in `cumulative_overload_test`: two constant unit tasks of length two
  and one of length `[1, 3]`, all free in `[0, 2]` at capacity one. The window
  `[0, 4)` supplies four units and the constant tasks want four, so the
  conflict is exactly the one unit the variable-duration task guarantees. Its
  mandatory part is `[2, 1)` — empty — so the (TTOC) profile term, which is
  where such a task used to end up in full, has nothing to say, and neither has
  time-tabling. This is the spike the issue asked for: the bridged lemma
  establishes `k`, not `ect − lst`.
- **F3's twin** is the same instance with the duration allowed to be zero. It
  is satisfiable, and stays unrefuted — which is also what says that counting a
  task at anything above `lb(l)` would lose solutions.
- Both test files now carry lengths as ranges, and the overload file's oracle
  counts the same way the propagator does. **201 of the 300 random instances it
  cross-checks now have a variable duration**, and the propagator agrees with
  the oracle on every one.
- `cumulative_edge_finding_test` gains a contained and a pushed
  variable-duration task, which is where the third guard is exercised. Both
  push to the same bound as their constant twins.
- Both branches of the length unit (boundary pin, RUP fallback) and the guarded
  path were each confirmed live by a temporary throw, not assumed.
- **Constant-duration proofs are byte-identical.** Every `.pbp`/`.opb` written
  by the kaoc, TTEF, not-first/not-last and edge-finding suites matches #747's
  byte for byte, bar one: `cumulative_kaoc_enumeration`, which turns out to
  differ *between two runs of the same binary* — see below.
- Full `ctest`: 682/682 with the runtime caps on and again with them off; GCC
  with `-DGCS_WERROR=ON` and clang both clean of new diagnostics.

## Not measured, and why

There is no local instance with a variable duration to measure on:
`examples/rcpsp` posts `vector<Integer>` durations, and the multi-mode models
this is for are `minizinc/tests/cumulativemodetest.mzn` sized. So this is a
strength claim backed by fixtures, not a speedup claim backed by a table.

## Left for later

`#689`'s **other** half — a *posted* constraint's variable height — is untouched
and still turned away. A derived constraint's already passes, by #686
converting it before the filter sees it. The follow-up note in
`dev_docs/cumulative-proof-logging.md` is rewritten to say so.

## Unrelated, found on the way — now fixed on #747

`cumulative_kaoc_test` was the only test in the family that never called
`establish_and_announce_seed`, so its branching order came from `random_device`,
`--seed=N` was silently ignored, and `cumulative_kaoc_enumeration.pbp` differed
between two runs of the same binary (589 vs 625 lines; not ASLR). That is why
the byte-diff above has one outlier. Fixed by a one-line commit on #747, where
the file lives; with it, the same seed gives a byte-identical proof and a
different seed a different one, and 40 seeds pass.
