### PR TITLE
Say when an AllDifferent clique has a duplicate variable

### DIFF
--- a/gcs/constraints/all_different/all_different.cc
+++ b/gcs/constraints/all_different/all_different.cc
@@ -142,7 +142,8 @@ auto AllDifferent::define_proof_model(ProofModel & model, const State &) -> void
 auto AllDifferent::install_propagators(Propagators & propagators) -> void
 {
     if (_has_duplicate_vars) {
-        install_clique_duplicate_contradiction_initialiser(propagators, hints::AllDifferent{constraint_id()});
+        install_clique_duplicate_contradiction_initialiser(propagators, constraint_id(), constraint_type(),
+            "An AllDifferent constraint was posted with the same variable more than once", hints::AllDifferent{constraint_id()});
         return;
     }
 

--- a/gcs/constraints/all_different/all_different_except.cc
+++ b/gcs/constraints/all_different/all_different_except.cc
@@ -131,7 +131,9 @@ auto AllDifferentExcept::install_propagators(Propagators & propagators) -> void
     // keeps -- see define_proof_model), the rows need the per-value inferences
     // of the general duplicate path below to reach the wipeout.
     if (_has_duplicates && _excluded.empty()) {
-        install_clique_duplicate_contradiction_initialiser(propagators, hints::AllDifferentExcept{constraint_id()});
+        install_clique_duplicate_contradiction_initialiser(propagators, constraint_id(), constraint_type(),
+            "An AllDifferentExcept constraint with no excluded values was posted with the same variable more than once",
+            hints::AllDifferentExcept{constraint_id()});
         return;
     }
 

--- a/gcs/constraints/all_different/encoding.cc
+++ b/gcs/constraints/all_different/encoding.cc
@@ -39,15 +39,16 @@ auto gcs::innards::define_clique_not_equals_encoding(
 }
 
 template <typename Hint_>
-auto gcs::innards::install_clique_duplicate_contradiction_initialiser(Propagators & propagators, const Hint_ & hint) -> void
+auto gcs::innards::install_clique_duplicate_contradiction_initialiser(Propagators & propagators, const ConstraintID & constraint_id,
+    const string & constraint_type, const string & what_is_wrong, const Hint_ & hint) -> void
 {
-    propagators.install_initialiser(
-        [hint](State &, auto & inference, ProofLogger * const logger) -> void { inference.contradiction(logger, JustifyUsingRUP{hint}, NoReason{}); },
-        InitialiserPriority::SimpleDefinition);
+    propagators.install_initial_contradiction(constraint_id, constraint_type, what_is_wrong, JustifyUsingRUP{hint});
 }
 
-template auto gcs::innards::install_clique_duplicate_contradiction_initialiser(Propagators &, const hints::AllDifferent &) -> void;
-template auto gcs::innards::install_clique_duplicate_contradiction_initialiser(Propagators &, const hints::AllDifferentExcept &) -> void;
+template auto gcs::innards::install_clique_duplicate_contradiction_initialiser(
+    Propagators &, const ConstraintID &, const string &, const string &, const hints::AllDifferent &) -> void;
+template auto gcs::innards::install_clique_duplicate_contradiction_initialiser(
+    Propagators &, const ConstraintID &, const string &, const string &, const hints::AllDifferentExcept &) -> void;
 
 auto gcs::innards::define_clique_not_equals_except_encoding(
     ProofModel & model, const vector<gcs::IntegerVariableID> & vars, const vector<gcs::Integer> & excluded) -> map<IntegerVariableID, ProofFlag>

--- a/gcs/constraints/all_different/encoding.hh
+++ b/gcs/constraints/all_different/encoding.hh
@@ -40,8 +40,17 @@ namespace gcs
         // caller (AllDifferent's gac/vc/symmetric propagators, AllDifferentExcept)
         // names the contradiction with its own constraint. Instantiated in
         // encoding.cc for hints::AllDifferent and hints::AllDifferentExcept.
+        //
+        // What is shared here is the *proof* argument --- the pair rows collapse
+        // to units, so the contradiction is bare RUP with no reason --- and not
+        // the diagnostic, which names a kind of constraint and so belongs to the
+        // caller. Take the type from Constraint::constraint_type() rather than
+        // from Hint_: SymmetricAllDifferent justifies with hints::AllDifferent,
+        // correctly, since the proof step is the clique one, and a note taking
+        // its component from the hint would call it an all_different.
         template <typename Hint_>
-        auto install_clique_duplicate_contradiction_initialiser(Propagators & propagators, const Hint_ & hint) -> void;
+        auto install_clique_duplicate_contradiction_initialiser(Propagators & propagators, const ConstraintID & constraint_id,
+            const std::string & constraint_type, const std::string & what_is_wrong, const Hint_ & hint) -> void;
     }
 }
 

