### PR TITLE
disjunctive: Vilim's set-based detectable precedence, measured and certified (#754)

### DIFF
--- a/dev_docs/disjunctive-proof-logging.md
+++ b/dev_docs/disjunctive-proof-logging.md
@@ -723,6 +723,97 @@ one measured here to be worth nothing. That is not a reason to close
 #754, whose gap is against a different rule's fixpoint rather than a
 weaker form of its own, but it is the number to beat before building it.
 
+## The set-based detectable precedence, measured before it is certified (#754)
+
+#734 pushes `lb(s_j)` to `max_{k∈Ω} ect_k` over the detected
+predecessors — the latest *single* predecessor's earliest end. Vilím's
+rule pushes to the **set's** earliest completion time,
+
+```
+ect(Ω) = max_{Ω' ⊆ Ω} ( est(Ω') + p(Ω') )        lb(s_j) ← ect(Ω)
+lst(Ω) = min_{Ω' ⊆ Ω} ( lct(Ω') − p(Ω') )        ub(s_j) ← lst(Ω) − p_j
+```
+
+which is larger exactly when the predecessors **cannot all fit** before
+that point. `DisjunctiveRules::detectable_precedences_set`, off by
+default, computed by a left-cut scan rather than a Θ-tree: the maximum
+over subsets is attained at a cut, since taking every predecessor with
+`est ≥ a` never lowers `est(Ω')` below `a` and only adds duration, so
+one pass over the ests sorted descending gives it.
+
+**It is deliberately uncertified and throws under `--prove`**, and only
+when the target it takes is past what #734's pairwise justification
+supports — a target the domain clip caps is one that justification still
+covers. This is #757's discipline: a stronger rule with no certificate
+is measured before it is built, because the certificate is the expensive
+part and a detection gap need not be a search gap.
+
+### It is sound, checked against enumeration
+
+A rule that removed a solution would measure as a large win, so the
+sweep cannot make this check. Both left-cut scans were transcribed back
+out of the propagator and every push reaching past the pairwise target
+checked against a **full enumeration** of its instance's solutions:
+
+| draw | pushes | past the pairwise target | removed a solution |
+|---|---|---|---|
+| 30,000 instances, 4 tasks | 125,060 | 33,307 | **0** |
+| 20,000 instances, 5 tasks | 114,500 | 41,566 | **0** |
+| 12,000 instances, 6 tasks | 87,214 | 37,710 | **0** |
+
+### And unlike #757 it is worth building
+
+The same 68 instances and 60 s timeout as the tables above:
+
+| arm | against | summed | median | geomean | better | closed |
+|---|---|---|---|---|---|---|
+| **set-based** | pairwise | **0.547x** | **0.386x** | **0.289x** | 34/36 | **44/68** |
+| ef | pairwise | 0.169x | 0.127x | 0.099x | 36/36 | 46/68 |
+| **ef + set-based** | ef | **0.820x** | **0.941x** | **0.824x** | **23/36** | **47/68** |
+| ef + nfnl | ef | 1.024x | 1.000x | 1.001x | 1/36 | 46/68 |
+| ef + nfnl + set-based | ef + nfnl | 0.807x | 0.955x | 0.827x | 23/36 | 46/68 |
+
+`ef` and `ef + nfnl` reproduce their earlier rows to the digit.
+
+**On its own it is worth nearly half the search** and closes three more
+instances, which is a lot for a rule that adds a linear scan rather than
+edge-finding's cubic one.
+
+**On top of edge-finding it is the first rung here that adds anything.**
+Better on **23 of 36**, worse on 6, unchanged on 7, and it closes one
+more instance — including `--size 18 --seed 5`, which *no other arm
+closes at all*. Set that against not-first/not-last's 1 of 36 and the
+published detection's 4 of 36, both at a median of exactly 1.000x.
+
+Quote the median and the geomean, not the summed figure: the largest
+instance carries **52%** of the summed total by itself, and dropping it
+takes 0.820x to 0.971x. The rule's real size is 0.941x at the median
+with a long tail — the best instance goes to 0.128x.
+
+### What the certificate wants
+
+Not edge-finding's at another threshold: **#757's shape**, which is why
+that issue was measured first. Writing `Ω'` for the maximising left cut
+and `T = est(Ω') + p(Ω')`:
+
+1. Each `i ∈ Ω'` is a detected predecessor, so `before_{i,j}` follows
+   from the reason by #734's own refutation pol, giving `s_i + l_i ≤ s_j`.
+2. Under the negated conclusion `s_j ≤ T − 1` that gives
+   `s_i ≤ T − 1 − p_i`, i.e. the two-literal clause
+   `[s_j ≥ T] ∨ ¬[s_i ≥ T − p_i]` — and `T − p_i` is exactly the **high
+   guard** of `i`'s guarded window-energy row over `[est(Ω'), T − 1)`.
+3. Cite `guarded_energy(i, est(Ω'), T − 1, est(Ω'), T − p_i)` per
+   `i ∈ Ω'`; the low guard falls to the reason (`est_i ≥ est(Ω')` is what
+   a left cut means) and the high guard to step 2's clause, which leaves
+   `[s_j ≥ T]` standing at that row's coefficient; fold the per-time
+   at-most-ones over the window and sum.
+
+The window is `p(Ω') − 1` wide and `Ω'` needs `p(Ω')` of it, so the pol
+lands on `(Σ coeffs)·[s_j ≥ T] ≥ 1` and **derives** the conclusion rather
+than assuming it. The window is derived rather than enumerated, and the
+edge derived is the *right* one here where #757 derives the left — the
+same mechanism mirrored.
+
 ## Strict-mode zero-length tasks
 
 Strict mode forbids a zero-length task from sitting strictly inside

--- a/dev_docs/disjunctive-proof-logging.md
+++ b/dev_docs/disjunctive-proof-logging.md
@@ -741,12 +741,10 @@ over subsets is attained at a cut, since taking every predecessor with
 `est ≥ a` never lowers `est(Ω')` below `a` and only adds duration, so
 one pass over the ests sorted descending gives it.
 
-**It is deliberately uncertified and throws under `--prove`**, and only
-when the target it takes is past what #734's pairwise justification
-supports — a target the domain clip caps is one that justification still
-covers. This is #757's discipline: a stronger rule with no certificate
-is measured before it is built, because the certificate is the expensive
-part and a detection gap need not be a search gap.
+Measured before it was certified, which is #757's discipline: a stronger
+rule ships as a switch first, because the certificate is the expensive
+part and a detection gap need not be a search gap. Unlike #757 the answer
+came back yes, so it **is** certified — see below.
 
 ### It is sound, checked against enumeration
 
@@ -820,12 +818,25 @@ than assuming it.
 
 Simulated standalone before any C++, as #730, #751 and #757 all were:
 126 lines, veripb exit 0, every load-bearing row on its predicted shape,
-and **all seven mutation lanes rejected** (`emit_nothing`, `drop_folds`,
-`drop_omega_energy`, `over_push`, `drop_clause`, `rup_clause`,
-`rup_fold`) on a generated four-predecessor fixture. As #731, #752 and
-#757 all found, the demonstration fixture is not the one the lanes bite
-on: over two predecessors the fold is a single bridge row the closing RUP
-reconstructs, so the mutation fixture needs `|Ω'| ≥ 3`.
+and **all seven mutation lanes rejected** on a generated four-predecessor
+fixture. Then built, and `disjunctive_set_precedences_test` carries the
+same battery in the solver — six lanes (`emit_nothing`, `skip_fold`,
+`drop_energy`, `drop_clause`, `rup_clause`, `one_too_far`), all
+rejected — plus a `--search` lane that generated 60 instances, verified a
+proof for each, and found the rule firing on 51.
+
+`drop_clause` and `rup_clause` are the two aimed at what is actually new.
+The first leaves out the derived clause, so the guard is never discharged
+and the conclusion never enters the sum; the second asks whether unit
+propagation can reach that clause on its own, and it cannot — the same
+cross-variable limit `RupOverloadBridge` finds for the bridge.
+
+As #731, #752 and #757 all found, the demonstration fixture is not the
+one the lanes bite on: on `sharp` only four of the six do, because with
+two tasks in the derived window the fold is a single bridge row the
+closing RUP reconstructs. **`|Ω'| ≥ 3` is the threshold**, the same one
+the simulation found, and the mutation fixture is a generated instance
+with a cut of three.
 
 **Steps 1 and 2 are not load-bearing, and step 3 is.** Replacing the
 detection pol and the separation clause with a bare `rup b_ij ≥ 1`
@@ -840,9 +851,25 @@ two pols: it cannot cheaply tell which case it is in, and the cost is two
 lines.
 
 Unlike #757 the final division is **not** load-bearing here — the
-surplus is exactly one, so saturation alone lands on the unit clause.
-Divide anyway: a surplus of one is a property of the tight case, not of
-the rule.
+surplus is exactly one, so the propagator leaves the closing RUP to read
+the pol off, exactly as edge-finding's does.
+
+### The trap the build hit, which no sweep would have caught
+
+The first version read the bounds its arithmetic needed back out of
+`state` inside the justification, and **every generated proof above a
+handful of tasks was rejected**. By the time a justification runs, an
+earlier push in the same propagation has landed, so the state holds a
+bound the reason does not support — and a `pol` built on it is arithmetic
+about a fact nothing has established. The ub push already carried a
+comment recording exactly this for #734's own certificate.
+
+The fix is that every bound the arithmetic reads is captured at
+*detection* time and carried into the closure, which is why `SetTask`
+holds `lb` and `ub` beside the edge its cut is sorted by. Worth stating
+as a rule: **a justification may read the reason and the model, and
+nothing else.** Anything else it reads out of `state` is a bound that has
+since moved.
 
 ## Strict-mode zero-length tasks
 

--- a/dev_docs/disjunctive-proof-logging.md
+++ b/dev_docs/disjunctive-proof-logging.md
@@ -790,11 +790,17 @@ instance carries **52%** of the summed total by itself, and dropping it
 takes 0.820x to 0.971x. The rule's real size is 0.941x at the median
 with a long tail — the best instance goes to 0.128x.
 
-### What the certificate wants
+### The certificate, settled in simulation
 
-Not edge-finding's at another threshold: **#757's shape**, which is why
-that issue was measured first. Writing `Ω'` for the maximising left cut
-and `T = est(Ω') + p(Ω')`:
+Not edge-finding's at another threshold: **#757's shape, mirrored**.
+That window has its *left* edge derived from the negated conclusion;
+this one has its **right** edge derived, and is one unit too narrow for
+`Ω'` exactly when the rule fires. So the guard the reason cannot
+discharge is the **high** one rather than the low one, and everything
+else is inherited — the simulation's `SetPrecedence` subclasses #751's
+`Certificate` and adds two methods, as #757's `DerivedWindow` added one.
+
+Writing `Ω'` for the maximising left cut and `T = est(Ω') + p(Ω')`:
 
 1. Each `i ∈ Ω'` is a detected predecessor, so `before_{i,j}` follows
    from the reason by #734's own refutation pol, giving `s_i + l_i ≤ s_j`.
@@ -810,9 +816,33 @@ and `T = est(Ω') + p(Ω')`:
 
 The window is `p(Ω') − 1` wide and `Ω'` needs `p(Ω')` of it, so the pol
 lands on `(Σ coeffs)·[s_j ≥ T] ≥ 1` and **derives** the conclusion rather
-than assuming it. The window is derived rather than enumerated, and the
-edge derived is the *right* one here where #757 derives the left — the
-same mechanism mirrored.
+than assuming it.
+
+Simulated standalone before any C++, as #730, #751 and #757 all were:
+126 lines, veripb exit 0, every load-bearing row on its predicted shape,
+and **all seven mutation lanes rejected** (`emit_nothing`, `drop_folds`,
+`drop_omega_energy`, `over_push`, `drop_clause`, `rup_clause`,
+`rup_fold`) on a generated four-predecessor fixture. As #731, #752 and
+#757 all found, the demonstration fixture is not the one the lanes bite
+on: over two predecessors the fold is a single bridge row the closing RUP
+reconstructs, so the mutation fixture needs `|Ω'| ≥ 3`.
+
+**Steps 1 and 2 are not load-bearing, and step 3 is.** Replacing the
+detection pol and the separation clause with a bare `rup b_ij ≥ 1`
+verifies on **27 of 27** generated firings — which is not a corruption
+surviving but the same fact reached another way: `before_{i,j}` is
+RUP-available from the bounds the reason carries, because #734's
+detection condition and its refuting pol's positive degree are the same
+statement. Asking the same question of the *clause* (`rup_clause`) is
+rejected, so the arithmetic in step 3 does need its pol. A propagator
+should still emit all of it, for the reason #734 records about its own
+two pols: it cannot cheaply tell which case it is in, and the cost is two
+lines.
+
+Unlike #757 the final division is **not** load-bearing here — the
+surplus is exactly one, so saturation alone lands on the unit clause.
+Divide anyway: a surplus of one is a property of the tight case, not of
+the rule.
 
 ## Strict-mode zero-length tasks
 

--- a/examples/rcpsp/rcpsp.cc
+++ b/examples/rcpsp/rcpsp.cc
@@ -456,6 +456,13 @@ auto main(int argc, char * argv[]) -> int
                 "measurement is made: that detection is worth 0.6% of the summed recursions and "  //
                 "nothing at the median, so it is deliberately uncertified and throws rather than " //
                 "propagating under --prove (#757)")                                                //
+            ("disjunctive-detectable-precedences-set",
+                "Push a detectable precedence to the set's earliest completion time rather than "  //
+                "to the latest single predecessor's earliest end, and the mirror --- Vilim's "     //
+                "rule rather than the pairwise one. Worth 0.386x the median recursions on its "    //
+                "own, and better on 23 of 36 on top of edge-finding. Off by default only because " //
+                "that push has no certificate yet, so it throws rather than propagating under "    //
+                "--prove (#754)")                                                                  //
             ("disjunctive-overload",
                 "Give every posted Disjunctive the overload check, off by default because its "   //
                 "certificate is expensive enough that whether it pays is what #730 is measuring") //
@@ -771,6 +778,7 @@ auto main(int argc, char * argv[]) -> int
         disjunctive_rules.not_first_not_last = true;
         disjunctive_rules.not_first_not_last_published = true;
     }
