### PR TITLE
disjunctive: certified not-first / not-last, both directions

### DIFF
--- a/dev_docs/cumulative-proof-logging.md
+++ b/dev_docs/cumulative-proof-logging.md
@@ -1424,6 +1424,21 @@ which is whether the divergence is a standing assumption on the task set that
 the transcription drops, or a genuine argument the window-energy lemma cannot
 make.
 
+**The disjunctive side has since answered its own version of that question, and
+the answer is the second one.** #752 carried the same weakening onto
+`Disjunctive`, where it is worse — every one of our firings is also a published
+firing and 1,145 of 4,218 are theirs alone — and #757 found where the extra
+strength comes from: not a different lemma but a different **window**. The
+published unary argument runs over `[ect_j, lct(Ω))`, whose left edge is
+*derived from the negated conclusion* rather than carried by the reason, and a
+task is put inside it by a pairwise ordering that #734's own refutation pol
+supplies as a two-literal clause. The certificate is machine-checked in
+`~/claude/tmp/disj-derived-757/`. Whether that transfers here is not obvious —
+the pairwise separation clause it turns on is exactly what a cumulative encoding
+does not have — but "the window-energy lemma is complete for what it computes,
+and the extra detection comes from arguing over a narrower window" is the shape
+of the answer #746 was looking for.
+
 Testing is `cumulative_nfnl_test`, whose fixtures were searched the same way
 TTEF's were and against the same two conditions --- the rule must move a bound
 that time-tabling, the overload check, edge-finding and TTEF together do not,

--- a/dev_docs/disjunctive-proof-logging.md
+++ b/dev_docs/disjunctive-proof-logging.md
@@ -343,7 +343,8 @@ This is the capacity-one case of `CumulativeRules::edge_finding`, where
 `rest = energy − (capacity − h_j)·width` collapses to `p(Θ)`. A task with
 *neither* end inside spans the window and no closed form pushes it: its
 guaranteed energy is a hump in its start rather than monotone, which is
