### PR TITLE
cumulative: price the published not-first / not-last detection, and settle #746

### DIFF
--- a/dev_docs/cumulative-proof-logging.md
+++ b/dev_docs/cumulative-proof-logging.md
@@ -1427,26 +1427,84 @@ end** of the negated conclusion's start range; this takes `window_energy_bound`
 over the whole range, i.e. the minimum over both, because that is exactly what
 `derive_guarded_window_energy` can derive and the certificate then cites. Where
 each paper's setting makes the overlap monotone across that range the two
-coincide; where it does not, we fire less --- 3535 published-only firings
-against 7 of ours on one seed. #746 has the measurements and the open question,
-which is whether the divergence is a standing assumption on the task set that
-the transcription drops, or a genuine argument the window-energy lemma cannot
-make.
+coincide; where it does not, they diverge --- 3535 published-only firings
+against 7 of ours on one seed, so the two conditions are **incomparable**, each
+firing where the other does not.
 
-**The disjunctive side has since answered its own version of that question, and
-the answer is the second one.** #752 carried the same weakening onto
-`Disjunctive`, where it is worse — every one of our firings is also a published
-firing and 1,145 of 4,218 are theirs alone — and #757 found where the extra
-strength comes from: not a different lemma but a different **window**. The
-published unary argument runs over `[ect_j, lct(Ω))`, whose left edge is
-*derived from the negated conclusion* rather than carried by the reason, and a
-task is put inside it by a pairwise ordering that #734's own refutation pol
-supplies as a two-literal clause. The certificate is machine-checked in
-`~/claude/tmp/disj-derived-757/`. Whether that transfers here is not obvious —
-the pairwise separation clause it turns on is exactly what a cumulative encoding
-does not have — but "the window-energy lemma is complete for what it computes,
-and the extra detection comes from arguing over a narrower window" is the shape
-of the answer #746 was looking for.
+**The disjunctive side answered its own version of that question first.** #752
+carried the same weakening onto `Disjunctive`, where it is worse --- every one
+of our firings is also a published firing and 1,145 of 4,218 are theirs alone
+--- and #757 found where the extra strength comes from there: not a different
+lemma but a different **window**. The published unary argument runs over
+`[ect_j, lct(Ω))`, whose left edge is *derived from the negated conclusion*
+rather than carried by the reason, and a task is put inside it by a pairwise
+ordering that #734's own refutation pol supplies as a two-literal clause. That
+certificate is machine-checked, and was measured and then declined (#760).
+
+### #746, settled: the published argument is not a window-energy one
+
+**Both papers are sound as printed, and neither carries a standing assumption
+the transcription drops.** Suppose the not-first conclusion fails, so some
+schedule has `s_i < ECT(Ω)`. Every task in `Ω` has `ect_j > s_i`, so its actual
+end is after `s_i` --- which means any `j` with energy *before* `s_i` satisfies
+`s_j < s_i < s_j + p_j` and so is **running at `s_i`**, beside `i`. The capacity
+row at that one time point gives `Σ c_j ≤ C − c_i` over exactly those tasks, so
+across the whole prefix `[est(Ω), s_i)` the set can use `C − c_i` per unit and
+not `C`; over `[s_i, u)` with `u = min(ect_i, lct(Ω))` task `i` runs throughout,
+so the same holds; and `[u, lct(Ω))` supplies the full `C`. All of `e_Ω` lies in
+the window, so
+
+```
+e_Ω  ≤  (C − c_i)(u − est(Ω)) + C(lct(Ω) − u)
+     =   C(lct(Ω) − est(Ω)) − c_i(u − est(Ω))
+```
+
+which is the negation of the published condition. Mirrored for not-last, where
+the step reads: every `j` starts before `i` ends, so any `j` with energy after
+`i`'s end is running at `i`'s last time unit --- the remark Schutt & Wolf make
+when they motivate their pseudo-tasks.
+
+**That step is contiguity plus `ECT(Ω)` at a single time point**, and it lowers
+the capacity available to the set across a *prefix* of the window.
+`derive_guarded_window_energy` cannot see it: it bounds, per task, how much of
+*that task* must fall inside a window, and it is complete for that. So the
+divergence is real, and closing it is a different lemma rather than different
+thresholds.
+
+Checked as well as argued, in `~/claude/tmp/nfnl-746/`: every `(i, Ω)` pair on
+8,874 tiny CuSPs, each conclusion tested against the **complete** solution set.
+~4,800 published firings, none removing a solution --- including the ~2,000 that
+depend on the unclamped end. Two further numbers shape the work item:
+
+- **~95% of the divergence is the unclamped end** and ~5% the endpoint choice,
+  so sub-windowing alone was never going to close it;
+- but **97% of published firings are derivable over *some* window anyway**
+  (622/642 not-first, 564/578 not-last, usually not the paper's own) --- #757's
+  derived-window mechanism. The residue is reachable by no window and no task
+  set at all.
+
+### And what the gap is worth, which is why it stays open
+
+`CumulativeRules::not_first_not_last_published` fires the published condition
+verbatim, uncertified, so the difference can be priced the way #757 priced its
+own. Over `data_bl` + `data_pack` at 60 s, the same 37 instances:
+
+| arm | vs the detection we certify | better | worse |
+|---|---|---|---|
+| published, over edge-finding | 0.991x summed, 0.999x median | 23 of 37 | 0 |
+| published, over TTEF | 0.999x summed, 1.000x median | 13 of 37 | 3 |
+
+The largest instance carries **46%** of the summed saving; without it the ratio
+is 0.995x. So the published detection is genuinely stronger here --- it never
+loses on top of edge-finding, where our own rule changes the search on 5
+instances and it changes 23 --- and it is worth **under 1% of the search**,
+which is what #757 concluded on the other encoding by a different route. Neither
+detection pays for its own sweep: at 60 s the published arm closes 38 instances
+against plain edge-finding's 39.
+
+**That is the paper claim, now on both encodings.** Where a rule certifies a
+weaker detection than the literature states, the gap is priced rather than
+confessed: 0.6% of the search on `Disjunctive`, under 1% here.
 
 Testing is `cumulative_nfnl_test`, whose fixtures were searched the same way
 TTEF's were and against the same two conditions --- the rule must move a bound

--- a/examples/rcpsp/rcpsp.cc
+++ b/examples/rcpsp/rcpsp.cc
@@ -364,6 +364,11 @@ auto main(int argc, char * argv[]) -> int
                 "Run not-first / not-last on every posted Cumulative, alongside edge-finding. Implies "  //
                 "--cumulative-edge-finding",                                                             //
                 cxxopts::value<bool>()->default_value("false"))                                          //
+            ("cumulative-not-first-not-last-published",                                                  //
+                "Run the published not-first / not-last detection instead of the one we certify, to "    //
+                "price the difference (#746). Deliberately uncertified, so a run with --prove refuses. " //
+                "Implies --cumulative-not-first-not-last, which it replaces",                            //
+                cxxopts::value<bool>()->default_value("false"))                                          //
             ("mutate-makespan-bound",                                                                    //
                 "Claim a makespan one larger than the inferred constraints' energy supports. For "       //
                 "validating the bound only: VeriPB must reject the resulting proof, and a run that "     //
@@ -687,7 +692,8 @@ auto main(int argc, char * argv[]) -> int
     auto cumulative_rules = CumulativeRules{};
     cumulative_rules.time_table_edge_finding = options_vars["cumulative-time-table-edge-finding"].as<bool>();
     cumulative_rules.energetic_edge_finding = options_vars["cumulative-energetic-edge-finding"].as<bool>();
-    cumulative_rules.not_first_not_last = options_vars["cumulative-not-first-not-last"].as<bool>();
+    cumulative_rules.not_first_not_last_published = options_vars["cumulative-not-first-not-last-published"].as<bool>();
+    cumulative_rules.not_first_not_last = options_vars["cumulative-not-first-not-last"].as<bool>() || cumulative_rules.not_first_not_last_published;
     cumulative_rules.edge_finding = options_vars["cumulative-edge-finding"].as<bool>() || cumulative_rules.time_table_edge_finding ||
         cumulative_rules.energetic_edge_finding || cumulative_rules.not_first_not_last;
     cumulative_rules.knapsack_overload = options_vars["cumulative-knapsack-overload"].as<bool>();

--- a/gcs/constraints/cumulative/cumulative.cc
+++ b/gcs/constraints/cumulative/cumulative.cc
@@ -353,6 +353,8 @@ auto Cumulative::define_proof_model(ProofModel & model, const State &) -> void
     // declines: refuse here rather than emit a proof VeriPB will reject.
     if (_rules.energetic_edge_finding)
         throw UnimplementedException{"energetic edge-finding is not yet certified"};
+    if (_rules.not_first_not_last_published)
+        throw UnimplementedException{"the published not-first / not-last detection is not certified: see #746"};
 
     // Time-table OPB encoding:
     //   for each task i and each time point t in its possible-active range:
@@ -1296,7 +1298,7 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
 
             // min_ect and max_lst are not-first / not-last's thresholds, over
             // the same growing contained set the energy accumulates over.
-            Integer energy = 0_i, inside_mandatory = 0_i, min_ect = 0_i, max_lst = 0_i;
+            Integer energy = 0_i, inside_mandatory = 0_i, min_ect = 0_i, max_lst = 0_i, min_est = 0_i;
             vector<size_t> inside_tasks;
             for (const auto & c : candidates) {
                 if (c.est < a)
@@ -1307,6 +1309,9 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
                 if (elastic_rules)
                     join_elastic(c);
                 min_ect = inside_tasks.size() == 1 ? c.est + c.length : min(min_ect, c.est + c.length);
+                // The papers' window is the contained set's own [est, lct), not
+                // the swept one: only the published arm below reads this.
+                min_est = inside_tasks.size() == 1 ? c.est : min(min_est, c.est);
                 max_lst = inside_tasks.size() == 1 ? c.lct - c.length : max(max_lst, c.lct - c.length);
 
                 auto b = c.lct;
@@ -1507,6 +1512,27 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
                         auto h_j = j.height, p_j = j.length;
                         auto other_energy = window_total - own_contribution(j);
                         auto [s_lo, s_hi] = state.bounds(starts[j.task]);
+
+                        // The published detection instead, verbatim, over the
+                        // papers' own window [est(Omega), lct(Omega)). Their
+                        // term is the overlap at one end of the negated
+                        // conclusion's start range, unclamped against j's far
+                        // bound, so it is neither above nor below what the
+                        // lemma derives. Measurement only, hence the refusal in
+                        // define_proof_model --- see
+                        // CumulativeRules::not_first_not_last_published, which
+                        // carries both why it is sound and what it is worth.
+                        if (rules.not_first_not_last_published) {
+                            auto ect_j = s_lo + p_j, lst_j = j.lct - p_j;
+                            auto span = b - min_est;
+                            if (s_lo < min_ect && energy + h_j * (min(ect_j, b) - min_est) > capacity * span)
+                                inference.infer_greater_than_or_equal(
+                                    logger, starts[j.task], min_ect, JustifyUsingRUP{hints::Cumulative{owner}}, reason_with_presence());
+                            if (max_lst < j.lct && energy + h_j * (b - max(lst_j, min_est)) > capacity * span)
+                                inference.infer_less_than(
+                                    logger, starts[j.task], max_lst - p_j + 1_i, JustifyUsingRUP{hints::Cumulative{owner}}, reason_with_presence());
+                            continue;
+                        }
 
                         // Not-first: refute "j starts before every contained
                         // task has ended". The guarded row's low guard is what

--- a/gcs/constraints/cumulative/cumulative.hh
+++ b/gcs/constraints/cumulative/cumulative.hh
@@ -147,6 +147,49 @@ namespace gcs
         /// take the overlap at one end of that range. So this is a weakening of
         /// them, sound and certified but firing less often. See #746.
         bool not_first_not_last = false;
+
+        /// Run the **published** not-first / not-last detection instead of
+        /// \ref not_first_not_last's, over the papers' own window.
+        ///
+        /// Schutt &amp; Wolf (CP 2010, Proposition 1) and Kameugne et al.
+        /// (CPAIOR 2018, rule (NF)) take the pushed task's overlap at *one end*
+        /// of the negated conclusion's start range, and do not clamp it against
+        /// the task's own far bound; ours is the least overlap over that whole
+        /// range, which is what the window-energy lemma derives. The two are
+        /// **incomparable** --- each fires where the other does not --- so this
+        /// replaces the rule rather than strengthening it.
+        ///
+        /// **Deliberately uncertified**, and \ref Cumulative::define_proof_model
+        /// throws rather than propagating when it is set: the published
+        /// condition is sound (see below), but its argument is not one
+        /// `derive_guarded_window_energy` can make, and a rule that quietly
+        /// weakened itself under `--prove` would confound the comparison this
+        /// switch exists to make.
+        ///
+        /// **Why it is sound, which is #746's answer.** Suppose the not-first
+        /// conclusion fails, so some schedule has `s_i < ECT(Omega)`. Every
+        /// task in `Omega` has `ect_j > s_i`, so any of them with energy before
+        /// `s_i` is *running at* `s_i` beside `i` --- and the capacity row at
+        /// that one time point then caps what `Omega` may use across the whole
+        /// prefix at `C - c_i` rather than `C`. Summing that over the window is
+        /// exactly the published inequality. It is a contiguity-plus-`ECT`
+        /// argument at a single time point, not a window-energy one, and it is
+        /// the mirror of the remark Schutt &amp; Wolf make about their
+        /// pseudo-tasks. Neither paper states a standing assumption, and none
+        /// is needed.
+        ///
+        /// **What the gap is worth**, measured here against
+        /// \ref not_first_not_last over `data_bl` + `data_pack`: **0.991x the
+        /// summed recursions, 0.999x the median**, better on 23 of the 37
+        /// instances every arm closes and worse on none --- and on top of
+        /// \ref time_table_edge_finding, 0.999x summed and 1.000x median,
+        /// better on 13 and *worse on 3*. The single largest instance carries
+        /// 46% of the summed saving. So the gap between the published detection
+        /// and the certifiable one is worth **under 1% of the search**, which
+        /// is what #757 found on the disjunctive encoding by a different route.
+        /// Neither detection pays for its own sweep: at 60 s both close fewer
+        /// instances than leaving the rule off.
+        bool not_first_not_last_published = false;
     };
 
     /**


### PR DESCRIPTION
Track B1 of the certified-scheduling worklist. **Closes #746.**

Stacked on #763 (which is stacked on #761), because both touch the same part of
`dev_docs/cumulative-proof-logging.md`.

## The question #746 asked, and the answer

Whether the divergence between our not-first/not-last detection and the
published one is a standing assumption our transcription drops — in which case
there is no gap — or an argument the window-energy lemma genuinely cannot make.

**It is the second, and neither paper carries the assumption.** Schutt & Wolf
(CP 2010, Prop. 1) assume E-feasibility and nothing about `d_i` versus
`d_Omega`; Kameugne et al. (CPAIOR 2018, rule (NF)) assume `ect_i <= lct_i` and
`c_i <= C`, and their `LCut` does not force `est_k >= est_i` either.

The published rule is nevertheless **sound as printed**, by an argument our
lemma cannot make. If the not-first conclusion fails, every task in `Omega` has
`ect_j > s_i`, so any of them with energy before `s_i` is *running at* `s_i`
beside `i` — one capacity row at one time point then caps what `Omega` may use
across the whole **prefix** at `C - c_i`, and the published inequality is that
accounting rearranged. `derive_guarded_window_energy` bounds, per task, how much
of *that task* must be inside a window, and is complete for that; this is a
different statement.

Full write-up, with the enumeration checks, is the [comment on #746](https://github.com/ciaranm/glasgow-constraint-solver/issues/746#issuecomment-5330735374).

## What the gap is worth

`CumulativeRules::not_first_not_last_published`, deliberately uncertified, with
`define_proof_model` throwing rather than propagating under a logger — the same
treatment `DisjunctiveRules::not_first_not_last_published` got in #760.

Over `data_bl` + `data_pack` at 60 s, the 37 instances every arm closes,
against the detection we certify:

| arm | summed | median | better | worse |
|---|---|---|---|---|
| published, over edge-finding | 0.991x | 0.999x | 23 of 37 | 0 |
| published, over TTEF | 0.999x | 1.000x | 13 of 37 | 3 |

The largest instance carries 46% of the summed saving; without it, 0.995x.
Neither detection pays for its own sweep — at 60 s the published arm closes 38
instances against plain edge-finding's 39.

**The edge-finding, TTEF and both certified not-first/not-last arms reproduce
#745's table to the digit on current `main`** — the check that the runs are
comparable, and incidentally the first re-run of any of those numbers since they
were taken on a branch.

## Checks

* `cumulative_nfnl_test` and `cumulative_test` pass unchanged (the arm is off by
  default and replaces nothing when unset).
* `--prove` with the flag set refuses, rather than emitting a proof VeriPB would
  reject.
* Soundness of the uncertified arm: **400 generated instances enumerated
  exhaustively** with it and with no energy rule at all — 137,090,111 solutions,
  **zero count mismatches** — plus no optimum disagreement anywhere in the
  95-instance sweep, and the exhaustive tiny-CuSP checks in the issue comment.

## Why this closes the issue rather than opening work

#746's own option list said to measure before building. The measurement says the
gap is worth under 1% of the search, which is what #757 found on the disjunctive
encoding by a different route — so the weakening stands, deliberately, with a
number on it. What a future attempt would need is recorded: #757's derived-window
mechanism reaches 97% of the published firings, and the residue needs the
prefix-capacity lemma above.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