+    disjunctive_rules.detectable_precedences_set = options_vars["disjunctive-detectable-precedences-set"].as<bool>();
     disjunctive_rules.overload = options_vars["disjunctive-overload"].as<bool>();
     disjunctive_rules.overload_max_window = options_vars["disjunctive-overload-max-window"].as<std::size_t>();
     if (options_vars["disjunctive-overload-temporary"].as<bool>())

--- a/examples/rcpsp/rcpsp.cc
+++ b/examples/rcpsp/rcpsp.cc
@@ -457,12 +457,12 @@ auto main(int argc, char * argv[]) -> int
                 "nothing at the median, so it is deliberately uncertified and throws rather than " //
                 "propagating under --prove (#757)")                                                //
             ("disjunctive-detectable-precedences-set",
-                "Push a detectable precedence to the set's earliest completion time rather than "  //
-                "to the latest single predecessor's earliest end, and the mirror --- Vilim's "     //
-                "rule rather than the pairwise one. Worth 0.386x the median recursions on its "    //
-                "own, and better on 23 of 36 on top of edge-finding. Off by default only because " //
-                "that push has no certificate yet, so it throws rather than propagating under "    //
-                "--prove (#754)")                                                                  //
+                "Push a detectable precedence to the set's earliest completion time rather than " //
+                "to the latest single predecessor's earliest end, and the mirror --- Vilim's "    //
+                "rule rather than the pairwise one. Worth 0.386x the median recursions on its "   //
+                "own, and better on 23 of 36 on top of edge-finding. Certified over a window "    //
+                "the negated conclusion derives; off by default because those windows share "     //
+                "nothing with the energetic sweep's, which has not been measured (#754)")         //
             ("disjunctive-overload",
                 "Give every posted Disjunctive the overload check, off by default because its "   //
                 "certificate is expensive enough that whether it pays is what #730 is measuring") //

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -290,6 +290,7 @@ if(GCS_BUILD_TESTS)
     add_executable(disjunctive_edge_finding_test constraints/disjunctive/disjunctive_edge_finding_test.cc)
     add_executable(disjunctive_nfnl_test constraints/disjunctive/disjunctive_nfnl_test.cc)
     add_executable(disjunctive_precedences_test constraints/disjunctive/disjunctive_precedences_test.cc)
+    add_executable(disjunctive_set_precedences_test constraints/disjunctive/disjunctive_set_precedences_test.cc)
     add_executable(disjunctive_2d_test constraints/disjunctive_2d/disjunctive_2d_test.cc)
     add_executable(divide_modulus_test constraints/divide_modulus/divide_modulus_test.cc)
     add_executable(element_test constraints/element/element_test.cc)
@@ -336,7 +337,7 @@ if(GCS_BUILD_TESTS)
 
     foreach(test_target
             abs_test all_different_test all_different_except_test all_equal_test among_test at_most_one_test bin_packing_test comparison_test
-            count_test cumulative_test cumulative_overload_test cumulative_edge_finding_test cumulative_ttef_test cumulative_nfnl_test cumulative_kaoc_test cumulative_optional_test derived_cumulative_test difference_test disjunctive_test disjunctive_optional_test disjunctive_overload_test disjunctive_edge_finding_test disjunctive_nfnl_test disjunctive_precedences_test disjunctive_2d_test divide_modulus_test element_test equals_test bounds_global_cardinality_test gac_global_cardinality_test in_test increasing_test inverse_test knapsack_test knapsack_upfront_test lex_test linear_test linear_constant_test
+            count_test cumulative_test cumulative_overload_test cumulative_edge_finding_test cumulative_ttef_test cumulative_nfnl_test cumulative_kaoc_test cumulative_optional_test derived_cumulative_test difference_test disjunctive_test disjunctive_optional_test disjunctive_overload_test disjunctive_edge_finding_test disjunctive_nfnl_test disjunctive_precedences_test disjunctive_set_precedences_test disjunctive_2d_test divide_modulus_test element_test equals_test bounds_global_cardinality_test gac_global_cardinality_test in_test increasing_test inverse_test knapsack_test knapsack_upfront_test lex_test linear_test linear_constant_test
             logical_test mdd_test min_distance_test min_distance_matching_test min_max_test mini_linear_test multiply_test n_value_test nogoods_test parity_test
             plus_minus_test power_test product_bounds_test product_justify_test regular_test regular_bacchus_test regular_legacy_test seq_precede_chain_test smart_table_test sort_test arg_sort_test symmetric_all_different_test
             negative_table_test table_test tabulation_test value_precede_test)
