### PR TITLE
docs: one figure for the published-detection gap, and both uncertified flags (#757)

### DIFF
--- a/dev_docs/cumulative-proof-logging.md
+++ b/dev_docs/cumulative-proof-logging.md
@@ -1433,13 +1433,15 @@ firing where the other does not.
 
 **The disjunctive side answered its own version of that question first.** #752
 carried the same weakening onto `Disjunctive`, where it is worse --- every one
-of our firings is also a published firing and 1,145 of 4,218 are theirs alone
---- and #757 found where the extra strength comes from there: not a different
-lemma but a different **window**. The published unary argument runs over
-`[ect_j, lct(Ω))`, whose left edge is *derived from the negated conclusion*
-rather than carried by the reason, and a task is put inside it by a pairwise
-ordering that #734's own refutation pol supplies as a two-literal clause. That
-certificate is machine-checked, and was measured and then declined (#760).
+of our firings is also a published firing, and over #757's wider draw (20,000
+random instances at each of four and five tasks) 38-41% of the published firings
+are theirs alone --- and #757 found where the extra strength comes from there:
+not a different lemma but a different **window**. The published unary argument
+runs over `[ect_j, lct(Ω))`, whose left edge is *derived from the negated
+conclusion* rather than carried by the reason, and a task is put inside it by a
+pairwise ordering that #734's own refutation pol supplies as a two-literal
+clause. That certificate is machine-checked, and was measured and then declined
+(#760).
 
 ### #746, settled: the published argument is not a window-energy one
 

--- a/dev_docs/disjunctive-proof-logging.md
+++ b/dev_docs/disjunctive-proof-logging.md
@@ -888,7 +888,7 @@ gap, which is the whole reason it is here.
 Across every instance more than one arm closed, all six arms proved the same
 optimum — the check no proof lane can make.
 
-### The published detection, and what it is worth: 37% more firings, 0.6% less search (#757)
+### The published detection, and what it is worth: 1.6-1.7x the firings, 0.6% less search (#757)
 
 What the section above certifies is a **strict weakening** of the rule as
 published (Baptiste, Le Pape and Nuijten; Vilím's Θ-tree presentation).
@@ -915,17 +915,19 @@ is one of theirs, by arithmetic rather than by observation. Counting them
 over the same transcribed sweep, and checking every published firing
 against a full enumeration of its instance's solutions:
 
-| draw | ours | published | only ours | firings that removed a solution |
-|---|---|---|---|---|
-| 20,000 instances, 4 tasks | 44,720 | 75,806 | **0** | **0** |
-| 20,000 instances, 5 tasks | 89,039 | 143,525 | **0** | **0** |
+| draw | ours | published | published / ours | theirs alone | only ours | firings that removed a solution |
+|---|---|---|---|---|---|---|
+| 20,000 instances, 4 tasks | 44,720 | 75,806 | **1.70×** | 41% | **0** | **0** |
+| 20,000 instances, 5 tasks | 89,039 | 143,525 | **1.61×** | 38% | **0** | **0** |
 
-So the published condition detects **1.7×** as much. The question #757
-exists to answer is whether that is worth a certificate, and the
-certificate is not free: `[ect_j, lct(Θ))` is keyed on `j`'s own lower
-bound, so its activity flags, bridge rows, folds and guarded rows share
-with nothing the sweep already derives — #737's caching result is about
-windows the *instance* gives, and these move with the search.
+So the published condition detects **1.7×** as much at four tasks and
+**1.6×** at five, and 38-41% of its firings are ones ours never makes.
+The question #757 exists to answer is whether that is worth a
+certificate, and the certificate is not free: `[ect_j, lct(Θ))` is keyed
+on `j`'s own lower bound, so its activity flags, bridge rows, folds and
+guarded rows share with nothing the sweep already derives — #737's
+caching result is about windows the *instance* gives, and these move with
+the search.
 
 **It is not worth it.** The same 68 instances and the same 60 s timeout
 as the two tables above, so all three read together:
@@ -939,10 +941,10 @@ as the two tables above, so all three read together:
 | **ef + nfnl published** | **ef** | **1.026x** | **1.000x** | **1.036x** | 4/36 | 46/68 |
 
 Three of those rows reproduce the earlier tables to the digit, which is
-the check that the runs are comparable. **The 37% detection gap buys
-0.6% of the summed recursions and nothing at all at the median.** It is
-not that the stronger detection sits idle — propagation counts differ on
-**64 of 68** instances, and it changes the search on 21 of the 36 — but
+the check that the runs are comparable. **That 1.6-1.7× detection gap
+buys 0.6% of the summed recursions and nothing at all at the median.** It
+is not that the stronger detection sits idle — propagation counts differ
+on **64 of 68** instances, and it changes the search on 21 of the 36 — but
 every change is small and they run both ways: the best instance goes to
 0.965x and the worst to 1.060x. On top of edge-finding it is a small
 loss, and the 1.026x is one instance at 4.05x carrying it.
@@ -956,11 +958,12 @@ The result is worth more than the propagator would have been. #746 asks,
 on the cumulative side, whether certifying a weaker detection than the
 literature states costs anything real, and could not answer it. **This is
 that answer, on the encoding where the gap is cleanest**: the weakening
-is strict, it is 37% of the firings, and it is worth 0.6% of the search.
-What is certifiable here is not what the rule can detect but what
-detection is *worth* — and a rule that fires 1.7× as often reaching the
-same fixpoint is the same finding as not-first/not-last reaching
-edge-finding's fixpoint by a different route, one rung further down.
+is strict, it gives up 38-41% of the published firings, and it is worth
+0.6% of the search. What is certifiable here is not what the rule can
+detect but what detection is *worth* — and a rule that fires 1.6-1.7× as
+often reaching the same fixpoint is the same finding as not-first/not-last
+reaching edge-finding's fixpoint by a different route, one rung further
+down.
 
 It also prices #754. Set-based detectable precedences want the same
 derived-window mechanism, and their stage zero found `ect(Ω)` reaching

--- a/examples/rcpsp/rcpsp.cc
+++ b/examples/rcpsp/rcpsp.cc
@@ -456,7 +456,7 @@ auto main(int argc, char * argv[]) -> int
             ("disjunctive-not-first-not-last-published",
                 "Detect not-first / not-last by the published unary condition rather than by the " //
                 "guarded window-energy one: the published rule argues over a narrower window "     //
-                "whose left edge the negated conclusion derives, and fires 1.7x as often. "        //
+                "whose left edge the negated conclusion derives, and fires 1.6-1.7x as often. "    //
                 "Implies --disjunctive-not-first-not-last. A measurement switch, and the "         //
                 "measurement is made: that detection is worth 0.6% of the summed recursions and "  //
                 "nothing at the median, so it is deliberately uncertified and throws rather than " //

--- a/gcs/constraints/cumulative/cumulative.hh
+++ b/gcs/constraints/cumulative/cumulative.hh
@@ -225,9 +225,9 @@ namespace gcs
      * horizontally elastic overload rungs, edge-finding, its time-table and
      * energetic forms, and not-first / not-last --- is behind the flags in
      * \ref CumulativeRules, off by default because each costs a sweep that a
-     * solve never firing it still pays. All of them are certified but \ref
-     * CumulativeRules::energetic_edge_finding, which refuses to run against a
-     * proof logger.
+     * solve never firing it still pays. Whether a rule is certified is stated
+     * on its own flag, and one that is not refuses to run against a proof
+     * logger rather than emit a proof VeriPB would reject.
      *
      * A task whose presence is still undecided is left out of the profile and
      * out of the overload check's energy set entirely, and its own start bounds

--- a/gcs/constraints/disjunctive/disjunctive.hh
+++ b/gcs/constraints/disjunctive/disjunctive.hh
@@ -194,8 +194,9 @@ namespace gcs
         ///
         /// Ours is a strict subset of that --- the window-energy figure at
         /// `s_j = lb(s_j)` is at most `ect_j - a`, so every firing of ours is
-        /// one of these --- and measured over 30,000 random unary instances the
-        /// published condition fires 37% more often (#757).
+        /// one of these --- and over 20,000 random unary instances at each of
+        /// four and five tasks the published condition fires 1.7x and 1.6x as
+        /// often (#757).
         ///
         /// **Deliberately uncertified**, and it throws rather than
         /// propagating when proof logging is on: a rule that quietly weakened
@@ -204,7 +205,7 @@ namespace gcs
         /// it is \ref edge_finding's, with the low guard discharged by a
         /// derived two-literal clause rather than by the reason --- and was
         /// **not built**, because this switch is what decided that:
-        /// **37% more detection is worth 0.6% of the summed recursions and
+        /// **1.6-1.7x the detection is worth 0.6% of the summed recursions and
         /// nothing at the median**, and a little worse than nothing on top of
         /// edge-finding. Not for want of firing --- propagation counts differ
         /// on 64 of 68 instances. See `dev_docs/disjunctive-proof-logging.md`.


### PR DESCRIPTION
Two review findings from the scheduling stack, as a fresh PR so the six in-flight PRs are left alone. Stacked on #764 because the first fix is to a paragraph #763 wrote and #764 falsifies; **retarget to `main` once #764 lands** (GitHub will do it automatically when the base branch is deleted).

## 1. `Cumulative`'s class comment counted the uncertified flags

#763 rewrote a stale paragraph into "all of them are certified but `CumulativeRules::energetic_edge_finding`". #764, the next commit in the same stack, adds `CumulativeRules::not_first_not_last_published`, which is also deliberately uncertified and also throws in `define_proof_model` — so the paragraph is wrong on arrival.

Rather than name both and wait for a third, the sentence now points at the flags' own documentation, each of which already states whether its rule is certified. That is the durable form of the fix #753 asked for.

## 2. The published-detection gap was quoted as three numbers

`disjunctive.hh` (twice), the `dev_docs/disjunctive-proof-logging.md` heading and two prose sites said **37% more often**; `rcpsp.cc` and two other prose sites said **1.7×**; `dev_docs/cumulative-proof-logging.md` said **1,145 of 4,218**.

The 37% is #752's draw (3,073 against 4,218 over 30,000 random instances, ratio 1.373×), quoted inside #757's section, whose own table is a different draw:

| draw | ours | published | published / ours | theirs alone |
|---|---|---|---|---|
| 20,000 instances, 4 tasks | 44,720 | 75,806 | 1.70× | 41% |
| 20,000 instances, 5 tasks | 89,039 | 143,525 | 1.61× | 38% |

Neither measurement is wrong — they count firings over different populations — but one section should not report the other's ratio. Both rows were reproduced before anything was rewritten (`python3 published.py 4 20000` and `... 5 20000` in `~/claude/tmp/disj-derived-757/`, byte-identical to the table, 0 firings only ours and 0 that removed a solution).

The fix:

- the table gains a `published / ours` and a `theirs alone` column, so every figure the prose quotes is now tabulated rather than derived in a sentence;
- the six prose sites say **1.6-1.7×**, or **38-41% of the published firings** where the sentence is about what the weakening gives up;
- #752's coarser draw is retired rather than given its own sentence — #757's is the same comparison, wider and enumeration-checked — so `cumulative-proof-logging.md` now cites #757's share and names the draw it comes from.

No measurement is restated, no arm re-run, and no propagator touched: comments, docs and one `--help` string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PAZYGJdsP3dmWAepRGi5T5