### PR TITLE
disjunctive: certified edge-finding, both directions

### DIFF
--- a/dev_docs/disjunctive-proof-logging.md
+++ b/dev_docs/disjunctive-proof-logging.md
@@ -5,14 +5,31 @@ backed by VeriPB. The propagator runs time-table consistency
 specialised to `h_i = 1`, `capacity = 1`
 (see [`cumulative-proof-logging.md`](cumulative-proof-logging.md) for
 the general time-table proof machinery) plus **detectable
-precedences**, but the *proofs* do not use the time-indexed vocabulary
-at all: at unit heights and capacity, every inference the propagator
-makes is a statement about one **pair** of tasks, and is justified
-directly against the declarative pairwise OPB encoding. There is no
-per-(task, time) scaffolding anywhere — no flags, no proof-only
-variables, no prefix emitted before search (a previous design bridged
-to cumulative-style time-indexed flags at `O(n × horizon)` cost; #495
-has the measurements from removing it).
+precedences**, and behind flags an **overload check** (#730, #737–#741)
+and **edge-finding** (#751).
+
+**The declarative OPB encoding is the same whatever the rules say**, and
+it is purely pairwise: no per-(task, time) rows, no proof-only variables,
+no prefix emitted before search. What differs between the rules is the
+*justification*, and that splits in two.
+
+The pairwise rules — every `h = 1`, `c = 1` time-table inference, and
+detectable precedences — do not use a time index at all: each is a
+statement about one **pair** of tasks, justified directly against the
+encoding's own reified rows. That is what #495 measured and what the
+rewrite bought (a previous design bridged to cumulative-style
+time-indexed flags at `O(n × horizon)` cost *in the model*, before
+search, whether or not anything used them).
+
+The energetic rules cannot be pairwise — a *set* of tasks blocks an
+interval — so they re-encode time **inside the proof**, per firing: an
+activity flag per (task, time) minted by `red` over order literals the
+encoding already has, and the pairwise separation rows folded into a
+per-time at-most-one. The distinction that matters is not
+"time-indexed or not" but **where the time index lives**: in the model
+and paid for unconditionally, or in the proof and paid for only by the
+firings that want it. The OPB is genuinely untouched, which is the
+interesting part.
 
 For the constraint itself — semantics, propagator, the strict / non-strict
 flag — read `gcs/constraints/disjunctive/disjunctive.{hh,cc}`.
@@ -309,6 +326,134 @@ justification pins the involved escapes false first (one RUP under
 reason each, from `lb(l) ≥ 1`), and the separation clauses reduce to
 their before-flag disjunctions for the rest of the derivation.
 
+## Edge-finding, and the guarded window-energy row (#751)
+
+The rule: for a window `[a, b)` and the set `Θ` of tasks it contains
+(`est_i ≥ a`, `lct_i ≤ b`), a task `j` with **one** end inside that
+cannot fit alongside `Θ` is pushed out of the window:
+
+```
+est(Θ ∪ {j}) + p(Θ) + p_j > lct(Θ)      detection
+
+lb(s_j) ← a + p(Θ)                      j starts inside, ends after
+ub(s_j) ← b − p_j − p(Θ)                j ends inside, starts before
+```
+
+This is the capacity-one case of `CumulativeRules::edge_finding`, where
+`rest = energy − (capacity − h_j)·width` collapses to `p(Θ)`. A task with
+*neither* end inside spans the window and no closed form pushes it: its
+guaranteed energy is a hump in its start rather than monotone, which is
+what #752 exists for. `DisjunctiveRules::edge_finding`, off by default —
+the sweep is cubic, so a solve that never fires it still pays, which is
+the trade #742 records on the cumulative side.
+
+**The certificate is the overload check's, emitted under the negated
+conclusion.** Same window, same activity flags, same bridge, same fold.
+One step differs, and it is the whole of what a *pruning* rule needs
+that a conflict-only one does not.
+
+### Why `energy_pol` cannot serve
+
+The overload check's `energy_pol` sums a task's backward rows and
+resolves the order literals the telescope leaves over **against the
+current bounds**, one reason-wrapped RUP each. That is exactly right for
+a conflict: a conflict-only rule never has to keep a row past the
+firing. It is no use here for two reasons — a pruning rule has to carry
+the *negated conclusion* into the row, and a row good for one node is
+not worth deriving at all when the same window recurs.
+
+So the survivors are weakened onto **two guards** instead, along the
+order encoding's own monotonicity, giving
+
+```
+Σ_{t∈[a,b)} act_{i,t} + c_lo·¬[s_i ≥ L] + c_hi·[s_i ≥ Hg]  ≥  p_i
+```
+
+which holds for every value of `s_i`. It cites nothing but the flags'
+own backward `red`s and rows of the form `[s ≥ u] → [s ≥ v]`, both facts
+about the model, so it lives at `overload_vocabulary_at` with the rest
+of the vocabulary and is cited rather than re-derived.
+
+**That is `derive_guarded_window_energy`, the same lemma the cumulative
+energy rules cite** (`gcs/constraints/innards/window_energy.hh`). The
+two encodings reach it differently and share everything after: there,
+three bridges over fully reified `before` / `after` / `active` flags;
+here, the reverse half of an activity flag reified straight onto the two
+order literals, which *is* the statement those bridges are built to
+produce. `WindowRows` is the seam. Sharing it is not tidiness — the
+telescope's guard arithmetic is easy to get subtly wrong in a way that
+still verifies (see below), and one copy is one thing to get right.
+
+### The conclusion is derived, not assumed
+
+A firing discharges whichever guards its reason refutes. A contained
+task is inside the window whichever way the push goes, so both of its
+guards fall. The pushed task's are asymmetric: one is refuted by the
+reason, and **the other is the negated conclusion and is left standing**.
+What the summed `pol` lands on is therefore
+
+```
+bound·[s_j ≥ push]  ≥  p(Θ) + bound − (b − a)      > 0
+```
+
+so the `pol` *derives* the pushed literal and the framework's wrapping
+RUP only reads it off. The negated conclusion never enters the proof as
+an assumption.
+
+### Clipping is not a separate mechanism
+
+`j` has one end outside, so it is guaranteed less than `p_j` inside the
+window. That falls out with nothing added: the guard sits past
+`b − p_j + 1`, so the leftover thresholds between the two cannot be
+weakened onto it — the implication runs the wrong way — and each is
+discharged by its own literal axiom at a unit of the bound. The count is
+exactly `p_j − (b − push + 1)`.
+
+The invariant that keeps this honest: **the propagator asks
+`window_energy_bound` for exactly the guards the derivation will be
+given**, not for the state's bounds. The row is a model fact; the state
+is looser in one direction and tighter in the other, and either way the
+rule would fire on energy the certificate does not establish. There is
+no mutation lane that catches this — citing a row at a threshold the
+reason still entails yields a *stronger* row, which verifies happily —
+so it has to be read rather than tested. `disjunctive_mutations.hh`
+records the lane that was written for it and why it was removed.
+
+### What it costs, and what caches
+
+Per firing: the fold, one guard-discharge RUP per guard, and one `pol`.
+Everything else is cited. Per (task, window), measured on the standalone
+simulation (`~/claude/tmp/disj-ef-751/`, and the comment on #751):
+
+| row | derivation | cache key | stable? |
+|---|---|---|---|
+| contained task `i` | 5–7 lines | `(i, a, b)` — its guards are `(a, b − p_i + 1)`, a function of task and window | yes |
+| pushed task `j` | `p_j + 3` lines | `(j, a, b, push)`, and `push = a + p(Θ)` moves with the contained set | no |
+
+So `|Θ|` of the `|Θ| + 1` rows are keyed exactly as the bridge is and
+cache on the same terms; only the pushed task's guard moves. Deferring
+its ladder walk to the citation would buy a stable key for about one
+proof line, which is why there is one code path and not two.
+
+### Testing
+
+`disjunctive_edge_finding_test`, and the shape of it is decided by the
+rule being a *push*: once the reason context extended with the negated
+conclusion has gone contradictory, every RUP under it is vacuously
+valid, so **a corruption that merely shortens the derivation verifies**.
+The `+1` on the conclusion is the signature test, and the fixtures put
+exactly one unit between a valid push and a false one. Five lanes, all
+rejected; `sharp` measures the lb push and `mirror` the ub push, because
+measuring one half of a symmetric rule tells you almost nothing. Each
+fixture carries a control with the rule off — no task has a mandatory
+part and no pair's ordering is bounds-forced, so time-tabling and
+detectable precedences are both silent, and the control is what keeps
+that true as the rest of the propagator changes.
+
+`--search` generates instances and verifies a proof per instance, which
+is the lane that matters: hand-built fixtures are symmetric and generous
+and verify straight through certificate bugs.
+
 ## Strict-mode zero-length tasks
 
 Strict mode forbids a zero-length task from sitting strictly inside
@@ -401,7 +546,10 @@ would take from *this* encoding:
   larger when the predecessors cannot all fit before it. That is an
   energy statement about a set, so it is the same obstacle as the
   overload check below, not a variation on the pairwise proof.
-- **An overload check** (#730). The conclusion,
+- ~~**An overload check** (#730)~~ — done, #737–#741, and
+  ~~**edge-finding** (#733)~~ — done, #751. Kept here in outline because
+  the shape of the obstacle is what the two sections above are answers
+  to. The conclusion,
   `Σ_{i∈Ω} p_i > lct(Ω) − est(Ω)`, is already in this document's
   vocabulary; the derivation is the problem, and giving `Disjunctive`
   per-time `active_{i,t}` flags to reach it would reintroduce exactly
@@ -409,9 +557,15 @@ would take from *this* encoding:
   construction that avoids them — a proof-only comparator network over
   bit-encoded wires — verified for `k = 3 … 8` at equal durations, and
   a refutation rather than a propagator so far.
-- **Not-first / not-last, and edge-finding** (#732, #733). The first
-  genuinely set-based *pruning* rules, and they need whatever the
-  overload check settles on first.
+- **Not-first / not-last** (#752). The thresholds are the contained
+  set's own `min ect` and `max lst` rather than a figure computed from
+  the leftover energy. On the cumulative side this was edge-finding's
+  certificate *unchanged* — a different threshold and a different guard,
+  both already parameters of the guarded lemma — so expect the same
+  here, and expect it not to be worth its scan (0.997x there, closing
+  fewer instances). Do not inherit #746's weakening silently: at
+  capacity one the papers' standing assumption may be easier to
+  discharge, which would be a result rather than a caveat.
 - **Optional tasks for `Disjunctive2D`.** The 1D form has them
   (#735, above); the 2D 4-way separation clause would take the same
   two disjuncts per pair, but nothing asks for it yet.

--- a/dev_docs/disjunctive-proof-logging.md
+++ b/dev_docs/disjunctive-proof-logging.md
@@ -435,6 +435,46 @@ cache on the same terms; only the pushed task's guard moves. Deferring
 its ladder walk to the citation would buy a stable key for about one
 proof line, which is why there is one code path and not two.
 
+### What it is worth, and which half is worth it
+
+Generated RCPSP with a unary machine (`--machine-fraction 0.8`, without
+which hardly any resource has capacity one and the rule never fires),
+sizes 8–30, 68 instances at a 60 s timeout. Ratios are over the 36
+instances **every arm closed** that needed at least a hundred
+recursions — an arm that timed out contributes a lower bound rather
+than a count, and a ratio of 98/98 is not evidence.
+
+| arm | summed | median | geomean | better than off |
+|---|---|---|---|---|
+| off | 1.000x | 1.000x | 1.000x | — |
+| lb push only | 0.655x | 0.758x | 0.418x | 34/36 |
+| ub push only | 0.273x | 0.242x | 0.172x | 35/36 |
+| **both** | **0.169x** | **0.127x** | **0.099x** | **36/36** |
+
+and 46 of the 68 close within the timeout against 41 with the rule off,
+so unlike cumulative not-first/not-last this pays for itself rather than
+being a table row. Three statistics rather than one because the summed
+ratio is a division and not a sample: the largest instance carries 37%
+of the summed recursions on its own, and dropping it moves the summed
+figure (0.169x to 0.129x) far more than the median (0.127x to 0.123x).
+
+**The two halves are not worth the same, and by a factor of three.**
+That is the whole reason both are separately switchable and both are in
+the table: a run measuring only the lb push would have reported 0.758x
+and concluded the rule was marginal. Which half dominates is a property
+of the instance family rather than of the rule — the cumulative side
+found the same asymmetry with the roles reversed — so the number to
+quote for a new family is one measured on it.
+
+Adding the lb half to the ub half is a small loss on exactly one of the
+36 (233 recursions against 286). It is worth knowing that a stronger
+rule can cost search, and not worth acting on.
+
+Across every instance more than one arm closed, all arms proved the
+**same optimum**. That is the check the proof lanes cannot make: a rule
+that removed a solution would still emit perfectly valid proofs of the
+pushes it did make.
+
 ### Testing
 
 `disjunctive_edge_finding_test`, and the shape of it is decided by the

--- a/examples/rcpsp/rcpsp.cc
+++ b/examples/rcpsp/rcpsp.cc
@@ -424,6 +424,19 @@ auto main(int argc, char * argv[]) -> int
                 "default, so every resource is handled the same way and a variant comparison " //
                 "is not confounded by which resources happen to be unary) or disjunctive",     //
                 cxxopts::value<string>()->default_value("cumulative"))                         //
+            ("disjunctive-edge-finding",
+                "Give every posted Disjunctive edge-finding, both directions: a task with one end " //
+                "inside a window its contained tasks already fill is pushed out of it. Off by "     //
+                "default because the sweep is cubic, so a solve that never fires it still pays "    //
+                "for it (#751, and #742 for the same trade on the cumulative side)")                //
+            ("disjunctive-edge-finding-lb-only",
+                "Restrict edge-finding to the direction that raises a lower bound, and "      //
+                "--disjunctive-edge-finding-ub-only to the one that lowers an upper bound. "  //
+                "Measuring one half of a symmetric rule tells you almost nothing --- on the " //
+                "cumulative side the two came out at 2.2% and 51% --- so both halves are "    //
+                "separately switchable and the table has a row for each")                     //
+            ("disjunctive-edge-finding-ub-only",
+                "See --disjunctive-edge-finding-lb-only") //
             ("disjunctive-overload",
                 "Give every posted Disjunctive the overload check, off by default because its "   //
                 "certificate is expensive enough that whether it pays is what #730 is measuring") //
@@ -717,6 +730,15 @@ auto main(int argc, char * argv[]) -> int
     // Off unless asked for: the overload check has no certificate, so this is a
     // measurement switch rather than a model choice. See #730.
     DisjunctiveRules disjunctive_rules;
+    disjunctive_rules.edge_finding = options_vars["disjunctive-edge-finding"].as<bool>();
+    if (options_vars["disjunctive-edge-finding-lb-only"].as<bool>()) {
+        disjunctive_rules.edge_finding = true;
+        disjunctive_rules.edge_finding_ub = false;
+    }
+    if (options_vars["disjunctive-edge-finding-ub-only"].as<bool>()) {
+        disjunctive_rules.edge_finding = true;
+        disjunctive_rules.edge_finding_lb = false;
+    }
     disjunctive_rules.overload = options_vars["disjunctive-overload"].as<bool>();
     disjunctive_rules.overload_max_window = options_vars["disjunctive-overload-max-window"].as<std::size_t>();
     if (options_vars["disjunctive-overload-temporary"].as<bool>())

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -287,6 +287,7 @@ if(GCS_BUILD_TESTS)
     add_executable(disjunctive_test constraints/disjunctive/disjunctive_test.cc)
     add_executable(disjunctive_optional_test constraints/disjunctive/disjunctive_optional_test.cc)
     add_executable(disjunctive_overload_test constraints/disjunctive/disjunctive_overload_test.cc)
+    add_executable(disjunctive_edge_finding_test constraints/disjunctive/disjunctive_edge_finding_test.cc)
     add_executable(disjunctive_precedences_test constraints/disjunctive/disjunctive_precedences_test.cc)
     add_executable(disjunctive_2d_test constraints/disjunctive_2d/disjunctive_2d_test.cc)
     add_executable(divide_modulus_test constraints/divide_modulus/divide_modulus_test.cc)
@@ -334,7 +335,7 @@ if(GCS_BUILD_TESTS)
 
     foreach(test_target
             abs_test all_different_test all_different_except_test all_equal_test among_test at_most_one_test bin_packing_test comparison_test
-            count_test cumulative_test cumulative_overload_test cumulative_edge_finding_test cumulative_ttef_test cumulative_nfnl_test cumulative_kaoc_test cumulative_optional_test derived_cumulative_test difference_test disjunctive_test disjunctive_optional_test disjunctive_overload_test disjunctive_precedences_test disjunctive_2d_test divide_modulus_test element_test equals_test bounds_global_cardinality_test gac_global_cardinality_test in_test increasing_test inverse_test knapsack_test knapsack_upfront_test lex_test linear_test linear_constant_test
+            count_test cumulative_test cumulative_overload_test cumulative_edge_finding_test cumulative_ttef_test cumulative_nfnl_test cumulative_kaoc_test cumulative_optional_test derived_cumulative_test difference_test disjunctive_test disjunctive_optional_test disjunctive_overload_test disjunctive_edge_finding_test disjunctive_precedences_test disjunctive_2d_test divide_modulus_test element_test equals_test bounds_global_cardinality_test gac_global_cardinality_test in_test increasing_test inverse_test knapsack_test knapsack_upfront_test lex_test linear_test linear_constant_test
             logical_test mdd_test min_distance_test min_distance_matching_test min_max_test mini_linear_test multiply_test n_value_test nogoods_test parity_test
             plus_minus_test power_test product_bounds_test product_justify_test regular_test regular_bacchus_test regular_legacy_test seq_precede_chain_test smart_table_test sort_test arg_sort_test symmetric_all_different_test
             negative_table_test table_test tabulation_test value_precede_test)
@@ -435,6 +436,21 @@ if(GCS_BUILD_TESTS)
         add_test(NAME disjunctive_overload_mutation_${mutation}
             COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_expect_verify_failure.bash
                 --basename disjunctive_overload_mutation_${mutation} $<TARGET_FILE:disjunctive_overload_test> --mutate=${mutation})
+    endforeach()
+    # Edge-finding, same shape: the test writes its own proofs and checks each
+    # with veripb in-process. The --search lane is separate because it verifies
+    # a proof per generated instance and takes correspondingly longer --- and it
+    # is the one that matters, hand-built fixtures being symmetric and generous
+    # enough to verify straight through a certificate bug.
+    add_test(NAME disjunctive_edge_finding COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:disjunctive_edge_finding_test>)
+    add_test(NAME disjunctive_edge_finding_search
+        COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:disjunctive_edge_finding_test> --search 28)
+    # The pushed-task row cited at an unclipped threshold is deliberately not a
+    # lane here: see innards/disjunctive_mutations.hh for why it cannot bite.
+    foreach(mutation emit_nothing skip_fold drop_contained one_too_far drop_pushed)
+        add_test(NAME disjunctive_edge_finding_mutation_${mutation}
+            COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_expect_verify_failure.bash
+                --basename disjunctive_edge_finding_mutation_${mutation} $<TARGET_FILE:disjunctive_edge_finding_test> --mutate=${mutation})
     endforeach()
     add_test(NAME disjunctive_precedences COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:disjunctive_precedences_test>)
     # Mutation lanes: each writes a deliberately corrupted proof of the

--- a/gcs/constraints/disjunctive/disjunctive.cc
+++ b/gcs/constraints/disjunctive/disjunctive.cc
@@ -1,12 +1,14 @@
 #include <gcs/constraints/disjunctive/disjunctive.hh>
 #include <gcs/constraints/disjunctive/hints.hh>
 #include <gcs/constraints/innards/task_presence.hh>
+#include <gcs/constraints/innards/window_energy.hh>
 #include <gcs/exception.hh>
 #include <gcs/innards/inference_tracker.hh>
 #include <gcs/innards/proofs/am1_from_pairs.hh>
 #include <gcs/innards/proofs/comparator_network.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
 #include <gcs/innards/proofs/pol_builder.hh>
+#include <gcs/innards/proofs/proof_error.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/proofs/proof_model.hh>
 #include <gcs/innards/propagators.hh>
@@ -16,6 +18,7 @@
 #include <algorithm>
 #include <bit>
 #include <cstdlib>
+#include <functional>
 #include <iostream>
 #include <map>
 #include <memory>
@@ -375,6 +378,11 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
             // three things and on nothing else, so they are reusable on exactly
             // the same terms.
             bridge = make_shared<map<tuple<size_t, size_t, long long, long long, long long>, ProofLine>>(),
+            // Edge-finding's window-energy rows, on the same terms: the row is
+            // a fact about the model, so it is keyed on the task, the window,
+            // the two guards and the duration it was counted at, and on nothing
+            // the search state can move.
+            guarded = make_shared<map<tuple<size_t, long long, long long, long long, long long, long long>, window_energy::GuardedWindowEnergy>>(),
             floors = make_shared<map<size_t, ProofLine>>(), escapes = make_shared<map<size_t, ProofLine>>(),
             owner = constraint_id()](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
             // Current guaranteed (min) and possible (max) duration of task i:
@@ -596,6 +604,36 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                 return line;
             };
 
+            // The window's per-time at-most-ones: one bridge row per ordered
+            // pair and time, folded by recover_am1_from_pairs. Shared between
+            // the overload check and edge-finding, which want the same rows
+            // over the same encoding and differ only in what they add them to.
+            //
+            // Every bridge first and then every fold, rather than interleaved,
+            // because that is the order the overload check has always emitted
+            // them in and its proofs are diffed against it.
+            auto fold_at_most_ones = [&](const vector<size_t> & tasks, Integer lo, Integer hi, bool skip_fold) -> vector<ProofLine> {
+                map<Integer, vector<vector<ProofLine>>> at_most_ones;
+                for (Integer t = lo; t < hi; ++t) {
+                    auto & tri = at_most_ones[t];
+                    tri.resize(tasks.size());
+                    for (size_t y = 0; y < tasks.size(); ++y)
+                        for (size_t x = 0; x < y; ++x)
+                            tri[y].push_back(bridge_pair(tasks[x], tasks[y], t));
+                }
+                vector<ProofLine> folds;
+                if (skip_fold)
+                    return folds;
+                folds.reserve(static_cast<size_t>((hi - lo).raw_value));
+                for (Integer t = lo; t < hi; ++t) {
+                    vector<ProofLiteralOrFlag> members;
+                    for (auto i : tasks)
+                        members.push_back(activity_flag(i, t).flag);
+                    folds.push_back(recover_am1_from_pairs(*logger, members, at_most_ones[t], ProofLevel::Temporary));
+                }
+                return folds;
+            };
+
             // A task in the window occupies at least lb(l) of its time points.
             // Summing the backward rows telescopes --- each order literal
             // appears once positively and once negatively --- and what is left
@@ -612,6 +650,50 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                 for (Integer v = hi - energy_len(i) + 1_i; v <= hi; ++v)
                     pol.add(logger->emit_rup_proof_line_under_reason(reason, WPBSum{} + 1_i * (starts[i] < v) >= 1_i, ProofLevel::Temporary));
                 return pol.emit(*logger, ProofLevel::Temporary);
+            };
+
+            // A task's activity over a window, as a row that says nothing about
+            // the current bounds. `energy_pol` above resolves its leftover
+            // order literals against the reason, which is exactly right for the
+            // overload check --- a conflict-only rule never has to keep a row
+            // past the firing --- and no use at all to a rule that moves a
+            // bound: edge-finding has to carry the *negated conclusion* into
+            // the row, and the row has to outlive the firing to be worth
+            // deriving.
+            //
+            // So this weakens the survivors onto two guard literals instead,
+            // along the order encoding's own monotonicity, and that is
+            // `derive_guarded_window_energy` --- the same lemma Cumulative's
+            // energy rules cite. The two encodings differ only in where the
+            // per-time row comes from: three bridges over fully reified flags
+            // there, and here the reverse half of an activity flag reified
+            // straight onto the two order literals, which is the same statement
+            // those bridges are built to produce.
+            //
+            // The row range given is the window itself rather than the task's
+            // possible-active interval, so the lemma does no clipping of its
+            // own: unlike Cumulative's, these flags are minted on demand and
+            // exist for whatever time is asked for. The clipping that does
+            // happen is the one that matters --- a guard falling inside the
+            // survivors' range, which is what turns a contained task's whole
+            // duration into a pushed task's guaranteed overlap.
+            auto guarded_energy = [&](size_t i, Integer lo, Integer hi, Integer low_guard,
+                                      Integer high_guard) -> const window_energy::GuardedWindowEnergy & {
+                auto key = make_tuple(i, lo.raw_value, hi.raw_value, low_guard.raw_value, high_guard.raw_value, energy_len(i).raw_value);
+                if (auto found = guarded->find(key); found != guarded->end())
+                    return found->second;
+                const auto * simple = std::get_if<SimpleIntegerVariableID>(&starts[i]);
+                if (! simple)
+                    throw ProofError{"disjunctive edge-finding wants a simple start variable for task " + std::to_string(i)};
+                std::function<auto(Integer)->ProofLine> row = [&](Integer t) -> ProofLine { return activity_flag(i, t).backward; };
+                auto derived = window_energy::derive_guarded_window_energy(*logger,
+                    window_energy::WindowRows{*simple, energy_len(i), lo, static_cast<size_t>((hi - lo).raw_value), row}, lo, hi, low_guard,
+                    high_guard, rules.overload_vocabulary_at);
+                if (! derived)
+                    throw ProofError{"disjunctive edge-finding: task " + std::to_string(i) + " has no derivable window energy over [" +
+                        std::to_string(lo.raw_value) + "," + std::to_string(hi.raw_value) + ") guarded by [" + std::to_string(low_guard.raw_value) +
+                        "," + std::to_string(high_guard.raw_value) + ")"};
+                return guarded->emplace(key, *derived).first->second;
             };
 
             // --- the overload certificate as a sorting network -----------------
@@ -708,6 +790,86 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                 for (auto r : tasks)
                     if (zero[r])
                         logger->emit_rup_proof_line_under_reason(reason, WPBSum{} + 1_i * *zero[r] <= 0_i, ProofLevel::Temporary);
+            };
+
+            // Edge-finding's certificate: the overload check's, emitted under
+            // the negated conclusion. Over the same window, the contained
+            // tasks' energy plus what the pushed task must still occupy if the
+            // conclusion were false, against the same per-time at-most-ones.
+            // That needs more of the window than the window has.
+            //
+            // Every guard but one is discharged by the reason. The one left
+            // standing is the negated conclusion, so what the pol lands on is
+            // `bound * [conclusion] >= something positive` --- which is to say
+            // the pol *derives* the conclusion rather than assuming it, and the
+            // framework's wrapping RUP has only to read it off.
+            //
+            // Every energy row is a guarded one, so it says nothing about the
+            // current bounds and is cited rather than re-derived. What a firing
+            // pays is the fold, the guard discharges, and one pol.
+            auto edge_finding_justification = [&](Integer a, Integer b, const vector<size_t> & inside, size_t pushed, Integer pushed_low_guard,
+                                                  Integer pushed_high_guard, bool discharge_low) {
+                return [&, a, b, inside, pushed, pushed_low_guard, pushed_high_guard, discharge_low](const ReasonLiterals & reason) -> void {
+                    logger->emit_proof_comment("disjunctive edge-finding w=" + std::to_string(inside.size()) +
+                        " span=" + std::to_string((b - a).raw_value) + (discharge_low ? " lb" : " ub"));
+                    if (std::holds_alternative<disjunctive_proof_mutation::EdgeFindingEmitNothing>(mutation))
+                        return;
+
+                    auto tasks = inside;
+                    tasks.push_back(pushed);
+                    pin_escapes(reason, tasks);
+
+                    // A Temporary vocabulary does not outlive the firing that
+                    // made it, so what the caches hold from last time has been
+                    // deleted and citing it would be citing a dead row.
+                    if (ProofLevel::Top != rules.overload_vocabulary_at) {
+                        activity->clear();
+                        bridge->clear();
+                        floors->clear();
+                        escapes->clear();
+                        guarded->clear();
+                    }
+
+                    for (auto i : tasks)
+                        for (Integer t = a; t < b; ++t)
+                            (void)activity_flag(i, t);
+
+                    PolBuilder total;
+                    for (auto line :
+                        fold_at_most_ones(tasks, a, b, std::holds_alternative<disjunctive_proof_mutation::SkipEdgeFindingFold>(mutation)))
+                        total.add(line);
+
+                    auto cite = [&](size_t i, Integer low_guard, Integer high_guard, bool do_low, bool do_high) {
+                        const auto & row = guarded_energy(i, a, b, low_guard, high_guard);
+                        total.add(row.line);
+                        // The row carries low_coeff copies of ~[s >= low_guard]
+                        // and `bound` copies of [s >= high_guard]; discharging
+                        // one means adding that many copies of the literal the
+                        // reason refutes it with.
+                        if (do_low && row.low_coeff > 0_i)
+                            total.add(logger->emit_rup_proof_line_under_reason(
+                                          reason, WPBSum{} + 1_i * (starts[i] >= row.low_guard) >= 1_i, ProofLevel::Temporary),
+                                row.low_coeff);
+                        if (do_high && row.bound > 0_i)
+                            total.add(logger->emit_rup_proof_line_under_reason(
+                                          reason, WPBSum{} + 1_i * (starts[i] < row.high_guard) >= 1_i, ProofLevel::Temporary),
+                                row.bound);
+                    };
+
+                    // A contained task is inside the window whichever way the
+                    // push goes, so the reason refutes both its guards: it
+                    // starts at or after the window does, and it starts early
+                    // enough to end inside it.
+                    for (auto i : inside) {
+                        if (std::holds_alternative<disjunctive_proof_mutation::DropContainedEnergy>(mutation) && i == inside.front())
+                            continue;
+                        cite(i, a, b - energy_len(i) + 1_i, true, true);
+                    }
+                    if (! std::holds_alternative<disjunctive_proof_mutation::DropPushedEnergy>(mutation))
+                        cite(pushed, pushed_low_guard, pushed_high_guard, discharge_low, ! discharge_low);
+
+                    total.emit(*logger, ProofLevel::Temporary);
+                };
             };
 
             // Time-table consistency, specialised to heights = 1 and
@@ -1298,6 +1460,124 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                 // since either way the node is refuted inside the same
                 // propagation fixpoint.
                 //
+                // Edge-finding. For a window [a, b) and the set Theta of tasks
+                // it contains, a task j with one end outside that cannot fit
+                // alongside Theta is pushed away from the window. At capacity
+                // one the cumulative form's `rest = energy - (capacity - h_j) *
+                // width` collapses to p(Theta), so the two thresholds are
+                //
+                //     starts inside, ends after   lb(s_j) -> a + p(Theta)
+                //     ends inside, starts before  ub(s_j) -> b - p_j - p(Theta)
+                //
+                // and they are mirror images over the same sweep. A task with
+                // *neither* end inside spans the window, and no closed form
+                // pushes it: its guaranteed energy is a hump in its start
+                // rather than monotone, which is the case #752 exists for.
+                //
+                // Before the overload check rather than after it, because this
+                // rule prunes where that one only refutes, and a window this
+                // has already emptied is not one the overload check has to pay
+                // a certificate for.
+                if (rules.edge_finding) {
+                    struct EdgeTask
+                    {
+                        size_t task;
+                        Integer est, lct, duration;
+                    };
+
+                    vector<EdgeTask> candidates;
+                    candidates.reserve(active_tasks.size());
+                    for (auto i : active_tasks) {
+                        // As for the overload check: a task with no guaranteed
+                        // duration carries no energy, and one not known present
+                        // might not be here to carry any.
+                        if (energy_len(i) == 0_i || ! is_present(i))
+                            continue;
+                        auto [s_lo, s_hi] = state.bounds(starts[i]);
+                        candidates.push_back(EdgeTask{i, s_lo, s_hi + energy_len(i), energy_len(i)});
+                    }
+                    sort(candidates, [](const EdgeTask & x, const EdgeTask & y) { return x.lct < y.lct; });
+
+                    vector<Integer> window_starts;
+                    window_starts.reserve(candidates.size());
+                    for (const auto & c : candidates)
+                        window_starts.push_back(c.est);
+                    sort(window_starts);
+
+                    auto reason_vars = starts;
+                    for (auto i : active_tasks)
+                        if (is_var_len(i))
+                            reason_vars.push_back(length_vars[i]);
+
+                    for (size_t w = 0; w < window_starts.size(); ++w) {
+                        if (w > 0 && window_starts[w] == window_starts[w - 1])
+                            continue;
+                        auto a = window_starts[w];
+
+                        Integer energy = 0_i;
+                        vector<size_t> inside;
+                        for (size_t c = 0; c < candidates.size(); ++c) {
+                            if (candidates[c].est < a)
+                                continue;
+                            energy += candidates[c].duration;
+                            inside.push_back(candidates[c].task);
+                            auto b = candidates[c].lct;
+                            // Candidates are in lct order, so `inside` is every
+                            // task the window contains only once the last of a
+                            // run of equal lcts has been taken.
+                            if (c + 1 < candidates.size() && candidates[c + 1].lct == b && candidates[c + 1].est >= a)
+                                continue;
+                            // A window its own contained tasks overload is a
+                            // conflict rather than a push, and the overload
+                            // check below owns it: the arithmetic here would
+                            // put the threshold past the window entirely, where
+                            // the pushed task's clipped energy is zero and
+                            // there is nothing to certify with.
+                            if (energy > b - a)
+                                continue;
+
+                            for (const auto & j : candidates) {
+                                if (j.lct <= b && j.est >= a)
+                                    continue;
+                                auto p_j = j.duration;
+                                auto starts_inside = j.est >= a;
+                                // Neither end inside: the task spans the
+                                // window, and an energy argument over it has no
+                                // closed-form push (#752).
+                                if (starts_inside == (j.lct <= b))
+                                    continue;
+                                if (! (starts_inside ? rules.edge_finding_lb : rules.edge_finding_ub))
+                                    continue;
+
+                                auto low_guard = starts_inside ? a : b - p_j - energy + 1_i;
+                                auto high_guard = starts_inside ? a + energy : b - p_j + 1_i;
+                                // Ask the lemma for exactly what the row it will
+                                // cite establishes, rather than for the state's
+                                // own figure: the row is a model fact, and firing
+                                // on more energy than it carries is a rejected
+                                // proof rather than an unsound push.
+                                auto clipped = window_energy::window_energy_bound(
+                                    p_j, a, static_cast<size_t>((b - a).raw_value), a, b, pair{low_guard, high_guard - 1_i});
+                                if (clipped <= 0_i || energy + clipped <= b - a)
+                                    continue;
+
+                                auto [j_lo, j_hi] = state.bounds(starts[j.task]);
+                                if (starts_inside ? high_guard <= j_lo : low_guard - 1_i >= j_hi)
+                                    continue;
+
+                                auto one_too_far = std::holds_alternative<disjunctive_proof_mutation::EdgeFindingOneTooFar>(mutation);
+                                auto justify = edge_finding_justification(a, b, inside, j.task, low_guard, high_guard, starts_inside);
+                                if (starts_inside)
+                                    inference.infer_greater_than_or_equal(logger, starts[j.task], one_too_far ? high_guard + 1_i : high_guard,
+                                        JustifyExplicitly{justify, ThenRUP::Yes, hints::Disjunctive{owner}}, reason_over(reason_vars));
+                                else
+                                    inference.infer_less_than(logger, starts[j.task], one_too_far ? low_guard - 1_i : low_guard,
+                                        JustifyExplicitly{justify, ThenRUP::Yes, hints::Disjunctive{owner}}, reason_over(reason_vars));
+                            }
+                        }
+                    }
+                }
+
                 if (rules.overload) {
                     // Measuring what a firing would cost means measuring the
                     // *smallest* window that refutes the state, since the
@@ -1458,15 +1738,6 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                                 // row plus the two operands' order-literal
                                 // definitions cancels the starts and lands on
                                 // degree p_x + (t - p_x + 1) - t = 1.
-                                map<Integer, vector<vector<ProofLine>>> at_most_ones;
-                                for (Integer t = lo; t < hi; ++t) {
-                                    auto & tri = at_most_ones[t];
-                                    tri.resize(tasks.size());
-                                    for (size_t b = 0; b < tasks.size(); ++b)
-                                        for (size_t a = 0; a < b; ++a)
-                                            tri[b].push_back(bridge_pair(tasks[a], tasks[b], t));
-                                }
-
                                 // (3) The fold, and (4) the energies, summed:
                                 // the folds say at most one task occupies each
                                 // of the window's hi - lo times, the energies
@@ -1474,13 +1745,9 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                                 // that, and the framework's closing RUP has
                                 // nothing left to do.
                                 PolBuilder total;
-                                if (! std::holds_alternative<disjunctive_proof_mutation::SkipOverloadFold>(mutation))
-                                    for (Integer t = lo; t < hi; ++t) {
-                                        vector<ProofLiteralOrFlag> members;
-                                        for (auto i : tasks)
-                                            members.push_back(activity_flag(i, t).flag);
-                                        total.add(recover_am1_from_pairs(*logger, members, at_most_ones[t], ProofLevel::Temporary));
-                                    }
+                                for (auto line :
+                                    fold_at_most_ones(tasks, lo, hi, std::holds_alternative<disjunctive_proof_mutation::SkipOverloadFold>(mutation)))
+                                    total.add(line);
                                 if (! std::holds_alternative<disjunctive_proof_mutation::SkipOverloadEnergy>(mutation))
                                     for (auto i : tasks)
                                         total.add(energy_pol(i, lo, hi, reason));

--- a/gcs/constraints/disjunctive/disjunctive.hh
+++ b/gcs/constraints/disjunctive/disjunctive.hh
@@ -81,6 +81,37 @@ namespace gcs
         /// for where the re-encoding lives.
         bool overload = false;
 
+        /// Edge-finding: for a window [a, b) and the set Theta of tasks it
+        /// contains, a task with one end outside that cannot fit alongside
+        /// Theta is pushed away from the window --- up to ect(Theta) if it
+        /// starts inside, down to lct(Theta) - p(Theta) - p_j if it ends
+        /// inside. Both directions. The capacity-one case of what
+        /// CumulativeRules::edge_finding does, where `rest` collapses to
+        /// p(Theta).
+        ///
+        /// Certified over the overload check's own vocabulary: the same
+        /// activity flags, the same bridge to a per-time at-most-one, and the
+        /// same fold, with the energies cited from *guarded* rows rather than
+        /// telescoped under the reason. A guarded row states the bounds a
+        /// firing would have resolved its order literals against as guard
+        /// literals instead, so it is a fact about the model, lives at
+        /// \ref overload_vocabulary_at with the rest of the vocabulary, and is
+        /// cited by every later firing over the same window. The one whose
+        /// guard is the negated conclusion is what the pol lands on.
+        ///
+        /// Off by default, and for the reason #742 records on the cumulative
+        /// side: the sweep is cubic, so it taxes a solve that never fires it.
+        bool edge_finding = false;
+
+        /// The two halves of \ref edge_finding, separately switchable. Both on
+        /// by default, so the rule is symmetric unless something asks for
+        /// otherwise; a run with one of them off measures what the other is
+        /// worth on its own, which is the only way to find out that a symmetric
+        /// rule is not symmetric in what it buys. On the cumulative side the
+        /// two halves came out at 2.2% and 51%.
+        bool edge_finding_lb = true;
+        bool edge_finding_ub = true;
+
         /// Refuse an overload conflict whose smallest window holds more than
         /// this many tasks; zero, the default, takes every conflict. Measured
         /// on generated RCPSP (#730), every cap closes fewer instances *and*
@@ -197,8 +228,11 @@ namespace gcs
      * by another. On top of that, <em>detectable precedences</em> order the
      * pairs whose ordering the bounds already force &mdash; which needs no
      * mandatory part on either task, so it prunes where time-tabling cannot.
-     * Stronger reasoning (an overload check, not-first / not-last,
-     * edge-finding) is left for future work.
+     * An <em>overload check</em> and <em>edge-finding</em> reason about the
+     * energy of a whole set of tasks in a window; both are off by default,
+     * since each costs a sweep that a solve never firing them still pays.
+     * Not-first / not-last is left for future work (#752), as is the set-based
+     * form of detectable precedences (#754).
      *
      * A task whose presence is still undecided is left out of the profile and
      * out of every push, in either role: it blocks nothing, and nothing is

--- a/gcs/constraints/disjunctive/disjunctive_edge_finding_test.cc
+++ b/gcs/constraints/disjunctive/disjunctive_edge_finding_test.cc
@@ -1,0 +1,330 @@
+/* Edge-finding for Disjunctive, and its certificate.
+ *
+ * The rule prunes rather than fails, and that changes what can serve as a test.
+ * The overload check's destination is a contradiction, so every route to it is
+ * valid and corrupting the route is what bites; here the reason context
+ * extended with the negated conclusion goes contradictory as soon as the
+ * argument lands, so a corruption that merely *shortens* the derivation is
+ * still sound and VeriPB is right to accept it. **The `+1` on the conclusion is
+ * the signature test**, and the fixtures are built so that one unit is exactly
+ * the difference between a valid push and a false one.
+ *
+ * Both fixtures put a window `[a, b)` around a set `Theta` that fits in it, and
+ * one further task with a single end inside. `sharp` has that end at the left,
+ * so the push raises a lower bound; `mirror` has it at the right, so the push
+ * lowers an upper bound. Both are here because measuring one direction of a
+ * symmetric rule tells you almost nothing --- on the cumulative side the two
+ * halves came out at 2.2% and 51%.
+ *
+ * Every fixture comes with a control: the same instance with the rule off. If
+ * the control already makes the push then the fixture is measuring
+ * time-tabling or detectable precedences, not this. Neither fires on either
+ * fixture by construction --- no task has a mandatory part, and no pair's
+ * ordering is forced by bounds alone --- and the controls are what keep that
+ * true as the rest of the propagator changes.
+ *
+ * `--search` generates random unary instances, verifies a proof per instance,
+ * and checks the rule removes no solutions. Hand-built fixtures are symmetric
+ * and generous, and verify straight through certificate bugs; generated ones
+ * are what actually found them on the cumulative side.
+ */
+
+#include <gcs/constraints/disjunctive.hh>
+#include <gcs/constraints/innards/constraints_test_utils.hh>
+#include <gcs/problem.hh>
+#include <gcs/solve.hh>
+
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <optional>
+#include <random>
+#include <string>
+#include <utility>
+#include <variant>
+#include <vector>
+#include <version>
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+#include <print>
+#else
+#include <fmt/core.h>
+#include <fmt/ostream.h>
+#endif
+
+using std::cerr;
+using std::make_optional;
+using std::mt19937;
+using std::nullopt;
+using std::optional;
+using std::pair;
+using std::string;
+using std::to_string;
+using std::uniform_int_distribution;
+using std::vector;
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+using std::println;
+#else
+using fmt::println;
+#endif
+
+using namespace gcs;
+using namespace gcs::innards;
+
+namespace
+{
+    struct Instance
+    {
+        vector<pair<int, int>> start_ranges;
+        vector<int> lengths;
+    };
+
+    auto fail(const string & message) -> void
+    {
+        println(cerr, "disjunctive_edge_finding_test: {}", message);
+        exit(EXIT_FAILURE);
+    }
+
+    auto post(Problem & p, const Instance & inst, DisjunctiveRules rules, DisjunctiveProofMutation mutation) -> vector<IntegerVariableID>
+    {
+        vector<IntegerVariableID> starts;
+        vector<Integer> lengths;
+        for (const auto & [lo, hi] : inst.start_ranges)
+            starts.push_back(p.create_integer_variable(Integer{lo}, Integer{hi}));
+        for (auto l : inst.lengths)
+            lengths.push_back(Integer{l});
+        p.post(Disjunctive{starts, lengths}.with_rules(rules).with_proof_mutation(mutation));
+        return starts;
+    }
+
+    /// What root propagation alone came to. Unlike the overload check this rule
+    /// moves a bound, so what a control has to compare is the *bound*: an
+    /// instance it prunes is usually still satisfiable, and comparing
+    /// satisfiability would compare nothing.
+    struct Probe
+    {
+        vector<pair<int, int>> root_bounds;
+        int markers = 0;
+        int solutions = 0;
+        bool refuted_at_root = false;
+    };
+
+    auto count_markers(const string & basename, const string & marker) -> int
+    {
+        std::ifstream f{basename + ".pbp"};
+        string line;
+        auto count = 0;
+        while (getline(f, line))
+            if (line.find(marker) != string::npos)
+                ++count;
+        return count;
+    }
+
+    auto probe(const Instance & inst, DisjunctiveRules rules, const optional<string> & proof_name,
+        DisjunctiveProofMutation mutation = disjunctive_proof_mutation::None{}, bool enumerate = false) -> Probe
+    {
+        Problem p;
+        auto starts = post(p, inst, rules, mutation);
+        Probe result;
+        auto reached_a_node = false;
+        solve_with(p,
+            SolveCallbacks{.solution = [&](const CurrentState &) -> bool {
+                               ++result.solutions;
+                               return enumerate;
+                           },
+                .trace = [&](const CurrentState & s) -> bool {
+                    if (! reached_a_node) {
+                        reached_a_node = true;
+                        // The first node is the root, after propagation to a
+                        // fixpoint: what the rule inferred without searching.
+                        for (const auto & v : starts)
+                            result.root_bounds.emplace_back(
+                                static_cast<int>(s.lower_bound(v).raw_value), static_cast<int>(s.upper_bound(v).raw_value));
+                    }
+                    return enumerate;
+                }},
+            proof_name ? make_optional<ProofOptions>(ProofFileNames{*proof_name}) : nullopt);
+        result.refuted_at_root = ! reached_a_node && 0 == result.solutions;
+        if (proof_name)
+            result.markers = count_markers(*proof_name, "disjunctive edge-finding w=");
+        return result;
+    }
+
+    const DisjunctiveRules with_ef{.edge_finding = true};
+    const DisjunctiveRules without_ef{};
+
+    /// Random unary instances with enough slack to be satisfiable and enough
+    /// pressure for the rule to have something to say. Durations are small and
+    /// windows overlap, which is where a set argument beats a pairwise one.
+    auto generate(mt19937 & rnd, int n) -> Instance
+    {
+        Instance inst;
+        uniform_int_distribution<int> dur{1, 4}, slack{0, 6};
+        auto total = 0;
+        for (auto i = 0; i < n; ++i) {
+            auto l = dur(rnd);
+            inst.lengths.push_back(l);
+            total += l;
+        }
+        for (auto i = 0; i < n; ++i) {
+            auto lo = uniform_int_distribution<int>{0, total / 2}(rnd);
+            inst.start_ranges.emplace_back(lo, lo + inst.lengths[i] + slack(rnd));
+        }
+        return inst;
+    }
+}
+
+auto main(int argc, char * argv[]) -> int
+{
+    auto proofs = gcs::test_innards::can_run_veripb();
+
+    // Window [2, 8), six wide. Theta = two tasks of two and three, so five
+    // units, which fits. Task 2 starts inside the window and ends past it: if
+    // it started before 7 it would have to spend at least two of the window's
+    // time points there, and five plus two does not fit in six. So its start
+    // rises to 7 = ect(Theta), and 7 is reachable --- 2 at [2,5), 0 at [5,7),
+    // 2 at [7,9) --- so one further would be false.
+    //
+    // No task has a mandatory part (every latest start is past its earliest
+    // end), and no pair's ordering is forced by bounds alone, so time-tabling
+    // and detectable precedences are both silent.
+    const Instance sharp{{{2, 6}, {2, 5}, {2, 20}}, {2, 3, 2}};
+
+    // The mirror, about the window [4, 10): task 2 now starts before the window
+    // and ends inside it, so the push lowers its upper bound to
+    // b - p_j - p(Theta) = 3. At 4 it would spend two of the window's points
+    // inside; at 3 only one, and six units fit in six.
+    const Instance mirror{{{4, 8}, {4, 7}, {0, 8}}, {2, 3, 2}};
+
+    // Mutation mode: emit one deliberately corrupted proof and stop, for
+    // run_test_and_expect_verify_failure.bash to hand to veripb.
+    {
+        optional<DisjunctiveProofMutation> mutation;
+        string proof_basename = "disjunctive_edge_finding_mutation";
+        for (auto a = 1; a < argc; ++a) {
+            string arg = argv[a];
+            if (arg == "--mutate=emit_nothing")
+                mutation = disjunctive_proof_mutation::EdgeFindingEmitNothing{};
+            else if (arg == "--mutate=skip_fold")
+                mutation = disjunctive_proof_mutation::SkipEdgeFindingFold{};
+            else if (arg == "--mutate=drop_contained")
+                mutation = disjunctive_proof_mutation::DropContainedEnergy{};
+            else if (arg == "--mutate=one_too_far")
+                mutation = disjunctive_proof_mutation::EdgeFindingOneTooFar{};
+            else if (arg == "--mutate=drop_pushed")
+                mutation = disjunctive_proof_mutation::DropPushedEnergy{};
+            else if (arg == "--proof-files-basename" && a + 1 < argc)
+                proof_basename = argv[++a];
+        }
+
+        if (mutation) {
+            auto result = probe(sharp, with_ef, make_optional(proof_basename), *mutation);
+            if (result.markers == 0)
+                fail("mutation mode: no edge-finding push was justified, so the proof is empty");
+            println(cerr, "wrote a deliberately corrupted proof to {}.pbp", proof_basename);
+            return EXIT_SUCCESS;
+        }
+    }
+
+    // --search: generated instances, a proof verified per instance, and a
+    // solution count against the rule off.
+    if (argc > 1 && string{argv[1]} == "--search") {
+        auto seed = argc > 2 ? static_cast<unsigned>(std::stoul(argv[2])) : 0u;
+        mt19937 rnd{seed};
+        auto fired = 0, checked = 0;
+        for (auto attempt = 0; attempt < 60; ++attempt) {
+            auto inst = generate(rnd, 4 + static_cast<int>(attempt % 3));
+            auto name = "disjunctive_edge_finding_gen_" + to_string(attempt);
+            auto on = probe(inst, with_ef, proofs ? make_optional(name) : nullopt, disjunctive_proof_mutation::None{}, true);
+            auto off = probe(inst, without_ef, nullopt, disjunctive_proof_mutation::None{}, true);
+            if (on.solutions != off.solutions)
+                fail("generated instance " + to_string(attempt) + ": " + to_string(on.solutions) + " solutions with the rule on against " +
+                    to_string(off.solutions) + " with it off");
+            if (proofs) {
+                ++checked;
+                if (on.markers > 0)
+                    ++fired;
+                if (! gcs::test_innards::run_veripb(name + ".opb", name + ".pbp"))
+                    fail("generated instance " + to_string(attempt) + ": veripb rejected the proof");
+            }
+        }
+        println(cerr, "checked {} generated proofs, {} of them carrying an edge-finding push", checked, fired);
+        if (proofs && fired == 0)
+            fail("--search: no generated instance fired the rule, so nothing was tested");
+        return EXIT_SUCCESS;
+    }
+
+    // The lb push, and --- the half that makes the fixture worth having ---
+    // that nothing else makes it.
+    {
+        auto on = probe(sharp, with_ef, proofs ? make_optional("disjunctive_edge_finding_sharp") : nullopt);
+        if (on.root_bounds.at(2).first != 7)
+            fail("sharp: expected the pushed task's lower bound at 7, got " + to_string(on.root_bounds.at(2).first));
+        if (proofs && on.markers != 1)
+            fail("sharp: expected exactly one edge-finding marker, got " + to_string(on.markers));
+        if (proofs && ! gcs::test_innards::run_veripb("disjunctive_edge_finding_sharp.opb", "disjunctive_edge_finding_sharp.pbp"))
+            fail("sharp: veripb rejected the certificate");
+
+        auto off = probe(sharp, without_ef, nullopt);
+        if (off.root_bounds.at(2).first >= 7)
+            fail("sharp: the bound moved with the rule off, so the fixture says nothing about the rule");
+    }
+
+    // The ub push, which is the same certificate with the guards the other way
+    // round --- and the one a test that measured only the lb push would miss.
+    {
+        auto on = probe(mirror, with_ef, proofs ? make_optional("disjunctive_edge_finding_mirror") : nullopt);
+        if (on.root_bounds.at(2).second != 3)
+            fail("mirror: expected the pushed task's upper bound at 3, got " + to_string(on.root_bounds.at(2).second));
+        if (proofs && on.markers != 1)
+            fail("mirror: expected exactly one edge-finding marker, got " + to_string(on.markers));
+        if (proofs && ! gcs::test_innards::run_veripb("disjunctive_edge_finding_mirror.opb", "disjunctive_edge_finding_mirror.pbp"))
+            fail("mirror: veripb rejected the certificate");
+
+        auto off = probe(mirror, without_ef, nullopt);
+        if (off.root_bounds.at(2).second <= 3)
+            fail("mirror: the bound moved with the rule off, so the fixture says nothing about the rule");
+    }
+
+    // The margin of one: widen the window by a single unit and the rule has
+    // nothing to say, so neither fixture above is firing on a technicality.
+    {
+        const Instance loose{{{2, 7}, {2, 6}, {2, 20}}, {2, 3, 2}};
+        auto result = probe(loose, with_ef, proofs ? make_optional("disjunctive_edge_finding_loose") : nullopt);
+        if (proofs && result.markers != 0)
+            fail("loose: a push was claimed where the work fits");
+        if (proofs && ! gcs::test_innards::run_veripb("disjunctive_edge_finding_loose.opb", "disjunctive_edge_finding_loose.pbp"))
+            fail("loose: veripb rejected the proof");
+    }
+
+    // Both vocabulary placements certify the same push. They differ only in
+    // whether the flags and the guarded rows outlive the firing that made
+    // them, so a difference here is a bug in one of them.
+    if (proofs)
+        for (auto at : {ProofLevel::Top, ProofLevel::Temporary}) {
+            DisjunctiveRules rules{.edge_finding = true};
+            rules.overload_vocabulary_at = at;
+            auto name = string{"disjunctive_edge_finding_"} + (at == ProofLevel::Top ? "top" : "temporary");
+            auto result = probe(sharp, rules, make_optional(name));
+            if (result.root_bounds.at(2).first != 7)
+                fail(name + ": the push did not land");
+            if (! gcs::test_innards::run_veripb(name + ".opb", name + ".pbp"))
+                fail(name + ": veripb rejected the certificate");
+        }
+
+    // Alongside the overload check, which shares every piece of the
+    // vocabulary with it. Running both is what would catch a cache keyed on
+    // too little.
+    if (proofs) {
+        DisjunctiveRules rules{.edge_finding = true};
+        rules.overload = true;
+        auto result = probe(sharp, rules, make_optional("disjunctive_edge_finding_with_overload"));
+        if (result.root_bounds.at(2).first != 7)
+            fail("with_overload: the push did not land");
+        if (! gcs::test_innards::run_veripb("disjunctive_edge_finding_with_overload.opb", "disjunctive_edge_finding_with_overload.pbp"))
+            fail("with_overload: veripb rejected the certificate");
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/gcs/constraints/innards/disjunctive_mutations.hh
+++ b/gcs/constraints/innards/disjunctive_mutations.hh
@@ -115,12 +115,63 @@ namespace gcs::innards
         struct RupOverloadBridge
         {
         };
+
+        /// Emit no edge-finding certificate at all, leaving the push to the
+        /// framework's wrapping RUP. The control for that rule.
+        struct EdgeFindingEmitNothing
+        {
+        };
+
+        /// Leave the per-time at-most-ones out of edge-finding's endgame, so
+        /// nothing says the window can hold only one task at a time.
+        struct SkipEdgeFindingFold
+        {
+        };
+
+        /// Leave one contained task's guarded energy row out, so the window is
+        /// charged less work than the detection counted.
+        struct DropContainedEnergy
+        {
+        };
+
+        /// Push the bound one unit past where the energy argument reaches.
+        /// **The signature test for this rule**: unlike the overload check,
+        /// whose destination makes every route valid, edge-finding prunes, so
+        /// corrupting the conclusion is what a mutation has to do. Corruptions
+        /// that merely shorten the route verify happily once the reason context
+        /// extended with the negated conclusion has gone contradictory.
+        struct EdgeFindingOneTooFar
+        {
+        };
+
+        /// Leave the *pushed* task's guarded energy row out, so nothing says
+        /// the task has to be in the window at all and the contained tasks'
+        /// energy alone has to overflow it --- which, the window having been
+        /// checked not to be overloaded, it cannot.
+        struct DropPushedEnergy
+        {
+        };
+
+        // Deliberately absent: citing the pushed task's row at the *unclipped*
+        // threshold, as if the window contained it. It was written, and it
+        // verified. A row derived at a threshold the reason still entails is a
+        // sound row --- a *stronger* one --- so a proof that cites it closes
+        // just the same, and the mutation tests nothing. What it would have
+        // been aimed at is the propagator firing on more energy than the row it
+        // cites establishes, and `cumulative-proof-logging.md` records the same
+        // conclusion: no mutation lane can catch that, so the propagator asks
+        // `window_energy_bound` for exactly the guards the derivation will be
+        // given instead, and that invariant is what has to be read rather than
+        // tested.
     }
 
     using DisjunctiveProofMutation = std::variant<disjunctive_proof_mutation::None, disjunctive_proof_mutation::EmitNothing,
         disjunctive_proof_mutation::SkipRefutation, disjunctive_proof_mutation::SkipTargetFold, disjunctive_proof_mutation::LooseDetectionBound,
         disjunctive_proof_mutation::PushOneTooFar, disjunctive_proof_mutation::OverloadEmitNothing, disjunctive_proof_mutation::SkipOverloadFold,
-        disjunctive_proof_mutation::SkipOverloadEnergy, disjunctive_proof_mutation::RupOverloadBridge>;
+        disjunctive_proof_mutation::SkipOverloadEnergy, disjunctive_proof_mutation::RupOverloadBridge,
+        disjunctive_proof_mutation::EdgeFindingEmitNothing, disjunctive_proof_mutation::SkipEdgeFindingFold,
+        disjunctive_proof_mutation::DropContainedEnergy, disjunctive_proof_mutation::EdgeFindingOneTooFar,
+        disjunctive_proof_mutation::DropPushedEnergy>;
 
     /**
      * \brief Deliberate corruptions of the presence-falsification derivation,

--- a/gcs/constraints/innards/window_energy.cc
+++ b/gcs/constraints/innards/window_energy.cc
@@ -239,6 +239,69 @@ auto gcs::innards::window_energy::derive_window_energy(ProofLogger & logger, con
     return WindowEnergy{sum.emit(logger, level), shape.bound, shape.a, shape.b};
 }
 
+namespace
+{
+    // Everything the guarded derivation does once it has one row per time point
+    // saying `active_t \/ [s >= t+1] \/ ~[s >= t - p + 1]`: the telescope, the
+    // two guard weakenings, and the clipping. Shared between the two encodings,
+    // which differ only in where that row comes from --- three bridges over
+    // Cumulative's fully reified flags, or the reverse half of a Disjunctive
+    // activity flag reified straight onto the two order literals.
+    auto guarded_from_rows(ProofLogger & logger, SimpleIntegerVariableID start, const Shape & shape, const vector<ProofLine> & per_time,
+        Integer low_guard, Integer high_guard, Integer length_guard, Integer length_coeff, ProofLevel level) -> optional<GuardedWindowEnergy>
+    {
+        auto & tracker = logger.names_and_ids_tracker();
+
+        PolBuilder sum;
+        for (const auto & line : per_time)
+            sum.add(line);
+
+        // Each ~[s >= u] is cancelled by the order encoding's own monotonicity
+        // rather than by a bound: `[s >= u] \/ ~[s >= low_guard]` turns it into
+        // ~[s >= low_guard], so the survivors collapse onto one literal carrying
+        // their whole count. A survivor *above* the guard cannot be weakened onto
+        // it --- the implication runs the wrong way --- so it is discharged by its
+        // own literal axiom, at the cost of one unit of the bound.
+        auto low_coeff = 0_i, kept_u = 0_i;
+        for (Integer u = shape.u_lo; u <= shape.u_hi; ++u) {
+            if (u > low_guard)
+                sum.add(tracker.xliteral_for_ensuring(start >= u), tracker);
+            else {
+                // The survivor that *is* the guard needs no implication of its
+                // own, and adding one would discharge it at a unit's cost
+                // instead.
+                if (u != low_guard)
+                    sum.add(order_implication(logger, tracker, start, u, low_guard, level));
+                ++low_coeff;
+                ++kept_u;
+            }
+        }
+
+        // Mirror image at the other end, and where the clipping comes from: the
+        // bound falls by exactly the number of time points the threshold puts out
+        // of reach.
+        auto lost_v = 0_i;
+        for (Integer v = shape.v_lo; v <= shape.v_hi; ++v) {
+            if (v < high_guard) {
+                sum.add(! tracker.xliteral_for_ensuring(start >= v), tracker);
+                ++lost_v;
+            }
+            else if (v != high_guard)
+                sum.add(order_implication(logger, tracker, start, high_guard, v, level));
+        }
+
+        // What the emission built must be what shape_of predicted: the citer
+        // scales this line by a height and expects a specific total, so a
+        // disagreement would surface only as a rejected proof a long way from
+        // here.
+        if (kept_u - lost_v != shape.bound)
+            throw ProofError{"guarded window energy derivation and its predicted bound disagree"};
+
+        return GuardedWindowEnergy{
+            sum.emit(logger, level), shape.bound, shape.a, shape.b, low_guard, low_coeff, high_guard, length_guard, length_coeff};
+    }
+}
+
 auto gcs::innards::window_energy::derive_guarded_window_energy(ProofLogger & logger, const Task & task, Integer lo, Integer hi, Integer low_guard,
     Integer high_guard, ProofLevel level) -> optional<GuardedWindowEnergy>
 {
@@ -248,59 +311,27 @@ auto gcs::innards::window_energy::derive_guarded_window_energy(ProofLogger & log
     if (shape.empty() || shape.bound <= 0_i)
         return nullopt;
 
-    auto & tracker = logger.names_and_ids_tracker();
-    IntegerVariableID start = task.start;
-
     // No length line, so a variable length's `~[l >= p]` stays in every per-time
     // clause and the sum below carries one copy per time point. That is more
     // than the bound, and the citer pays for all of them; making it exactly the
     // bound would need the sum divided, which the leftover order literals do
     // not survive.
     auto per_time = emit_per_time_bridges(logger, task, shape, nullopt, level);
-
-    PolBuilder sum;
-    for (const auto & line : per_time)
-        sum.add(line);
-
-    // Each ~[s >= u] is cancelled by the order encoding's own monotonicity
-    // rather than by a bound: `[s >= u] \/ ~[s >= low_guard]` turns it into
-    // ~[s >= low_guard], so the survivors collapse onto one literal carrying
-    // their whole count. A survivor *above* the guard cannot be weakened onto
-    // it --- the implication runs the wrong way --- so it is discharged by its
-    // own literal axiom, at the cost of one unit of the bound.
-    auto low_coeff = 0_i, kept_u = 0_i;
-    for (Integer u = shape.u_lo; u <= shape.u_hi; ++u) {
-        if (u > low_guard)
-            sum.add(tracker.xliteral_for_ensuring(task.start >= u), tracker);
-        else {
-            // The survivor that *is* the guard needs no implication of its own,
-            // and adding one would discharge it at a unit's cost instead.
-            if (u != low_guard)
-                sum.add(order_implication(logger, tracker, start, u, low_guard, level));
-            ++low_coeff;
-            ++kept_u;
-        }
-    }
-
-    // Mirror image at the other end, and where the clipping comes from: the
-    // bound falls by exactly the number of time points the threshold puts out
-    // of reach.
-    auto lost_v = 0_i;
-    for (Integer v = shape.v_lo; v <= shape.v_hi; ++v) {
-        if (v < high_guard) {
-            sum.add(! tracker.xliteral_for_ensuring(task.start >= v), tracker);
-            ++lost_v;
-        }
-        else if (v != high_guard)
-            sum.add(order_implication(logger, tracker, start, high_guard, v, level));
-    }
-
-    // What the emission built must be what shape_of predicted: the citer scales
-    // this line by a height and expects a specific total, so a disagreement
-    // would surface only as a rejected proof a long way from here.
-    if (kept_u - lost_v != shape.bound)
-        throw ProofError{"guarded window energy derivation and its predicted bound disagree"};
-
     auto length_coeff = task.length_variable ? shape.b - shape.a : 0_i;
-    return GuardedWindowEnergy{sum.emit(logger, level), shape.bound, shape.a, shape.b, low_guard, low_coeff, high_guard, task.length, length_coeff};
+    return guarded_from_rows(logger, task.start, shape, per_time, low_guard, high_guard, task.length, length_coeff, level);
+}
+
+auto gcs::innards::window_energy::derive_guarded_window_energy(ProofLogger & logger, const WindowRows & rows, Integer lo, Integer hi,
+    Integer low_guard, Integer high_guard, ProofLevel level) -> optional<GuardedWindowEnergy>
+{
+    auto shape = shape_of(rows.length, rows.rows_t_lo, rows.rows_size, lo, hi, pair{low_guard, high_guard - 1_i});
+    if (shape.empty() || shape.bound <= 0_i)
+        return nullopt;
+
+    vector<ProofLine> per_time;
+    per_time.reserve(static_cast<size_t>((shape.b - shape.a).raw_value));
+    for (Integer t = shape.a; t < shape.b; ++t)
+        per_time.push_back(rows.row(t));
+
+    return guarded_from_rows(logger, rows.start, shape, per_time, low_guard, high_guard, 0_i, 0_i, level);
 }

--- a/gcs/constraints/innards/window_energy.hh
+++ b/gcs/constraints/innards/window_energy.hh
@@ -8,6 +8,8 @@
 #include <gcs/integer.hh>
 #include <gcs/variable_id.hh>
 
+#include <cstddef>
+#include <functional>
 #include <optional>
 #include <utility>
 #include <vector>
@@ -63,6 +65,44 @@ namespace gcs::innards::window_energy
         /// <code>length_variable &ge; length</code> is what it needs to bridge
         /// back onto <code>start</code>'s order literals.
         std::optional<SimpleIntegerVariableID> length_variable = std::nullopt;
+    };
+
+    /**
+     * \brief The per-time facts the lemma telescopes, for a caller that mints
+     * them itself rather than through \ref Task's three fully reified flags.
+     *
+     * <code>Disjunctive</code>'s encoding has no time index at all, so its
+     * certificates re-encode one inside the proof: an activity flag reified
+     * directly on a conjunction of two order literals, whose reverse half
+     * <em>is</em> the per-time fact below. That is the same statement
+     * \ref Task's three bridges are built to produce, so everything after it
+     * --- the telescope, the guard weakening, the clipping --- is shared, and
+     * the two encodings cite one lemma rather than two copies of it.
+     *
+     * <code>row(t)</code> must return a line reading
+     *
+     * <blockquote>
+     * <code>active_t &or; [start &ge; t+1] &or; ~[start &ge; t - length + 1]</code>
+     * </blockquote>
+     *
+     * and is called once per time point of the <em>clipped</em> window, in
+     * increasing order of <code>t</code>. <code>length</code> must be a length
+     * the task is guaranteed to run for, and must be the one the rows were
+     * built at --- a row minted at a different length has different order
+     * literals in it and the telescope will not close.
+     *
+     * There is no length guard here. A caller minting its own rows states the
+     * length in the flag's own definition, so it has already chosen one; if
+     * that choice is to be reason-free it must be the declared lower bound,
+     * exactly as it must be for \ref Task.
+     */
+    struct WindowRows
+    {
+        SimpleIntegerVariableID start;
+        Integer length;
+        Integer rows_t_lo;
+        std::size_t rows_size;
+        const std::function<auto(Integer)->ProofLine> & row;
     };
 
     /**
@@ -211,6 +251,18 @@ namespace gcs::innards::window_energy
      */
     [[nodiscard]] auto derive_guarded_window_energy(
         ProofLogger &, const Task &, Integer lo, Integer hi, Integer low_guard, Integer high_guard, ProofLevel) -> std::optional<GuardedWindowEnergy>;
+
+    /**
+     * \brief The same derivation over caller-minted per-time rows.
+     *
+     * Everything the \ref Task form does after its bridges: the telescope, the
+     * two guard weakenings, and the clipping that falls out of a guard sitting
+     * inside the survivors' range. See \ref WindowRows for what the rows have
+     * to say. <code>length_guard</code> and <code>length_coeff</code> come back
+     * zero, there being no length term in a row the caller minted.
+     */
+    [[nodiscard]] auto derive_guarded_window_energy(ProofLogger &, const WindowRows &, Integer lo, Integer hi, Integer low_guard, Integer high_guard,
+        ProofLevel) -> std::optional<GuardedWindowEnergy>;
 }
 
 #endif


### PR DESCRIPTION
Closes #751. Edge-finding for `Disjunctive`, both directions, certified,
off by default.

For a window `[a, b)` and the set `Θ` of tasks it contains, a task with
**one** end inside that cannot fit alongside `Θ` is pushed out of it: up to
`ect(Θ)` if it starts inside, down to `lct(Θ) − p(Θ) − p_j` if it ends inside.
The capacity-one case of `CumulativeRules::edge_finding`, where
`rest = energy − (capacity − h_j)·width` collapses to `p(Θ)`. A task with
*neither* end inside spans the window and no closed form pushes it, which is
what #752 is for.

## The certificate

**It is the overload check's, emitted under the negated conclusion.** Same
window, same activity flags, same bridge to a per-time at-most-one, same fold.
One step differs, and it is exactly what a *pruning* rule needs that a
conflict-only one does not.

`energy_pol` resolves the order literals its telescope leaves over against the
current bounds, one reason-wrapped RUP each. That is right for a conflict — a
conflict-only rule never has to keep a row past the firing — and no use here,
for two reasons: a pruning rule has to carry the negated conclusion *into* the
row, and a row good for one node is not worth deriving when the same window
recurs. So the survivors are weakened onto **two guards** instead, along the
order encoding's own monotonicity.

That is `derive_guarded_window_energy` — **the lemma the cumulative energy
rules already cite**. `window_energy::WindowRows` is the new seam: the two
encodings differ only in where the per-time row comes from (three bridges over
fully reified `before`/`after`/`active` flags there; the reverse half of an
activity flag reified straight onto two order literals here, which *is* the
statement those bridges are built to produce) and share the telescope, the
guard weakening and the clipping. One copy of arithmetic that is easy to get
subtly wrong in a way that still verifies.

A firing discharges whichever guards its reason refutes and leaves the one the
conclusion is about standing, so the `pol` lands on

```
bound·[s_j ≥ push]  ≥  p(Θ) + bound − (b − a)      > 0
```

— it **derives** the conclusion rather than assuming it, and the wrapping RUP
only reads it off. The negated conclusion never enters the proof as an
assumption. Clipping needs no separate mechanism: the guard sits past
`b − p_j + 1`, the thresholds between cannot be weakened onto it, and each is
discharged by its own literal axiom at a unit of the bound.

## Settled before it was written

Per #730's precedent, the whole construction was simulated standalone and
machine-checked before a line of propagator (`~/claude/tmp/disj-ef-751/`, and
the comment on #751). That is also where the caching question #751 flagged as
the real risk was answered: **`|Θ|` of the `|Θ|+1` rows are keyed on
`(task, window)`** and cache on exactly the terms #737's bridge already does;
only the pushed task's high guard is the push threshold, which moves with the
contained set, and stabilising it would buy about one proof line. So there is
one code path, and the cost model is the cumulative one rather than a different
one.

Worth recording from that simulation: the first version **verified end to end
while every ladder row had the wrong coefficients**, because a `pol` ending in
`+ s` saturates to its *degree* rather than to a clause, and the closing RUP
quietly picked up the slack. Exit code 0 says a proof is valid, not that it is
the proof you meant.

## What it is worth

Generated RCPSP with a unary machine (`--machine-fraction 0.8`, without which
hardly any resource has capacity one and the rule never fires), sizes 8–30,
68 instances at 60 s. Over the **36 instances every arm closed** that needed at
least a hundred recursions:

| arm | summed | median | geomean | better than off |
|---|---|---|---|---|
| off | 1.000× | 1.000× | 1.000× | — |
| lb push only | 0.655× | 0.758× | 0.418× | 34/36 |
| ub push only | 0.273× | 0.242× | 0.172× | 35/36 |
| **both** | **0.169×** | **0.127×** | **0.099×** | **36/36** |

and 46 of the 68 close within the timeout against 41 with the rule off. So
unlike cumulative not-first/not-last (0.997×, closing *fewer*), this pays for
itself rather than being a coverage row.

Three statistics rather than one because a summed ratio is a division and not a
sample: the largest instance carries 37% of the summed recursions by itself,
and dropping it moves the summed figure (0.169× → 0.129×) far more than the
median (0.127× → 0.123×).

**The two halves are not worth the same, by a factor of three.** A run
measuring only the lb push would have reported 0.758× and called the rule
marginal. That is what the two separate switches are for. The cumulative side
found the same asymmetry with the roles reversed, so which half dominates is a
property of the instance family and not of the rule.

Adding the lb half to the ub half costs search on exactly one of the 36 (233
against 286 recursions). Worth knowing that a stronger rule can cost search;
not worth acting on.

## Testing

The rule *prunes*, and that decides the shape. Once the reason context extended
with the negated conclusion has gone contradictory, every RUP under it is
vacuously valid, so a corruption that merely **shortens** the derivation
verifies. The `+1` on the conclusion is the signature test and the fixtures put
exactly one unit between a valid push and a false one.

- `sharp` measures the lb push, `mirror` the ub push. Both, because measuring
  one half of a symmetric rule tells you almost nothing.
- Each carries a control with the rule off. No task has a mandatory part and no
  pair's ordering is bounds-forced, so time-tabling and detectable precedences
  are silent — and the control is what keeps that true as the propagator
  changes.
- Five mutation lanes, all rejected. **A sixth was written and removed**: citing
  the pushed task's row at an unclipped threshold *verified*, because a row at a
  threshold the reason still entails is a **stronger** row. `cumulative-proof-logging.md`
  records the same conclusion. What it would have tested is instead an invariant
  to be read — the propagator asks `window_energy_bound` for exactly the guards
  the derivation will be given. `disjunctive_mutations.hh` says so where the
  lane would have been.
- `--search` verifies a proof per generated instance and checks the rule removes
  no solutions: 300 proofs across five seeds, all verified, no mismatches. This
  is the lane that matters — hand-built fixtures are symmetric and generous and
  verify straight through certificate bugs.
- Across every sweep instance more than one arm closed, all arms proved the
  **same optimum**, which is the check no proof lane can make.

Existing `cumulative_{overload,edge_finding,ttef,nfnl,kaoc}_test` and
`disjunctive_{overload,precedences}_test` all still pass, which is what covers
the `window_energy` and fold refactors. The overload certificate's emission
order is deliberately preserved, so its proofs diff unchanged.

## Docs

`dev_docs/disjunctive-proof-logging.md` gains a section, and **its opening
paragraph is corrected**: it asserted, citing #495's measurements, that there is
no per-(task, time) scaffolding anywhere, which the merged overload check had
already made false and this makes more so. The distinction that matters is not
"time-indexed or not" but *where the time index lives* — in the model and paid
for unconditionally, or in the proof and paid for only by the firings that want
it. The rest of what #753 asks for is still open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