@@ -466,6 +467,20 @@ if(GCS_BUILD_TESTS)
         add_test(NAME disjunctive_nfnl_mutation_${mutation}
             COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_expect_verify_failure.bash
                 --basename disjunctive_nfnl_mutation_${mutation} $<TARGET_FILE:disjunctive_nfnl_test> --mutate=${mutation})
+    endforeach()
+    # Vilim's set-based form, over #757's certificate mirrored. Its own
+    # mutation lanes rather than edge-finding's, because what is new here is the
+    # derived two-way clause that discharges the guard the reason cannot ---
+    # `drop_clause` and `rup_clause` are aimed at exactly that, and the rest
+    # check the pieces it is built on are load-bearing too.
+    add_test(NAME disjunctive_set_precedences
+        COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:disjunctive_set_precedences_test>)
+    add_test(NAME disjunctive_set_precedences_search
+        COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:disjunctive_set_precedences_test> --search 28)
+    foreach(mutation emit_nothing skip_fold drop_energy drop_clause rup_clause one_too_far)
+        add_test(NAME disjunctive_set_precedences_mutation_${mutation}
+            COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_expect_verify_failure.bash
+                --basename disjunctive_set_precedences_mutation_${mutation} $<TARGET_FILE:disjunctive_set_precedences_test> --mutate=${mutation})
     endforeach()
     add_test(NAME disjunctive_precedences COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:disjunctive_precedences_test>)
     # Mutation lanes: each writes a deliberately corrupted proof of the

--- a/gcs/constraints/disjunctive/disjunctive.cc
+++ b/gcs/constraints/disjunctive/disjunctive.cc
@@ -443,9 +443,15 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
             // `duration_floor`, when given, replaces the duration's current
             // bound row with one the caller has: the overload certificate
             // needs a *reason-free* floor, and cites the model's declared one.
+            //
+            // `divisor`, when given, divides before saturating. A caller that
+            // only wants the row *cited* wants it saturated at whatever degree
+            // it came out with; a caller that wants to add it to something else
+            // wants a clause, and saturation alone leaves the coefficients at
+            // the degree rather than at one. #754 is the second kind.
             auto emit_before_pol = [&](size_t a, size_t b, const optional<IntegerVariableCondition> & cond_a,
-                                       const optional<IntegerVariableCondition> & cond_b,
-                                       const optional<ProofLine> & duration_floor = nullopt) -> ProofLine {
+                                       const optional<IntegerVariableCondition> & cond_b, const optional<ProofLine> & duration_floor = nullopt,
+                                       const optional<Integer> & divisor = nullopt) -> ProofLine {
                 auto & tracker = logger->names_and_ids_tracker();
                 PolBuilder pol;
                 pol.add(before_flags.at(make_pair(a, b)).forward_line);
@@ -471,6 +477,8 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                     add_defining_row(length_vars[a] >= state.lower_bound(length_vars[a]));
                 if (cond_b)
                     add_defining_row(*cond_b);
+                if (divisor)
+                    pol.divide_by(*divisor);
                 return pol.saturate().emit(*logger, ProofLevel::Temporary);
             };
 
@@ -868,6 +876,184 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                     }
                     if (! std::holds_alternative<disjunctive_proof_mutation::DropPushedEnergy>(mutation))
                         cite(pushed, pushed_low_guard, pushed_high_guard, discharge_low, ! discharge_low);
