### PR TITLE
disjunctive: price the published not-first / not-last detection, and decline it (#757)

### DIFF
--- a/dev_docs/disjunctive-proof-logging.md
+++ b/dev_docs/disjunctive-proof-logging.md
@@ -642,6 +642,87 @@ gap, which is the whole reason it is here.
 Across every instance more than one arm closed, all six arms proved the same
 optimum — the check no proof lane can make.
 
+### The published detection, and what it is worth: 37% more firings, 0.6% less search (#757)
+
+What the section above certifies is a **strict weakening** of the rule as
+published (Baptiste, Le Pape and Nuijten; Vilím's Θ-tree presentation).
+The published conditions do not ask about the enumerated window at all:
+
+```
+p(Θ) > lct(Θ) − ect_j            not-first
+p(Θ) > ub(s_j) − est(Θ)          not-last
+```
+
+Under the negated conclusion `s_j < min ect(Θ)`, every `i ∈ Θ` has
+`s_j < ect_i`, so `j` cannot be *after* `i`, so `j` is *before* it — and
+then all of `Θ` has to fit in `[ect_j, lct(Θ))`, a **narrower** window
+than `[a, b)`, whose left edge the negated conclusion *derives* rather
+than the reason carrying it. `DisjunctiveRules::not_first_not_last_published`
+is that detection, over the same sweep, the same contained sets and the
+same thresholds — the condition is the only thing that differs, which is
+what makes the two comparable.
+
+**Ours is a subset of it, and not by luck.** The window-energy figure
+over `[a, b)` at `s_j = lb(s_j)` is at most `ect_j − a`, so
+`p(Θ) + clipped > b − a` implies `p(Θ) > b − ect_j`: every firing of ours
+is one of theirs, by arithmetic rather than by observation. Counting them
+over the same transcribed sweep, and checking every published firing
+against a full enumeration of its instance's solutions:
+
+| draw | ours | published | only ours | firings that removed a solution |
+|---|---|---|---|---|
+| 20,000 instances, 4 tasks | 44,720 | 75,806 | **0** | **0** |
+| 20,000 instances, 5 tasks | 89,039 | 143,525 | **0** | **0** |
+
+So the published condition detects **1.7×** as much. The question #757
+exists to answer is whether that is worth a certificate, and the
+certificate is not free: `[ect_j, lct(Θ))` is keyed on `j`'s own lower
+bound, so its activity flags, bridge rows, folds and guarded rows share
+with nothing the sweep already derives — #737's caching result is about
+windows the *instance* gives, and these move with the search.
+
+**It is not worth it.** The same 68 instances and the same 60 s timeout
+as the two tables above, so all three read together:
+
+| arm | against | summed | median | geomean | better | closed |
+|---|---|---|---|---|---|---|
+| nfnl | off | 0.676x | 0.668x | 0.536x | 36/36 | 42/68 |
+| **nfnl published** | **nfnl** | **0.994x** | **1.000x** | **1.002x** | 9/36 | 42/68 |
+| ef | off | 0.169x | 0.127x | 0.099x | 36/36 | 46/68 |
+| ef + nfnl | ef | 1.024x | 1.000x | 1.001x | 1/36 | 46/68 |
+| **ef + nfnl published** | **ef** | **1.026x** | **1.000x** | **1.036x** | 4/36 | 46/68 |
+
+Three of those rows reproduce the earlier tables to the digit, which is
+the check that the runs are comparable. **The 37% detection gap buys
+0.6% of the summed recursions and nothing at all at the median.** It is
+not that the stronger detection sits idle — propagation counts differ on
+**64 of 68** instances, and it changes the search on 21 of the 36 — but
+every change is small and they run both ways: the best instance goes to
+0.965x and the worst to 1.060x. On top of edge-finding it is a small
+loss, and the 1.026x is one instance at 4.05x carrying it.
+
+So the certificate is **not built**, and the switch is here as the record
+of why. It throws rather than propagating under `--prove`: a rule that
+quietly weakened itself when proof logging came on would confound exactly
+the comparison it exists to make.
+
+The result is worth more than the propagator would have been. #746 asks,
+on the cumulative side, whether certifying a weaker detection than the
+literature states costs anything real, and could not answer it. **This is
+that answer, on the encoding where the gap is cleanest**: the weakening
+is strict, it is 37% of the firings, and it is worth 0.6% of the search.
+What is certifiable here is not what the rule can detect but what
+detection is *worth* — and a rule that fires 1.7× as often reaching the
+same fixpoint is the same finding as not-first/not-last reaching
+edge-finding's fixpoint by a different route, one rung further down.
+
+It also prices #754. Set-based detectable precedences want the same
+derived-window mechanism, and their stage zero found `ect(Ω)` reaching
+past everything else running on 2.9% of nodes — a *smaller* gap than the
+one measured here to be worth nothing. That is not a reason to close
+#754, whose gap is against a different rule's fixpoint rather than a
+weaker form of its own, but it is the number to beat before building it.
+
 ## Strict-mode zero-length tasks
 
 Strict mode forbids a zero-length task from sitting strictly inside

--- a/examples/rcpsp/rcpsp.cc
+++ b/examples/rcpsp/rcpsp.cc
@@ -448,6 +448,14 @@ auto main(int argc, char * argv[]) -> int
                 "--disjunctive-not-last-only to the half that lowers an upper bound")       //
             ("disjunctive-not-last-only",
                 "See --disjunctive-not-first-only") //
+            ("disjunctive-not-first-not-last-published",
+                "Detect not-first / not-last by the published unary condition rather than by the " //
+                "guarded window-energy one: the published rule argues over a narrower window "     //
+                "whose left edge the negated conclusion derives, and fires 1.7x as often. "        //
+                "Implies --disjunctive-not-first-not-last. A measurement switch, and the "         //
+                "measurement is made: that detection is worth 0.6% of the summed recursions and "  //
+                "nothing at the median, so it is deliberately uncertified and throws rather than " //
+                "propagating under --prove (#757)")                                                //
             ("disjunctive-overload",
                 "Give every posted Disjunctive the overload check, off by default because its "   //
                 "certificate is expensive enough that whether it pays is what #730 is measuring") //
@@ -758,6 +766,10 @@ auto main(int argc, char * argv[]) -> int
     if (options_vars["disjunctive-not-last-only"].as<bool>()) {
         disjunctive_rules.not_first_not_last = true;
         disjunctive_rules.not_first = false;
+    }
+    if (options_vars["disjunctive-not-first-not-last-published"].as<bool>()) {
+        disjunctive_rules.not_first_not_last = true;
+        disjunctive_rules.not_first_not_last_published = true;
     }
     disjunctive_rules.overload = options_vars["disjunctive-overload"].as<bool>();
     disjunctive_rules.overload_max_window = options_vars["disjunctive-overload-max-window"].as<std::size_t>();

--- a/gcs/constraints/disjunctive/disjunctive.cc
+++ b/gcs/constraints/disjunctive/disjunctive.cc
@@ -1520,8 +1520,11 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
 
                         // min_ect and max_lst are not-first / not-last's
                         // thresholds, over the same growing contained set the
-                        // energy accumulates over.
-                        Integer energy = 0_i, min_ect = 0_i, max_lst = 0_i;
+                        // energy accumulates over. min_est is est(Theta), which
+                        // the published not-last condition wants and which is
+                        // not `a`: `a` is an est the sweep enumerates, and a
+                        // task holding it need not be contained.
+                        Integer energy = 0_i, min_ect = 0_i, max_lst = 0_i, min_est = 0_i;
                         vector<size_t> inside;
                         for (size_t c = 0; c < candidates.size(); ++c) {
                             if (candidates[c].est < a)
@@ -1532,6 +1535,7 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                                                          : min(min_ect, candidates[c].est + candidates[c].duration);
                             max_lst = inside.size() == 1 ? candidates[c].lct - candidates[c].duration
                                                          : max(max_lst, candidates[c].lct - candidates[c].duration);
+                            min_est = inside.size() == 1 ? candidates[c].est : min(min_est, candidates[c].est);
                             auto b = candidates[c].lct;
                             // Candidates are in lct order, so `inside` is every
                             // task the window contains only once the last of a
@@ -1636,13 +1640,32 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                                     // edge-finding's rather than keyed on a
                                     // bound that moves.
                                     if (rules.not_first && min_ect > s_lo) {
-                                        auto low_guard = min(s_lo, a);
-                                        auto clipped = window_energy::window_energy_bound(
-                                            p_j, a, static_cast<size_t>((b - a).raw_value), a, b, pair{low_guard, min_ect - 1_i});
-                                        if (clipped > 0_i && energy + clipped > b - a) {
-                                            auto justify = edge_finding_justification(a, b, inside, j.task, low_guard, min_ect, true, "not-first");
-                                            inference.infer_greater_than_or_equal(logger, starts[j.task], one_too_far ? min_ect + 1_i : min_ect,
-                                                JustifyExplicitly{justify, ThenRUP::Yes, hints::Disjunctive{owner}}, reason_over(reason_vars));
+                                        // The published detection instead, over
+                                        // the narrower window
+                                        // [ect_j, lct(Theta)): under the
+                                        // negated conclusion j is before every
+                                        // contained task, so all of Theta lies
+                                        // in it. Measurement only, hence the
+                                        // throw --- see
+                                        // DisjunctiveRules::not_first_not_last_published.
+                                        if (rules.not_first_not_last_published) {
+                                            if (logger)
+                                                throw UnimplementedException{
+                                                    "disjunctive not-first by the published condition has no certificate yet (#757)"};
+                                            if (energy > b - (s_lo + p_j))
+                                                inference.infer_greater_than_or_equal(logger, starts[j.task], one_too_far ? min_ect + 1_i : min_ect,
+                                                    JustifyUsingRUP{hints::Disjunctive{owner}}, reason_over(reason_vars));
+                                        }
+                                        else {
+                                            auto low_guard = min(s_lo, a);
+                                            auto clipped = window_energy::window_energy_bound(
+                                                p_j, a, static_cast<size_t>((b - a).raw_value), a, b, pair{low_guard, min_ect - 1_i});
+                                            if (clipped > 0_i && energy + clipped > b - a) {
+                                                auto justify =
+                                                    edge_finding_justification(a, b, inside, j.task, low_guard, min_ect, true, "not-first");
+                                                inference.infer_greater_than_or_equal(logger, starts[j.task], one_too_far ? min_ect + 1_i : min_ect,
+                                                    JustifyExplicitly{justify, ThenRUP::Yes, hints::Disjunctive{owner}}, reason_over(reason_vars));
+                                            }
                                         }
                                     }
 
@@ -1656,12 +1679,26 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                                     // edge-finding.
                                     if (rules.not_last && max_lst - p_j < s_hi) {
                                         auto low_guard = max_lst - p_j + 1_i;
-                                        auto clipped = window_energy::window_energy_bound(
-                                            p_j, a, static_cast<size_t>((b - a).raw_value), a, b, pair{low_guard, s_hi});
-                                        if (clipped > 0_i && energy + clipped > b - a) {
-                                            auto justify = edge_finding_justification(a, b, inside, j.task, low_guard, s_hi + 1_i, false, "not-last");
-                                            inference.infer_less_than(logger, starts[j.task], one_too_far ? low_guard - 1_i : low_guard,
-                                                JustifyExplicitly{justify, ThenRUP::Yes, hints::Disjunctive{owner}}, reason_over(reason_vars));
+                                        // The mirror, over [est(Theta), ub(s_j)):
+                                        // under the negated conclusion every
+                                        // contained task ends by s_j.
+                                        if (rules.not_first_not_last_published) {
+                                            if (logger)
+                                                throw UnimplementedException{
+                                                    "disjunctive not-last by the published condition has no certificate yet (#757)"};
+                                            if (energy > s_hi - min_est)
+                                                inference.infer_less_than(logger, starts[j.task], one_too_far ? low_guard - 1_i : low_guard,
+                                                    JustifyUsingRUP{hints::Disjunctive{owner}}, reason_over(reason_vars));
+                                        }
+                                        else {
+                                            auto clipped = window_energy::window_energy_bound(
+                                                p_j, a, static_cast<size_t>((b - a).raw_value), a, b, pair{low_guard, s_hi});
+                                            if (clipped > 0_i && energy + clipped > b - a) {
+                                                auto justify =
+                                                    edge_finding_justification(a, b, inside, j.task, low_guard, s_hi + 1_i, false, "not-last");
+                                                inference.infer_less_than(logger, starts[j.task], one_too_far ? low_guard - 1_i : low_guard,
+                                                    JustifyExplicitly{justify, ThenRUP::Yes, hints::Disjunctive{owner}}, reason_over(reason_vars));
+                                            }
                                         }
                                     }
                                 }

--- a/gcs/constraints/disjunctive/disjunctive.hh
+++ b/gcs/constraints/disjunctive/disjunctive.hh
@@ -130,6 +130,11 @@ namespace gcs
         /// whether or not \ref edge_finding is set. Off by default for the same
         /// reason, and because it is measurably not worth running: see
         /// `dev_docs/disjunctive-proof-logging.md`.
+        ///
+        /// The detection is a strict weakening of the rule as published, and
+        /// deliberately so --- see \ref not_first_not_last_published, which
+        /// measures what that weakening costs, and answers: 0.6% of the summed
+        /// recursions, nothing at the median.
         bool not_first_not_last = false;
 
         /// The two halves of \ref not_first_not_last, separately switchable, as
@@ -137,6 +142,45 @@ namespace gcs
         /// lower bound and not-last lowers an upper bound.
         bool not_first = true;
         bool not_last = true;
+
+        /// Detect \ref not_first_not_last by the published unary condition
+        /// rather than by the guarded window-energy one.
+        ///
+        /// #752 inherits `Cumulative`'s detection, which asks whether the
+        /// window `[a, b)` the sweep enumerates is overfilled by the contained
+        /// set plus whatever of `j` must lie in it under the negated
+        /// conclusion. The rule as published (Baptiste, Le Pape and Nuijten;
+        /// Vilim's Theta-tree presentation) argues over a *different* window
+        /// instead --- for not-first, `[ect_j, lct(Theta))`, whose left edge
+        /// the negated conclusion derives:
+        ///
+        ///     p(Theta) > lct(Theta) - ect_j          not-first
+        ///     p(Theta) > ub(s_j) - est(Theta)        not-last, the mirror
+        ///
+        /// Ours is a strict subset of that --- the window-energy figure at
+        /// `s_j = lb(s_j)` is at most `ect_j - a`, so every firing of ours is
+        /// one of these --- and measured over 30,000 random unary instances the
+        /// published condition fires 37% more often (#757).
+        ///
+        /// **Deliberately uncertified**, and it throws rather than
+        /// propagating when proof logging is on: a rule that quietly weakened
+        /// itself under `--prove` would confound the very comparison this
+        /// switch exists to make. The certificate is settled in simulation ---
+        /// it is \ref edge_finding's, with the low guard discharged by a
+        /// derived two-literal clause rather than by the reason --- and was
+        /// **not built**, because this switch is what decided that:
+        /// **37% more detection is worth 0.6% of the summed recursions and
+        /// nothing at the median**, and a little worse than nothing on top of
+        /// edge-finding. Not for want of firing --- propagation counts differ
+        /// on 64 of 68 instances. See `dev_docs/disjunctive-proof-logging.md`.
+        ///
+        /// So this exists to reproduce a measurement, in the way
+        /// \ref overload_max_window does, and not because it is expected to
+        /// pay. What it establishes is worth more than the propagator would
+        /// have been: it prices, on the encoding where the gap is cleanest,
+        /// what #746 asks and cannot answer --- how much certifying a weaker
+        /// detection than the literature states actually costs.
+        bool not_first_not_last_published = false;
 
         /// Refuse an overload conflict whose smallest window holds more than
         /// this many tasks; zero, the default, takes every conflict. Measured


### PR DESCRIPTION
Stacked on #758. Closes out #757 with a measurement rather than a propagator, which is what that issue said to do first.

## What this is

#752 (PR #758) certifies a **strict weakening** of the published unary not-first / not-last rule. #757 asked whether the pairwise encoding can certify the published detection instead. It can — over a window whose left edge the *negated conclusion* derives rather than the reason carrying it — and that certificate is settled and machine-checked in simulation (`~/claude/tmp/disj-derived-757/`, seven mutation lanes rejected). The issue's own instruction was to measure the propagation before building it, because the rule it strengthens is already off by default for not paying for its scan.

`DisjunctiveRules::not_first_not_last_published` is that detection over the same sweep, the same contained sets and the same thresholds, so the *condition* is the only thing that differs:

```
p(Θ) > lct(Θ) − ect_j            not-first
p(Θ) > ub(s_j) − est(Θ)          not-last
```

It is **deliberately uncertified** and throws rather than propagating under `--prove`. A rule that quietly weakened itself when proof logging came on would confound exactly the comparison it exists to make.

## Ours is a subset of it, by arithmetic

The window-energy figure over `[a, b)` at `s_j = lb(s_j)` is at most `ect_j − a`, so `p(Θ) + clipped > b − a` implies `p(Θ) > b − ect_j`. Every firing of ours is one of theirs — not merely observed to be, as #757 measured, but forced. Counting both over the same transcribed sweep, and checking every published firing against a full enumeration of its instance's solutions:

| draw | ours | published | only ours | firings removing a solution |
|---|---|---|---|---|
| 20,000 instances, 4 tasks | 44,720 | 75,806 | **0** | **0** |
| 20,000 instances, 5 tasks | 89,039 | 143,525 | **0** | **0** |

So the published condition detects **1.7×** as much.

## And it is worth nothing

The same 68 generated instances and the same 60 s timeout as #756's and #758's tables, so all three read together:

| arm | against | summed | median | geomean | better | closed |
|---|---|---|---|---|---|---|
| nfnl | off | 0.676x | 0.668x | 0.536x | 36/36 | 42/68 |
| **nfnl published** | **nfnl** | **0.994x** | **1.000x** | **1.002x** | 9/36 | 42/68 |
| edge-finding | off | 0.169x | 0.127x | 0.099x | 36/36 | 46/68 |
| ef + nfnl | ef | 1.024x | 1.000x | 1.001x | 1/36 | 46/68 |
| **ef + nfnl published** | **ef** | **1.026x** | **1.000x** | **1.036x** | 4/36 | 46/68 |

Three of those rows reproduce the earlier tables **to the digit**, which is the check that the runs are comparable.

**The 37% detection gap buys 0.6% of the summed recursions and nothing at the median.** Not for want of firing: propagation counts differ on **64 of 68** instances, and the search changes on 21 of the 36 — but every change is small and they run both ways, best 0.965x and worst 1.060x. On top of edge-finding it is a small loss, and the 1.026x is one instance at 4.05x carrying it.

So the certificate is **not built**, and the switch is here as the record of why.

## Why that is the better outcome

#746 asks, on the cumulative side, whether certifying a weaker detection than the literature states costs anything real, and could not answer it. **This is that answer, on the encoding where the gap is cleanest**: the weakening is strict, it is 37% of the firings, and it is worth 0.6% of the search. A rule firing 1.7× as often and reaching the same fixpoint is the same finding as not-first/not-last reaching edge-finding's fixpoint by a different route, one rung further down.

It also prices #754, which wants the same derived-window mechanism: its stage zero found `ect(Ω)` reaching past everything else running on **2.9% of nodes**, a smaller gap than the one measured here to be worth nothing. Not a reason to close it — its gap is against a different rule's fixpoint rather than a weaker form of its own — but it is the number to beat before building it.

## Also here

- `disjunctive_edge_finding_test` and `disjunctive_nfnl_test` both pass unchanged: the detection branch is an `if`/`else` around code neither of them reaches.
- `dev_docs/disjunctive-proof-logging.md` gains the section, beside not-first/not-last's own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PAZYGJdsP3dmWAepRGi5T5