### PR TITLE
Say which constraint was trivially unsatisfiable, and why

### DIFF
--- a/gcs/constraints/difference/difference_constraints.cc
+++ b/gcs/constraints/difference/difference_constraints.cc
@@ -238,7 +238,9 @@ auto DifferenceConstraints::install_propagators(Propagators & propagators) -> vo
         // view offset, and the half-reified counterpart's `!cond' likewise. So
         // this is DifferenceConstraints' own row and its own contradiction, and
         // it belongs where the edges it came from were posted.
-        propagators.install_initial_contradiction("difference constraint x - x <= d with d < 0", JustifyUsingRUP{}, NoReason{});
+        propagators.install_initial_contradiction(constraint_id(), constraint_type(),
+            "Edge " + to_string(*_root_contradiction_posted_index) + " of a difference constraint says an expression is strictly less than itself",
+            JustifyUsingRUP{}, NoReason{});
         return;
     }
 

--- a/gcs/constraints/divide_modulus/divide_modulus.cc
+++ b/gcs/constraints/divide_modulus/divide_modulus.cc
@@ -1187,11 +1187,17 @@ namespace
     // off, where those line handles are nullopt and the stages filter on their terms
     // alone.
     template <typename Hint_>
-    auto install_propagators_divide_modulus(InstallState & st, const ConstraintID & owner, bool expose_quotient, const IntegerVariableID & x,
-        const IntegerVariableID & y, const IntegerVariableID & out, Propagators & propagators) -> void
+    auto install_propagators_divide_modulus(InstallState & st, const ConstraintID & owner, const string & constraint_type, bool expose_quotient,
+        const IntegerVariableID & x, const IntegerVariableID & y, const IntegerVariableID & out, Propagators & propagators) -> void
     {
         if (st.zero_divisor) {
-            propagators.install_initial_contradiction("division by constant zero", JustifyUsingRUP{Hint_{owner}});
+            // expose_quotient is this file's Divide-versus-Modulus discriminator
+            // everywhere else too; constraint_type is the same distinction in the
+            // .scp's lower-case spelling, which is the note's component rather
+            // than its prose.
+            propagators.install_initial_contradiction(owner, constraint_type,
+                string{expose_quotient ? "A Divide" : "A Modulus"} + " constraint was posted with a divisor of constant zero",
+                JustifyUsingRUP{Hint_{owner}});
             return;
         }
 
@@ -1316,7 +1322,7 @@ auto Divide::define_proof_model(ProofModel & model, const State &) -> void
 
 auto Divide::install_propagators(Propagators & propagators) -> void
 {
-    install_propagators_divide_modulus<hints::Divide>(_install, constraint_id(), true, _x, _y, _quotient, propagators);
+    install_propagators_divide_modulus<hints::Divide>(_install, constraint_id(), constraint_type(), true, _x, _y, _quotient, propagators);
 }
 
 auto Divide::constraint_type() const -> std::string
@@ -1362,7 +1368,7 @@ auto Modulus::define_proof_model(ProofModel & model, const State &) -> void
 
 auto Modulus::install_propagators(Propagators & propagators) -> void
 {
-    install_propagators_divide_modulus<hints::Modulus>(_install, constraint_id(), false, _x, _y, _remainder, propagators);
+    install_propagators_divide_modulus<hints::Modulus>(_install, constraint_id(), constraint_type(), false, _x, _y, _remainder, propagators);
 }
 
 auto Modulus::constraint_type() const -> std::string

--- a/gcs/constraints/element/element.cc
+++ b/gcs/constraints/element/element.cc
@@ -240,7 +240,8 @@ template <typename EntryType_, unsigned dimensions_>
 auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagators & propagators) -> void
 {
     if (_has_empty_dim) {
-        propagators.install_initial_contradiction("NDimensionalElement constraint with no values", JustifyUsingRUP{hints::Element{constraint_id()}});
+        propagators.install_initial_contradiction(constraint_id(), constraint_type(),
+            "An Element constraint was posted over an array with a zero-length dimension", JustifyUsingRUP{hints::Element{constraint_id()}});
         return;
     }
 

--- a/gcs/constraints/in/in.cc
+++ b/gcs/constraints/in/in.cc
@@ -143,8 +143,8 @@ auto In::define_proof_model(ProofModel & model, const State &) -> void
 auto In::install_propagators(Propagators & propagators) -> void
 {
     if (_has_no_values) {
-        propagators.install_initial_contradiction(
-            "No values or variables present for an 'In' constraint", JustifyUsingRUP{hints::In{constraint_id()}});
+        propagators.install_initial_contradiction(constraint_id(), constraint_type(),
+            "An In constraint was posted with no values for its variable to take", JustifyUsingRUP{hints::In{constraint_id()}});
         return;
     }
 

--- a/gcs/constraints/power/power.cc
+++ b/gcs/constraints/power/power.cc
@@ -260,7 +260,9 @@ auto Power::define_proof_model(ProofModel & model, const State & initial_state) 
 auto Power::install_propagators(Propagators & propagators) -> void
 {
     if (_no_representable_result) {
-        propagators.install_initial_contradiction("no representable power result", JustifyUsingRUP{hints::Power{constraint_id()}});
+        propagators.install_initial_contradiction(constraint_id(), constraint_type(),
+            "A Power constraint was posted with constant arguments whose result would overflow, or with a zero base and a negative exponent",
+            JustifyUsingRUP{hints::Power{constraint_id()}});
         return;
     }
 

--- a/gcs/constraints/table/table.cc
+++ b/gcs/constraints/table/table.cc
@@ -169,7 +169,8 @@ auto Table::define_proof_model(ProofModel & model, const State &) -> void
 auto Table::install_propagators(Propagators & propagators) -> void
 {
     if (_has_no_tuples) {
-        propagators.install_initial_contradiction("Empty table constraint from table", JustifyUsingRUP{hints::Table{constraint_id()}});
+        propagators.install_initial_contradiction(
+            constraint_id(), constraint_type(), "A Table constraint was posted with no tuples", JustifyUsingRUP{hints::Table{constraint_id()}});
         return;
     }
 

--- a/gcs/innards/propagators.hh
+++ b/gcs/innards/propagators.hh
@@ -535,7 +535,7 @@ namespace gcs::innards
         /**
          * Install an initialiser whose only job is to immediately raise a
          * contradiction with the given Justification (RUP, explicit, or
-         * none) and Reason. Convenience wrapper around
+         * none) and Reason, and say so. Convenience wrapper around
          * install_initialiser; intended for cases where the OPB encoding
          * emitted by define_proof_model collapses to a trivially-false
          * constraint and we want propagation to detect that up front.
@@ -544,11 +544,37 @@ namespace gcs::innards
          * a typed assertion hint (JustifyUsingRUP{hints::Foo{owner}}) and the
          * up-front contradiction names the constraint it came from, exactly as
          * the constraint's in-search inferences do.
+         *
+         * A constraint that works out at install time that it is the empty
+         * relation is the solver answering correctly, so this is a note and not
+         * an exception --- but it is the one answer a non-expert cannot tell
+         * apart from "your constraints genuinely conflict", which is what
+         * StatsLevel::Important is for. So `what_is_wrong` is reported as a
+         * StatsNote at Important, here, before the initialiser is installed:
+         * the model is broken whether or not the initialiser is ever reached,
+         * an earlier one having got there first.
+         *
+         * Write `what_is_wrong` for that reader --- name the kind of constraint
+         * and what is wrong with it, and stop. The consequence is appended
+         * here, since it belongs to installing an initial contradiction rather
+         * than to any one thing that was wrong, and the constraint's identity is
+         * added by render() from the ConstraintID.
+         *
+         * `constraint_type` is the note's component. A constraint has no
+         * ComponentStats block of its own, and its Constraint::constraint_type()
+         * --- `table`, `power`, `element_2d` --- is what "which component said
+         * it" means for one. It is rendered only below Important, which is where
+         * a reader who knows what a `table` is would be reading.
          */
         template <typename Justification_>
-        auto install_initial_contradiction(const std::string &, Justification_ why, Reason reason = NoReason{},
-            InitialiserPriority priority = InitialiserPriority::SimpleDefinition) -> void
+        auto install_initial_contradiction(const ConstraintID & constraint, const std::string & constraint_type, const std::string & what_is_wrong,
+            Justification_ why, Reason reason = NoReason{}, InitialiserPriority priority = InitialiserPriority::SimpleDefinition) -> void
         {
+            report(StatsNote{.level = StatsLevel::Important,
+                .component = constraint_type,
+                .constraint = constraint,
+                .text = what_is_wrong + ", so the model is unsatisfiable before search starts"});
+
             install_initialiser([why = std::move(why), reason = std::move(reason)](const State &, auto & inference,
                                     ProofLogger * const logger) -> void { inference.contradiction(logger, why, reason); },
                 priority);

--- a/gcs/solve_test.cc
+++ b/gcs/solve_test.cc
@@ -1,9 +1,15 @@
 #include <gcs/constraints/all_different.hh>
 #include <gcs/constraints/comparison.hh>
+#include <gcs/constraints/difference.hh>
+#include <gcs/constraints/divide.hh>
 #include <gcs/constraints/element.hh>
 #include <gcs/constraints/equals.hh>
+#include <gcs/constraints/in.hh>
 #include <gcs/constraints/innards/constraints_test_utils.hh>
+#include <gcs/constraints/modulus.hh>
 #include <gcs/constraints/plus.hh>
+#include <gcs/constraints/power.hh>
+#include <gcs/constraints/table.hh>
 #include <gcs/expression.hh>
 #include <gcs/presolver.hh>
 #include <gcs/presolvers/auto_table.hh>
@@ -26,8 +32,10 @@ using namespace gcs;
 using namespace gcs::innards;
 using namespace gcs::test_innards;
 
+using std::function;
 using std::nullopt;
 using std::optional;
+using std::string;
 using std::vector;
 
 namespace
@@ -747,4 +755,66 @@ TEST_CASE("A caller's AutoTable stats block is the one that gets filled in and r
     CHECK(block->ran);
     CHECK(block->tuples == 4);
     CHECK(component_named(stats, "auto_table").get() == static_cast<const ComponentStats *>(block.get()));
+}
+
+TEST_CASE("A constraint that is trivially unsatisfiable at install time says which one, and why")
+{
+    // Six sites --- seven constraints, Divide and Modulus sharing one --- work
+    // out while installing that what they encode is the empty relation, and
+    // install a contradiction initialiser instead of a propagator. Each has
+    // always passed an explanation of what was wrong with it; the parameter that
+    // took it was unnamed and dropped it (#722), so the whole visible
+    // consequence of `x div 0` was an unsatisfiable answer that looks exactly
+    // like a model whose constraints genuinely conflict.
+    struct Case
+    {
+        string component;
+        string mentions;
+        function<auto(Problem &, IntegerVariableID, IntegerVariableID)->void> post;
+    };
+
+    const vector<Case> cases{
+        {"table", "no tuples", [](Problem & p, IntegerVariableID x, IntegerVariableID y) { p.post(Table{{x, y}, SimpleTuples{}}); }},
+        {"in", "no values", [](Problem & p, IntegerVariableID x, IntegerVariableID) { p.post(In{x, vector<Integer>{}}); }},
+        {"element", "zero-length dimension",
+            [](Problem & p, IntegerVariableID x, IntegerVariableID y) { p.post(Element{x, y, vector<IntegerVariableID>{}}); }},
+        {"power", "overflow", [](Problem & p, IntegerVariableID x, IntegerVariableID) { p.post(Power{0_c, constant_variable(-1_i), x}); }},
+        {"divide", "divisor of constant zero", [](Problem & p, IntegerVariableID x, IntegerVariableID y) { p.post(Divide{x, 0_c, y}); }},
+        {"modulus", "divisor of constant zero", [](Problem & p, IntegerVariableID x, IntegerVariableID y) { p.post(Modulus{x, 0_c, y}); }},
+        {"difference", "strictly less than itself", [](Problem & p, IntegerVariableID x, IntegerVariableID) {
+             p.post(DifferenceConstraints{vector<DifferenceEdge>{DifferenceEdge{x, x, -1_i}}});
+         }}};
+
+    for (const auto & c : cases) {
+        INFO("constraint type " << c.component);
+
+        Problem p;
+        auto x = p.create_integer_variable(0_i, 3_i);
+        auto y = p.create_integer_variable(0_i, 3_i);
+        c.post(p, x, y);
+
+        Recorder recorder;
+        auto stats =
+            solve_with(p, SolveCallbacks{.solution = [](const CurrentState &) -> bool { return true; }, .stats_report = recorder.callback()});
+
+        CHECK(0 == stats.solutions);
+
+        // Exactly one note, and Important: the reader it is for is the
+        // non-expert who cannot otherwise tell "your constraints conflict" from
+        // "one of them was empty", and who is reading a solve that got no
+        // further than installing this constraint.
+        auto important = recorder.at_level(StatsLevel::Important);
+        REQUIRE(important.size() == 1);
+        CHECK(important[0].component == c.component);
+        CHECK(important[0].constraint == ConstraintID{NumberedConstraint{1}});
+
+        // The text names what kind of constraint it was and what was wrong with
+        // it, since at Important the component label is not rendered; the
+        // consequence is there too, because "unsatisfiable" is the thing the
+        // reader is trying to account for. The identity is the note's own field
+        // rather than words, and render() is what puts it into the line.
+        CHECK(important[0].text.contains(c.mentions));
+        CHECK(important[0].text.ends_with(", so the model is unsatisfiable before search starts"));
+        CHECK(render(important[0]).ends_with(" (_1)"));
+    }
 }


### PR DESCRIPTION
Closes #722.

## What was wrong

Six constraints detect at install time that their OPB encoding has collapsed to
something trivially false, and install an immediate contradiction instead of a
propagator. Each passed an explanation of what was wrong to
`Propagators::install_initial_contradiction` — whose first parameter was
**unnamed**. The lambda captured the `Justification` and the `Reason`; the string
was compiled away. So the whole user-visible consequence of `x div 0` was
`=====UNSATISFIABLE=====`, indistinguishable from a model whose constraints
genuinely conflict.

## What it says now

`install_initial_contradiction` names the parameter and reports it as a
`StatsNote` at `StatsLevel::Important`, before installing the initialiser (the
model is broken whether or not the initialiser is ever reached — an earlier one
may have got there first). It also takes the `ConstraintID` and the
`Constraint::constraint_type()`, so the note names the constraint without the
message having to, and it appends the consequence clause, which belongs to
installing an initial contradiction rather than to any one thing that was wrong.

All seven now render as:

```
A Table constraint was posted with no tuples, so the model is unsatisfiable before search starts (_1)
An In constraint was posted with no values for its variable to take, so the model is unsatisfiable before search starts (_1)
An Element constraint was posted over an array with a zero-length dimension, so the model is unsatisfiable before search starts (_1)
A Power constraint was posted with constant arguments whose result would overflow, or with a zero base and a negative exponent, so the model is unsatisfiable before search starts (_1)
A Divide constraint was posted with a divisor of constant zero, so the model is unsatisfiable before search starts (_1)
A Modulus constraint was posted with a divisor of constant zero, so the model is unsatisfiable before search starts (_1)
Edge 0 of a difference constraint says an expression is strictly less than itself, so the model is unsatisfiable before search starts (_1)
```

Six sites, seven constraints: `Divide` and `Modulus` share
`install_propagators_divide_modulus`, which now takes the type through.

## Decisions worth reviewing

- **`constraint_type()` as the note's component.** A constraint has no
  `ComponentStats` block, and its type — `table`, `power`, `element_2d` — is what
  "which component said it" means for one. It is rendered only *below* Important,
  which is where a reader who knows what a `table` is would be reading; the prose
  therefore names the kind of constraint itself, since the Important reader never
  sees the label.
- **The consequence clause is the wrapper's, not the site's.** The site says what
  is wrong; ", so the model is unsatisfiable before search starts" is what
  installing an initial contradiction means, and saying it once keeps the seven
  from drifting apart.
- **One note per such constraint, not an aggregate** (the issue's open question).
  Each names a different constraint, so they are not repeats of each other, and
  unlike the cumulative presolver there is no run boundary to aggregate at. A
  model that posts a thousand empty tables gets a thousand notes; a caller who
  does not want them sets `SolveCallbacks::stats_report`.
- **Nothing goes to the proof.** #662's rule was to move decisions *off*
  `emit_proof_comment`, and the OPB already carries the trivially-false row in a
  block labelled with the constraint, so the proof already says which one.
- Sites that `throw` (`disjunctive_2d.cc:85` and the other non-negativity
  guards) are untouched, per the issue's "not in scope".

## Testing

New `solve_test` case posts all seven degenerate constraints and checks each
produces exactly one `Important` note, with the right component, the right
`ConstraintID`, prose naming what was wrong, and the consequence clause — asserting
on the notes rather than on rendered output, since the *level* is what rendering
throws away. The pre-existing enumeration tests for these degenerate cases (empty
table, empty `In`, empty array, overflowing power, degenerate difference edge) all
still pass; full `ctest` is 725/725 green, and the changed files are
clang-format-clean and clang-syntax-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PAZYGJdsP3dmWAepRGi5T5