+
+                    total.emit(*logger, ProofLevel::Temporary);
+                };
+            };
+
+            // --- #754: the set-based detectable precedence -------------------
+            //
+            // #734 pushes lb(s_j) to the latest single predecessor's earliest
+            // end. Vilim's rule pushes to the *set's* earliest completion time
+            // `ect(Omega) = max over cuts of (est(Omega') + p(Omega'))`, which
+            // is larger exactly when the predecessors cannot all fit before it.
+            //
+            // The certificate is #757's mechanism, and both of its halves.
+            // Under the negated conclusion every task in the maximising cut is
+            // squeezed into a window one unit too narrow for it:
+            //
+            //   lb push, threshold T = est(Omega') + p(Omega'):
+            //       s_j < T  and  k before j  =>  s_k < T - p_k
+            //       so Omega' lies in [est(Omega'), T - 1), p(Omega') - 1 wide
+            //
+            //   ub push, threshold L = lst(Omega') = lct(Omega') - p(Omega'):
+            //       s_j > L - p_j  and  j before k  =>  s_k >= L + 1
+            //       so Omega' lies in [L + 1, lct(Omega')), p(Omega') - 1 wide
+            //
+            // Either way the guarded rows are the *standard contained-task*
+            // ones --- guards `(a, b - p_k + 1)` over the derived window, the
+            // same call edge-finding makes --- and what is new is only how one
+            // of the two guards is discharged. In the lb push the low guard
+            // falls to the reason (`est_k >= est(Omega')` is what a left cut
+            // means) and the high one does not; in the ub push it is the other
+            // way round. So the window is derived rather than enumerated, and
+            // #757's is the left edge where this is the right one, or the other
+            // way round for the mirror.
+            //
+            // `precedence_clause` is what discharges the guard the reason
+            // cannot. It carries the conclusion literal along at that guard's
+            // coefficient, so the conclusion accumulates across Omega' and the
+            // summed pol *derives* it rather than assuming it.
+            //
+            // Every bound the arithmetic reads is one the *caller* captured at
+            // detection time, never one read back out of `state` here. By the
+            // time a justification runs, an earlier push in the same
+            // propagation has landed and the state holds a bound the reason
+            // does not support --- the trap the ub push below already records,
+            // and it produces a rejected proof rather than a wrong one.
+            struct SetTask
+            {
+                std::size_t task;
+                Integer edge, duration, lb, ub;
+            };
+            auto precedence_clause = [&](const SetTask & k, std::size_t j, Integer j_lb, Integer j_ub, Integer p_j, Integer threshold, bool lb_push,
+                                         const ReasonLiterals & reason) -> ProofLine {
+                // 1. The detection, as a row: the ordering the rule found is
+                // the one the bounds refute, and this is #734's own refutation
+                // pol. Its degree is positive exactly when the precedence is
+                // detectable, which is the same statement.
+                //
+                // Divided rather than merely saturated, because this row is
+                // going to be *added* to another: saturation alone would leave
+                // its coefficients at the degree.
+                if (std::holds_alternative<disjunctive_proof_mutation::RupSetPrecedenceClause>(mutation)) {
+                    // Can unit propagation reach the clause on its own? If it
+                    // can, the pairwise pols are decoration and this rule needs
+                    // no new step.
+                    auto lit = lb_push ? (starts[j] >= threshold) : (starts[j] < threshold - p_j + 1_i);
+                    auto other = lb_push ? (starts[k.task] < threshold - k.duration) : (starts[k.task] >= threshold + 1_i);
+                    return logger->emit_rup_proof_line(WPBSum{} + 1_i * lit + 1_i * other >= 1_i, ProofLevel::Temporary);
+                }
+
+                auto [refuted_from, refuted_to] = lb_push ? pair{j, k.task} : pair{k.task, j};
+                auto from_lb = lb_push ? j_lb : k.lb;
+                auto to_ub = lb_push ? k.ub : j_ub;
+                auto degree = lb_push ? p_j + j_lb - k.ub : k.duration + k.lb - j_ub;
+                if (degree <= 0_i)
+                    throw ProofError{"disjunctive set-based precedence: the ordering is not detectable"};
+                PolBuilder refute;
+                refute.add(
+                    emit_before_pol(refuted_from, refuted_to, starts[refuted_from] >= from_lb, starts[refuted_to] < to_ub + 1_i, nullopt, degree));
+                // What the divided row still carries is the two bounds the
+                // reason holds, one on each task.
+                if (! is_constant_variable(starts[refuted_from]))
+                    refute.add(logger->emit_rup_proof_line_under_reason(
+                        reason, WPBSum{} + 1_i * (starts[refuted_from] >= from_lb) >= 1_i, ProofLevel::Temporary));
+                if (! is_constant_variable(starts[refuted_to]))
+                    refute.add(logger->emit_rup_proof_line_under_reason(
+                        reason, WPBSum{} + 1_i * (starts[refuted_to] < to_ub + 1_i) >= 1_i, ProofLevel::Temporary));
+                auto refutation = refute.saturate().emit(*logger, ProofLevel::Temporary);
+
+                // 2. The pair's separation clause then forces the other
+                // ordering. A zero-length escape would survive into it, where
+                // the step below has no use for it.
+                PolBuilder forced;
+                forced.add(clause_lines.at(make_pair(min(j, k.task), max(j, k.task))));
+                forced.add(refutation);
+                for (auto r : {j, k.task})
+                    if (auto row = escape_is_false(r))
+                        forced.add(*row);
+                auto ordering = forced.saturate().emit(*logger, ProofLevel::Temporary);
+
+                // 3. That ordering's own arithmetic, against the two
+                // thresholds, cancels the starts and comes out at degree
+                // exactly one --- and 4. discharging the ordering leaves the
+                // two-literal clause the guarded row wants.
+                PolBuilder clause;
+                if (lb_push)
+                    clause.add(emit_before_pol(k.task, j, starts[k.task] >= threshold - k.duration, starts[j] < threshold));
+                else
+                    clause.add(emit_before_pol(j, k.task, starts[j] >= threshold - p_j + 1_i, starts[k.task] < threshold + 1_i));
+                clause.add(ordering);
+                return clause.saturate().emit(*logger, ProofLevel::Temporary);
+            };
+
+            // One set-based push. `a` and `b` are the derived window, `omega`
+            // the maximising cut, and `threshold` the bound being derived: `T`
+            // for the lb push and `L` for the ub one.
+            auto set_precedence_justification = [&](Integer a, Integer b, const vector<SetTask> & omega, size_t j, Integer j_lb, Integer j_ub,
+                                                    Integer p_j, Integer threshold, bool lb_push) {
+                return [&, a, b, omega, j, j_lb, j_ub, p_j, threshold, lb_push](const ReasonLiterals & reason) -> void {
+                    logger->emit_proof_comment("disjunctive set-based detectable precedence w=" + std::to_string(omega.size()) +
+                        " span=" + std::to_string((b - a).raw_value) + (lb_push ? " lb" : " ub"));
+                    if (std::holds_alternative<disjunctive_proof_mutation::SetPrecedenceEmitNothing>(mutation))
+                        return;
+
+                    vector<size_t> members;
+                    for (const auto & k : omega)
+                        members.push_back(k.task);
+                    auto tasks = members;
+                    tasks.push_back(j);
+                    pin_escapes(reason, tasks);
+
+                    // As edge-finding: a Temporary vocabulary does not outlive
+                    // the firing that made it, so what the caches hold has been
+                    // deleted and citing it would be citing a dead row.
+                    if (ProofLevel::Top != rules.overload_vocabulary_at) {
+                        activity->clear();
+                        bridge->clear();
+                        floors->clear();
+                        escapes->clear();
+                        guarded->clear();
+                    }
+
+                    for (auto i : members)
+                        for (Integer t = a; t < b; ++t)
+                            (void)activity_flag(i, t);
+
+                    PolBuilder total;
+                    // j is not in this window, so the at-most-ones are over the
+                    // cut alone --- unlike edge-finding's, whose pushed task is
+                    // inside the window it argues about.
+                    for (auto line :
+                        fold_at_most_ones(members, a, b, std::holds_alternative<disjunctive_proof_mutation::SkipSetPrecedenceFold>(mutation)))
+                        total.add(line);
+
+                    for (const auto & k : omega) {
+                        if (std::holds_alternative<disjunctive_proof_mutation::DropSetPrecedenceEnergy>(mutation) && k.task == omega.front().task)
+                            continue;
+                        const auto & row = guarded_energy(k.task, a, b, a, b - k.duration + 1_i);
+                        total.add(row.line);
+                        // The guard the reason holds, and the guard only the
+                        // negated conclusion holds. Which is which is the whole
+                        // difference between the two halves.
+                        if (lb_push) {
+                            if (row.low_coeff > 0_i)
+                                total.add(logger->emit_rup_proof_line_under_reason(
+                                              reason, WPBSum{} + 1_i * (starts[k.task] >= row.low_guard) >= 1_i, ProofLevel::Temporary),
+                                    row.low_coeff);
+                            if (row.bound > 0_i && ! std::holds_alternative<disjunctive_proof_mutation::DropSetPrecedenceClause>(mutation))
+                                total.add(precedence_clause(k, j, j_lb, j_ub, p_j, threshold, true, reason), row.bound);
+                        }
+                        else {
+                            if (row.low_coeff > 0_i && ! std::holds_alternative<disjunctive_proof_mutation::DropSetPrecedenceClause>(mutation))
+                                total.add(precedence_clause(k, j, j_lb, j_ub, p_j, threshold, false, reason), row.low_coeff);
+                            if (row.bound > 0_i)
+                                total.add(logger->emit_rup_proof_line_under_reason(
+                                              reason, WPBSum{} + 1_i * (starts[k.task] < row.high_guard) >= 1_i, ProofLevel::Temporary),
+                                    row.bound);
+                        }
+                    }
 
                     total.emit(*logger, ProofLevel::Temporary);
                 };
@@ -1393,10 +1579,14 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                         optional<size_t> predecessor, successor;
                         Integer predecessor_eet = 0_i, successor_lst = 0_i;
                         // The whole detected sets, for the set-based rule
-                        // below: (est, p) for the predecessors and (lct, p)
-                        // for the successors. Only collected when something
-                        // asks for them.
-                        vector<pair<Integer, Integer>> predecessors, successors;
+                        // below, and only collected when something asks for
+                        // them. `edge` is a predecessor's est and a successor's
+                        // lct, which is what each left cut is ordered by; the
+                        // bounds are captured here rather than read back out of
+                        // `state` in the justification, since by then an earlier
+                        // push has landed and the state holds a bound the reason
+                        // does not support.
+                        vector<SetTask> predecessors, successors;
                         for (auto k : active_tasks) {
                             if (k == j || min_len(k) == 0_i || ! is_present(k))
                                 continue;
@@ -1408,7 +1598,7 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                                     predecessor_eet = eet_k;
                                 }
                                 if (rules.detectable_precedences_set)
-                                    predecessors.emplace_back(k_lb, min_len(k));
+                                    predecessors.push_back(SetTask{k, k_lb, min_len(k), k_lb, k_ub});
                             }
                             if (eet_k > cur_ub) {
                                 if (! successor || k_ub < successor_lst) {
@@ -1416,7 +1606,7 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                                     successor_lst = k_ub;
                                 }
                                 if (rules.detectable_precedences_set)
-                                    successors.emplace_back(k_ub + min_len(k), min_len(k));
+                                    successors.push_back(SetTask{k, k_ub + min_len(k), min_len(k), k_lb, k_ub});
                             }
                         }
 
@@ -1427,23 +1617,50 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                         // never lowers `est(Omega')` below `a` and only adds
                         // duration --- so sorting by est descending and
                         // accumulating gives it in one pass.
