### PR TITLE
cumulative: count a variable demand's guaranteed energy

### DIFF
--- a/dev_docs/cumulative-proof-logging.md
+++ b/dev_docs/cumulative-proof-logging.md
@@ -566,17 +566,64 @@ part of that cache's key for the same reason.
 when `after` was reified the two-variable way. Everything else in
 `window_energy.cc` is shared between the two kinds.
 
+### A variable demand, and where it lands instead
+
+A variable height changes nothing about what the lemma derives. It
+changes what a *capacity row carries*: `C_t` holds the bit-linearised
+`contrib` rather than `h·active`, so an activity bound has nothing to
+cancel against until it is converted into contribution terms.
+
+`guaranteed_contribution_row` is the conversion, and it is #686's line:
+
+    Σ_k 2^k·cc_k  +  lb(h)·¬active_t  ≥  lb(h)
+
+— "either the task is not active here, or it contributes at least
+`lb(h)`". A citer emits one per time point of the energy row's *clipped*
+window and adds the row itself at `lb(h)`. Each conversion line carries
+`lb(h)·¬active_t` where the scaled row carries `lb(h)·active_t`, so the
+activity cancels between them and what is left is
+
+    Σ_{t∈[a,b)} contrib_t  ≥  lb(h)·bound
+
+which is what cancels against `C_t`. Anything else the row carried — a
+guarded row's guard literals — rides through at the same scale, so the
+citer discharges them exactly as it would have.
+
+The window has to be the row's own clipped one and not the requested
+one, or the conversion lines do not cover the time points the row's sum
+runs over and the cancellation is partial.
+
+It is a RUP and not a `pol`, and the argument is in the lemma's own
+header. **It has to go out under the reason**, though, and not merely to
+record what it depends on: the unit saying the height reaches the bound
+is itself reason-backed whenever the bound is not the declared one, so
+it is a *clause* carrying the reason's negations rather than a unit. A
+goal stated without the reason leaves those literals unassigned, the
+clause does not propagate, and the hint is worth nothing — which is a
+rejected proof, not a slow one. (That is the one thing the derived path
+did not have to know, its conversion running at the root.)
+
+`donor_view`'s conversion is the same call. There it happens *before*
+the filter, rewriting the derived constraint's capacity rows, which is
+why an all-variable-height donor's energy was counted long before a
+posted constraint's was.
+
 ### Restrictions, and why they are only weakenings
 