-what #752 exists for. `DisjunctiveRules::edge_finding`, off by default —
+what [not-first / not-last](#not-first--not-last-752) is for, below.
+`DisjunctiveRules::edge_finding`, off by default —
 the sweep is cubic, so a solve that never fires it still pays, which is
 the trade #742 records on the cumulative side.
 
@@ -494,6 +495,153 @@ that true as the rest of the propagator changes.
 is the lane that matters: hand-built fixtures are symmetric and generous
 and verify straight through certificate bugs.
 
+## Not-first / not-last (#752)
+
+The rule: for the same window `[a, b)` and contained set `Θ`, and a task
+`j ∉ Θ`,
+
+```
+lb(s_j) ← min_{i∈Θ} ect_i        j cannot start before all of Θ has ended
+ub(s_j) ← max_{i∈Θ} lst_i − p_j  j cannot end after all of Θ has started
+```
+
+`DisjunctiveRules::not_first_not_last`, off by default, with
+`not_first` and `not_last` separately switchable.
+
+**The certificate is edge-finding's, unchanged.** Not a rewrite of it, not
+a variation on it: `edge_finding_justification` already takes the pushed
+task's two guards and a flag saying which of them the reason discharges,
+which is the entire difference. Not-first puts the negated conclusion on
+the high guard at `min ect` and lets the reason discharge the low one;
+not-last is the mirror, with the negated conclusion on the low guard at
+`max lst − p_j + 1` and `ub(s_j) + 1` as the high one. The first generated
+proof verified, and the five mutation lanes are edge-finding's own with
+nothing added.
+
+So this section is about the *firing set*, which is the only part that is
+new.
+
+### The `continue` this rule exists for
+
+Edge-finding's sweep carries
+
+```cpp
+if (starts_inside == (j.lct <= b))
+    continue;
+```
+
+— a task with **neither** end inside the window spans it, its guaranteed
+energy inside is a hump in its start rather than monotone, and no closed
+form pushes it. Restricting the start to one side of a threshold is what
+makes a hump's minimum say something, and that is exactly what these two
+thresholds do. So the rule shares the sweep rather than adding one, and
+turning it on turns that sweep on whether or not edge-finding is set.
+
+Where `j` has one end inside, the two rules overlap and edge-finding's
+threshold is the furthest an energy argument over that window can reach,
+so its push subsumes this one and the live-bound tests drop the
+duplicate. The rule is still run over those tasks, because it is
+separately switchable and has to be worth measuring on its own.
+
+### What the lemma gives, which is not the overlap
+
+The propagator asks `window_energy_bound` for the pushed task's
+contribution rather than computing an overlap, and the two are **not the
+same number**. The guarded row states one bound uniformly over the whole
+negation range using only its two guard literals: it keeps the "ends by
+`t`" survivors the low guard decides and concedes a unit for every "starts
+after `t`" survivor the high guard does not. Those are two worst cases
+that need not occur at the same start value, so where the true minimum
+overlap sits in the middle of the range the row is strictly weaker than
+it.
+
+A propagator that fired on the overlap would be firing on energy its own
+certificate does not establish, and would emit a *rejected proof* rather
+than an unsound push. This is the same invariant edge-finding records, and
+it bites harder here, because not-first's range runs from outside the
+window to inside it and so straddles the hump.
+
+### Two facts about the rule, and what they cost the test
+
+Both came out of scanning random unary instances, and both are worth
+knowing before writing a fixture:
+
+- **Where the rule adds a push, the push is never tight.** Of 800,000
+  random instances, 615,263 survive time-tabling and detectable
+  precedences; those carry 35,189 firings that push past them, and **not
+  one** has a target equal to the bound enumeration gives.
+- **At one contained task the push is exactly a detectable precedence's**,
+  to that task's earliest end, under a weaker detection condition. Which
+  is the same fact from the other side: the exact pushes are the ones the
+  pairwise rule already makes.
+
+So a fixture cannot be both load-bearing and exact. `disjunctive_nfnl_test`
+splits the difference: `sharp` and `mirror` push a spanning task where
+nothing else does (and their controls say so), while `tight_nf` and
+`tight_nl` land on the enumerated bound with the pairwise rules turned
+off.
+
+The mutation lanes needed a third kind of fixture again, and a
+**generated** one. On every hand-built fixture at least one route
+corruption still verified — the instances are small enough that the
+closing RUP finishes from whatever the corrupted derivation left, which is
+sound and VeriPB is right to accept. Scanning found 222 generated
+instances that fired the rule and exactly one that rejected all five
+lanes. `drop_contained` (35 of 222) and `drop_pushed` (20) are the fragile
+ones, and the reason is this rule's own: `min ect` and `max lst` are
+quantities pairwise reasoning can often reach by itself, where
+edge-finding's `a + p(Θ)` is not. That is a sharper form of a finding
+#731 left behind: the fixture that best *demonstrates* a rule is not the
+fixture that makes its mutations bite.
+
+### What it is worth: it fires everywhere and buys nothing
+
+The same generated RCPSP as edge-finding's table above, and deliberately the
+same 68 instances and the same 60 s timeout, so the two are read together. Six
+arms, because "against nothing" is not the question a reader has: this rule
+shares edge-finding's sweep and its firing sets overlap, so what matters is what
+it adds *on top of* edge-finding.
+
+| arm | against | summed | median | geomean | better | closed |
+|---|---|---|---|---|---|---|
+| off | — | 1.000x | 1.000x | 1.000x | — | 41/68 |
+| not-first only | off | 0.893x | 0.884x | 0.760x | 34/36 | 41/68 |
+| not-last only | off | 0.712x | 0.796x | 0.644x | 33/36 | 41/68 |
+| **both** | off | **0.676x** | **0.668x** | **0.536x** | 36/36 | 42/68 |
+| edge-finding | off | 0.169x | 0.127x | 0.099x | 36/36 | 46/68 |
+| **edge-finding + both** | **edge-finding** | **1.024x** | **1.000x** | **1.001x** | **1/36** | **46/68** |
+
+Edge-finding's row reproduces the table above exactly — same 36 of 68 in the
+common set, same three ratios — which is the check that the two measurements are
+comparable and that #752 changed nothing about #751.
+
+**On its own the rule is worth real search**: two thirds of the recursions,
+better on 36 of 36, and one more instance closed. Both halves pay, with not-last
+the stronger — the same direction edge-finding's asymmetry runs on this family,
+which is a small piece of evidence that the asymmetry belongs to the instances
+rather than to either rule.
+
+**On top of edge-finding it is worth nothing at all.** The median is exactly
+1.000x and it is better on 1 of 36. It changes the search on **4** of the 36:
+two by a handful of recursions in either direction, and two for the worse, by
+0.7% and by 4.7%. That last one is the 1.024x summed figure on its own — it
+carries 37% of the summed recursions, and dropping it takes the summed ratio to
+1.000x. Neither arm closes a different set of instances.
+
+**And it is not that the rule does not fire.** Propagation counts differ on 57
+of the 68, so it fires nearly everywhere and reaches the same fixpoint by a
+different route — sometimes in fewer propagator invocations, sometimes more.
+Every bound it moves is a bound edge-finding was going to move.
+
+That is a sharper verdict than the cumulative side's 0.997x, and the same one:
+**certifiable for nothing, and worth nothing once the stronger rule is on.**
+Hence off by default, and hence a table row rather than a recommendation. A rung
+that is free to certify and measurably not worth running is a better row than a
+gap, which is the whole reason it is here.
+
+Across every instance more than one arm closed, all six arms proved the same
+optimum — the check no proof lane can make.
+
 ## Strict-mode zero-length tasks
 
 Strict mode forbids a zero-length task from sitting strictly inside
@@ -597,15 +745,12 @@ would take from *this* encoding:
   construction that avoids them — a proof-only comparator network over
   bit-encoded wires — verified for `k = 3 … 8` at equal durations, and
   a refutation rather than a propagator so far.
-- **Not-first / not-last** (#752). The thresholds are the contained
-  set's own `min ect` and `max lst` rather than a figure computed from
-  the leftover energy. On the cumulative side this was edge-finding's
-  certificate *unchanged* — a different threshold and a different guard,
-  both already parameters of the guarded lemma — so expect the same
-  here, and expect it not to be worth its scan (0.997x there, closing
-  fewer instances). Do not inherit #746's weakening silently: at
-  capacity one the papers' standing assumption may be easier to
-  discharge, which would be a result rather than a caveat.
+- ~~**Not-first / not-last** (#752)~~ — done, and its own section
+  above. It did inherit #746's weakening, deliberately: the guarded row
+  is what the detection may use, and at capacity one that turns out to
+  cost more than it does on `Cumulative`, since the negation range
+  straddles the hump. What the published unary rule detects instead, and
+  whether the pairwise encoding can certify *that*, is #757.
 - **Optional tasks for `Disjunctive2D`.** The 1D form has them
   (#735, above); the 2D 4-way separation clause would take the same
   two disjuncts per pair, but nothing asks for it yet.

--- a/examples/rcpsp/rcpsp.cc
+++ b/examples/rcpsp/rcpsp.cc
@@ -437,6 +437,17 @@ auto main(int argc, char * argv[]) -> int
                 "separately switchable and the table has a row for each")                     //
             ("disjunctive-edge-finding-ub-only",
                 "See --disjunctive-edge-finding-lb-only") //
+            ("disjunctive-not-first-not-last",
+                "Give every posted Disjunctive not-first / not-last, both directions: a task that " //
+                "spans a window its contained tasks already fill cannot start before all of them "  //
+                "have ended, nor end after all of them have started. Shares edge-finding's sweep, " //
+                "so this turns that sweep on whether or not --disjunctive-edge-finding is given "   //
+                "(#752)")                                                                           //
+            ("disjunctive-not-first-only",
+                "Restrict not-first / not-last to the half that raises a lower bound, and " //
+                "--disjunctive-not-last-only to the half that lowers an upper bound")       //
+            ("disjunctive-not-last-only",
+                "See --disjunctive-not-first-only") //
             ("disjunctive-overload",
                 "Give every posted Disjunctive the overload check, off by default because its "   //
                 "certificate is expensive enough that whether it pays is what #730 is measuring") //
@@ -738,6 +749,15 @@ auto main(int argc, char * argv[]) -> int
     if (options_vars["disjunctive-edge-finding-ub-only"].as<bool>()) {
         disjunctive_rules.edge_finding = true;
         disjunctive_rules.edge_finding_lb = false;
+    }
+    disjunctive_rules.not_first_not_last = options_vars["disjunctive-not-first-not-last"].as<bool>();
+    if (options_vars["disjunctive-not-first-only"].as<bool>()) {
+        disjunctive_rules.not_first_not_last = true;
+        disjunctive_rules.not_last = false;
+    }
+    if (options_vars["disjunctive-not-last-only"].as<bool>()) {
+        disjunctive_rules.not_first_not_last = true;
+        disjunctive_rules.not_first = false;
     }
     disjunctive_rules.overload = options_vars["disjunctive-overload"].as<bool>();
     disjunctive_rules.overload_max_window = options_vars["disjunctive-overload-max-window"].as<std::size_t>();

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -288,6 +288,7 @@ if(GCS_BUILD_TESTS)
     add_executable(disjunctive_optional_test constraints/disjunctive/disjunctive_optional_test.cc)
     add_executable(disjunctive_overload_test constraints/disjunctive/disjunctive_overload_test.cc)
     add_executable(disjunctive_edge_finding_test constraints/disjunctive/disjunctive_edge_finding_test.cc)
+    add_executable(disjunctive_nfnl_test constraints/disjunctive/disjunctive_nfnl_test.cc)
     add_executable(disjunctive_precedences_test constraints/disjunctive/disjunctive_precedences_test.cc)
     add_executable(disjunctive_2d_test constraints/disjunctive_2d/disjunctive_2d_test.cc)
     add_executable(divide_modulus_test constraints/divide_modulus/divide_modulus_test.cc)
@@ -335,7 +336,7 @@ if(GCS_BUILD_TESTS)
 
     foreach(test_target
             abs_test all_different_test all_different_except_test all_equal_test among_test at_most_one_test bin_packing_test comparison_test
-            count_test cumulative_test cumulative_overload_test cumulative_edge_finding_test cumulative_ttef_test cumulative_nfnl_test cumulative_kaoc_test cumulative_optional_test derived_cumulative_test difference_test disjunctive_test disjunctive_optional_test disjunctive_overload_test disjunctive_edge_finding_test disjunctive_precedences_test disjunctive_2d_test divide_modulus_test element_test equals_test bounds_global_cardinality_test gac_global_cardinality_test in_test increasing_test inverse_test knapsack_test knapsack_upfront_test lex_test linear_test linear_constant_test
+            count_test cumulative_test cumulative_overload_test cumulative_edge_finding_test cumulative_ttef_test cumulative_nfnl_test cumulative_kaoc_test cumulative_optional_test derived_cumulative_test difference_test disjunctive_test disjunctive_optional_test disjunctive_overload_test disjunctive_edge_finding_test disjunctive_nfnl_test disjunctive_precedences_test disjunctive_2d_test divide_modulus_test element_test equals_test bounds_global_cardinality_test gac_global_cardinality_test in_test increasing_test inverse_test knapsack_test knapsack_upfront_test lex_test linear_test linear_constant_test
             logical_test mdd_test min_distance_test min_distance_matching_test min_max_test mini_linear_test multiply_test n_value_test nogoods_test parity_test
             plus_minus_test power_test product_bounds_test product_justify_test regular_test regular_bacchus_test regular_legacy_test seq_precede_chain_test smart_table_test sort_test arg_sort_test symmetric_all_different_test
             negative_table_test table_test tabulation_test value_precede_test)
@@ -451,6 +452,20 @@ if(GCS_BUILD_TESTS)
         add_test(NAME disjunctive_edge_finding_mutation_${mutation}
             COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_expect_verify_failure.bash
                 --basename disjunctive_edge_finding_mutation_${mutation} $<TARGET_FILE:disjunctive_edge_finding_test> --mutate=${mutation})
+    endforeach()
+    # Not-first / not-last, over edge-finding's certificate. The mutation lanes
+    # are edge-finding's own, unchanged, which is the claim: a different
+    # threshold and a different guard are all that differ, so the same
+    # corruptions have to bite. The fixture they run on has the pairwise rules
+    # off --- see the header comment on disjunctive_nfnl_test.cc for why a
+    # load-bearing fixture cannot serve the one_too_far lane.
+    add_test(NAME disjunctive_nfnl COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:disjunctive_nfnl_test>)
+    add_test(NAME disjunctive_nfnl_search
+        COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:disjunctive_nfnl_test> --search 28)
+    foreach(mutation emit_nothing skip_fold drop_contained one_too_far drop_pushed)
+        add_test(NAME disjunctive_nfnl_mutation_${mutation}
+            COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_expect_verify_failure.bash
+                --basename disjunctive_nfnl_mutation_${mutation} $<TARGET_FILE:disjunctive_nfnl_test> --mutate=${mutation})
     endforeach()
     add_test(NAME disjunctive_precedences COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:disjunctive_precedences_test>)
     # Mutation lanes: each writes a deliberately corrupted proof of the

--- a/gcs/constraints/disjunctive/disjunctive.cc
+++ b/gcs/constraints/disjunctive/disjunctive.cc
@@ -53,6 +53,7 @@ using std::nullopt;
 using std::optional;
 using std::pair;
 using std::size_t;
+using std::string;
 using std::tuple;
 using std::unique_ptr;
 using std::vector;
@@ -808,9 +809,9 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
             // current bounds and is cited rather than re-derived. What a firing
             // pays is the fold, the guard discharges, and one pol.
             auto edge_finding_justification = [&](Integer a, Integer b, const vector<size_t> & inside, size_t pushed, Integer pushed_low_guard,
-                                                  Integer pushed_high_guard, bool discharge_low) {
-                return [&, a, b, inside, pushed, pushed_low_guard, pushed_high_guard, discharge_low](const ReasonLiterals & reason) -> void {
-                    logger->emit_proof_comment("disjunctive edge-finding w=" + std::to_string(inside.size()) +
+                                                  Integer pushed_high_guard, bool discharge_low, const char * rule = "edge-finding") {
+                return [&, a, b, inside, pushed, pushed_low_guard, pushed_high_guard, discharge_low, rule](const ReasonLiterals & reason) -> void {
+                    logger->emit_proof_comment("disjunctive " + string{rule} + " w=" + std::to_string(inside.size()) +
                         " span=" + std::to_string((b - a).raw_value) + (discharge_low ? " lb" : " ub"));
                     if (std::holds_alternative<disjunctive_proof_mutation::EdgeFindingEmitNothing>(mutation))
                         return;
@@ -1472,13 +1473,16 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                 // and they are mirror images over the same sweep. A task with
                 // *neither* end inside spans the window, and no closed form
                 // pushes it: its guaranteed energy is a hump in its start
-                // rather than monotone, which is the case #752 exists for.
+                // rather than monotone. Restricting the start to one side of a
+                // threshold is what makes such a hump's minimum say something,
+                // and that is not-first / not-last, below, which shares this
+                // sweep and so shares its gate.
                 //
-                // Before the overload check rather than after it, because this
-                // rule prunes where that one only refutes, and a window this
-                // has already emptied is not one the overload check has to pay
+                // Before the overload check rather than after it, because these
+                // rules prune where that one only refutes, and a window they
+                // have already emptied is not one the overload check has to pay
                 // a certificate for.
-                if (rules.edge_finding) {
+                if (rules.edge_finding || rules.not_first_not_last) {
                     struct EdgeTask
                     {
                         size_t task;
@@ -1514,13 +1518,20 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                             continue;
                         auto a = window_starts[w];
 
-                        Integer energy = 0_i;
+                        // min_ect and max_lst are not-first / not-last's
+                        // thresholds, over the same growing contained set the
+                        // energy accumulates over.
+                        Integer energy = 0_i, min_ect = 0_i, max_lst = 0_i;
                         vector<size_t> inside;
                         for (size_t c = 0; c < candidates.size(); ++c) {
                             if (candidates[c].est < a)
                                 continue;
                             energy += candidates[c].duration;
                             inside.push_back(candidates[c].task);
+                            min_ect = inside.size() == 1 ? candidates[c].est + candidates[c].duration
+                                                         : min(min_ect, candidates[c].est + candidates[c].duration);
+                            max_lst = inside.size() == 1 ? candidates[c].lct - candidates[c].duration
+                                                         : max(max_lst, candidates[c].lct - candidates[c].duration);
                             auto b = candidates[c].lct;
                             // Candidates are in lct order, so `inside` is every
                             // task the window contains only once the last of a
@@ -1536,44 +1547,124 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                             if (energy > b - a)
                                 continue;
 
-                            for (const auto & j : candidates) {
-                                if (j.lct <= b && j.est >= a)
-                                    continue;
-                                auto p_j = j.duration;
-                                auto starts_inside = j.est >= a;
-                                // Neither end inside: the task spans the
-                                // window, and an energy argument over it has no
-                                // closed-form push (#752).
-                                if (starts_inside == (j.lct <= b))
-                                    continue;
-                                if (! (starts_inside ? rules.edge_finding_lb : rules.edge_finding_ub))
-                                    continue;
+                            if (rules.edge_finding)
+                                for (const auto & j : candidates) {
+                                    if (j.lct <= b && j.est >= a)
+                                        continue;
+                                    auto p_j = j.duration;
+                                    auto starts_inside = j.est >= a;
+                                    // Neither end inside: the task spans the
+                                    // window, and no closed form pushes it.
+                                    // That is not-first / not-last's firing
+                                    // set, and this `continue` is the whole of
+                                    // it.
+                                    if (starts_inside == (j.lct <= b))
+                                        continue;
+                                    if (! (starts_inside ? rules.edge_finding_lb : rules.edge_finding_ub))
+                                        continue;
 
-                                auto low_guard = starts_inside ? a : b - p_j - energy + 1_i;
-                                auto high_guard = starts_inside ? a + energy : b - p_j + 1_i;
-                                // Ask the lemma for exactly what the row it will
-                                // cite establishes, rather than for the state's
-                                // own figure: the row is a model fact, and firing
-                                // on more energy than it carries is a rejected
-                                // proof rather than an unsound push.
-                                auto clipped = window_energy::window_energy_bound(
-                                    p_j, a, static_cast<size_t>((b - a).raw_value), a, b, pair{low_guard, high_guard - 1_i});
-                                if (clipped <= 0_i || energy + clipped <= b - a)
-                                    continue;
+                                    auto low_guard = starts_inside ? a : b - p_j - energy + 1_i;
+                                    auto high_guard = starts_inside ? a + energy : b - p_j + 1_i;
+                                    // Ask the lemma for exactly what the row it
+                                    // will cite establishes, rather than for the
+                                    // state's own figure: the row is a model
+                                    // fact, and firing on more energy than it
+                                    // carries is a rejected proof rather than an
+                                    // unsound push.
+                                    auto clipped = window_energy::window_energy_bound(
+                                        p_j, a, static_cast<size_t>((b - a).raw_value), a, b, pair{low_guard, high_guard - 1_i});
+                                    if (clipped <= 0_i || energy + clipped <= b - a)
+                                        continue;
 
-                                auto [j_lo, j_hi] = state.bounds(starts[j.task]);
-                                if (starts_inside ? high_guard <= j_lo : low_guard - 1_i >= j_hi)
-                                    continue;
+                                    auto [j_lo, j_hi] = state.bounds(starts[j.task]);
+                                    if (starts_inside ? high_guard <= j_lo : low_guard - 1_i >= j_hi)
+                                        continue;
 
-                                auto one_too_far = std::holds_alternative<disjunctive_proof_mutation::EdgeFindingOneTooFar>(mutation);
-                                auto justify = edge_finding_justification(a, b, inside, j.task, low_guard, high_guard, starts_inside);
-                                if (starts_inside)
-                                    inference.infer_greater_than_or_equal(logger, starts[j.task], one_too_far ? high_guard + 1_i : high_guard,
-                                        JustifyExplicitly{justify, ThenRUP::Yes, hints::Disjunctive{owner}}, reason_over(reason_vars));
-                                else
-                                    inference.infer_less_than(logger, starts[j.task], one_too_far ? low_guard - 1_i : low_guard,
-                                        JustifyExplicitly{justify, ThenRUP::Yes, hints::Disjunctive{owner}}, reason_over(reason_vars));
-                            }
+                                    auto one_too_far = std::holds_alternative<disjunctive_proof_mutation::EdgeFindingOneTooFar>(mutation);
+                                    auto justify = edge_finding_justification(a, b, inside, j.task, low_guard, high_guard, starts_inside);
+                                    if (starts_inside)
+                                        inference.infer_greater_than_or_equal(logger, starts[j.task], one_too_far ? high_guard + 1_i : high_guard,
+                                            JustifyExplicitly{justify, ThenRUP::Yes, hints::Disjunctive{owner}}, reason_over(reason_vars));
+                                    else
+                                        inference.infer_less_than(logger, starts[j.task], one_too_far ? low_guard - 1_i : low_guard,
+                                            JustifyExplicitly{justify, ThenRUP::Yes, hints::Disjunctive{owner}}, reason_over(reason_vars));
+                                }
+
+                            // Not-first / not-last. Edge-finding asks how far a
+                            // task can be pushed and answers with a closed form;
+                            // this asks a different question --- can j start
+                            // before every task the window contains has
+                            // finished, or end after every one of them has
+                            // started --- and takes its thresholds from the
+                            // contained set rather than from the leftover
+                            // energy.
+                            //
+                            // Where j has one end inside the window the two
+                            // overlap, and edge-finding's threshold is the
+                            // furthest an energy argument over this window can
+                            // reach, so its push subsumes this one and the
+                            // live-bound tests below drop the duplicate. What is
+                            // new is a j that SPANS the window, which
+                            // edge-finding skips: its guaranteed energy is a
+                            // hump in its start rather than monotone, and
+                            // restricting the start to one side of a threshold
+                            // is exactly what makes the hump's minimum say
+                            // something.
+                            if (rules.not_first_not_last)
+                                for (const auto & j : candidates) {
+                                    if (j.est >= a && j.lct <= b)
+                                        continue;
+
+                                    auto p_j = j.duration;
+                                    auto [s_lo, s_hi] = state.bounds(starts[j.task]);
+                                    auto one_too_far = std::holds_alternative<disjunctive_proof_mutation::EdgeFindingOneTooFar>(mutation);
+
+                                    // Not-first: refute "j starts before every
+                                    // contained task has ended". The guarded
+                                    // row's low guard is what the reason
+                                    // discharges and its high guard is the
+                                    // threshold, which is the negated
+                                    // conclusion.
+                                    //
+                                    // Any low guard at or past the window's
+                                    // start discharges every survivor the ladder
+                                    // has, so where j's own lower bound is
+                                    // inside the window the window's start does
+                                    // just as well --- and it is a fact about
+                                    // the window rather than about the search,
+                                    // so the row it derives is shared with
+                                    // edge-finding's rather than keyed on a
+                                    // bound that moves.
+                                    if (rules.not_first && min_ect > s_lo) {
+                                        auto low_guard = min(s_lo, a);
+                                        auto clipped = window_energy::window_energy_bound(
+                                            p_j, a, static_cast<size_t>((b - a).raw_value), a, b, pair{low_guard, min_ect - 1_i});
+                                        if (clipped > 0_i && energy + clipped > b - a) {
+                                            auto justify = edge_finding_justification(a, b, inside, j.task, low_guard, min_ect, true, "not-first");
+                                            inference.infer_greater_than_or_equal(logger, starts[j.task], one_too_far ? min_ect + 1_i : min_ect,
+                                                JustifyExplicitly{justify, ThenRUP::Yes, hints::Disjunctive{owner}}, reason_over(reason_vars));
+                                        }
+                                    }
+
+                                    // Not-last: the mirror. Refute "j ends after
+                                    // every contained task has started", so the
+                                    // negated conclusion lands on the low guard
+                                    // and j's own upper bound is what the reason
+                                    // discharges --- which, unlike not-first's,
+                                    // is a bound that moves, so this row is the
+                                    // one place the rule cannot share a key with
+                                    // edge-finding.
+                                    if (rules.not_last && max_lst - p_j < s_hi) {
+                                        auto low_guard = max_lst - p_j + 1_i;
+                                        auto clipped = window_energy::window_energy_bound(
+                                            p_j, a, static_cast<size_t>((b - a).raw_value), a, b, pair{low_guard, s_hi});
+                                        if (clipped > 0_i && energy + clipped > b - a) {
+                                            auto justify = edge_finding_justification(a, b, inside, j.task, low_guard, s_hi + 1_i, false, "not-last");
+                                            inference.infer_less_than(logger, starts[j.task], one_too_far ? low_guard - 1_i : low_guard,
+                                                JustifyExplicitly{justify, ThenRUP::Yes, hints::Disjunctive{owner}}, reason_over(reason_vars));
+                                        }
+                                    }
+                                }
                         }
                     }
                 }

--- a/gcs/constraints/disjunctive/disjunctive.hh
+++ b/gcs/constraints/disjunctive/disjunctive.hh
@@ -112,6 +112,32 @@ namespace gcs
         bool edge_finding_lb = true;
         bool edge_finding_ub = true;
 
+        /// Not-first / not-last: for a window `[a, b)` and the set Theta it
+        /// contains, a task `j` that cannot start before every task in Theta has
+        /// ended is pushed up to `min_{i} ect_i`, and one that cannot end after
+        /// every task in Theta has started is pushed down to
+        /// `max_{i} lst_i - p_j`. Both directions, and the capacity-one case of
+        /// what CumulativeRules::not_first_not_last does.
+        ///
+        /// The certificate is \ref edge_finding's, unchanged: a different
+        /// threshold and a different guard carrying the negated conclusion, both
+        /// already parameters of the guarded window-energy lemma. What is new is
+        /// the *firing set* --- edge-finding's closed form needs a task with one
+        /// end inside the window, and this rule is what a task **spanning** the
+        /// window gets instead.
+        ///
+        /// Shares edge-finding's sweep, so turning this on turns that sweep on
+        /// whether or not \ref edge_finding is set. Off by default for the same
+        /// reason, and because it is measurably not worth running: see
+        /// `dev_docs/disjunctive-proof-logging.md`.
+        bool not_first_not_last = false;
+
+        /// The two halves of \ref not_first_not_last, separately switchable, as
+        /// \ref edge_finding_lb and \ref edge_finding_ub are: not-first raises a
+        /// lower bound and not-last lowers an upper bound.
+        bool not_first = true;
+        bool not_last = true;
+
         /// Refuse an overload conflict whose smallest window holds more than
         /// this many tasks; zero, the default, takes every conflict. Measured
         /// on generated RCPSP (#730), every cap closes fewer instances *and*
@@ -228,11 +254,11 @@ namespace gcs
      * by another. On top of that, <em>detectable precedences</em> order the
      * pairs whose ordering the bounds already force &mdash; which needs no
      * mandatory part on either task, so it prunes where time-tabling cannot.
-     * An <em>overload check</em> and <em>edge-finding</em> reason about the
-     * energy of a whole set of tasks in a window; both are off by default,
-     * since each costs a sweep that a solve never firing them still pays.
-     * Not-first / not-last is left for future work (#752), as is the set-based
-     * form of detectable precedences (#754).
+     * An <em>overload check</em>, <em>edge-finding</em> and
+     * <em>not-first / not-last</em> reason about the energy of a whole set of
+     * tasks in a window; all three are off by default, since each costs a sweep
+     * that a solve never firing them still pays. The set-based form of
+     * detectable precedences is left for future work (#754).
      *
      * A task whose presence is still undecided is left out of the profile and
      * out of every push, in either role: it blocks nothing, and nothing is

--- a/gcs/constraints/disjunctive/disjunctive_nfnl_test.cc
+++ b/gcs/constraints/disjunctive/disjunctive_nfnl_test.cc
@@ -12,13 +12,13 @@
  * before adding a fixture (`dev_docs/disjunctive-proof-logging.md` has the
  * measurement behind them):
  *
- *  - **Where the rule adds a push, that push is never tight.** Searching
- *    800,000 random unary instances found no firing whose target was the bound
- *    enumeration gives unless time-tabling or detectable precedences already
- *    reached it. So a fixture the rule is load-bearing on cannot also be one
- *    where one-past-the-conclusion is false, and the `tight_nf` / `tight_nl`
- *    fixtures below --- which do land exactly on the enumerated bound --- have
- *    the pairwise rules turned off to get there.
+ *  - **Where the rule adds a push, that push is never tight.** Of 800,000 random
+ *    unary instances, 615,263 survive time-tabling and detectable precedences;
+ *    those carry 35,189 firings that push past them, and **not one** has a
+ *    target equal to the bound enumeration gives. So a fixture the rule is
+ *    load-bearing on cannot also be one where one-past-the-conclusion is false,
+ *    and the `tight_nf` / `tight_nl` fixtures below --- which do land exactly on
+ *    the enumerated bound --- have the pairwise rules turned off to get there.
  *  - **At one contained task the push is exactly a detectable precedence's**,
  *    to that task's earliest end, under a weaker detection condition. That is
  *    where the tight pushes are, which is the same fact from the other side.

--- a/gcs/constraints/disjunctive/disjunctive_nfnl_test.cc
+++ b/gcs/constraints/disjunctive/disjunctive_nfnl_test.cc
@@ -1,0 +1,406 @@
+/* Not-first / not-last for Disjunctive, and its certificate.
+ *
+ * The certificate is edge-finding's, with a different threshold and the negated
+ * conclusion on the other guard, so this test's job is the *firing set* rather
+ * than the derivation: a task with one end inside a window is edge-finding's,
+ * and what this rule is for is a task that SPANS the window, whose guaranteed
+ * energy inside it is a hump in its start rather than monotone. Both fixtures
+ * below push a spanning task, `sharp` upwards and `mirror` downwards, and each
+ * comes with a control that has the rule off.
+ *
+ * Two things about this rule shape what can be tested and are worth knowing
+ * before adding a fixture (`dev_docs/disjunctive-proof-logging.md` has the
+ * measurement behind them):
+ *
+ *  - **Where the rule adds a push, that push is never tight.** Searching
+ *    800,000 random unary instances found no firing whose target was the bound
+ *    enumeration gives unless time-tabling or detectable precedences already
+ *    reached it. So a fixture the rule is load-bearing on cannot also be one
+ *    where one-past-the-conclusion is false, and the `tight_nf` / `tight_nl`
+ *    fixtures below --- which do land exactly on the enumerated bound --- have
+ *    the pairwise rules turned off to get there.
+ *  - **At one contained task the push is exactly a detectable precedence's**,
+ *    to that task's earliest end, under a weaker detection condition. That is
+ *    where the tight pushes are, which is the same fact from the other side.
+ *
+ * Both are why the mutation lanes run on a *generated* instance rather than on
+ * any fixture here: see the comment on `mutating` below.
+ *
+ * `--search` generates random unary instances, verifies a proof per instance,
+ * and checks the rule removes no solutions.
+ */
+
+#include <gcs/constraints/disjunctive.hh>
+#include <gcs/constraints/innards/constraints_test_utils.hh>
+#include <gcs/problem.hh>
+#include <gcs/solve.hh>
+
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <optional>
+#include <random>
+#include <string>
+#include <utility>
+#include <variant>
+#include <vector>
+#include <version>
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+#include <print>
+#else
+#include <fmt/core.h>
+#include <fmt/ostream.h>
+#endif
+
+using std::cerr;
+using std::make_optional;
+using std::mt19937;
+using std::nullopt;
+using std::optional;
+using std::pair;
+using std::string;
+using std::to_string;
+using std::uniform_int_distribution;
+using std::vector;
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+using std::println;
+#else
+using fmt::println;
+#endif
+
+using namespace gcs;
+using namespace gcs::innards;
+
+namespace
+{
+    struct Instance
+    {
+        vector<pair<int, int>> start_ranges;
+        vector<int> lengths;
+    };
+
+    auto fail(const string & message) -> void
+    {
+        println(cerr, "disjunctive_nfnl_test: {}", message);
+        exit(EXIT_FAILURE);
+    }
+
+    auto post(Problem & p, const Instance & inst, DisjunctiveRules rules, DisjunctiveProofMutation mutation) -> vector<IntegerVariableID>
+    {
+        vector<IntegerVariableID> starts;
+        vector<Integer> lengths;
+        for (const auto & [lo, hi] : inst.start_ranges)
+            starts.push_back(p.create_integer_variable(Integer{lo}, Integer{hi}));
+        for (auto l : inst.lengths)
+            lengths.push_back(Integer{l});
+        p.post(Disjunctive{starts, lengths}.with_rules(rules).with_proof_mutation(mutation));
+        return starts;
+    }
+
+    /// What root propagation alone came to. As for edge-finding, what a control
+    /// has to compare is the *bound*: an instance the rule prunes is usually
+    /// still satisfiable, and comparing satisfiability would compare nothing.
+    struct Probe
+    {
+        vector<pair<int, int>> root_bounds;
+        int markers = 0;
+        int solutions = 0;
+    };
+
+    auto count_markers(const string & basename, const string & marker) -> int
+    {
+        std::ifstream f{basename + ".pbp"};
+        string line;
+        auto count = 0;
+        while (getline(f, line))
+            if (line.find(marker) != string::npos)
+                ++count;
+        return count;
+    }
+
+    auto probe(const Instance & inst, DisjunctiveRules rules, const optional<string> & proof_name,
+        DisjunctiveProofMutation mutation = disjunctive_proof_mutation::None{}, bool enumerate = false, const string & marker = "disjunctive not-")
+        -> Probe
+    {
+        Problem p;
+        auto starts = post(p, inst, rules, mutation);
+        Probe result;
+        auto reached_a_node = false;
+        solve_with(p,
+            SolveCallbacks{.solution = [&](const CurrentState &) -> bool {
+                               ++result.solutions;
+                               return enumerate;
+                           },
+                .trace = [&](const CurrentState & s) -> bool {
+                    if (! reached_a_node) {
+                        reached_a_node = true;
+                        // The first node is the root, after propagation to a
+                        // fixpoint: what the rule inferred without searching.
+                        for (const auto & v : starts)
+                            result.root_bounds.emplace_back(
+                                static_cast<int>(s.lower_bound(v).raw_value), static_cast<int>(s.upper_bound(v).raw_value));
+                    }
+                    return enumerate;
+                }},
+            proof_name ? make_optional<ProofOptions>(ProofFileNames{*proof_name}) : nullopt);
+        if (proof_name)
+            result.markers = count_markers(*proof_name, marker);
+        return result;
+    }
+
+    const DisjunctiveRules with_nfnl{.not_first_not_last = true};
+    const DisjunctiveRules without_nfnl{};
+
+    /// The tight fixtures' rules. Time-tabling and detectable precedences are off
+    /// because a tight firing is a single-task window, and a single-task window's
+    /// push is exactly where a detectable precedence pushes: with those rules on
+    /// the sweep never sees the bound left to move. Nothing about the certificate
+    /// depends on them --- the mandatory-overlap check that makes the propagator
+    /// a *checker* is unconditional, so the solutions are still checked.
+    const DisjunctiveRules tight_rules{.time_table = false, .detectable_precedences = false, .not_first_not_last = true};
+
+    /// Random unary instances with enough slack to be satisfiable and enough
+    /// pressure for the rule to have something to say --- the same generator
+    /// edge-finding's test uses, so the two rules are measured on one family.
+    auto generate(mt19937 & rnd, int n) -> Instance
+    {
+        Instance inst;
+        uniform_int_distribution<int> dur{1, 4}, slack{0, 6};
+        auto total = 0;
+        for (auto i = 0; i < n; ++i) {
+            auto l = dur(rnd);
+            inst.lengths.push_back(l);
+            total += l;
+        }
+        for (auto i = 0; i < n; ++i) {
+            auto lo = uniform_int_distribution<int>{0, total / 2}(rnd);
+            inst.start_ranges.emplace_back(lo, lo + inst.lengths[i] + slack(rnd));
+        }
+        return inst;
+    }
+}
+
+auto main(int argc, char * argv[]) -> int
+{
+    auto proofs = gcs::test_innards::can_run_veripb();
+
+    // Window [5, 8), three wide, with Theta = {1, 2} carrying two units, which
+    // fits. Task 0 starts at 3 and ends at 13 at the latest, so it spans the
+    // window: edge-finding's closed form does not apply to it and its sweep skips
+    // it. If task 0 started before ect(Theta) = 6 the guarded row over the window
+    // carries two of its units, and two plus two does not fit in three --- so its
+    // lower bound rises to 6.
+    //
+    // The sweep then runs again over the moved bound and fires a second time,
+    // now on the window [6, 8) with Theta = {2}, taking the bound to 7. So the
+    // fixture is worth two markers and lands at 7: the first firing is the one
+    // this rule exists for, and the second is what the first unlocked.
+    //
+    // No task has a mandatory part (every latest start is at or past its
+    // earliest end) and every earliest end is at or before every latest start,
+    // which at capacity one is exactly "no detectable precedence": so
+    // time-tabling and detectable precedences are both silent, and the control
+    // says so.
+    const Instance sharp{{{3, 9}, {5, 7}, {6, 7}}, {4, 1, 1}};
+
+    // The mirror, about the window [8, 10): two unit tasks fill it exactly, and
+    // task 0 spans it. If task 0 ended after max lst(Theta) = 9 the row carries
+    // one of its units, and two plus one does not fit in two --- so its upper
+    // bound drops to 6.
+    const Instance mirror{{{2, 9}, {8, 9}, {8, 9}}, {3, 1, 1}};
+
+    // A single unit of slack in the window and the rule has nothing to say, so
+    // neither fixture above is firing on a technicality.
+    const Instance loose{{{3, 9}, {5, 8}, {6, 7}}, {4, 1, 1}};
+
+    // The two tight fixtures: `tight_nf` pushes task 0's lower bound to 11 and
+    // `tight_nl` task 0's upper bound to 4, and in each case that is the bound
+    // enumeration gives, so the rule is not merely sound here but exact. Both
+    // windows hold one task, which is where the exact pushes are --- and is why
+    // the pairwise rules have to be off for the rule to be the one making them.
+    const Instance tight_nf{{{8, 13}, {9, 10}, {8, 15}}, {4, 2, 2}};
+    const Instance tight_nl{{{0, 6}, {8, 8}, {9, 13}}, {4, 1, 4}};
+
+    // The mutation fixture, and it is a generated instance rather than a
+    // hand-built one on purpose. On every fixture above at least one route
+    // corruption still verifies: the fixtures are small enough that the closing
+    // RUP finishes the job from whatever the corrupted derivation left behind,
+    // which is sound and VeriPB is right to accept. Scanning generated instances
+    // for one where all five lanes are rejected found this in a few hundred
+    // tries --- 222 instances fired the rule at all, and one rejected every
+    // lane. The two most fragile are `drop_contained` (35 of 222) and
+    // `drop_pushed` (20), and the reason is this rule's own: its thresholds are
+    // `min ect` and `max lst`, quantities pairwise reasoning can often reach on
+    // its own, where edge-finding's `a + p(Theta)` is not.
+    const Instance mutating{{{0, 4}, {3, 10}, {2, 10}, {1, 9}, {2, 8}, {4, 10}}, {3, 2, 3, 3, 2, 1}};
+
+    // Mutation mode: emit one deliberately corrupted proof and stop, for
+    // run_test_and_expect_verify_failure.bash to hand to veripb.
+    {
+        optional<DisjunctiveProofMutation> mutation;
+        string proof_basename = "disjunctive_nfnl_mutation";
+        for (auto a = 1; a < argc; ++a) {
+            string arg = argv[a];
+            if (arg == "--mutate=emit_nothing")
+                mutation = disjunctive_proof_mutation::EdgeFindingEmitNothing{};
+            else if (arg == "--mutate=skip_fold")
+                mutation = disjunctive_proof_mutation::SkipEdgeFindingFold{};
+            else if (arg == "--mutate=drop_contained")
+                mutation = disjunctive_proof_mutation::DropContainedEnergy{};
+            else if (arg == "--mutate=one_too_far")
+                mutation = disjunctive_proof_mutation::EdgeFindingOneTooFar{};
+            else if (arg == "--mutate=drop_pushed")
+                mutation = disjunctive_proof_mutation::DropPushedEnergy{};
+            else if (arg == "--proof-files-basename" && a + 1 < argc)
+                proof_basename = argv[++a];
+        }
+
+        if (mutation) {
+            auto result = probe(mutating, with_nfnl, make_optional(proof_basename), *mutation);
+            if (result.markers == 0)
+                fail("mutation mode: no not-first push was justified, so the proof is empty");
+            println(cerr, "wrote a deliberately corrupted proof to {}.pbp", proof_basename);
+            return EXIT_SUCCESS;
+        }
+    }
+
+    // --search: generated instances, a proof verified per instance, and a
+    // solution count against the rule off.
+    if (argc > 1 && string{argv[1]} == "--search") {
+        auto seed = argc > 2 ? static_cast<unsigned>(std::stoul(argv[2])) : 0u;
+        mt19937 rnd{seed};
+        auto fired = 0, checked = 0;
+        for (auto attempt = 0; attempt < 60; ++attempt) {
+            auto inst = generate(rnd, 4 + static_cast<int>(attempt % 3));
+            auto name = "disjunctive_nfnl_gen_" + to_string(attempt);
+            auto on = probe(inst, with_nfnl, proofs ? make_optional(name) : nullopt, disjunctive_proof_mutation::None{}, true);
+            auto off = probe(inst, without_nfnl, nullopt, disjunctive_proof_mutation::None{}, true);
+            if (on.solutions != off.solutions)
+                fail("generated instance " + to_string(attempt) + ": " + to_string(on.solutions) + " solutions with the rule on against " +
+                    to_string(off.solutions) + " with it off");
+            if (proofs) {
+                ++checked;
+                if (on.markers > 0)
+                    ++fired;
+                if (! gcs::test_innards::run_veripb(name + ".opb", name + ".pbp"))
+                    fail("generated instance " + to_string(attempt) + ": veripb rejected the proof");
+            }
+        }
+        println(cerr, "checked {} generated proofs, {} of them carrying a not-first / not-last push", checked, fired);
+        if (proofs && fired == 0)
+            fail("--search: no generated instance fired the rule, so nothing was tested");
+        return EXIT_SUCCESS;
+    }
+
+    // The lb push, on a spanning task, and --- the half that makes the fixture
+    // worth having --- that nothing else makes it.
+    {
+        auto on = probe(sharp, with_nfnl, proofs ? make_optional("disjunctive_nfnl_sharp") : nullopt);
+        if (on.root_bounds.at(0).first != 7)
+            fail("sharp: expected the pushed task's lower bound at 7, got " + to_string(on.root_bounds.at(0).first));
+        if (proofs && on.markers != 2)
+            fail("sharp: expected exactly two not-first markers, got " + to_string(on.markers));
+        if (proofs && ! gcs::test_innards::run_veripb("disjunctive_nfnl_sharp.opb", "disjunctive_nfnl_sharp.pbp"))
+            fail("sharp: veripb rejected the certificate");
+
+        auto off = probe(sharp, without_nfnl, nullopt);
+        if (off.root_bounds.at(0).first >= 6)
+            fail("sharp: the bound moved with the rule off, so the fixture says nothing about the rule");
+    }
+
+    // The ub push, which is the same certificate with the negated conclusion on
+    // the other guard --- and the one a test that measured only not-first would
+    // miss.
+    {
+        auto on = probe(mirror, with_nfnl, proofs ? make_optional("disjunctive_nfnl_mirror") : nullopt);
+        if (on.root_bounds.at(0).second != 6)
+            fail("mirror: expected the pushed task's upper bound at 6, got " + to_string(on.root_bounds.at(0).second));
+        if (proofs && on.markers != 1)
+            fail("mirror: expected exactly one not-last marker, got " + to_string(on.markers));
+        if (proofs && ! gcs::test_innards::run_veripb("disjunctive_nfnl_mirror.opb", "disjunctive_nfnl_mirror.pbp"))
+            fail("mirror: veripb rejected the certificate");
+
+        auto off = probe(mirror, without_nfnl, nullopt);
+        if (off.root_bounds.at(0).second <= 6)
+            fail("mirror: the bound moved with the rule off, so the fixture says nothing about the rule");
+    }
+
+    // Each half is what makes its own fixture's push, and neither makes the
+    // other's. A symmetric rule measured in one direction only is the mistake
+    // this exists to prevent.
+    {
+        DisjunctiveRules first_only{.not_first_not_last = true};
+        first_only.not_last = false;
+        DisjunctiveRules last_only{.not_first_not_last = true};
+        last_only.not_first = false;
+
+        if (probe(sharp, first_only, nullopt).root_bounds.at(0).first != 7)
+            fail("not-first alone did not make the sharp fixture's push");
+        if (probe(sharp, last_only, nullopt).root_bounds.at(0).first == 7)
+            fail("not-last made the sharp fixture's push, so the halves are not what they say");
+        if (probe(mirror, last_only, nullopt).root_bounds.at(0).second != 6)
+            fail("not-last alone did not make the mirror fixture's push");
+        if (probe(mirror, first_only, nullopt).root_bounds.at(0).second == 6)
+            fail("not-first made the mirror fixture's push, so the halves are not what they say");
+    }
+
+    // The margin of one: a single unit more room in the window and there is
+    // nothing to claim.
+    {
+        auto result = probe(loose, with_nfnl, proofs ? make_optional("disjunctive_nfnl_loose") : nullopt);
+        if (proofs && result.markers != 0)
+            fail("loose: a push was claimed where the work fits");
+        if (proofs && ! gcs::test_innards::run_veripb("disjunctive_nfnl_loose.opb", "disjunctive_nfnl_loose.pbp"))
+            fail("loose: veripb rejected the proof");
+    }
+
+    // The two tight fixtures: the push lands exactly where enumeration says the
+    // bound is. Everywhere the rule is load-bearing it is loose, so this is the
+    // only place its conclusion can be checked against the truth rather than
+    // only against being sound.
+    {
+        auto nf = probe(tight_nf, tight_rules, proofs ? make_optional("disjunctive_nfnl_tight_nf") : nullopt);
+        if (nf.root_bounds.at(0).first != 11)
+            fail("tight_nf: expected the pushed task's lower bound at 11, got " + to_string(nf.root_bounds.at(0).first));
+        if (proofs && ! gcs::test_innards::run_veripb("disjunctive_nfnl_tight_nf.opb", "disjunctive_nfnl_tight_nf.pbp"))
+            fail("tight_nf: veripb rejected the certificate");
+
+        auto nl = probe(tight_nl, tight_rules, proofs ? make_optional("disjunctive_nfnl_tight_nl") : nullopt);
+        if (nl.root_bounds.at(0).second != 4)
+            fail("tight_nl: expected the pushed task's upper bound at 4, got " + to_string(nl.root_bounds.at(0).second));
+        if (proofs && ! gcs::test_innards::run_veripb("disjunctive_nfnl_tight_nl.opb", "disjunctive_nfnl_tight_nl.pbp"))
+            fail("tight_nl: veripb rejected the certificate");
+    }
+
+    // Both vocabulary placements certify the same push: they differ only in
+    // whether the flags and the guarded rows outlive the firing that made them.
+    if (proofs)
+        for (auto at : {ProofLevel::Top, ProofLevel::Temporary}) {
+            DisjunctiveRules rules{.not_first_not_last = true};
+            rules.overload_vocabulary_at = at;
+            auto name = string{"disjunctive_nfnl_"} + (at == ProofLevel::Top ? "top" : "temporary");
+            auto result = probe(sharp, rules, make_optional(name));
+            if (result.root_bounds.at(0).first != 7)
+                fail(name + ": the push did not land");
+            if (! gcs::test_innards::run_veripb(name + ".opb", name + ".pbp"))
+                fail(name + ": veripb rejected the certificate");
+        }
+
+    // Alongside edge-finding and the overload check, which share every piece of
+    // the vocabulary with it and reach the guarded rows at different guards.
+    // Running all three is what would catch a cache keyed on too little.
+    if (proofs) {
+        DisjunctiveRules rules{.not_first_not_last = true};
+        rules.edge_finding = true;
+        rules.overload = true;
+        auto result = probe(sharp, rules, make_optional("disjunctive_nfnl_with_everything"));
+        if (result.root_bounds.at(0).first < 7)
+            fail("with_everything: the push did not land");
+        if (! gcs::test_innards::run_veripb("disjunctive_nfnl_with_everything.opb", "disjunctive_nfnl_with_everything.pbp"))
+            fail("with_everything: veripb rejected the certificate");
+    }
+
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Closes #752. **Stacked on #756** — the base is `disjunctive-edge-finding`, so review that first.

## It is edge-finding's certificate, unchanged

That was the prediction in #752, and it held exactly. `edge_finding_justification` already took the pushed task's two guards and a flag saying which one the reason discharges, so the only new code is the thresholds and the firing set. **The first generated proof verified**, and the five mutation lanes are edge-finding's own with nothing added — which makes "the same certificate" a fact about the code rather than a claim about it.

Not-first puts the negated conclusion on the high guard at `min ect` and lets the reason discharge the low one; not-last mirrors it, with the negated conclusion on the low guard at `max lst − p_j + 1` and `ub(s_j) + 1` as the high one — the one row keyed on a bound that moves, and the comment says so.

## What is new is the firing set

Edge-finding's sweep carries one `continue`:

```cpp
// Neither end inside: the task spans the window, and no closed form
// pushes it. That is not-first / not-last's firing set, and this
// `continue` is the whole of it.
if (starts_inside == (j.lct <= b))
    continue;
```

A task with neither end inside spans the window, its guaranteed energy inside is a hump in its start rather than monotone, and no closed form pushes it. Restricting the start to one side of a threshold is what makes a hump's minimum say something. So the rule **shares** the sweep rather than adding one, and turning it on turns that sweep on whether or not edge-finding is set.

Both halves are separately switchable, as edge-finding's are.

## What it is worth: it fires everywhere and buys nothing

Same 68 generated instances and same 60 s timeout as #756's table, so the two read together. Edge-finding's row reproduces #751 exactly — same 36 of 68 in the common set, same three ratios — which is the check that the measurements are comparable and that this changed nothing about that one.

| arm | against | summed | median | geomean | better | closed |
|---|---|---|---|---|---|---|
| off | — | 1.000x | 1.000x | 1.000x | — | 41/68 |
| not-first only | off | 0.893x | 0.884x | 0.760x | 34/36 | 41/68 |
| not-last only | off | 0.712x | 0.796x | 0.644x | 33/36 | 41/68 |
| **both** | off | **0.676x** | **0.668x** | **0.536x** | 36/36 | 42/68 |
| edge-finding | off | 0.169x | 0.127x | 0.099x | 36/36 | 46/68 |
| **edge-finding + both** | **edge-finding** | **1.024x** | **1.000x** | **1.001x** | **1/36** | **46/68** |

On its own the rule is worth two thirds of the search, better on 36 of 36, and closes one more instance. Both halves pay, not-last the stronger — the same direction edge-finding's asymmetry runs on this family.

**On top of edge-finding it is worth nothing.** Median exactly 1.000x, better on 1 of 36. It changes the search on 4 of the 36: two by a handful of recursions either way, two *for the worse*, by 0.7% and 4.7%. That last one is the whole of the 1.024x summed figure — it carries 37% of the summed recursions, and dropping it takes the summed ratio to 1.000x. Neither arm closes a different set of instances.

Not for want of firing: **propagation counts differ on 57 of the 68**, so it fires nearly everywhere and reaches the same fixpoint by a different route. Every bound it moves is one edge-finding was going to move.

Sharper than the cumulative side's 0.997x, and the same verdict: certifiable for nothing, worth nothing once the stronger rule is on. Off by default. A rung that is free to certify and measurably not worth running is a better table row than a gap, which is why it is here.

All six arms proved the same optimum on every instance more than one closed.

## The weakening was measured, not inherited silently

#752 said not to take #746's weakening on trust. Measured per (window, task) pair over 30,000 random instances: **ours fires 3,073 times against the published unary rule's 4,218, and every one of ours is also one of theirs** — a strict subset, where #746 found firings on both sides.

The arithmetic says why, and it is the trap that cost the most time here: **`window_energy_bound` is not the minimum overlap.** It is `kept_u − lost_v` — the guarded row states one bound uniformly over the whole negation range from two guard literals, keeping the survivors the low guard decides and conceding a unit for every one the high guard does not. Two worst cases that need not coincide, and not-first's range straddles the hump.

Filed as **#757**, *with a route*, which is what #746 does not have: the published argument is an overload check over a window whose left edge is **derived from the negated conclusion**, and #734's dichotomy supplies the two-literal clause that discharges each contained row's low guard. **That certificate is already machine-checked** (`~/claude/tmp/disj-derived-757/`): exit 0, every row on its predicted shape, seven mutation lanes rejected. This PR does not implement it.

`cumulative-proof-logging.md` gains a paragraph beside #746's open question saying so, since the shape of the answer transfers even if the pairwise clause does not.

## Testing, and why the fixtures look odd

`disjunctive_nfnl_test`, five mutation lanes, and a `--search` lane verifying a proof per generated instance (56 of 60 carry a push). Two facts about the rule shape what a fixture can be:

- **Where it adds a push, that push is never tight.** Of 800,000 random unary instances, 615,263 survive time-tabling and detectable precedences; those carry 35,189 firings past them, and **not one** lands on the enumerated bound.
- **At one contained task the push is exactly a detectable precedence's**, to that task's earliest end, under a weaker detection condition — so the exact firings are ones the pairwise rule already makes.

So no fixture is both load-bearing and exact: `sharp` and `mirror` push a spanning task where nothing else does and their controls say so; `tight_nf` and `tight_nl` land on the enumerated bound with the pairwise rules turned off. And the mutation lanes run on a **generated** instance — on every hand-built fixture at least one route corruption still verifies, soundly. Scanning found 222 instances that fired the rule and exactly one that rejected all five lanes; `drop_contained` (35 of 222) and `drop_pushed` (20) are the fragile ones, because `min ect` and `max lst` are quantities pairwise reasoning can often reach by itself where `a + p(Θ)` is not.

## Checks

- All 49 `disjunctive` ctest lanes pass, with `GCS_TEST_CAP_DEFAULTS=OFF`.
- GCC 15 with `GCS_WERROR=ON`, clean.
- clang 21.1.8: the three changed C++ files compile clean with `-Werror`. Two *pre-existing* clang errors elsewhere had to be suppressed to get that far (`variable_weighting.hh` inconsistent-missing-override, `element.cc` unused-lambda-capture) — both in files this branch does not touch, both present on `main`, so the local clang is now stricter than CI's. Worth a separate look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MM5qG1q7rGspQPUz5G7454