-                        auto set_ect = [&]() -> Integer {
-                            sort(predecessors, [](const auto & x, const auto & y) { return x.first > y.first; });
-                            Integer best = predecessor_eet, running = 0_i;
-                            for (const auto & [est_k, p_k] : predecessors) {
-                                running += p_k;
-                                best = max(best, est_k + running);
+                        //
+                        // Returns the cut as well as the threshold, since the
+                        // certificate argues about the cut's own window; and
+                        // nullopt where no cut beats the pairwise rule, which
+                        // is what says to take #734's certificate instead.
+                        struct SetCut
+                        {
+                            Integer threshold, edge;
+                            vector<SetTask> cut;
+                        };
+                        auto set_ect = [&]() -> optional<SetCut> {
+                            sort(predecessors, [](const auto & x, const auto & y) { return x.edge > y.edge; });
+                            optional<SetCut> best;
+                            Integer running = 0_i;
+                            for (size_t n = 0; n < predecessors.size(); ++n) {
+                                running += predecessors[n].duration;
+                                auto est_k = predecessors[n].edge;
+                                // Only the last of a run of equal ests is a cut:
+                                // an earlier one leaves a task with the same est
+                                // out of a set it belongs to.
+                                if (n + 1 < predecessors.size() && predecessors[n + 1].edge == est_k)
+                                    continue;
+                                auto threshold = est_k + running;
+                                if (threshold <= predecessor_eet || (best && threshold <= best->threshold))
+                                    continue;
+                                best = SetCut{threshold, est_k, vector<SetTask>{predecessors.begin(), predecessors.begin() + n + 1}};
                             }
                             return best;
                         };
                         // The mirror: `lst(Omega)` is the smallest
                         // `lct(Omega') - p(Omega')`, so sort by lct ascending.
-                        auto set_lst = [&]() -> Integer {
-                            sort(successors, [](const auto & x, const auto & y) { return x.first < y.first; });
-                            Integer best = successor_lst, running = 0_i;
-                            for (const auto & [lct_k, p_k] : successors) {
-                                running += p_k;
-                                best = min(best, lct_k - running);
+                        auto set_lst = [&]() -> optional<SetCut> {
+                            sort(successors, [](const auto & x, const auto & y) { return x.edge < y.edge; });
+                            optional<SetCut> best;
+                            Integer running = 0_i;
+                            for (size_t n = 0; n < successors.size(); ++n) {
+                                running += successors[n].duration;
+                                auto lct_k = successors[n].edge;
+                                if (n + 1 < successors.size() && successors[n + 1].edge == lct_k)
+                                    continue;
+                                auto threshold = lct_k - running;
+                                if (threshold >= successor_lst || (best && threshold >= best->threshold))
+                                    continue;
+                                best = SetCut{threshold, lct_k, vector<SetTask>{successors.begin(), successors.begin() + n + 1}};
                             }
                             return best;
                         };
@@ -1455,16 +1672,23 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                         // domain is a contradiction, and the target has to
                         // stay somewhere the order literal exists.
                         if (predecessor) {
-                            auto reach = rules.detectable_precedences_set ? set_ect() : predecessor_eet;
-                            auto target = min(reach, cur_ub + 1_i) + (one_too_far ? 1_i : 0_i);
-                            // Only what the set rule reaches *past* the
-                            // pairwise one lacks a certificate --- and only
-                            // after the clip, since a target the domain caps
-                            // is one the pairwise justification still covers.
-                            if (logger && target > min(predecessor_eet, cur_ub + 1_i) + (one_too_far ? 1_i : 0_i))
-                                throw UnimplementedException{"disjunctive set-based detectable precedences have no certificate yet (#754)"};
+                            auto cut = rules.detectable_precedences_set ? set_ect() : nullopt;
+                            auto pairwise_target = min(predecessor_eet, cur_ub + 1_i) + (one_too_far ? 1_i : 0_i);
+                            auto target = cut ? min(cut->threshold, cur_ub + 1_i) + (one_too_far ? 1_i : 0_i) : pairwise_target;
+                            // A target the domain clip caps is one #734's own
+                            // justification still covers, so the set-based
+                            // certificate is emitted only where the set rule
+                            // actually reaches further.
+                            auto set_based = target > pairwise_target;
                             if (target > cur_lb) {
-                                auto justify = [&, j, k = *predecessor, cur_lb, target](const ReasonLiterals & reason) -> void {
+                                auto p_j = min_len(j);
+                                auto justify = [&, j, k = *predecessor, cur_lb, cur_ub, p_j, target, set_based, cut](
+                                                   const ReasonLiterals & reason) -> void {
+                                    if (set_based) {
+                                        set_precedence_justification(
+                                            cut->edge, cut->threshold - 1_i, cut->cut, j, cur_lb, cur_ub, p_j, cut->threshold, true)(reason);
+                                        return;
+                                    }
                                     logger->emit_proof_comment(
                                         "disjunctive detectable precedence " + std::to_string(k) + "<<" + std::to_string(j) + " push=lb");
                                     pin_escapes(reason, {j, k});
@@ -1482,12 +1706,19 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                         // runs, the state holds the pushed bound, which the
                         // reason does not support.
                         if (successor) {
-                            auto reach = rules.detectable_precedences_set ? set_lst() : successor_lst;
-                            auto target = max(reach - min_len(j), cur_lb - 1_i) - (one_too_far ? 1_i : 0_i);
-                            if (logger && target < max(successor_lst - min_len(j), cur_lb - 1_i) - (one_too_far ? 1_i : 0_i))
-                                throw UnimplementedException{"disjunctive set-based detectable precedences have no certificate yet (#754)"};
+                            auto cut = rules.detectable_precedences_set ? set_lst() : nullopt;
+                            auto pairwise_target = max(successor_lst - min_len(j), cur_lb - 1_i) - (one_too_far ? 1_i : 0_i);
+                            auto target = cut ? max(cut->threshold - min_len(j), cur_lb - 1_i) - (one_too_far ? 1_i : 0_i) : pairwise_target;
+                            auto set_based = target < pairwise_target;
                             if (target < cur_ub) {
-                                auto justify = [&, j, k = *successor, cur_ub, target](const ReasonLiterals & reason) -> void {
+                                auto p_j = min_len(j);
+                                auto justify = [&, j, k = *successor, cur_lb, cur_ub, p_j, target, set_based, cut](
+                                                   const ReasonLiterals & reason) -> void {
+                                    if (set_based) {
+                                        set_precedence_justification(
+                                            cut->threshold + 1_i, cut->edge, cut->cut, j, cur_lb, cur_ub, p_j, cut->threshold, false)(reason);
+                                        return;
+                                    }
                                     logger->emit_proof_comment(
                                         "disjunctive detectable precedence " + std::to_string(j) + "<<" + std::to_string(k) + " push=ub");
                                     pin_escapes(reason, {j, k});

--- a/gcs/constraints/disjunctive/disjunctive.cc
+++ b/gcs/constraints/disjunctive/disjunctive.cc
@@ -1392,20 +1392,61 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                         // has no zero-length escape to pin false.
                         optional<size_t> predecessor, successor;
                         Integer predecessor_eet = 0_i, successor_lst = 0_i;
+                        // The whole detected sets, for the set-based rule
+                        // below: (est, p) for the predecessors and (lct, p)
+                        // for the successors. Only collected when something
+                        // asks for them.
+                        vector<pair<Integer, Integer>> predecessors, successors;
                         for (auto k : active_tasks) {
                             if (k == j || min_len(k) == 0_i || ! is_present(k))
                                 continue;
                             auto [k_lb, k_ub] = state.bounds(starts[k]);
                             auto eet_k = k_lb + min_len(k);
-                            if (cur_lb + min_len(j) > k_ub && (! predecessor || eet_k > predecessor_eet)) {
-                                predecessor = k;
-                                predecessor_eet = eet_k;
+                            if (cur_lb + min_len(j) > k_ub) {
+                                if (! predecessor || eet_k > predecessor_eet) {
+                                    predecessor = k;
+                                    predecessor_eet = eet_k;
+                                }
+                                if (rules.detectable_precedences_set)
+                                    predecessors.emplace_back(k_lb, min_len(k));
                             }
-                            if (eet_k > cur_ub && (! successor || k_ub < successor_lst)) {
-                                successor = k;
-                                successor_lst = k_ub;
+                            if (eet_k > cur_ub) {
+                                if (! successor || k_ub < successor_lst) {
+                                    successor = k;
+                                    successor_lst = k_ub;
+                                }
+                                if (rules.detectable_precedences_set)
+                                    successors.emplace_back(k_ub + min_len(k), min_len(k));
                             }
                         }
+
+                        // Vilim's set-based thresholds, by a left-cut scan
+                        // rather than a Theta-tree. The maximum over subsets
+                        // is attained at a cut --- for a candidate `a` among
+                        // the ests, taking every predecessor with `est >= a`
+                        // never lowers `est(Omega')` below `a` and only adds
+                        // duration --- so sorting by est descending and
+                        // accumulating gives it in one pass.
+                        auto set_ect = [&]() -> Integer {
+                            sort(predecessors, [](const auto & x, const auto & y) { return x.first > y.first; });
+                            Integer best = predecessor_eet, running = 0_i;
+                            for (const auto & [est_k, p_k] : predecessors) {
+                                running += p_k;
+                                best = max(best, est_k + running);
+                            }
+                            return best;
+                        };
+                        // The mirror: `lst(Omega)` is the smallest
+                        // `lct(Omega') - p(Omega')`, so sort by lct ascending.
+                        auto set_lst = [&]() -> Integer {
+                            sort(successors, [](const auto & x, const auto & y) { return x.first < y.first; });
+                            Integer best = successor_lst, running = 0_i;
+                            for (const auto & [lct_k, p_k] : successors) {
+                                running += p_k;
+                                best = min(best, lct_k - running);
+                            }
+                            return best;
+                        };
 
                         auto one_too_far = std::holds_alternative<disjunctive_proof_mutation::PushOneTooFar>(mutation);
 
@@ -1414,7 +1455,14 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                         // domain is a contradiction, and the target has to
                         // stay somewhere the order literal exists.
                         if (predecessor) {
-                            auto target = min(predecessor_eet, cur_ub + 1_i) + (one_too_far ? 1_i : 0_i);
+                            auto reach = rules.detectable_precedences_set ? set_ect() : predecessor_eet;
+                            auto target = min(reach, cur_ub + 1_i) + (one_too_far ? 1_i : 0_i);
+                            // Only what the set rule reaches *past* the
+                            // pairwise one lacks a certificate --- and only
+                            // after the clip, since a target the domain caps
+                            // is one the pairwise justification still covers.
+                            if (logger && target > min(predecessor_eet, cur_ub + 1_i) + (one_too_far ? 1_i : 0_i))
+                                throw UnimplementedException{"disjunctive set-based detectable precedences have no certificate yet (#754)"};
                             if (target > cur_lb) {
                                 auto justify = [&, j, k = *predecessor, cur_lb, target](const ReasonLiterals & reason) -> void {
                                     logger->emit_proof_comment(
@@ -1434,7 +1482,10 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                         // runs, the state holds the pushed bound, which the
                         // reason does not support.
                         if (successor) {
-                            auto target = max(successor_lst - min_len(j), cur_lb - 1_i) - (one_too_far ? 1_i : 0_i);
+                            auto reach = rules.detectable_precedences_set ? set_lst() : successor_lst;
+                            auto target = max(reach - min_len(j), cur_lb - 1_i) - (one_too_far ? 1_i : 0_i);
+                            if (logger && target < max(successor_lst - min_len(j), cur_lb - 1_i) - (one_too_far ? 1_i : 0_i))
+                                throw UnimplementedException{"disjunctive set-based detectable precedences have no certificate yet (#754)"};
                             if (target < cur_ub) {
                                 auto justify = [&, j, k = *successor, cur_ub, target](const ReasonLiterals & reason) -> void {
                                     logger->emit_proof_comment(

--- a/gcs/constraints/disjunctive/disjunctive.hh
+++ b/gcs/constraints/disjunctive/disjunctive.hh
@@ -68,6 +68,35 @@ namespace gcs
         /// successor's latest start less its own duration.
         bool detectable_precedences = true;
 
+        /// Push a detectable precedence to the *set's* earliest completion
+        /// time rather than to the latest single predecessor's earliest end.
+        ///
+        /// \ref detectable_precedences pushes `lb(s_j)` to
+        /// `max_{k} ect_k` over the detected predecessors. Vilim's rule pushes
+        /// to `ect(Omega) = max_{Omega' subset Omega} (est(Omega') +
+        /// p(Omega'))`, which is larger exactly when the predecessors cannot
+        /// all fit before that point --- the set needs `p(Omega')` of room
+        /// after `est(Omega')`, and if that runs past every individual `ect_k`
+        /// then `j` cannot start until it clears. The mirror lowers `ub(s_j)`
+        /// to `lst(Omega) - p_j`, `lst(Omega)` being the set's latest start.
+        /// Computed by a left-cut scan rather than by a Theta-tree, this being
+        /// a measurement rather than a competitive implementation.
+        ///
+        /// **Uncertified for now**, and throws rather than propagating under
+        /// proof logging --- but only where the target it takes is past what
+        /// \ref detectable_precedences' own justification supports, a target
+        /// the domain clip caps being one that justification still covers.
+        /// Measured before being certified, the way
+        /// \ref not_first_not_last_published was, and unlike that one **this
+        /// is worth building**: on its own it is 0.386x the median recursions
+        /// and closes three more instances, and on top of \ref edge_finding it
+        /// is better on 23 of 36 at a median of 0.941x, closing one instance no
+        /// other arm closes. Set that against not-first/not-last's 1 of 36.
+        /// See `dev_docs/disjunctive-proof-logging.md`, which also carries the
+        /// certificate the rule wants (#757's shape, mirrored: a window whose
+        /// *right* edge the negated conclusion derives).
+        bool detectable_precedences_set = false;
+
         /// The overload check: a window whose fully-contained tasks carry more
         /// duration than the window is wide is infeasible. Conflict-only, and
         /// the capacity-one case of what CumulativeRules::overload does.

--- a/gcs/constraints/disjunctive/disjunctive.hh
+++ b/gcs/constraints/disjunctive/disjunctive.hh
@@ -82,19 +82,25 @@ namespace gcs
         /// Computed by a left-cut scan rather than by a Theta-tree, this being
         /// a measurement rather than a competitive implementation.
         ///
-        /// **Uncertified for now**, and throws rather than propagating under
-        /// proof logging --- but only where the target it takes is past what
-        /// \ref detectable_precedences' own justification supports, a target
-        /// the domain clip caps being one that justification still covers.
         /// Measured before being certified, the way
         /// \ref not_first_not_last_published was, and unlike that one **this
-        /// is worth building**: on its own it is 0.386x the median recursions
+        /// was worth building**: on its own it is 0.386x the median recursions
         /// and closes three more instances, and on top of \ref edge_finding it
         /// is better on 23 of 36 at a median of 0.941x, closing one instance no
         /// other arm closes. Set that against not-first/not-last's 1 of 36.
-        /// See `dev_docs/disjunctive-proof-logging.md`, which also carries the
-        /// certificate the rule wants (#757's shape, mirrored: a window whose
-        /// *right* edge the negated conclusion derives).
+        ///
+        /// **Certified, and by \ref not_first_not_last_published's mechanism
+        /// mirrored** (#757). The window is *derived* rather than enumerated:
+        /// `[est(Omega'), T - 1)` for the lb push, whose right edge the negated
+        /// conclusion supplies, and `[L + 1, lct(Omega'))` for the ub push,
+        /// whose left edge it does. Either way the rows cited are the standard
+        /// contained-task guarded ones, and what is new is that one of the two
+        /// guards is discharged by a *derived two-literal clause* rather than
+        /// by the reason --- the clause carrying the conclusion literal along
+        /// at that guard's coefficient, so the conclusion accumulates across
+        /// the cut and the summed pol derives it. Off by default only because
+        /// the derived windows share nothing with the sweep's, which is a cost
+        /// nobody has measured yet.
         bool detectable_precedences_set = false;
 
         /// The overload check: a window whose fully-contained tasks carry more

--- a/gcs/constraints/disjunctive/disjunctive_set_precedences_test.cc
+++ b/gcs/constraints/disjunctive/disjunctive_set_precedences_test.cc
@@ -1,0 +1,336 @@
+/* Vilim's set-based detectable precedence for Disjunctive, and its certificate.
+ *
+ * #734 pushes `lb(s_j)` to the latest single predecessor's earliest end. This
+ * pushes to `ect(Omega)`, the *set's* earliest completion time, which is larger
+ * exactly when the predecessors cannot all fit before that point. So this
+ * test's job is twofold: that the push is the set's rather than any single
+ * predecessor's, and that the certificate for it is tight.
+ *
+ * The certificate is #757's mechanism, mirrored, and the two halves of this
+ * rule use both orientations of it: the lb push argues over
+ * `[est(Omega'), T - 1)`, whose **right** edge the negated conclusion derives,
+ * and the ub push over `[L + 1, lct(Omega'))`, whose **left** edge it does.
+ * Either way the guarded rows are the standard contained-task ones and what is
+ * new is only how one guard is discharged --- by a derived two-literal clause
+ * rather than by the reason. `drop_clause` is the lane aimed at exactly that.
+ *
+ * Unlike not-first / not-last, this rule's pushes are often **tight**: both
+ * fixtures below land exactly on the bound enumeration gives, so the
+ * conclusion can be checked against the truth and not only against being
+ * sound. That is also what makes `one_too_far` a real test here.
+ *
+ * `--search` generates random unary instances, verifies a proof per instance,
+ * and checks the rule removes no solutions.
+ */
+
+#include <gcs/constraints/disjunctive.hh>
+#include <gcs/constraints/innards/constraints_test_utils.hh>
+#include <gcs/problem.hh>
+#include <gcs/solve.hh>
+
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <optional>
+#include <random>
+#include <string>
+#include <utility>
+#include <variant>
+#include <vector>
+#include <version>
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+#include <print>
+#else
+#include <fmt/core.h>
+#include <fmt/ostream.h>
+#endif
+
+using std::cerr;
+using std::make_optional;
+using std::mt19937;
+using std::nullopt;
+using std::optional;
+using std::pair;
+using std::string;
+using std::to_string;
+using std::uniform_int_distribution;
+using std::vector;
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+using std::println;
+#else
+using fmt::println;
+#endif
+
+using namespace gcs;
+using namespace gcs::innards;
+
+namespace
+{
+    struct Instance
+    {
+        vector<pair<int, int>> start_ranges;
+        vector<int> lengths;
+    };
+
+    auto fail(const string & message) -> void
+    {
+        println(cerr, "disjunctive_set_precedences_test: {}", message);
+        exit(EXIT_FAILURE);
+    }
+
+    auto post(Problem & p, const Instance & inst, DisjunctiveRules rules, DisjunctiveProofMutation mutation) -> vector<IntegerVariableID>
+    {
+        vector<IntegerVariableID> starts;
+        vector<Integer> lengths;
+        for (const auto & [lo, hi] : inst.start_ranges)
+            starts.push_back(p.create_integer_variable(Integer{lo}, Integer{hi}));
+        for (auto l : inst.lengths)
+            lengths.push_back(Integer{l});
+        p.post(Disjunctive{starts, lengths}.with_rules(rules).with_proof_mutation(mutation));
+        return starts;
+    }
+
+    struct Probe
+    {
+        vector<pair<int, int>> root_bounds;
+        int markers = 0;
+        int solutions = 0;
+    };
+
+    auto count_markers(const string & basename, const string & marker) -> int
+    {
+        std::ifstream f{basename + ".pbp"};
+        string line;
+        auto count = 0;
+        while (getline(f, line))
+            if (line.find(marker) != string::npos)
+                ++count;
+        return count;
+    }
+
+    auto probe(const Instance & inst, DisjunctiveRules rules, const optional<string> & proof_name,
+        DisjunctiveProofMutation mutation = disjunctive_proof_mutation::None{}, bool enumerate = false,
+        const string & marker = "disjunctive set-based") -> Probe
+    {
+        Problem p;
+        auto starts = post(p, inst, rules, mutation);
+        Probe result;
+        auto reached_a_node = false;
+        solve_with(p,
+            SolveCallbacks{.solution = [&](const CurrentState &) -> bool {
+                               ++result.solutions;
+                               return enumerate;
+                           },
+                .trace = [&](const CurrentState & s) -> bool {
+                    if (! reached_a_node) {
+                        reached_a_node = true;
+                        for (const auto & v : starts)
+                            result.root_bounds.emplace_back(
+                                static_cast<int>(s.lower_bound(v).raw_value), static_cast<int>(s.upper_bound(v).raw_value));
+                    }
+                    return enumerate;
+                }},
+            proof_name ? make_optional<ProofOptions>(ProofFileNames{*proof_name}) : nullopt);
+        if (proof_name)
+            result.markers = count_markers(*proof_name, marker);
+        return result;
+    }
+
+    const DisjunctiveRules with_set{.detectable_precedences_set = true};
+    const DisjunctiveRules without_set{};
+
+    /// Random unary instances, the same generator edge-finding's and
+    /// not-first/not-last's tests use, so the three rules are measured on one
+    /// family.
+    auto generate(mt19937 & rnd, int n) -> Instance
+    {
+        Instance inst;
+        uniform_int_distribution<int> dur{1, 4}, slack{0, 6};
+        auto total = 0;
+        for (auto i = 0; i < n; ++i) {
+            auto l = dur(rnd);
+            inst.lengths.push_back(l);
+            total += l;
+        }
+        for (auto i = 0; i < n; ++i) {
+            auto lo = uniform_int_distribution<int>{0, total / 2}(rnd);
+            inst.start_ranges.emplace_back(lo, lo + inst.lengths[i] + slack(rnd));
+        }
+        return inst;
+    }
+}
+
+auto main(int argc, char * argv[]) -> int
+{
+    auto proofs = gcs::test_innards::can_run_veripb();
+
+    // Task 2 has tasks 0, 1 and 3 as detected predecessors: it cannot finish
+    // before any of them starts. The pairwise rule reaches only
+    // max ect_k = max(5, 2, 5) = 5, which is below task 2's earliest start of 6
+    // and so pushes nothing at all. The set rule takes the cut {0, 3} --- both
+    // start at 3 and carry two units each --- so ect(Omega) = 3 + 4 = 7, and
+    // task 2's lower bound rises 6 -> 7.
+    //
+    // Time-tabling and pairwise detectable precedences are both silent here
+    // (the control below says so), and 7 is exactly the earliest start any
+    // feasible schedule gives task 2, so the push is tight as well as sound.
+    const Instance sharp{{{3, 5}, {0, 0}, {6, 13}, {3, 8}}, {2, 2, 4, 2}};
+
+    // The mirror, and it fires twice. Task 3 starts in [2, 5] and tasks 0 and 1
+    // are its detected successors: neither can finish before task 3's latest
+    // start. Both have lct 10 and carry five units between them, so the cut's
+    // latest start is 10 - 5 = 5 and task 3's upper bound drops 5 -> 4. That
+    // makes task 2 a detected successor as well, and the cut {0, 1, 2} needs
+    // seven units before lct 10, taking the bound to 2.
+    //
+    // The pairwise rule reaches only min lst_k - p_3 = 7 - 1 = 6, which is
+    // above the bound already held: it pushes nothing at all, which is what
+    // the control says.
+    const Instance mirror{{{4, 8}, {3, 7}, {3, 8}, {2, 5}}, {2, 3, 2, 1}};
+
+    // `sharp` with task 3's earliest start moved two later, so the cut {0, 3}
+    // and the single task {3} reach the same place: the set rule then adds
+    // nothing over the pairwise one, and emits nothing. The margin `sharp`
+    // fires on is exactly this, so it is not firing on a technicality.
+    const Instance loose{{{3, 5}, {0, 0}, {6, 13}, {5, 8}}, {2, 2, 4, 2}};
+
+    // The mutation fixture, generated rather than hand-built for the reason
+    // #731, #752 and #757 all record: a small fixture lets the closing RUP
+    // finish from whatever a corrupted derivation left behind, which is sound
+    // and VeriPB is right to accept. On `sharp` only four of the six lanes
+    // bite --- `skip_fold` and `drop_energy` survive, because with two tasks in
+    // the derived window the fold is a single bridge row the closing RUP
+    // reconstructs. **|Omega'| >= 3 is the threshold**, the same one #757's
+    // simulation found, and this instance (|Omega'| = 3, a ub push on task 3 to
+    // 6) is what scanning turned up: of 25 generated instances that fired the
+    // rule with a cut of three or more, exactly one rejected every lane.
+    const Instance mutating{{{6, 11}, {6, 10}, {6, 8}, {1, 7}, {6, 12}, {7, 10}}, {2, 1, 1, 2, 2, 2}};
+
+    // Mutation mode: emit one deliberately corrupted proof and stop, for
+    // run_test_and_expect_verify_failure.bash to hand to veripb.
+    {
+        optional<DisjunctiveProofMutation> mutation;
+        string proof_basename = "disjunctive_set_precedences_mutation";
+        for (auto a = 1; a < argc; ++a) {
+            string arg = argv[a];
+            if (arg == "--mutate=emit_nothing")
+                mutation = disjunctive_proof_mutation::SetPrecedenceEmitNothing{};
+            else if (arg == "--mutate=skip_fold")
+                mutation = disjunctive_proof_mutation::SkipSetPrecedenceFold{};
+            else if (arg == "--mutate=drop_energy")
+                mutation = disjunctive_proof_mutation::DropSetPrecedenceEnergy{};
+            else if (arg == "--mutate=drop_clause")
+                mutation = disjunctive_proof_mutation::DropSetPrecedenceClause{};
+            else if (arg == "--mutate=rup_clause")
+                mutation = disjunctive_proof_mutation::RupSetPrecedenceClause{};
+            else if (arg == "--mutate=one_too_far")
+                mutation = disjunctive_proof_mutation::PushOneTooFar{};
+            else if (arg == "--proof-files-basename" && a + 1 < argc)
+                proof_basename = argv[++a];
+        }
+
+        if (mutation) {
+            auto result = probe(mutating, with_set, make_optional(proof_basename), *mutation);
+            if (result.markers == 0)
+                fail("mutation mode: no set-based push was justified, so the proof is empty");
+            println(cerr, "wrote a deliberately corrupted proof to {}.pbp", proof_basename);
+            return EXIT_SUCCESS;
+        }
+    }
+
+    // --search: generated instances, a proof verified per instance, and a
+    // solution count against the rule off. The lane that matters --- hand-built
+    // fixtures are symmetric and generous and verify straight through
+    // certificate bugs.
+    if (argc > 1 && string{argv[1]} == "--search") {
+        auto seed = argc > 2 ? static_cast<unsigned>(std::stoul(argv[2])) : 0u;
+        mt19937 rnd{seed};
+        auto fired = 0, checked = 0;
+        for (auto attempt = 0; attempt < 60; ++attempt) {
+            auto inst = generate(rnd, 4 + static_cast<int>(attempt % 3));
+            auto name = "disjunctive_set_precedences_gen_" + to_string(attempt);
+            auto on = probe(inst, with_set, proofs ? make_optional(name) : nullopt, disjunctive_proof_mutation::None{}, true);
+            auto off = probe(inst, without_set, nullopt, disjunctive_proof_mutation::None{}, true);
+            if (on.solutions != off.solutions)
+                fail("generated instance " + to_string(attempt) + ": " + to_string(on.solutions) + " solutions with the rule on against " +
+                    to_string(off.solutions) + " with it off");
+            if (proofs) {
+                ++checked;
+                if (on.markers > 0)
+                    ++fired;
+                if (! gcs::test_innards::run_veripb(name + ".opb", name + ".pbp"))
+                    fail("generated instance " + to_string(attempt) + ": veripb rejected the proof");
+            }
+        }
+        println(cerr, "checked {} generated instances, {} fired the rule", checked, fired);
+        return EXIT_SUCCESS;
+    }
+
+    // The lb push, and the control that says nothing else makes it.
+    {
+        auto on = probe(sharp, with_set, proofs ? make_optional("disjunctive_set_precedences_sharp") : nullopt);
+        if (on.root_bounds.at(2).first != 7)
+            fail("sharp: expected task 2's lower bound at 7, got " + to_string(on.root_bounds.at(2).first));
+        auto off = probe(sharp, without_set, nullopt);
+        if (off.root_bounds.at(2).first == 7)
+            fail("sharp: the pairwise rules already made the push, so the fixture measures nothing");
+        if (proofs && ! gcs::test_innards::run_veripb("disjunctive_set_precedences_sharp.opb", "disjunctive_set_precedences_sharp.pbp"))
+            fail("sharp: veripb rejected the certificate");
+    }
+
+    // The ub push, and its control. Measuring one half of a symmetric rule
+    // tells you almost nothing, which is why both are here.
+    {
+        auto on = probe(mirror, with_set, proofs ? make_optional("disjunctive_set_precedences_mirror") : nullopt);
+        if (on.root_bounds.at(3).second != 2)
+            fail("mirror: expected task 3's upper bound at 2, got " + to_string(on.root_bounds.at(3).second));
+        auto off = probe(mirror, without_set, nullopt);
+        if (off.root_bounds.at(3).second == 2)
+            fail("mirror: the pairwise rules already made the push, so the fixture measures nothing");
+        if (proofs && ! gcs::test_innards::run_veripb("disjunctive_set_precedences_mirror.opb", "disjunctive_set_precedences_mirror.pbp"))
+            fail("mirror: veripb rejected the certificate");
+    }
+
+    // The margin of one: a unit more room and the set rule reaches no further
+    // than the pairwise one.
+    {
+        auto result = probe(loose, with_set, proofs ? make_optional("disjunctive_set_precedences_loose") : nullopt);
+        if (proofs && result.markers != 0)
+            fail("loose: a set-based push was claimed where the pairwise rule already reaches");
+        if (proofs && ! gcs::test_innards::run_veripb("disjunctive_set_precedences_loose.opb", "disjunctive_set_precedences_loose.pbp"))
+            fail("loose: veripb rejected the proof");
+    }
+
+    // Both vocabulary placements certify the same push: they differ only in
+    // whether the flags and the guarded rows outlive the firing that made them.
+    if (proofs)
+        for (auto at : {ProofLevel::Top, ProofLevel::Temporary}) {
+            DisjunctiveRules rules{.detectable_precedences_set = true};
+            rules.overload_vocabulary_at = at;
+            auto name = string{"disjunctive_set_precedences_"} + (at == ProofLevel::Top ? "top" : "temporary");
+            auto result = probe(sharp, rules, make_optional(name));
+            if (result.root_bounds.at(2).first != 7)
+                fail(name + ": the push did not land");
+            if (! gcs::test_innards::run_veripb(name + ".opb", name + ".pbp"))
+                fail(name + ": veripb rejected the certificate");
+        }
+
+    // Alongside every other rule, which share the whole vocabulary with it and
+    // reach the guarded rows at different guards over different windows.
+    // Running all of them is what would catch a cache keyed on too little.
+    if (proofs) {
+        DisjunctiveRules rules{.detectable_precedences_set = true};
+        rules.edge_finding = true;
+        rules.not_first_not_last = true;
+        rules.overload = true;
+        auto result = probe(sharp, rules, make_optional("disjunctive_set_precedences_with_everything"));
+        if (result.root_bounds.at(2).first < 7)
+            fail("with_everything: the push did not land");
+        if (! gcs::test_innards::run_veripb("disjunctive_set_precedences_with_everything.opb", "disjunctive_set_precedences_with_everything.pbp"))
+            fail("with_everything: veripb rejected the certificate");
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/gcs/constraints/innards/disjunctive_mutations.hh
+++ b/gcs/constraints/innards/disjunctive_mutations.hh
@@ -80,7 +80,9 @@ namespace gcs::innards
         /// Push the bound one unit past where the detected precedence puts it,
         /// which is false. The "bound + 1 must fail" check for this rule:
         /// it corrupts the conclusion rather than the route to it, which is
-        /// what a margin of exactly one unit is there to expose.
+        /// what a margin of exactly one unit is there to expose. Serves the
+        /// set-based form (#754) as well, which takes its target from the same
+        /// place and derives the honest one in its certificate.
         struct PushOneTooFar
         {
         };
@@ -152,6 +154,43 @@ namespace gcs::innards
         {
         };
 
+        /// Emit no set-based-precedence certificate at all, leaving the push
+        /// to the framework's wrapping RUP. The control for that rule.
+        struct SetPrecedenceEmitNothing
+        {
+        };
+
+        /// Leave the per-time at-most-ones out of the set-based precedence's
+        /// endgame, so nothing says the derived window can hold only one task
+        /// at a time.
+        struct SkipSetPrecedenceFold
+        {
+        };
+
+        /// Leave one cut task's guarded energy row out, so the derived window
+        /// is charged less work than the cut actually puts in it.
+        struct DropSetPrecedenceEnergy
+        {
+        };
+
+        /// Leave out the derived two-literal clause that discharges the guard
+        /// the reason cannot. **The mutation for what is new in this rule**:
+        /// without it the guarded row's guard is never discharged and the
+        /// conclusion never enters the sum, so if VeriPB accepts this the
+        /// derived window is doing no work.
+        struct DropSetPrecedenceClause
+        {
+        };
+
+        /// Conclude that clause by bare `rup` rather than by the pairwise
+        /// pols. Asks whether unit propagation can reach a statement that
+        /// relates two tasks' starts through a third's bound --- which is the
+        /// pairwise encoding's cross-variable limit, and the same question
+        /// \ref RupOverloadBridge asks of the bridge.
+        struct RupSetPrecedenceClause
+        {
+        };
+
         // Deliberately absent: citing the pushed task's row at the *unclipped*
         // threshold, as if the window contained it. It was written, and it
         // verified. A row derived at a threshold the reason still entails is a
@@ -171,7 +210,9 @@ namespace gcs::innards
         disjunctive_proof_mutation::SkipOverloadEnergy, disjunctive_proof_mutation::RupOverloadBridge,
         disjunctive_proof_mutation::EdgeFindingEmitNothing, disjunctive_proof_mutation::SkipEdgeFindingFold,
         disjunctive_proof_mutation::DropContainedEnergy, disjunctive_proof_mutation::EdgeFindingOneTooFar,
-        disjunctive_proof_mutation::DropPushedEnergy>;
+        disjunctive_proof_mutation::DropPushedEnergy, disjunctive_proof_mutation::SetPrecedenceEmitNothing,
+        disjunctive_proof_mutation::SkipSetPrecedenceFold, disjunctive_proof_mutation::DropSetPrecedenceEnergy,
+        disjunctive_proof_mutation::DropSetPrecedenceClause, disjunctive_proof_mutation::RupSetPrecedenceClause>;
 
     /**
      * \brief Deliberate corruptions of the presence-falsification derivation,


### PR DESCRIPTION
Stacked on #760. **Stage one of #754: the measurement, not the certificate** — and unlike #757, this one says *build it*.

## Why measurement first

#734 shipped the pairwise form, pushing `lb(s_j)` to `max_{k∈Ω} ect_k` over the detected predecessors. Vilím's pushes to the **set's** earliest completion time:

```
ect(Ω) = max_{Ω' ⊆ Ω} ( est(Ω') + p(Ω') )        lb(s_j) ← ect(Ω)
lst(Ω) = min_{Ω' ⊆ Ω} ( lct(Ω') − p(Ω') )        ub(s_j) ← lst(Ω) − p_j
```

larger exactly when the predecessors **cannot all fit** before that point. #754's stage zero counted *firings past a bound* and found `ect(Ω)` reaching past everything on 2.9% of nodes. #757 then showed that firing counts are not search — a 37% detection gap there bought 0.6% of the recursions — so this is the propagation measurement stage zero did not do.

`DisjunctiveRules::detectable_precedences_set`, by a **left-cut scan** rather than a Θ-tree: the maximum over subsets is attained at a cut, since taking every predecessor with `est ≥ a` never lowers `est(Ω')` below `a` and only adds duration. Uncertified, throwing under `--prove` — but only where its target is past what #734's own justification supports, a target the domain clip caps being one that justification still covers.

## Sound, checked against enumeration

A rule that removed a solution would measure as a large win, so the sweep cannot make this check. Both scans transcribed back out of the propagator, every push reaching past the pairwise target checked against a full enumeration of its instance's solutions:

| draw | pushes | past the pairwise target | removed a solution |
|---|---|---|---|
| 30,000 instances, 4 tasks | 125,060 | 33,307 | **0** |
| 20,000 instances, 5 tasks | 114,500 | 41,566 | **0** |
| 12,000 instances, 6 tasks | 87,214 | 37,710 | **0** |

## And it pays

Same 68 generated instances and 60 s timeout as #756's, #758's and #760's tables. `ef` and `ef + nfnl` reproduce their rows **to the digit**, which is the comparability check.

| arm | against | summed | median | geomean | better | closed |
|---|---|---|---|---|---|---|
| **set-based** | pairwise | **0.547x** | **0.386x** | **0.289x** | 34/36 | **44/68** |
| edge-finding | pairwise | 0.169x | 0.127x | 0.099x | 36/36 | 46/68 |
| **ef + set-based** | ef | **0.820x** | **0.941x** | **0.824x** | **23/36** | **47/68** |
| ef + nfnl | ef | 1.024x | 1.000x | 1.001x | 1/36 | 46/68 |
| ef + nfnl + set-based | ef + nfnl | 0.807x | 0.955x | 0.827x | 23/36 | 46/68 |

**On its own it is worth nearly half the search** and closes three more instances — a lot for a rule that adds a linear scan where edge-finding adds a cubic one.

**On top of edge-finding it is the first rung here that adds anything.** Better on **23 of 36**, worse on 6, unchanged on 7, and one more instance closed — including `--size 18 --seed 5`, which *no other arm closes at all*. Against not-first/not-last's 1 of 36 and the published detection's 4 of 36, both at a median of exactly 1.000x, that is a different verdict rather than a smaller one.

**Quote the median and the geomean, not the summed figure.** The largest instance carries **52%** of the summed total by itself, and dropping it takes 0.820x to 0.971x. The rule's real size is 0.941x at the median with a long tail — the best instance goes to 0.128x.

## What comes next

The certificate, which the dev doc now records in full. It is **#757's shape mirrored**: a window `[est(Ω'), T − 1)` whose *right* edge the negated conclusion derives, where #757 derives the left. Each `i ∈ Ω'` gives the two-literal clause `[s_j ≥ T] ∨ ¬[s_i ≥ T − p_i]` from #734's own refutation pol, and `T − p_i` is exactly the high guard of `i`'s guarded window-energy row over that window — so the low guard falls to the reason, the high guard to the clause, and what survives derives the conclusion rather than assuming it.

Simulate it first, as #730, #751 and #757 all did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PAZYGJdsP3dmWAepRGi5T5