-The energy set takes only tasks with a constant height (a variable
-height enters `C_t` as the bit-linearised `contrib`, not as `h·active`,
-so the cancellation would not be exact) and a start — and a variable
-length — that is a plain variable with an order encoding (the bridges
-need order literals; a `{0,1}` domain is direct-only encoded, and a
-view's atoms would need deview-mode arithmetic). The whole check is
-skipped when the capacity is a variable: a `(b−a)·capacity` term would
-survive into the conflict line for the wrapping RUP to dispose of over
-the capacity's bits, which it cannot do in general.
+The energy set takes a start — and a variable length — that is a plain
+variable with an order encoding (the bridges need order literals; a
+`{0,1}` domain is direct-only encoded, and a view's atoms would need
+deview-mode arithmetic). A `{0,1}` *height* is fine: its atom resolves
+to a bare literal rather than to a defining line, which costs the
+conversion its hints and nothing else. The whole check is skipped when
+the capacity is a variable: a `(b−a)·capacity` term would survive into
+the conflict line for the wrapping RUP to dispose of over the capacity's
+bits, which it cannot do in general.
+
+The **elastic** rules — (TTHE-OC) and (KAOC) — still decline a variable
+height outright, and that is not the same restriction: their knapsack
+item list and term-dropping read heights off the capacity row's
+coefficients, which a bit-linearised contribution is not.
 
 None of these lose soundness or solutions: a task the energy set will
 not take still counts through `F(a, b)`, and a check not made is a
@@ -1019,7 +1066,9 @@ improvement rather than a divergence, and
 siblings publish them.
 
 **The conversion is one hinted RUP** per (variable-height task, time), with `L`
-the height's lower bound:
+the height's lower bound. It is `guaranteed_contribution_row`, shared with the
+posted constraint's energy set, which reaches it from the other side (see "A
+variable demand, and where it lands instead"):
 
 ```
 rup  Σ_k 2^k·cc_{i,t,k} + L·¬active_{i,t} >= L   :  @c[id][<i>_<t>_cge]  <the height's lower-bound line> ;
@@ -1538,6 +1587,9 @@ can test it.
 Constant heights only: a variable height puts bit-linearised contribution terms
 in the capacity row, which neither the knapsack's item list nor the term-dropping
 can read, so v1 declines rather than approximates and the plain rules still run.
+This is *not* the restriction the energy set shed in #689 — there the conversion
+turns an activity bound into contribution terms, where here what would have to
+be converted is the row the items are read off.
 A capacity above 4096 falls back to the elastic cap, since the bitset is
 `capacity + 1` bits at every time point (scheduling capacities are nothing like
 that --- Cloutier & Quimper report `C <= 122` across their benchmarks).
@@ -1569,17 +1621,20 @@ per time point. Same trade as #742 for edge-finding's scan, and the same answer
   nothing measurable, but the window x task sweep that finds them is O(n^3) and
   taxes the solve about 1.5x at identical search. Propagation performance, not
   proof logging.
-- **A posted constraint's variable height in the energy set (#689's other
-  half).** The length half is done: a variable-duration task is counted at
-  `lb(l)`. The height half is done for a *derived* constraint by accident of
-  composition — a task #686 converted arrives at the filter as a constant and
-  passes, which `cumulative_strengthening_all_var_heights` demonstrates by
-  refuting at the root through the energy check — but a **posted** constraint's
-  variable-height task is still turned away, and need not be: #686's conversion
-  RUP is not specific to derived constraints, and the same line would let the
-  energy set count such a task at `lb(h)`. What it would cost is the
-  cancellation in the conflict `pol`, since a variable height enters `C_t` as
-  the bit-linearised `contrib` rather than as `h·active`.
+- **Guarded contribution rows.** A variable-height task's conversion is
+  reason-backed and re-derived per firing, one line per time point of the
+  window — the same shape as TTEF's pins above, and amenable to the same
+  answer. At the height's *declared* lower bound the line is a model fact
+  (`cge` plus the boundary pin) and could live at `ProofLevel::Top` and be
+  cached; taking the live bound instead is what makes it reason-backed, for the
+  same reason the length does. Whether the declared bound is worth having is a
+  measurement nobody has made.
+- **The elastic family over variable heights.** (TTHE-OC) and (KAOC) decline a
+  variable height, and unlike the energy set they are not one conversion away:
+  the knapsack's item list is a set of heights read off a capacity row's
+  coefficients, and a bit-linearised contribution is not a coefficient on a
+  flag. Converting the row first — which is exactly what `donor_view` does for
+  a derived constraint — is the obvious route and has not been tried.
 - **Conditional bounds for optional tasks.** An undecided task's start
   bounds are never pruned, because there is no conditional-bounds store
   and an unconditional prune would be unsound if the task turns out

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -54,6 +54,7 @@ add_library(glasgow_constraint_solver
         constraints/increasing/increasing.cc
         constraints/innards/cake_truthiness.cc
         constraints/innards/linear_stages.cc
+        constraints/innards/guaranteed_contribution.cc
         constraints/innards/makespan_energy.cc
         constraints/innards/product_encoding.cc
         constraints/innards/product_justify.cc

--- a/gcs/constraints/cumulative/cumulative.cc
+++ b/gcs/constraints/cumulative/cumulative.cc
@@ -1,6 +1,7 @@
 #include <gcs/constraints/cumulative/cumulative.hh>
 #include <gcs/constraints/cumulative/hints.hh>
 #include <gcs/constraints/cumulative/propagate.hh>
+#include <gcs/constraints/innards/guaranteed_contribution.hh>
 #include <gcs/constraints/innards/window_energy.hh>
 #include <gcs/exception.hh>
 #include <gcs/innards/inference_tracker.hh>
@@ -246,31 +247,35 @@ auto gcs::innards::prepare_cumulative_overload_check(const vector<IntegerVariabl
     const vector<Integer> & per_task_t_hi, const State & initial_state) -> CumulativeOverloadData
 {
     CumulativeOverloadData result;
-    // Which tasks the window-energy lemma can speak about: a constant height
-    // (so the task's load in C_t is h·active rather than the bit-linearised
-    // contrib), and a start that is a plain variable with an order encoding,
-    // since the lemma bridges the before/after flags to the start's order
-    // literals. A task that is not eligible is not lost to the check: whatever
-    // it must occupy still counts, through the profile term of the (TTOC)
-    // strengthening.
+    // Which tasks the window-energy lemma can speak about: a start that is a
+    // plain variable with an order encoding, since the lemma bridges the
+    // before/after flags to the start's order literals. A task that is not
+    // eligible is not lost to the check: whatever it must occupy still counts,
+    // through the profile term of the (TTOC) strengthening.
     //
-    // The height half is looser than it reads. A *derived* Cumulative's tasks
-    // carry constant heights by construction, so one whose donor height was a
-    // variable arrives here already converted to the demand it guarantees and
-    // passes --- which is how an all-variable-height donor's energy gets
-    // counted at all. A posted constraint's variable height is still turned
-    // away, and need not be: the same conversion would serve, and #689's
-    // remaining half is what it would take.
+    // Neither a variable length nor a variable height is turned away any more
+    // (#689). Both are counted at what the task *guarantees* rather than at
+    // what it might use, and both are plain variables for the same reason the
+    // start is --- what the derivations need is an order literal to cancel
+    // against.
     //
-    // A *variable* length is admitted (#689), at the length it is guaranteed to
-    // reach rather than at the one it might: the lemma counts the task over
-    // [start, start + lb(length)), which its execution interval contains, by
-    // bridging its `after` flags back onto the start's order literals through
-    // the length's own. What that needs from here is a length whose order
-    // literals exist to be bridged with, so a plain variable, and one that can
-    // be positive at all --- a task whose length can only be zero is not an
-    // active task in the first place. Whether the bound it reaches is worth
-    // anything is asked at every node, in the candidate sweep, and not here.
+    // A variable **length** is counted over [start, start + lb(length)), which
+    // the execution interval contains, by bridging the `after` flags back onto
+    // the start's order literals through the length's own.
+    //
+    // A variable **height** does not change what the lemma derives at all: it
+    // changes what a capacity row carries, which is the bit-linearised
+    // `contrib` rather than `h·active`, so a citer converts the activity into
+    // contribution terms with guaranteed_contribution_row before the two can
+    // cancel. That conversion is #686's, and it is what a *derived*
+    // Cumulative's tasks have already been through by the time they reach here
+    // --- which is how an all-variable-height donor's energy got counted at all
+    // while a posted one's did not.
+    //
+    // What is asked here of either is only that it can be positive: a task
+    // whose length or height can only be zero is not an active task in the
+    // first place. Whether the bound it reaches is worth anything is asked at
+    // every node, in the candidate sweep, and not here.
     //
     // Presence is not among the tests, and deliberately so. What is asked here
     // is whether the lemma could *ever* speak about a task, which is a question
@@ -290,8 +295,6 @@ auto gcs::innards::prepare_cumulative_overload_check(const vector<IntegerVariabl
 
     result.overload_tasks.clear();
     for (auto i : active_tasks) {
-        if (! is_constant_variable(heights[i]) || constant_value_of(heights[i]) <= 0_i)
-            continue;
         if (! std::holds_alternative<SimpleIntegerVariableID>(starts[i]) || direct_only_encoded(starts[i]))
             continue;
         if (is_constant_variable(lengths[i])) {
@@ -300,6 +303,15 @@ auto gcs::innards::prepare_cumulative_overload_check(const vector<IntegerVariabl
         }
         else if (! std::holds_alternative<SimpleIntegerVariableID>(lengths[i]) || initial_state.upper_bound(lengths[i]) <= 0_i ||
             direct_only_encoded(lengths[i]))
+            continue;
+        if (is_constant_variable(heights[i])) {
+            if (constant_value_of(heights[i]) <= 0_i)
+                continue;
+        }
+        // A {0,1} height is not excluded, unlike a {0,1} start or length: the
+        // conversion resolves its atom to a bare literal rather than to a
+        // defining line, which costs it its hints and nothing else.
+        else if (! std::holds_alternative<SimpleIntegerVariableID>(heights[i]) || initial_state.upper_bound(heights[i]) <= 0_i)
             continue;
         result.overload_tasks.push_back(i);
     }
@@ -672,6 +684,54 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
             active_flags[i], l_is_var(i) ? make_optional(std::get<SimpleIntegerVariableID>(lengths_var[i])) : optional<SimpleIntegerVariableID>{}};
     };
 
+    // What a variable-height task is guaranteed to contribute at one time
+    // point, as a term over the contribution bits a capacity row carries:
+    // `contrib >= lb(h)` unless the task is not active there. #686's line,
+    // reached from here rather than from a donor view.
+    auto guaranteed_contribution = [&](const ReasonLiterals & reason, size_t i, Integer t) -> ProofLine {
+        auto & tracker = logger->names_and_ids_tracker();
+        auto row = tracker.constraint_row_label(owner, ConstraintProofModelData<Cumulative>::contribution_ge_row_role(i, t));
+        // Emitted alongside the flags, so a task with a window here has one.
+        // Missing means the flags and the rows have come apart, which is worth
+        // saying here rather than as a rejected proof later.
+        if (! row)
+            throw ProofError{"cumulative: task " + std::to_string(i) + " has no contribution row at time " + std::to_string(t.raw_value)};
+        auto fi = static_cast<size_t>((t - per_task_t_lo[i]).raw_value);
+        return guaranteed_contribution_row(*logger, &reason, contrib_flags[i][fi], active_flags[i][fi],
+            std::get<SimpleIntegerVariableID>(heights_var[i]), hlb(i), ProofLine{*row}, ProofLevel::Temporary);
+    };
+
+    // An energy row as the capacity lines want it: the line to add to a pol
+    // whose other terms are C_t's, and the coefficient to add it at.
+    //
+    // For a constant height that is the row itself scaled by h, and its
+    // `active` terms cancel against C_t's directly. A variable height is not in
+    // C_t at all --- what is there is the bit-linearised contribution --- so
+    // the row is converted first: one guaranteed_contribution line per time
+    // point of its window, plus the row at lb(h). The activity cancels
+    // *between those two*, each conversion line carrying `lb(h)·~active` where
+    // the scaled row carries `lb(h)·active`, and what is left is
+    //
+    //     Sum_t contrib_t  >=  lb(h) · bound
+    //
+    // which is what cancels against C_t. Anything else the row carried --- a
+    // guarded row's guard literals --- rides through at the same scale, so a
+    // citer discharges them exactly as it would have.
+    //
+    // The window has to be the row's own *clipped* one and not the requested
+    // one: the conversion lines have to cover exactly the time points the row's
+    // sum runs over, or the cancellation is partial and the pol is left open.
+    auto energy_contribution = [&](const ReasonLiterals & reason, size_t i, ProofLine energy_line, Integer lo,
+                                   Integer hi) -> std::pair<ProofLine, Integer> {
+        if (! h_is_var(i))
+            return {energy_line, hlb(i)};
+        PolBuilder pol;
+        for (Integer t = lo; t < hi; ++t)
+            pol.add(guaranteed_contribution(reason, i, t));
+        pol.add(energy_line, hlb(i));
+        return {pol.emit(*logger, ProofLevel::Temporary), 1_i};
+    };
+
     // A task with no presence variable is always here. An optional one is here
     // only once its presence is fixed to 1: until then it contributes nothing
     // to the profile and nothing to the overload check's energy, and nothing
@@ -825,7 +885,8 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
 
             auto cite = [&](size_t i, Integer low_guard, Integer high_guard, bool discharge_low, bool discharge_high) {
                 const auto & row = guarded_energy(i, a, b, low_guard, high_guard);
-                pol.add(row.line, hlb(i));
+                auto [contribution_line, coeff] = energy_contribution(reason, i, row.line, row.lo, row.hi);
+                pol.add(contribution_line, coeff);
                 if (discharge_low && row.low_coeff > 0_i)
                     pol.add(
                         logger->emit_rup_proof_line_under_reason(reason, WPBSum{} + 1_i * (starts[i] >= row.low_guard) >= 1_i, ProofLevel::Temporary),
@@ -1078,13 +1139,13 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
             // with every other known-present task's.
             if (! is_present(i))
                 continue;
-            // A task guaranteed no duration at all carries no guaranteed
-            // energy, so there is nothing for the lemma to establish and
-            // nothing for the window to be charged. Only reachable for a
-            // variable length --- a constant one this small was turned away at
-            // prepare time --- and it can stop being true further down the
-            // search, which is why it is asked here and not there.
-            if (llb(i) <= 0_i)
+            // A task guaranteed no duration, or no demand, carries no
+            // guaranteed energy, so there is nothing for the lemma to establish
+            // and nothing for the window to be charged. Only reachable for a
+            // variable one --- a constant this small was turned away at prepare
+            // time --- and it can stop being true further down the search,
+            // which is why it is asked here and not there.
+            if (llb(i) <= 0_i || hlb(i) <= 0_i)
                 continue;
             auto [s_lo, s_hi] = state.bounds(starts[i]);
             auto p = llb(i), h = hlb(i);
@@ -1827,7 +1888,8 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
                             line =
                                 logger->emit_rup_proof_line_under_reason(reason, move(activity) >= energy_line->bound + 1_i, ProofLevel::Temporary);
                         }
-                        pol.add(line, hlb(i));
+                        auto [contribution_line, coeff] = energy_contribution(reason, i, line, energy_line->lo, energy_line->hi);
+                        pol.add(contribution_line, coeff);
                     }
 
                     for (const auto & [j, t] : pins) {

--- a/gcs/constraints/cumulative/cumulative_edge_finding_test.cc
+++ b/gcs/constraints/cumulative/cumulative_edge_finding_test.cc
@@ -49,14 +49,16 @@ using namespace gcs::test_innards;
 
 namespace
 {
-    // A length is a range: `{p, p}` is a constant, and `{p, q}` with p < q a
-    // decision variable, which the rule counts at `p` --- the duration the task
-    // guarantees, and the one its energy rows carry a guard for (#689).
+    // A length and a height are each a range: `{v, v}` is a constant, and
+    // `{v, w}` with v < w a decision variable, which the rule counts at `v` ---
+    // what the task guarantees. A variable length is what its energy rows carry
+    // a guard for; a variable height is what makes a citer convert those rows
+    // into contribution terms before they can cancel (#689).
     struct Instance
     {
         vector<pair<int, int>> start_ranges;
         vector<pair<int, int>> lengths;
-        vector<int> heights;
+        vector<pair<int, int>> heights;
         int capacity;
     };
 
@@ -65,24 +67,35 @@ namespace
         return inst.lengths[i].first != inst.lengths[i].second;
     }
 
+    auto height_is_var(const Instance & inst, size_t i) -> bool
+    {
+        return inst.heights[i].first != inst.heights[i].second;
+    }
+
     // Every variable an assignment has to fix, in the order the solutions carry
-    // them: the starts, then the variable lengths in task order.
+    // them: the starts, then the variable lengths and then the variable
+    // heights, each in task order.
     auto all_ranges(const Instance & inst) -> vector<pair<int, int>>
     {
         auto ranges = inst.start_ranges;
         for (size_t i = 0; i < inst.lengths.size(); ++i)
             if (length_is_var(inst, i))
                 ranges.push_back(inst.lengths[i]);
+        for (size_t i = 0; i < inst.heights.size(); ++i)
+            if (height_is_var(inst, i))
+                ranges.push_back(inst.heights[i]);
         return ranges;
     }
 
     auto is_satisfying(const Instance & inst, const vector<int> & vals) -> bool
     {
         auto n = inst.start_ranges.size();
-        vector<int> l(n);
+        vector<int> l(n), h(n);
         size_t k = n;
         for (size_t i = 0; i < n; ++i)
             l[i] = length_is_var(inst, i) ? vals.at(k++) : inst.lengths[i].first;
+        for (size_t i = 0; i < n; ++i)
+            h[i] = height_is_var(inst, i) ? vals.at(k++) : inst.heights[i].first;
 
         int t_lo = INT_MAX, t_hi = INT_MIN;
         for (size_t i = 0; i < n; ++i) {
@@ -93,7 +106,7 @@ namespace
             int load = 0;
             for (size_t i = 0; i < n; ++i)
                 if (vals[i] <= t && t < vals[i] + l[i])
-                    load += inst.heights[i];
+                    load += h[i];
             if (load > inst.capacity)
                 return false;
         }
@@ -117,7 +130,15 @@ namespace
             posted.starts.push_back(
                 p.create_integer_variable(Integer{inst.start_ranges[i].first}, Integer{inst.start_ranges[i].second}, "start" + std::to_string(i)));
             posted.all_vars.push_back(posted.starts.back());
-            heights.push_back(constant_variable(Integer{inst.heights[i]}));
+        }
+        for (size_t i = 0; i < inst.heights.size(); ++i) {
+            if (! height_is_var(inst, i))
+                heights.push_back(constant_variable(Integer{inst.heights[i].first}));
+            else {
+                heights.push_back(
+                    p.create_integer_variable(Integer{inst.heights[i].first}, Integer{inst.heights[i].second}, "height" + std::to_string(i)));
+                posted.all_vars.push_back(heights.back());
+            }
         }
         for (size_t i = 0; i < inst.lengths.size(); ++i) {
             if (! length_is_var(inst, i))
@@ -211,12 +232,14 @@ auto main(int argc, char * argv[]) -> int
     // and unit propagation over the time-table encoding closes the conclusion's
     // RUP whatever the derivation above it says. 301 randomly generated firings
     // were all of that kind before this family was found.
-    const Instance packed{{{0, 4}, {0, 4}, {0, 4}, {0, 4}, {0, 12}}, {{4, 4}, {4, 4}, {4, 4}, {4, 4}, {4, 4}}, {1, 1, 1, 1, 1}, 2};
+    const Instance packed{
+        {{0, 4}, {0, 4}, {0, 4}, {0, 4}, {0, 12}}, {{4, 4}, {4, 4}, {4, 4}, {4, 4}, {4, 4}}, {{1, 1}, {1, 1}, {1, 1}, {1, 1}, {1, 1}}, 2};
 
     // The same, over a window that does not start where the tasks' domains do,
     // so the derivation's lower guard is a real order literal rather than a
     // constant and the citing pol has to discharge it.
-    const Instance packed_offset{{{2, 6}, {2, 6}, {2, 6}, {2, 6}, {2, 20}}, {{4, 4}, {4, 4}, {4, 4}, {4, 4}, {4, 4}}, {1, 1, 1, 1, 1}, 2};
+    const Instance packed_offset{
+        {{2, 6}, {2, 6}, {2, 6}, {2, 6}, {2, 20}}, {{4, 4}, {4, 4}, {4, 4}, {4, 4}, {4, 4}}, {{1, 1}, {1, 1}, {1, 1}, {1, 1}, {1, 1}}, 2};
 
     // The mirror image: [4, 12) is full, and the fifth task ENDS inside it but
     // starts before, so it is its upper bound that has to fall --- to 2, the
@@ -227,20 +250,37 @@ auto main(int argc, char * argv[]) -> int
     // The pushed task is shorter than the rest on purpose. At length four the
     // push would pin it to its own lower bound, and then the one-too-far
     // mutation empties the domain rather than corrupting a proof.
-    const Instance packed_mirror{{{4, 8}, {4, 8}, {4, 8}, {4, 8}, {0, 8}}, {{4, 4}, {4, 4}, {4, 4}, {4, 4}, {2, 2}}, {1, 1, 1, 1, 1}, 2};
+    const Instance packed_mirror{
+        {{4, 8}, {4, 8}, {4, 8}, {4, 8}, {0, 8}}, {{4, 4}, {4, 4}, {4, 4}, {4, 4}, {2, 2}}, {{1, 1}, {1, 1}, {1, 1}, {1, 1}, {1, 1}}, 2};
 
     // `packed` with one of the four contained tasks given a variable duration.
     // It guarantees the same four units of energy, so the window is as full as
     // before and the push is to the same place --- but the row saying so is now
     // a statement about a length the model does not fix, and carries a guard
     // for it that the citing pol has to discharge (#689).
-    const Instance packed_var{{{0, 4}, {0, 4}, {0, 4}, {0, 4}, {0, 12}}, {{4, 5}, {4, 4}, {4, 4}, {4, 4}, {4, 4}}, {1, 1, 1, 1, 1}, 2};
+    const Instance packed_var{
+        {{0, 4}, {0, 4}, {0, 4}, {0, 4}, {0, 12}}, {{4, 5}, {4, 4}, {4, 4}, {4, 4}, {4, 4}}, {{1, 1}, {1, 1}, {1, 1}, {1, 1}, {1, 1}}, 2};
 
     // The other place a length guard turns up: on the *pushed* task's own row,
     // which is cited at the threshold rather than for containment. Its clipped
     // energy is measured at lb(l) like everything else, so the push is again to
     // eight, and it is the length it might have that has to not matter.
-    const Instance packed_var_pushed{{{0, 4}, {0, 4}, {0, 4}, {0, 4}, {0, 12}}, {{4, 4}, {4, 4}, {4, 4}, {4, 4}, {4, 6}}, {1, 1, 1, 1, 1}, 2};
+    const Instance packed_var_pushed{
+        {{0, 4}, {0, 4}, {0, 4}, {0, 4}, {0, 12}}, {{4, 4}, {4, 4}, {4, 4}, {4, 4}, {4, 6}}, {{1, 1}, {1, 1}, {1, 1}, {1, 1}, {1, 1}}, 2};
+
+    // `packed` with one of the four contained tasks given a variable height. It
+    // guarantees the same unit of demand, so the window is as full as before and
+    // the push is to the same place --- but that task is not in a capacity row
+    // as `h x active` at all, so the citing pol has to convert its energy row
+    // into contribution terms before anything cancels (#689).
+    const Instance packed_var_height{
+        {{0, 4}, {0, 4}, {0, 4}, {0, 4}, {0, 12}}, {{4, 4}, {4, 4}, {4, 4}, {4, 4}, {4, 4}}, {{1, 2}, {1, 1}, {1, 1}, {1, 1}, {1, 1}}, 2};
+
+    // And on the *pushed* task, whose row is cited at the threshold rather than
+    // for containment, so its own contribution comes back out of the window in
+    // the converted form too.
+    const Instance packed_var_height_pushed{
+        {{0, 4}, {0, 4}, {0, 4}, {0, 4}, {0, 12}}, {{4, 4}, {4, 4}, {4, 4}, {4, 4}, {4, 4}}, {{1, 1}, {1, 1}, {1, 1}, {1, 1}, {1, 2}}, 2};
 
     // Mutation mode: emit one deliberately corrupted proof and stop, for
     // run_test_and_expect_verify_failure.bash to hand to veripb.
@@ -281,7 +321,8 @@ auto main(int argc, char * argv[]) -> int
     // both directions. `raises` says which bound the fixture is about.
     for (const auto & [name, inst, raises, expected] :
         vector<tuple<string, Instance, bool, int>>{{"packed", packed, true, 8}, {"packed_offset", packed_offset, true, 10},
-            {"packed_mirror", packed_mirror, false, 2}, {"packed_var", packed_var, true, 8}, {"packed_var_pushed", packed_var_pushed, true, 8}}) {
+            {"packed_mirror", packed_mirror, false, 2}, {"packed_var", packed_var, true, 8}, {"packed_var_pushed", packed_var_pushed, true, 8},
+            {"packed_var_height", packed_var_height, true, 8}, {"packed_var_height_pushed", packed_var_height_pushed, true, 8}}) {
         auto off = root_bounds(inst, without, cumulative_proof_mutation::None{}, nullopt);
         auto on = root_bounds(inst, with, cumulative_proof_mutation::None{}, proofs ? make_optional("cumulative_edge_finding_" + name) : nullopt);
         if (! off || ! on)
@@ -299,11 +340,12 @@ auto main(int argc, char * argv[]) -> int
 
     // Soundness, over instances small enough to enumerate: the rule may not
     // lose a solution, with or without a proof being written.
-    for (const auto & [name, inst] :
-        vector<pair<string, Instance>>{{"packed", packed}, {"tight", Instance{{{0, 3}, {0, 3}, {0, 5}}, {{2, 2}, {2, 2}, {3, 3}}, {1, 1, 1}, 2}},
-            {"mixed_heights", Instance{{{0, 4}, {0, 4}, {0, 6}}, {{3, 3}, {2, 2}, {2, 2}}, {2, 1, 2}, 3}},
-            {"unit_lengths", Instance{{{0, 3}, {0, 3}, {0, 3}, {0, 5}}, {{1, 1}, {1, 1}, {1, 1}, {2, 2}}, {1, 1, 1, 1}, 2}},
-            {"var_contained", packed_var}, {"var_pushed", packed_var_pushed}}) {
+    for (const auto & [name, inst] : vector<pair<string, Instance>>{{"packed", packed},
+             {"tight", Instance{{{0, 3}, {0, 3}, {0, 5}}, {{2, 2}, {2, 2}, {3, 3}}, {{1, 1}, {1, 1}, {1, 1}}, 2}},
+             {"mixed_heights", Instance{{{0, 4}, {0, 4}, {0, 6}}, {{3, 3}, {2, 2}, {2, 2}}, {{2, 2}, {1, 1}, {2, 2}}, 3}},
+             {"unit_lengths", Instance{{{0, 3}, {0, 3}, {0, 3}, {0, 5}}, {{1, 1}, {1, 1}, {1, 1}, {2, 2}}, {{1, 1}, {1, 1}, {1, 1}, {1, 1}}, 2}},
+             {"var_contained", packed_var}, {"var_pushed", packed_var_pushed}, {"var_height_contained", packed_var_height},
+             {"var_height_pushed", packed_var_height_pushed}}) {
         check_enumeration(name, inst, with, nullopt);
         if (proofs)
             check_enumeration(name, inst, with, make_optional("cumulative_edge_finding_enum_" + name));

--- a/gcs/constraints/cumulative/cumulative_overload_test.cc
+++ b/gcs/constraints/cumulative/cumulative_overload_test.cc
@@ -54,16 +54,15 @@ using namespace gcs::test_innards;
 
 namespace
 {
-    // Every height in this file is a constant, which is what the overload
-    // check's energy set still requires. A length is a range: `{p, p}` is the
-    // constant most fixtures use, and `{p, q}` with p < q a decision variable,
-    // which the check counts at `p` --- the duration the task is guaranteed to
-    // run for, whatever the search does with the rest of it (#689).
+    // A length and a height are each a range: `{v, v}` is the constant most
+    // fixtures use, and `{v, w}` with v < w a decision variable, which the
+    // check counts at `v` --- what the task is guaranteed to want, whatever the
+    // search does with the rest of it (#689).
     struct Instance
     {
         vector<pair<int, int>> start_ranges;
         vector<pair<int, int>> lengths;
-        vector<int> heights;
+        vector<pair<int, int>> heights;
         int capacity;
     };
 
@@ -72,28 +71,39 @@ namespace
         return inst.lengths[i].first != inst.lengths[i].second;
     }
 
+    auto height_is_var(const Instance & inst, size_t i) -> bool
+    {
+        return inst.heights[i].first != inst.heights[i].second;
+    }
+
     // Every variable an assignment has to fix, in the order the solutions carry
-    // them: the starts, then the variable lengths in task order.
+    // them: the starts, then the variable lengths and then the variable heights,
+    // each in task order.
     auto all_ranges(const Instance & inst) -> vector<pair<int, int>>
     {
         auto ranges = inst.start_ranges;
         for (size_t i = 0; i < inst.lengths.size(); ++i)
             if (length_is_var(inst, i))
                 ranges.push_back(inst.lengths[i]);
+        for (size_t i = 0; i < inst.heights.size(); ++i)
+            if (height_is_var(inst, i))
+                ranges.push_back(inst.heights[i]);
         return ranges;
     }
 
     auto is_satisfying(const Instance & inst, const vector<int> & vals) -> bool
     {
         auto n = inst.start_ranges.size();
-        vector<int> l(n);
+        vector<int> l(n), h(n);
         size_t k = n;
         for (size_t i = 0; i < n; ++i)
             l[i] = length_is_var(inst, i) ? vals.at(k++) : inst.lengths[i].first;
+        for (size_t i = 0; i < n; ++i)
+            h[i] = height_is_var(inst, i) ? vals.at(k++) : inst.heights[i].first;
 
         int t_lo = INT_MAX, t_hi = INT_MIN;
         for (size_t i = 0; i < n; ++i) {
-            if (l[i] == 0 || inst.heights[i] == 0)
+            if (l[i] == 0 || h[i] == 0)
                 continue;
             t_lo = min(t_lo, vals[i]);
             t_hi = max(t_hi, vals[i] + l[i] - 1);
@@ -102,7 +112,7 @@ namespace
             int load = 0;
             for (size_t i = 0; i < n; ++i)
                 if (vals[i] <= t && t < vals[i] + l[i])
-                    load += inst.heights[i];
+                    load += h[i];
             if (load > inst.capacity)
                 return false;
         }
@@ -128,8 +138,15 @@ namespace
                 all_vars.push_back(lengths.back());
             }
         }
-        for (auto h : inst.heights)
-            heights.push_back(constant_variable(Integer{h}));
+        for (size_t i = 0; i < inst.heights.size(); ++i) {
+            auto [lo, hi] = inst.heights[i];
+            if (! height_is_var(inst, i))
+                heights.push_back(constant_variable(Integer{lo}));
+            else {
+                heights.push_back(p.create_integer_variable(Integer{lo}, Integer{hi}));
+                all_vars.push_back(heights.back());
+            }
+        }
 
         p.post(Cumulative{starts, lengths, heights, constant_variable(Integer{inst.capacity})}.with_rules(rules).with_proof_mutation(mutation));
         return all_vars;
@@ -278,17 +295,18 @@ namespace
     }
 
     // A task raises the load profile at all --- what prepare() calls an active
-    // task. Its length only has to be able to be positive.
+    // task. Its length and height only have to be able to be positive.
     auto is_active(const Instance & inst, size_t i) -> bool
     {
-        return inst.lengths[i].second > 0 && inst.heights[i] > 0;
+        return inst.lengths[i].second > 0 && inst.heights[i].second > 0;
     }
 
     // A task the window-energy lemma can speak about, so a task the energy set
-    // may contain. Mirrors prepare_overload_check: the heights are constants
-    // already, which leaves the encodings of the start and of a variable length
-    // --- a domain of exactly {0, 1} is direct-only encoded, so it has no order
-    // literals for the lemma's bridges to cancel against.
+    // may contain. Mirrors prepare_overload_check: the encodings of the start
+    // and of a variable length, a domain of exactly {0, 1} being direct-only
+    // encoded and so having no order literals for the lemma's bridges to cancel
+    // against. A {0, 1} *height* is not excluded, its conversion resolving to a
+    // bare literal rather than to a defining line.
     auto is_eligible(const Instance & inst, size_t i) -> bool
     {
         if (! is_active(inst, i) || (inst.start_ranges[i].first == 0 && inst.start_ranges[i].second == 1))
@@ -296,13 +314,14 @@ namespace
         return ! (length_is_var(inst, i) && inst.lengths[i].first == 0 && inst.lengths[i].second == 1);
     }
 
-    // A task the energy set actually counts: one whose guaranteed duration is
-    // positive, so that there is energy to count. A constant-length task this
-    // short was turned away at prepare time; a variable-length one is skipped by
-    // the candidate sweep instead, and both are then nothing but profile.
+    // A task the energy set actually counts: one whose guaranteed duration and
+    // guaranteed demand are both positive, so that there is energy to count. A
+    // constant this small was turned away at prepare time; a variable one is
+    // skipped by the candidate sweep instead, and both are then nothing but
+    // profile.
     auto counts_energy(const Instance & inst, size_t i) -> bool
     {
-        return is_eligible(inst, i) && inst.lengths[i].first > 0;
+        return is_eligible(inst, i) && inst.lengths[i].first > 0 && inst.heights[i].first > 0;
     }
 
     // The two rules, written out from their definitions over a plain double
@@ -325,6 +344,7 @@ namespace
         // mandatory part are measured in. Its *possible* duration is the
         // range's other end, and only the possibly-active range below uses it.
         auto p_of = [&](size_t i) { return inst.lengths[i].first; };
+        auto h_of = [&](size_t i) { return inst.heights[i].first; };
 
         for (size_t wa = 0; wa < n; ++wa) {
             if (! counts_energy(inst, wa))
@@ -344,7 +364,7 @@ namespace
                         continue;
                     auto est = inst.start_ranges[i].first, lct = inst.start_ranges[i].second + p_of(i);
                     if (counts_energy(inst, i) && est >= a && lct <= b) {
-                        energy += static_cast<long long>(p_of(i)) * inst.heights[i];
+                        energy += static_cast<long long>(p_of(i)) * h_of(i);
                         continue;
                     }
                     if (! with_profile)
@@ -353,7 +373,7 @@ namespace
                     // [ub(s), lb(s) + p) that lies inside the window
                     auto lst = inst.start_ranges[i].second, eet = inst.start_ranges[i].first + p_of(i);
                     for (auto t = max(lst, a); t < min(eet, b); ++t)
-                        profile += inst.heights[i];
+                        profile += h_of(i);
                 }
 
                 // Time points no task can occupy supply nothing to the window,
@@ -424,7 +444,7 @@ namespace
             if (length > horizon)
                 return nullopt;
             inst.lengths.emplace_back(length, length);
-            inst.heights.push_back(height);
+            inst.heights.emplace_back(height, height);
             inst.start_ranges.emplace_back(0, horizon - length);
             energy += static_cast<long long>(length) * height;
         }
@@ -466,7 +486,7 @@ auto main(int argc, char * argv[]) -> int
     // of exactly one is what makes every step of the derivation load-bearing:
     // one capacity line fewer, or one unit less energy from one task, and the
     // contradiction is gone.
-    const Instance sharp{{{0, 7}, {0, 6}, {0, 7}, {0, 11}}, {{5, 5}, {6, 6}, {5, 5}, {1, 1}}, {4, 3, 2, 1}, 4};
+    const Instance sharp{{{0, 7}, {0, 6}, {0, 7}, {0, 11}}, {{5, 5}, {6, 6}, {5, 5}, {1, 1}}, {{4, 4}, {3, 3}, {2, 2}, {1, 1}}, 4};
 
     // Mutation mode: emit one deliberately corrupted proof of `sharp` and
     // stop, for run_test_and_expect_verify_failure.bash to hand to veripb.
@@ -499,12 +519,12 @@ auto main(int argc, char * argv[]) -> int
     // a resource of capacity one. Every mandatory part is empty (lst = 2 is
     // not before eet = 2), so time-tabling sees nothing at all; but the window
     // [0, 4) must hold 3 x 2 = 6 units of energy and supplies 1 x 4 = 4.
-    const Instance f1{{{0, 2}, {0, 2}, {0, 2}}, {{2, 2}, {2, 2}, {2, 2}}, {1, 1, 1}, 1};
+    const Instance f1{{{0, 2}, {0, 2}, {0, 2}}, {{2, 2}, {2, 2}, {2, 2}}, {{1, 1}, {1, 1}, {1, 1}}, 1};
 
     // F1's negative twin: the same tasks with room to spread out. The widest
     // window [0, 8) now supplies exactly the 6 units the tasks need, so
     // nothing is overloaded and the rule must stay silent at the root.
-    const Instance f1_twin{{{0, 6}, {0, 6}, {0, 6}}, {{2, 2}, {2, 2}, {2, 2}}, {1, 1, 1}, 1};
+    const Instance f1_twin{{{0, 6}, {0, 6}, {0, 6}}, {{2, 2}, {2, 2}, {2, 2}}, {{1, 1}, {1, 1}, {1, 1}}, 1};
 
     {
         auto with_rule = probe_root(f1, all_rules, proofs ? make_optional("cumulative_overload_f1") : nullopt);
@@ -538,12 +558,14 @@ auto main(int argc, char * argv[]) -> int
     // Time-tabling can say nothing here: no task in the window has a mandatory
     // part, and the fifth task's one unit of load never blocks a height-one
     // task under a capacity of two, so no bound moves either.
-    const Instance f2{{{0, 2}, {0, 2}, {0, 2}, {0, 2}, {1, 2}}, {{2, 2}, {2, 2}, {2, 2}, {2, 2}, {4, 4}}, {1, 1, 1, 1, 1}, 2};
+    const Instance f2{
+        {{0, 2}, {0, 2}, {0, 2}, {0, 2}, {1, 2}}, {{2, 2}, {2, 2}, {2, 2}, {2, 2}, {4, 4}}, {{1, 1}, {1, 1}, {1, 1}, {1, 1}, {1, 1}}, 2};
 
     // F2's negative twin: the same, with the straddling task moved past the
     // window, so its mandatory part [5, 8) contributes nothing to [0, 4) and
     // the window's demand is back to exactly its supply.
-    const Instance f2_twin{{{0, 2}, {0, 2}, {0, 2}, {0, 2}, {4, 5}}, {{2, 2}, {2, 2}, {2, 2}, {2, 2}, {4, 4}}, {1, 1, 1, 1, 1}, 2};
+    const Instance f2_twin{
+        {{0, 2}, {0, 2}, {0, 2}, {0, 2}, {4, 5}}, {{2, 2}, {2, 2}, {2, 2}, {2, 2}, {4, 4}}, {{1, 1}, {1, 1}, {1, 1}, {1, 1}, {1, 1}}, 2};
 
     {
         auto with_rule = probe_root(f2, all_rules, proofs ? make_optional("cumulative_overload_f2") : nullopt);
@@ -581,14 +603,14 @@ auto main(int argc, char * argv[]) -> int
     // term, which is where a variable duration used to end up in full, has
     // nothing to contribute, and neither has time-tabling. The energy set
     // counting the task at lb(l) is the whole of the difference.
-    const Instance f3{{{0, 2}, {0, 2}, {0, 2}}, {{2, 2}, {2, 2}, {1, 3}}, {1, 1, 1}, 1};
+    const Instance f3{{{0, 2}, {0, 2}, {0, 2}}, {{2, 2}, {2, 2}, {1, 3}}, {{1, 1}, {1, 1}, {1, 1}}, 1};
 
     // F3's negative twin: the same instance with the variable duration allowed
     // to be zero, so the task guarantees nothing and the window is back to
     // wanting exactly what it supplies. It is satisfiable --- the two constant
     // tasks tile [0, 4) and the third takes no time at all --- so this also
     // says that counting a task at anything above lb(l) would lose solutions.
-    const Instance f3_twin{{{0, 2}, {0, 2}, {0, 2}}, {{2, 2}, {2, 2}, {0, 3}}, {1, 1, 1}, 1};
+    const Instance f3_twin{{{0, 2}, {0, 2}, {0, 2}}, {{2, 2}, {2, 2}, {0, 3}}, {{1, 1}, {1, 1}, {1, 1}}, 1};
 
     {
         auto with_rule = probe_root(f3, all_rules, proofs ? make_optional("cumulative_overload_f3") : nullopt);
@@ -608,6 +630,47 @@ auto main(int argc, char * argv[]) -> int
             fail("F3 twin: refuted at the root, but it is satisfiable");
         if (proofs && with_rule.markers.total() != 0)
             fail("F3 twin: the overload check claimed a conflict at the root");
+    }
+
+    // F4: F3's other half, on the demand rather than on the duration. Two unit
+    // tasks of length two free in [0, 2] against a capacity of one, and a third
+    // of length one whose *height* is a decision variable in [1, 3], free in
+    // [0, 3]. The window [0, 4) supplies four units and the two constant tasks
+    // want four, so the conflict is again exactly the one unit the third task
+    // guarantees --- this time one unit of demand for one unit of time.
+    //
+    // What it exercises is the conversion rather than the lemma. A variable
+    // height is not in a capacity row at all: what is there is the
+    // bit-linearised contribution, so the task's activity has to be turned into
+    // contribution terms before anything can cancel. Its mandatory part is
+    // [3, 1), empty, so nothing else in the propagator can find that unit
+    // either.
+    const Instance f4{{{0, 2}, {0, 2}, {0, 3}}, {{2, 2}, {2, 2}, {1, 1}}, {{1, 1}, {1, 1}, {1, 3}}, 1};
+
+    // F4's negative twin: the same instance with the variable demand allowed to
+    // be zero, so the task guarantees nothing. Satisfiable --- the two constant
+    // tasks tile [0, 4) and the third takes nothing --- so this is also what
+    // says that counting a task at anything above lb(h) would lose solutions.
+    const Instance f4_twin{{{0, 2}, {0, 2}, {0, 3}}, {{2, 2}, {2, 2}, {1, 1}}, {{1, 1}, {1, 1}, {0, 3}}, 1};
+
+    {
+        auto with_rule = probe_root(f4, all_rules, proofs ? make_optional("cumulative_overload_f4") : nullopt);
+        if (! with_rule.refuted)
+            fail("F4: the overload check did not count the variable-height task's guaranteed energy");
+        if (proofs && with_rule.markers.oc != 1)
+            fail("F4: expected exactly one (OC') marker, got " + std::to_string(with_rule.markers.oc));
+
+        auto without_rule = probe_root(f4, no_overload, nullopt);
+        if (without_rule.refuted)
+            fail("F4: time-tabling alone refuted at the root, so the fixture proves nothing");
+    }
+
+    {
+        auto with_rule = probe_root(f4_twin, all_rules, proofs ? make_optional("cumulative_overload_f4_twin") : nullopt);
+        if (with_rule.refuted)
+            fail("F4 twin: refuted at the root, but it is satisfiable");
+        if (proofs && with_rule.markers.total() != 0)
+            fail("F4 twin: the overload check claimed a conflict at the root");
     }
 
     // The sharp-margin fixture itself, with time-tabling out of the way so
@@ -670,22 +733,26 @@ auto main(int argc, char * argv[]) -> int
         std::uniform_int_distribution<> n_dist(2, 4), lo_dist(-3, 4), span_dist(0, 4), len_dist(0, 3), ht_dist(0, 3), cap_dist(0, 4),
             spread_dist(0, 2);
 
-        size_t fired = 0, verified = 0, with_var_length = 0;
+        size_t fired = 0, verified = 0, with_var_length = 0, with_var_height = 0;
         for (int k = 0; k < 300; ++k) {
             Instance inst;
             auto n = n_dist(rand);
-            auto var_task = std::uniform_int_distribution<>(0, n - 1)(rand);
-            auto spread = spread_dist(rand);
+            auto var_length_task = std::uniform_int_distribution<>(0, n - 1)(rand);
+            auto var_height_task = std::uniform_int_distribution<>(0, n - 1)(rand);
+            auto length_spread = spread_dist(rand), height_spread = spread_dist(rand);
             for (int i = 0; i < n; ++i) {
                 auto lo = lo_dist(rand), span = span_dist(rand);
                 inst.start_ranges.emplace_back(lo, lo + span);
                 auto len = len_dist(rand);
-                inst.lengths.emplace_back(len, len + (i == var_task ? spread : 0));
-                inst.heights.push_back(ht_dist(rand));
+                inst.lengths.emplace_back(len, len + (i == var_length_task ? length_spread : 0));
+                auto ht = ht_dist(rand);
+                inst.heights.emplace_back(ht, ht + (i == var_height_task ? height_spread : 0));
             }
             inst.capacity = cap_dist(rand);
-            if (spread > 0)
+            if (length_spread > 0)
                 ++with_var_length;
+            if (height_spread > 0)
+                ++with_var_height;
 
             auto oracle = oracle_says_overloaded(inst, true);
             // Verify a proof for the first few conflicts, rather than all of
@@ -713,9 +780,10 @@ auto main(int argc, char * argv[]) -> int
 
         if (fired == 0)
             fail("oracle cross-check: no instance in the corpus overloaded, so nothing was compared");
-        if (with_var_length == 0)
-            fail("oracle cross-check: no instance in the corpus had a variable duration");
-        println(cerr, "oracle cross-check: {} of 300 instances overloaded at the root, {} of them with a variable duration", fired, with_var_length);
+        if (with_var_length == 0 || with_var_height == 0)
+            fail("oracle cross-check: no instance in the corpus had a variable duration or no instance had a variable demand");
+        println(cerr, "oracle cross-check: {} of 300 instances overloaded at the root, {} with a variable duration and {} with a variable demand",
+            fired, with_var_length, with_var_height);
     }
 
     // Two tasks sharing one start variable. Each still has its own per-time
@@ -759,6 +827,7 @@ auto main(int argc, char * argv[]) -> int
         check_opb_unaffected("f2", f2);
         check_opb_unaffected("sharp", sharp);
         check_opb_unaffected("f3", f3);
+        check_opb_unaffected("f4", f4);
 
         std::mt19937 rand(*get_seed());
         std::uniform_int_distribution<> n_dist(2, 4), lo_dist(-2, 4), span_dist(0, 4), len_dist(0, 3), ht_dist(0, 3), cap_dist(0, 4),
@@ -771,7 +840,8 @@ auto main(int argc, char * argv[]) -> int
                 inst.start_ranges.emplace_back(lo, lo + span);
                 auto len = len_dist(rand);
                 inst.lengths.emplace_back(len, len + spread_dist(rand));
-                inst.heights.push_back(ht_dist(rand));
+                auto ht = ht_dist(rand);
+                inst.heights.emplace_back(ht, ht + spread_dist(rand));
             }
             inst.capacity = cap_dist(rand);
             check_opb_unaffected("random_" + std::to_string(k), inst);
@@ -790,6 +860,10 @@ auto main(int argc, char * argv[]) -> int
     // boundary pin cannot pay for and a unit RUP has to.
     check_enumeration("f3", f3, all_rules, proofs ? make_optional("cumulative_overload_enum_f3") : nullopt);
     check_enumeration("f3_twin", f3_twin, all_rules, proofs ? make_optional("cumulative_overload_enum_f3_twin") : nullopt);
+    // And F4's, where the search branches on the height variable instead, so
+    // the conversion runs at bounds the boundary pin cannot pay for.
+    check_enumeration("f4", f4, all_rules, proofs ? make_optional("cumulative_overload_enum_f4") : nullopt);
+    check_enumeration("f4_twin", f4_twin, all_rules, proofs ? make_optional("cumulative_overload_enum_f4_twin") : nullopt);
 
     return EXIT_SUCCESS;
 }

--- a/gcs/constraints/cumulative/donor_view.cc
+++ b/gcs/constraints/cumulative/donor_view.cc
@@ -1,5 +1,6 @@
 #include <gcs/constraints/cumulative/donor_view.hh>
 #include <gcs/constraints/cumulative/propagate.hh>
+#include <gcs/constraints/innards/guaranteed_contribution.hh>
 #include <gcs/innards/power.hh>
 #include <gcs/innards/proofs/bits_encoding.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
@@ -236,21 +237,25 @@ auto gcs::innards::recover_constant_argument_row(ProofLogger & logger, const Cum
 
     // Convert each variable-height task's bit terms into `lb(h) x active`,
     // which is a coefficient on a flag again and so a term a recipe can argue
-    // about. One line each:
+    // about. One guaranteed_contribution_row each, added to the row with
+    // coefficient one, so the bits cancel exactly and what is left on the task
+    // is `lb(h) x active`. That lemma carries the argument for why the line is
+    // a RUP and not a `pol`.
     //
-    //     Sum_k 2^k cc_k  +  lb(h) ~active  >=  lb(h)
-    //
-    // added to the row with coefficient one, so the bits cancel exactly and
-    // what is left on the task is `lb(h) x active`. It is a RUP rather than a
-    // `pol`, and that is not laziness: negating it forces `~active` to zero,
-    // and what remains is the `cge` row and the height's lower bound over two
-    // power-of-two bit counters, which unit propagation walks down a bit at a
-    // time. Every step is single-constraint, so any fixpoint finds it --- I
-    // swept it over several thousand (bound, upper bound, bit width) shapes,
-    // including contribution bits narrower than the height's, before believing
-    // it. The `pol` it replaces would be the `cge` row plus the bound, then a
-    // saturate to cap the reification constant down to the bound, then a
-    // literal axiom per bit to put the coefficients back.
+    // The bound is the one the height has *now*, by the same route the capacity
+    // takes and for the same reason: the declared one is a weaker number the
+    // moment anything has tightened it, and a declared zero would give up the
+    // conversion altogether. No reason is passed, because this runs at the root
+    // and the bound was reached before the search started. Where that bound is
+    // not the declared one the lemma falls back to a reason-free RUP, which has
+    // no fixture, because every in-tree model reaches this bound by the
+    // declared one and need_gevar has already pinned that. What makes it sound
+    // is that a tightening which got the bound here was *proof logged*: the RUP
+    // then closes against the line that logged it. A root tightening of a
+    // donor's height taken with NoJustificationNeeded would leave nothing to
+    // close against and this would fail at check time, not here --- which is a
+    // dependency on the rest of the solver rather than on anything in this
+    // file, and so is written down rather than tested.
     for (const auto & [i, cc] : convert) {
         auto height = std::get<SimpleIntegerVariableID>(*view.height_bounded_by[i]);
         auto active = tracker.find_proof_flag_values(donor, ConstraintProofModelData<Cumulative>::active_flag_key(i, t));
@@ -261,43 +266,8 @@ auto gcs::innards::recover_constant_argument_row(ProofLogger & logger, const Cum
         if (! active || ! contribution_row)
             return nullopt;
 
-        // The bound the height has *now*, by the same route the capacity takes
-        // and for the same reason: the declared one is a weaker number the
-        // moment anything has tightened it, and a declared zero would give up
-        // the conversion altogether. The atom's definition supplies the bits,
-        // and the unit saying the atom holds is what makes the row
-        // unconditional --- permanently, the bound having been reached before
-        // the search started.
-        //
-        // The fallback below --- the RUP where no pin was written down --- has
-        // no fixture, because every in-tree model reaches this bound by the
-        // declared one, which need_gevar has already pinned. What makes it
-        // sound is that a tightening that got the bound here was *proof
-        // logged*: the RUP then closes against the line that logged it. A root
-        // tightening of a donor's height taken with NoJustificationNeeded would
-        // leave nothing to close against and this would fail at check time, not
-        // here --- which is a dependency on the rest of the solver rather than
-        // on anything in this file, and so is written down rather than tested.
-        auto at_least = height >= view.heights[i];
-        auto definition = tracker.need_pol_item_defining_literal(at_least);
-        auto holds = tracker.boundary_pin_line(height, view.heights[i]);
-        if (! holds)
-            holds = logger.emit_rup_proof_line(WPBSum{} + 1_i * at_least >= 1_i, ProofLevel::Temporary);
-
-        // Hints, where the definition came back as a line: they are what makes
-        // this cheap to check, and they are exactly the three facts the
-        // argument above uses. A zero-one height resolves to a bare literal
-        // instead, which a hint list cannot carry --- so that one goes
-        // unhinted, which is slower to check and no less true.
-        std::optional<vector<ProofLine>> hints;
-        if (auto line = std::get_if<ProofLine>(&definition))
-            hints = vector<ProofLine>{ProofLine{*contribution_row}, *line, *holds};
-
-        WPBSum guaranteed;
-        for (size_t k = 0; k < cc.size(); ++k)
-            guaranteed += power2(Integer(static_cast<long long>(k))) * cc[k];
-        guaranteed += view.heights[i] * ! *active;
-        reduced.add(logger.emit(RUPProofRule{hints}, move(guaranteed) >= view.heights[i], ProofLevel::Temporary));
+        reduced.add(
+            guaranteed_contribution_row(logger, nullptr, cc, *active, height, view.heights[i], ProofLine{*contribution_row}, ProofLevel::Temporary));
     }
 
     if (view.capacity_bounded_by) {

--- a/gcs/constraints/innards/guaranteed_contribution.cc
+++ b/gcs/constraints/innards/guaranteed_contribution.cc
@@ -1,0 +1,57 @@
+#include <gcs/constraints/innards/guaranteed_contribution.hh>
+#include <gcs/innards/power.hh>
+#include <gcs/innards/proofs/names_and_ids_tracker.hh>
+#include <gcs/innards/proofs/proof_logger.hh>
+
+#include <optional>
+#include <utility>
+#include <variant>
+#include <vector>
+
+using namespace gcs;
+using namespace gcs::innards;
+
+using std::move;
+using std::optional;
+using std::size_t;
+using std::vector;
+
+auto gcs::innards::guaranteed_contribution_row(ProofLogger & logger, const ReasonLiterals * const reason, const vector<ProofFlag> & contribution_bits,
+    const ProofFlag & active, const SimpleIntegerVariableID & height, Integer bound, ProofLine contribution_ge_row, ProofLevel level) -> ProofLine
+{
+    auto & tracker = logger.names_and_ids_tracker();
+
+    // The atom's definition supplies the bits; the unit saying the atom holds
+    // is what makes the row unconditional. Where the bound is the height's
+    // declared one, need_gevar has already pinned that as a persistent
+    // top-of-proof line, so cite it rather than emit the same unit again per
+    // row. Anywhere else the fact is still permanent for the subtree, but
+    // nothing has written it down: a unit RUP does, under the reason where the
+    // caller gave one --- and a caller that did not is claiming the bound is a
+    // root fact, which is the case a proof-logged tightening closes against.
+    auto at_least = height >= bound;
+    auto definition = tracker.need_pol_item_defining_literal(at_least);
+    auto holds = tracker.boundary_pin_line(height, bound);
+    if (! holds)
+        holds = reason ? logger.emit_rup_proof_line_under_reason(*reason, WPBSum{} + 1_i * at_least >= 1_i, level)
+                       : logger.emit_rup_proof_line(WPBSum{} + 1_i * at_least >= 1_i, level);
+
+    optional<vector<ProofLine>> hints;
+    if (auto line = std::get_if<ProofLine>(&definition))
+        hints = vector<ProofLine>{contribution_ge_row, *line, *holds};
+
+    WPBSum guaranteed;
+    for (size_t k = 0; k < contribution_bits.size(); ++k)
+        guaranteed += power2(Integer(static_cast<long long>(k))) * contribution_bits[k];
+    guaranteed += bound * ! active;
+
+    // Under the reason where there is one, and not merely to record what the
+    // line depends on: the unit saying the height reaches the bound is itself
+    // reason-backed whenever the bound is not the declared one, so it is a
+    // *clause* carrying the reason's negations rather than a unit. A goal
+    // stated without the reason leaves those literals unassigned, the clause
+    // does not propagate, and the hint is worth nothing --- which is a rejected
+    // proof and not a slow one.
+    return reason ? logger.emit_under_reason(RUPProofRule{hints}, move(guaranteed) >= bound, level, *reason)
+                  : logger.emit(RUPProofRule{hints}, move(guaranteed) >= bound, level);
+}

--- a/gcs/constraints/innards/guaranteed_contribution.hh
+++ b/gcs/constraints/innards/guaranteed_contribution.hh
@@ -1,0 +1,71 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_INNARDS_GUARANTEED_CONTRIBUTION_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_INNARDS_GUARANTEED_CONTRIBUTION_HH
+
+#include <gcs/innards/proofs/proof_line.hh>
+#include <gcs/innards/proofs/proof_logger-fwd.hh>
+#include <gcs/innards/proofs/proof_only_variables.hh>
+#include <gcs/innards/reason.hh>
+#include <gcs/integer.hh>
+#include <gcs/variable_id.hh>
+
+#include <vector>
+
+namespace gcs::innards
+{
+    /**
+     * \brief What a variable-height task is guaranteed to contribute at one
+     * time point, stated over the contribution bits a capacity row actually
+     * carries.
+     *
+     * A constant-height task's load in <code>C<sub>t</sub></code> is
+     * <code>h·active</code>, a coefficient on a flag, and anything reasoning
+     * about a window's activity cancels against it directly. A variable height
+     * is nonlinear, so it is linearised over per-bit contribution flags and
+     * <code>C<sub>t</sub></code> carries <code>Σ 2<sup>k</sup>·cc<sub>k</sub></code>
+     * instead. This derives
+     *
+     * <blockquote>
+     * <code>Σ<sub>k</sub> 2<sup>k</sup>·cc<sub>k</sub> + bound·~active &ge; bound</code>
+     * </blockquote>
+     *
+     * --- "either the task is not active here, or it contributes at least
+     * <code>bound</code>" --- which is the bridge between the two forms.
+     * Added to a capacity row with coefficient one, the bits cancel exactly and
+     * what is left on the task is <code>bound·active</code>; summed over a
+     * window against an activity bound, it converts the whole of that bound
+     * into contribution terms.
+     *
+     * It is a RUP rather than a <code>pol</code>, and that is not laziness:
+     * negating it forces <code>~active</code> to zero, and what remains is the
+     * <code>cge</code> row and the height's lower bound over two power-of-two
+     * bit counters, which unit propagation walks down a bit at a time. Every
+     * step is single-constraint, so any fixpoint finds it --- swept over
+     * several thousand (bound, upper bound, bit width) shapes, including
+     * contribution bits narrower than the height's, before being believed. The
+     * <code>pol</code> it replaces would be the <code>cge</code> row plus the
+     * bound, then a saturate to cap the reification constant down to the bound,
+     * then a literal axiom per bit to put the coefficients back.
+     *
+     * <code>bound</code> is the height's lower bound, and which one is the
+     * caller's business: the <em>declared</em> one is a model fact, and a
+     * weaker number the moment anything has tightened it. Either way the unit
+     * saying the atom holds is what makes the row unconditional, and that comes
+     * from <code>need_gevar</code>'s boundary pin where the bound is the
+     * declared one and from a RUP where it is not --- so <code>reason</code>
+     * must entail the bound whenever it is not the declared one, and may be
+     * null where the caller knows it is.
+     *
+     * <code>contribution_ge_row</code> is the labelled <code>cge</code> row
+     * saying <code>active ⇒ contrib &ge; h</code>, which the caller looks up
+     * against whichever constraint published it.
+     *
+     * Hinted with exactly the three facts the argument uses, where the height's
+     * atom has a defining line. A zero-one height resolves to a bare literal
+     * instead, which a hint list cannot carry, so that one goes unhinted ---
+     * slower to check and no less true.
+     */
+    [[nodiscard]] auto guaranteed_contribution_row(ProofLogger &, const ReasonLiterals * reason, const std::vector<ProofFlag> & contribution_bits,
+        const ProofFlag & active, const SimpleIntegerVariableID & height, Integer bound, ProofLine contribution_ge_row, ProofLevel) -> ProofLine;
+}
+
+#endif


### PR DESCRIPTION
Closes #689's other half. Stacked on #748, which is stacked on #747; review those first.

## Why it matters on its own

#748 counts a variable *duration* at `lb(l)`. But the case both halves exist for
is multi-mode RCPSP, where a mode variable fixes duration **and** demand — and
such a task was still turned away for its height, so #748 alone gets it nothing.
Both halves together are what let its energy be counted.

## The move

A variable height changes nothing about what the window-energy lemma derives. It
changes what a capacity row *carries*: `C_t` holds the bit-linearised `contrib`
rather than `h·active`, so an activity bound has nothing to cancel against until
it is converted.

`guaranteed_contribution_row` is the conversion, and it is #686's line:

    Σ_k 2^k·cc_k  +  lb(h)·¬active_t  ≥  lb(h)

— "either the task is not active here, or it contributes at least `lb(h)`". A
citer emits one per time point of the energy row's **clipped** window and adds
the row itself at `lb(h)`. Each conversion line carries `lb(h)·¬active_t` where
the scaled row carries `lb(h)·active_t`, so the activity cancels between them and
what is left is

    Σ_{t∈[a,b)} contrib_t  ≥  lb(h)·bound

which is what cancels against `C_t`. A guarded row's guard literals ride through
at the same scale, so its citer discharges them exactly as before.

The line was already in the tree, inside `donor_view.cc`. It is lifted into
`gcs/constraints/innards/guaranteed_contribution.hh` rather than written twice —
what is worth sharing is not the fifteen lines but the argument for why it is a
RUP and not a `pol`, which had been established by a sweep over several thousand
(bound, upper bound, bit width) shapes.

## The one thing the derived path did not have to know

**It has to go out under the reason**, and not merely to record what it depends
on. The unit saying the height reaches the bound is itself reason-backed whenever
the bound is not the declared one, so it is a *clause* carrying the reason's
negations rather than a unit. Stated without the reason those literals are
unassigned, the clause does not propagate, and the hint is worth nothing.

That is not a slow proof, it is a rejected one, and it is how I found it: `F4`'s
root probe verified and its *enumeration* failed at `pbp:129`, on the first
conversion line emitted below the root. `donor_view` never met it because its
conversion runs at the root, where the bound is the declared one and the pin is a
unit.

## Evidence

- **F4** in `cumulative_overload_test`, F3's mirror on the demand: two constant
  unit tasks of length two free in `[0,2]` at capacity one, and a third of
  length one whose height is a variable in `[1,3]`. The window `[0,4)` supplies
  four and the constant tasks want four, so the conflict is exactly the one unit
  of demand the third guarantees. Its mandatory part is `[3,1)` — empty — so
  neither (TTOC) nor time-tabling can find it.
- **F4's twin** allows the demand to be zero. It is satisfiable and stays
  unrefuted, which is also what says counting above `lb(h)` would lose solutions.
- Both test files carry heights as ranges, and the overload oracle counts the
  same way. **190 of its 300 random instances now have a variable demand**, and
  the propagator agrees with the oracle on every one.
- `cumulative_edge_finding_test` gains a contained and a pushed variable-height
  task — where the conversion meets a *guarded* row — and both push to the same
  bound as their constant twins. Confirmed live by a temporary throw rather than
  assumed; the first version of these fixtures showed the conversion path was
  never reached at all.
- **Byte-identical proofs**: all 37 `.pbp`/`.opb` files written by the
  derived-cumulative, TTEF, not-first/not-last and KAOC suites match #748's
  exactly, so lifting the conversion out of `donor_view` is a no-op there.
- Full `ctest`: 682/682 with the runtime caps on and again with them off; GCC
  with `-DGCS_WERROR=ON` and clang both clean of new diagnostics.

## Not measured, same as #748

No local instance has a variable duration or a variable demand — `examples/rcpsp`
posts `vector<Integer>` for both — so this is a strength claim backed by fixtures.

## Left open, and written into the doc

- **Guarded contribution rows.** The conversion is reason-backed and re-derived
  per firing, one line per time point — the same shape as TTEF's pins, and open
  to the same answer: at the height's *declared* lower bound the line is a model
  fact and could live at `Top` and be cached.
- **The elastic family over variable heights.** (TTHE-OC) and (KAOC) still
  decline one, and that is a *different* restriction rather than the same one:
  their knapsack item list is read off a capacity row's coefficients, and a
  bit-linearised contribution is not a coefficient on a flag. Converting the row
  first — what `donor_view` does for a derived constraint — is the obvious route
  and has not been tried.