### PR TITLE
cmake: build the Sanitize configuration at -g1, not -g3

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,11 +5,15 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Build Commands
 
 Three build types are supported: `Release` (default), `Debug`, and `Sanitize`.
-All keep debug information, but scaled to purpose: `Release` uses `-g1` (`/Z7`
-on MSVC) — function names plus line tables, enough for backtraces and the
-`GCS_VERBOSE_LOGGING` stacktrace annotation — while `Debug` and `Sanitize` use
-`-g3` for full interactive debugging. Use named presets from
-`CMakePresets.json` for convenience:
+All keep debug information, but scaled to purpose: `Release` (with `/Z7` as the
+MSVC equivalent) and `Sanitize` use `-g1` — function names plus line tables,
+enough for backtraces, for the `GCS_VERBOSE_LOGGING` stacktrace annotation, and
+for an ASan or UBSan report to name a function and a `file:line` — while `Debug`
+uses `-g3` for full interactive debugging. `Sanitize` is `-g1` for size: every
+test binary links the solver statically and so carries its own copy of the same
+DWARF, which at `-g3` made a 93 GiB build tree and ran the CI runner out of
+disk; at `-g1` it is 56 GiB. Build `Debug` when you are going to attach a
+debugger. Use named presets from `CMakePresets.json` for convenience:
 
 ```shell
 cmake --preset release  && cmake --build --preset release   # optimised (default)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -230,15 +230,32 @@ if(PROJECT_IS_TOP_LEVEL)
         #               prints name + file:line. Keeping it in Release means crash
         #               reports and verbose proofs stay useful in optimised builds.
         #   Debug    -> -g3: full information, including macros, for interactive
-        #               debugging.
-        #   Sanitize -> -g3: fully-annotated ASan/UBSan stack traces.
+        #               debugging. This is the configuration to build when you are
+        #               going to attach a debugger; `cmake --preset debug` is not
+        #               used by any CI lane, so its size costs nobody anything.
+        #   Sanitize -> -g1 as well, which is a deliberate trade rather than an
+        #               oversight. Every test binary statically links the whole
+        #               solver, so each carries its own copy of the same DWARF, and
+        #               under -g3 the tree's 173 programs came to 84.6 GiB of a
+        #               93 GiB build tree -- around half of that being debug info,
+        #               going by among_test, one of the larger ones, at 434 MiB of
+        #               DWARF in an 819 MiB binary. That is more than a GitHub
+        #               runner has: the build fitted, and then the Sanitize lane
+        #               died mid-test with "No space left on device" when the tests
+        #               went to write their proof files (run 31973615777, 16 Aug
+        #               2026). At -g1 the same programs come to 52.1 GiB and the
+        #               tree to 56 GiB. An ASan/UBSan report still symbolises to
+        #               function + file:line there, which is all a CI log is ever
+        #               read for; what is given up is macros and local-variable
+        #               DWARF, and those want a debugger, i.e. the Debug
+        #               configuration above.
         #
-        # Anything other than Debug/Sanitize (Release, or an unset build type)
+        # Anything other than Debug (Release, Sanitize, or an unset build type)
         # gets -g1 so it always carries at least backtrace-quality debug info.
         # stacktrace_logging_test guards the Release end of this: it fails if a
         # build ever drops the debug info the verbose proof logging relies on.
         add_compile_options(-gdwarf-3)
-        add_compile_options($<IF:$<OR:$<CONFIG:Debug>,$<CONFIG:Sanitize>>,-g3,-g1>)
+        add_compile_options($<IF:$<CONFIG:Debug>,-g3,-g1>)
         add_compile_options(-pthread)
         add_link_options(-pthread)
 


### PR DESCRIPTION
The Sanitize lane on main is red, and not because a test failed: [run 31973615777](https://github.com/ciaranm/glasgow-constraint-solver/actions/runs/31973615777/job/95236658047)'s `Test (Sanitize)` step is still `in_progress` in the job record, its only annotation is `System.IO.IOException: No space left on device` thrown by the runner's *own* worker log writer, and `gh run view --job … --log` answers `log not found` — nothing was uploaded because there was nowhere to write it. Every other lane on that commit is green, and rebuilding `2ccabd97` locally with the same preset and the same GCC 15.2.0 passes **703/703**.

## What fills the disk

Debug info, multiplied by the link model. Every test binary statically links the whole solver, so `-g3` hands each of the 173 of them its own copy of the same DWARF:

| | `-g3` (before) | `-g1` (after) |
|---|---|---|
| `build-sanitize` | 93 GiB | **56.1 GiB** |
| 173 executables | 84.6 GiB | 52.1 GiB |
| mean binary | 501 MiB | 309 MiB |
| `among_test`, one of the larger ones | 819 MiB (434 MiB of it DWARF) | 503 MiB (118 MiB of it DWARF) |
| `libglasgow_constraint_solver.a` | 1.9 GiB | 901 MiB |

The build *fitted* on the runner; the tests did not, because a proof file needs somewhere to go. A full parallel `ctest` holds around 3 GiB of them at once (measured at -j24; largest single `.pbp` is 565 MiB, `linear_equality_test_ne_w0_pall_t0`), and that is what tipped it over. The margin had been shrinking for a while: the previous run linked 170 executables and passed, this one links 173 — `cumulative_{ttef,nfnl,kaoc}_test` from the #743→#749 stack are about 2.4 GiB between them.

## What -g1 gives up, checked rather than assumed

Nothing a CI log is ever read for. Two probes built with the lane's exact flags, once at `-g1` and once at `-g3`, produce frame-for-frame identical reports — same demangled function names, same `file:line`, and for UBSan the same column:

```
    #0 0x… in overflow_here(int*) /home/ciaranm/claude/tmp/asan_g1_probe.cc:5
    #1 0x… in main /home/ciaranm/claude/tmp/asan_g1_probe.cc:11
```

That is expected: the sanitizers carry their own location data for the diagnostic line, and symbolising a backtrace needs line tables, which `-g1` emits. What `-g1` drops is macros and local-variable DWARF, and those want a debugger — which is what the **Debug** configuration is for. It stays at `-g3`, and no CI lane builds it (the CMake workflow configures only `--preset release` and `--preset sanitize`; the Windows lanes are MSVC, where this whole block does not apply).

## Testing

`cmake --preset sanitize` + `ctest --preset sanitize -j24` on this branch: **703/703 passed** in 137 s, `sanitizers_enabled_test` and `stacktrace_logging_test` among them, so the sanitizers are still in the binaries and Release-grade backtrace info is still there.

This is the cheap half of the problem. The expensive half is that 173 binaries each carry a copy of one library; `BUILD_SHARED_LIBS=ON` for this lane would be the real fix, and is worth a separate look if 56 GiB turns out still to be too close to the line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