--- a/gcs/constraints/all_different/symmetric_all_different.cc
+++ b/gcs/constraints/all_different/symmetric_all_different.cc
@@ -110,7 +110,8 @@ auto SymmetricAllDifferent::define_proof_model(ProofModel & model, const State &
 auto SymmetricAllDifferent::install_propagators(Propagators & propagators) -> void
 {
     if (_has_duplicate_vars) {
-        install_clique_duplicate_contradiction_initialiser(propagators, hints::AllDifferent{constraint_id()});
+        install_clique_duplicate_contradiction_initialiser(propagators, constraint_id(), constraint_type(),
+            "A SymmetricAllDifferent constraint was posted with the same variable more than once", hints::AllDifferent{constraint_id()});
         return;
     }
 

--- a/gcs/solve_test.cc
+++ b/gcs/solve_test.cc
@@ -759,13 +759,19 @@ TEST_CASE("A caller's AutoTable stats block is the one that gets filled in and r
 
 TEST_CASE("A constraint that is trivially unsatisfiable at install time says which one, and why")
 {
-    // Six sites --- seven constraints, Divide and Modulus sharing one --- work
-    // out while installing that what they encode is the empty relation, and
-    // install a contradiction initialiser instead of a propagator. Each has
-    // always passed an explanation of what was wrong with it; the parameter that
-    // took it was unnamed and dropped it (#722), so the whole visible
-    // consequence of `x div 0` was an unsatisfiable answer that looks exactly
-    // like a model whose constraints genuinely conflict.
+    // Seven sites --- ten constraints --- work out while installing that what
+    // they encode is the empty relation, and install a contradiction initialiser
+    // instead of a propagator. Each has always passed an explanation of what was
+    // wrong with it; the parameter that took it was unnamed and dropped it
+    // (#722), so the whole visible consequence of `x div 0` was an unsatisfiable
+    // answer that looks exactly like a model whose constraints genuinely
+    // conflict.
+    //
+    // Divide and Modulus share install_propagators_divide_modulus; the three
+    // AllDifferent-family constraints share
+    // install_clique_duplicate_contradiction_initialiser, which is why they were
+    // not in #722's census -- that was a grep for install_initial_contradiction,
+    // and this one goes through the same wrapper only since #767.
     struct Case
     {
         string component;
@@ -781,9 +787,20 @@ TEST_CASE("A constraint that is trivially unsatisfiable at install time says whi
         {"power", "overflow", [](Problem & p, IntegerVariableID x, IntegerVariableID) { p.post(Power{0_c, constant_variable(-1_i), x}); }},
         {"divide", "divisor of constant zero", [](Problem & p, IntegerVariableID x, IntegerVariableID y) { p.post(Divide{x, 0_c, y}); }},
         {"modulus", "divisor of constant zero", [](Problem & p, IntegerVariableID x, IntegerVariableID y) { p.post(Modulus{x, 0_c, y}); }},
-        {"difference", "strictly less than itself", [](Problem & p, IntegerVariableID x, IntegerVariableID) {
-             p.post(DifferenceConstraints{vector<DifferenceEdge>{DifferenceEdge{x, x, -1_i}}});
-         }}};
+        {"difference", "strictly less than itself",
+            [](Problem & p, IntegerVariableID x, IntegerVariableID) {
+                p.post(DifferenceConstraints{vector<DifferenceEdge>{DifferenceEdge{x, x, -1_i}}});
+            }},
+        {"all_different", "same variable more than once",
+            [](Problem & p, IntegerVariableID x, IntegerVariableID) { p.post(AllDifferent{vector<IntegerVariableID>{x, x}}); }},
+        // With no excluded values, and only then: with any, the duplicate is a
+        // propagation route rather than an install-time verdict.
+        {"all_different_except", "no excluded values",
+            [](Problem & p, IntegerVariableID x, IntegerVariableID) {
+                p.post(AllDifferentExcept{vector<IntegerVariableID>{x, x}, vector<Integer>{}});
+            }},
+        {"symmetric_all_different", "same variable more than once",
+            [](Problem & p, IntegerVariableID x, IntegerVariableID) { p.post(SymmetricAllDifferent{vector<IntegerVariableID>{x, x}}); }}};
 
     for (const auto & c : cases) {
         INFO("constraint type " << c.component);


### PR DESCRIPTION
Closes #767. **Stacked on #766** — base is `report-trivially-unsatisfiable-constraints`, retarget to `main` when that merges.

## What was missed

#722's census found its sites by grepping `Propagators::install_initial_contradiction`, so it missed a seventh locus of exactly the behaviour it is about. `gcs::innards::install_clique_duplicate_contradiction_initialiser` installed the same unconditional contradiction directly, for three constraints:

| Site | Guard | `constraint_type()` |
|---|---|---|
| `all_different.cc:145` | `_has_duplicate_vars` | `all_different` |
| `all_different_except.cc:134` | `_has_duplicates && _excluded.empty()` | `all_different_except` |
| `symmetric_all_different.cc:113` | `_has_duplicate_vars` | `symmetric_all_different` |

None throws — `AllDifferent{x, x}` is legal and answered correctly — so #722's "not in scope" exclusion did not cover them, and they were silent for the same reason and with the same consequence.

## What it says now

The helper forwards to `install_initial_contradiction`, taking the constraint's identity, its type and its diagnostic from the caller:

```
An AllDifferent constraint was posted with the same variable more than once, so the model is unsatisfiable before search starts (_1)
An AllDifferentExcept constraint with no excluded values was posted with the same variable more than once, so the model is unsatisfiable before search starts (_1)
A SymmetricAllDifferent constraint was posted with the same variable more than once, so the model is unsatisfiable before search starts (_1)
```

## Decisions

- **The helper keeps only what is actually shared: the proof argument.** The pair rows collapse to units, so the contradiction is bare RUP with no reason, and that is one fact worth having in one place for three constraints and two hint types. The diagnostic names a *kind* of constraint, so it is the caller's, as at the other seven sites.
- **The type comes from `constraint_type()`, not from `Hint_`** — as the issue asks. `symmetric_all_different.cc:113` justifies with `hints::AllDifferent`, which is right (the proof step is the clique one), so a note taking its component from the hint would label a `SymmetricAllDifferent` as `all_different`.
- **The `AllDifferentExcept` note says there were no excluded values**, because that is what makes the duplicate fatal. The `_has_duplicates && ! _excluded.empty()` branch is untouched, per the issue's "not in scope".

## Testing

The `solve_test` case from #766 grows from seven constraints to ten, in the same table, with the same assertions: exactly one `Important` note each, right component, right `ConstraintID`, prose naming what was wrong, consequence clause. Full `ctest` 725/725 green; GCC build warning-free; changed files clang-format-clean and clang `-fsyntax-only` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PAZYGJdsP3dmWAepRGi5T5