### PR TITLE
Move the two inferred-constraint presolvers onto the StatsNote channel

### DIFF
--- a/gcs/presolvers/inferred_cumulative/inferred_cumulative.cc
+++ b/gcs/presolvers/inferred_cumulative/inferred_cumulative.cc
@@ -8,6 +8,7 @@
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/proofs/proof_scaffolding_scope.hh>
+#include <gcs/innards/propagators.hh>
 #include <gcs/innards/state.hh>
 #include <gcs/presolvers/inferred_cumulative/inferred_cumulative.hh>
 #include <gcs/presolvers/innards/makespan_links.hh>
@@ -33,11 +34,13 @@ using std::map;
 using std::max;
 using std::min;
 using std::move;
+using std::nullopt;
 using std::optional;
 using std::pair;
 using std::set;
 using std::shared_ptr;
 using std::size_t;
+using std::string;
 using std::to_string;
 using std::unique_ptr;
 using std::vector;
@@ -420,7 +423,11 @@ namespace
 }
 
 InferredCumulative::InferredCumulative(shared_ptr<InferredCumulativeStats> stats) :
-    _stats(move(stats)), _max_covers(100), _max_posted(5), _maximum_capacity(1000), _max_lifting_calls(20000), _max_programme_states(100000),
+    // Always a block, whether or not anyone asked for one: the default
+    // experience was silent because nothing was allocated, not because the
+    // channel was wrong.
+    _stats(stats ? move(stats) : make_shared<InferredCumulativeStats>()), _max_covers(100), _max_posted(5), _maximum_capacity(1000),
+    _max_lifting_calls(20000), _max_programme_states(100000),
     // Energy only: a valid cut holds at every 0/1 point the donor's row allows,
     // so no time-tabling verdict about a single time point can differ.
     _rules(CumulativeRules{.time_table = false, .overload = true, .profile_overload = true}), _mutation(inferred_cumulative_mutation::None{})
@@ -472,10 +479,21 @@ auto InferredCumulative::with_makespan(IntegerVariableID makespan) -> InferredCu
 
 auto InferredCumulative::run(Problem & problem, Propagators & propagators, State & state, ProofLogger * const logger) -> bool
 {
-    auto bump = [&](size_t InferredCumulativeStats::* field, size_t by = 1) {
-        if (_stats)
-            (*_stats).*field += by;
+    // Before the loop, and unconditionally: a presolver that found no Cumulative
+    // to look at is the case worth being able to see, and it is the one every
+    // other check passes without noticing.
+    propagators.add_component_stats(_stats);
+
+    auto bump = [&](size_t InferredCumulativeStats::* field, size_t by = 1) { (*_stats).*field += by; };
+
+    auto note = [&](StatsLevel level, optional<ConstraintID> constraint, string text) {
+        propagators.report(StatsNote{.level = level, .component = _stats->component_name(), .constraint = move(constraint), .text = move(text)});
     };
+
+    // This run's own tally, rather than the block's: a block shared across two
+    // solves would otherwise have the first solve's drops counted into the
+    // second's Important note.
+    size_t cuts_unposted_this_run = 0, cuts_uncertifiable_this_run = 0;
 
     // What the model says about the makespan, if the caller named one: the rows
     // saying each task finishes by it, which are what a bound on it is derived
@@ -506,8 +524,8 @@ auto InferredCumulative::run(Problem & problem, Propagators & propagators, State
         // until that has a rule of its own rather than a hopeful `pol`.
         if (! donor.presences().empty()) {
             bump(&InferredCumulativeStats::declined_optional);
-            if (logger)
-                logger->emit_proof_comment("presolve lifted cover: declining " + as_string(donor.constraint_id()) + ", optional tasks");
+            note(StatsLevel::General, donor.constraint_id(),
+                "passed over: it has optional tasks, whose presence conjuncts do not yet cancel across a bridge between donors");
             continue;
         }
 
@@ -521,8 +539,8 @@ auto InferredCumulative::run(Problem & problem, Propagators & propagators, State
         auto view = cumulative_donor_view(donor, state, logger);
         if (! view) {
             bump(&InferredCumulativeStats::declined_irreducible_capacity);
-            if (logger)
-                logger->emit_proof_comment("presolve lifted cover: declining " + as_string(donor.constraint_id()) + ", capacity is not reducible");
+            note(StatsLevel::General, donor.constraint_id(),
+                "passed over: its capacity is a view, which cannot be reduced to a number to lift a cut out of");
             continue;
         }
         if (! view->set_aside.empty())
@@ -720,7 +738,11 @@ auto InferredCumulative::run(Problem & problem, Propagators & propagators, State
         return a.support < b.support;
     });
     if (cuts.size() > _max_posted) {
-        bump(&InferredCumulativeStats::dropped_over_budget, cuts.size() - _max_posted);
+        cuts_unposted_this_run = cuts.size() - _max_posted;
+        bump(&InferredCumulativeStats::dropped_over_budget, cuts_unposted_this_run);
+        note(StatsLevel::General, nullopt,
+            to_string(cuts_unposted_this_run) + " of " + to_string(cuts.size()) +
+                " inferred constraints left unposted, against an output budget of " + to_string(_max_posted) + ", see with_budgets");
         cuts.erase(cuts.begin() + static_cast<long>(_max_posted), cuts.end());
     }
 
@@ -741,9 +763,18 @@ auto InferredCumulative::run(Problem & problem, Propagators & propagators, State
         cut.validated = move(validity.cut);
         if (! cut.validated) {
             bump(validity.over_state_budget ? &InferredCumulativeStats::dropped_over_state_budget : &InferredCumulativeStats::cuts_uncertifiable);
-            if (logger)
-                logger->emit_proof_comment("presolve lifted cover: dropping an inferred constraint over " + to_string(cut.support.size()) +
-                    " tasks, " + (validity.over_state_budget ? "its dynamic programme is over budget" : "it does not follow from the rows"));
+            if (validity.over_state_budget) {
+                ++cuts_uncertifiable_this_run;
+                note(StatsLevel::General, nullopt,
+                    "an inferred constraint over " + to_string(cut.support.size()) +
+                        " tasks was dropped: the dynamic programme that would derive it needs more than " + to_string(_max_programme_states) +
+                        " states, see with_programme_state_budget");
+            }
+            else
+                note(StatsLevel::General, nullopt,
+                    "an inferred constraint over " + to_string(cut.support.size()) +
+                        " tasks was dropped: it does not in fact follow from the rows, so the published method would have posted something "
+                        "unsound");
             continue;
         }
         accepted.push_back(move(cut));
@@ -830,8 +861,7 @@ auto InferredCumulative::run(Problem & problem, Propagators & propagators, State
                 // built, seeded before any of this ran.
                 auto cached = recipe.programmes->find(present);
                 if (cached == recipe.programmes->end()) {
-                    if (recipe.stats)
-                        ++recipe.stats->restricted_rows_rebuilt;
+                    ++recipe.stats->restricted_rows_rebuilt;
                     cached = recipe.programmes
                                  ->emplace(present,
                                      validate_lifted_cover_cut(present_demands, coefficients, capacities, recipe.rhs, recipe.state_budget).cut)
@@ -972,7 +1002,7 @@ auto InferredCumulative::run(Problem & problem, Propagators & propagators, State
             .makespan_links = links,
             .makespan_bound_reached =
                 [stats = _stats](Integer bound) {
-                    if (stats && bound > stats->certified_makespan_bound)
+                    if (bound > stats->certified_makespan_bound)
                         stats->certified_makespan_bound = bound;
                 },
             .makespan_mutation = std::holds_alternative<inferred_cumulative_mutation::ClaimHigherMakespanBound>(_mutation)
@@ -990,12 +1020,30 @@ auto InferredCumulative::run(Problem & problem, Propagators & propagators, State
             bump(&InferredCumulativeStats::non_unit_cuts_posted);
         if (cut.validated->row_indices.size() > 1)
             bump(&InferredCumulativeStats::multi_resource_cuts_posted);
-        if (_stats && cut.bound() > _stats->largest_capacity_bound)
+        if (cut.bound() > _stats->largest_capacity_bound)
             _stats->largest_capacity_bound = cut.bound();
         if (logger)
             logger->emit_proof_comment("presolve lifted cover: inferred a cut over " + to_string(cut.support.size()) + " tasks on " +
                 to_string(cut.validated->row_indices.size()) + " resources with capacity " + to_string(cut.rhs.raw_value) + ", makespan bound " +
                 to_string(cut.bound().raw_value));
+    }
+
+    // The model-level consequence, for a reader who does not know what this
+    // presolver is: a limit stopped it doing what it was asked to do, so the
+    // configuration being run is not the one that was asked for. The figures
+    // and the option that raises them are in the General notes above; this one
+    // names neither, because naming them is what makes a message unreadable to
+    // the person it is for. A constraint that simply does not follow from the
+    // rows is not on this rung: nothing was limited, and there is no knob.
+    if (0 != cuts_unposted_this_run || 0 != cuts_uncertifiable_this_run) {
+        string what;
+        if (0 != cuts_unposted_this_run)
+            what = to_string(cuts_unposted_this_run) + " inferred constraints were never posted";
+        if (0 != cuts_uncertifiable_this_run)
+            what += (what.empty() ? string{} : string{", and "}) + to_string(cuts_uncertifiable_this_run) + " were dropped for want of a derivation";
+        note(StatsLevel::Important, nullopt,
+            "Inferring lifted cover cuts was cut short because a size limit was reached: " + what +
+                "; answers are still correct, but search may be slower");
     }
 
     return true;
@@ -1012,5 +1060,54 @@ auto InferredCumulative::clone() const -> unique_ptr<Presolver>
     result->with_proof_mutation(_mutation);
     if (_makespan)
         result->with_makespan(*_makespan);
+    return result;
+}
+
+auto InferredCumulativeStats::component_name() const -> std::string
+{
+    return "inferred_cumulative";
+}
+
+auto InferredCumulativeStats::summary() const -> std::string
+{
+    if (0 == donors_seen)
+        return "no posted Cumulative to look at";
+
+    if (0 == cuts_posted)
+        return "nothing inferred, of " + to_string(covers_considered) + " covers over " + to_string(tasks) + " tasks from " + to_string(donors_seen) +
+            " posted Cumulative" + (1 == donors_seen ? "" : "s") + " looked at";
+
+    return to_string(cuts_posted) + " constraint" + (1 == cuts_posted ? "" : "s") + " inferred from " + to_string(donors_seen) +
+        " posted Cumulative" + (1 == donors_seen ? "" : "s") + ", " + to_string(non_unit_cuts_posted) +
+        " of them with a coefficient above one, the best worth a makespan bound of " + to_string(largest_capacity_bound.raw_value);
+}
+
+auto InferredCumulativeStats::entries() const -> vector<StatsEntry>
+{
+    vector<StatsEntry> result;
+    auto add = [&](const char * name, size_t value) { result.push_back(StatsEntry{name, static_cast<long long>(value)}); };
+
+    add("donors_seen", donors_seen);
+    add("tasks", tasks);
+    add("covers_considered", covers_considered);
+    add("lifting_subproblems", lifting_subproblems);
+    add("lifting_subproblems_over_budget", lifting_subproblems_over_budget);
+    add("cuts_found", cuts_found);
+    add("cuts_uncertifiable", cuts_uncertifiable);
+    add("cuts_posted", cuts_posted);
+    add("non_unit_cuts_posted", non_unit_cuts_posted);
+    add("multi_resource_cuts_posted", multi_resource_cuts_posted);
+    add("restricted_rows_rebuilt", restricted_rows_rebuilt);
+    result.push_back(StatsEntry{"largest_capacity_bound", largest_capacity_bound.raw_value});
+    result.push_back(StatsEntry{"certified_makespan_bound", certified_makespan_bound.raw_value});
+    add("declined_optional", declined_optional);
+    add("declined_irreducible_capacity", declined_irreducible_capacity);
+    add("donors_with_set_aside_tasks", donors_with_set_aside_tasks);
+    add("converted_heights", converted_heights);
+    add("dropped_dominated", dropped_dominated);
+    add("dropped_over_budget", dropped_over_budget);
+    add("dropped_over_state_budget", dropped_over_state_budget);
+    add("declined_by_install", declined_by_install);
+
     return result;
 }

--- a/gcs/presolvers/inferred_cumulative/inferred_cumulative.hh
+++ b/gcs/presolvers/inferred_cumulative/inferred_cumulative.hh
@@ -5,11 +5,14 @@
 #include <gcs/integer.hh>
 #include <gcs/presolver.hh>
 #include <gcs/presolvers/innards/inferred_cumulative_mutations.hh>
+#include <gcs/stats.hh>
 
 #include <cstddef>
 #include <memory>
 #include <optional>
+#include <string>
 #include <variant>
+#include <vector>
 
 namespace gcs
 {
@@ -23,9 +26,14 @@ namespace gcs
      * separates this from the capacity-one stage before it: a cut with every
      * coefficient one is something InferredDisjunctive could also have found.
      *
+     * The presolver allocates one of these whether or not a caller asked for
+     * one, so the block reaches Stats::components() --- and, through it,
+     * `%%%mzn-stat` --- and says what happened even when nobody was interested
+     * enough to pass a handle in.
+     *
      * \ingroup Presolvers
      */
-    struct InferredCumulativeStats
+    struct InferredCumulativeStats final : ComponentStats
     {
         /// Posted Cumulatives the presolver looked at.
         std::size_t donors_seen = 0;
@@ -179,6 +187,10 @@ namespace gcs
         std::size_t dropped_over_state_budget = 0;
         std::size_t declined_by_install = 0;
         ///@}
+
+        [[nodiscard]] virtual auto component_name() const -> std::string override;
+        [[nodiscard]] virtual auto summary() const -> std::string override;
+        [[nodiscard]] virtual auto entries() const -> std::vector<StatsEntry> override;
     };
 
     /**

--- a/gcs/presolvers/inferred_cumulative/inferred_cumulative_test.cc
+++ b/gcs/presolvers/inferred_cumulative/inferred_cumulative_test.cc
@@ -940,6 +940,183 @@ auto main(int argc, char * argv[]) -> int
         println(cerr, "an optional-task donor is declined");
     }
 
+    /* The diagnostics channel (#662, #723). What a counter says is how many,
+     * and what a note says is which one and with what figures --- and a note's
+     * *level* is exactly what rendering throws away, so one drifting from
+     * Important down to Detailed would still appear in a dump, still say the
+     * right words, and be read by nobody. Hence assertions on the notes rather
+     * than on rendered output.
+     */
+    {
+        auto names_of = [](const ComponentStats & block) -> vector<string> {
+            vector<string> result;
+            for (const auto & entry : block.entries())
+                result.push_back(entry.name);
+            return result;
+        };
+
+        auto joined = [](const vector<string> & names) -> string {
+            string result;
+            for (const auto & name : names)
+                result += (result.empty() ? "" : ", ") + name;
+            return result;
+        };
+
+        auto component_named = [](const Stats & stats, const string & name) -> shared_ptr<const ComponentStats> {
+            for (const auto & component : stats.components())
+                if (component->component_name() == name)
+                    return component;
+            return nullptr;
+        };
+
+        struct Recorded
+        {
+            Stats stats;
+            vector<StatsNote> notes;
+        };
+
+        auto solve_recording = [](Problem & p) -> Recorded {
+            auto notes = make_shared<vector<StatsNote>>();
+            auto stats = solve_with(p,
+                SolveCallbacks{.trace = [](const CurrentState &) -> bool { return false; },
+                    .stats_report = [notes](const StatsNote & note) -> void { notes->push_back(note); }},
+                nullopt);
+            return Recorded{move(stats), move(*notes)};
+        };
+
+        auto notes_at = [](const Recorded & recorded, StatsLevel level) -> vector<StatsNote> {
+            vector<StatsNote> result;
+            for (const auto & note : recorded.notes)
+                if (note.level == level)
+                    result.push_back(note);
+            return result;
+        };
+
+        // The flat view's names are public: fzn-glasgow camel-cases
+        // component_name() onto each of them to make a %%%mzn-stat name, so
+        // renaming a field or dropping one from entries() is a user-visible
+        // change to statistics output. Asserted as an ordered list rather than
+        // a count so that a rename fails as a rename.
+        if (InferredCumulativeStats{}.component_name() != "inferred_cumulative")
+            fail("the block calls itself '" + InferredCumulativeStats{}.component_name() +
+                "', which is the first half of every %%%mzn-stat name it produces");
+
+        const vector<string> expected_names{"donors_seen", "tasks", "covers_considered", "lifting_subproblems", "lifting_subproblems_over_budget",
+            "cuts_found", "cuts_uncertifiable", "cuts_posted", "non_unit_cuts_posted", "multi_resource_cuts_posted", "restricted_rows_rebuilt",
+            "largest_capacity_bound", "certified_makespan_bound", "declined_optional", "declined_irreducible_capacity", "donors_with_set_aside_tasks",
+            "converted_heights", "dropped_dominated", "dropped_over_budget", "dropped_over_state_budget", "declined_by_install"};
+        if (names_of(InferredCumulativeStats{}) != expected_names)
+            fail("the flat view is [" + joined(names_of(InferredCumulativeStats{})) + "], expected [" + joined(expected_names) +
+                "]. These names are public, so this is a user-visible change and not a tidy-up.");
+
+        // And that the list is all of them. Every field of this block is eight
+        // bytes wide --- a std::size_t or an Integer --- and the only other
+        // thing in the object is the vtable pointer ComponentStats brings, so
+        // sizeof counts the fields. A field added without a matching entries()
+        // line moves one side of this and not the other.
+        if (8 == sizeof(std::size_t)) {
+            auto fields = (sizeof(InferredCumulativeStats) - sizeof(void *)) / sizeof(std::size_t);
+            if (expected_names.size() != fields)
+                fail("the block has " + to_string(fields) + " fields and " + to_string(expected_names.size()) +
+                    " of them reach the flat view: add the new one to entries() and to the list here, rather than to neither");
+        }
+
+        // A *default-constructed* presolver --- one nobody passed a block to ---
+        // reaches Stats::components() with the figures in it. That is the
+        // always-allocate path, and the part with no other observable effect:
+        // every other check this presolver has to pass is passed just as well
+        // while its block is invisible.
+        {
+            Problem p;
+            post(p, lifted_instance(10), Setup{});
+            auto recorded = solve_recording(p);
+
+            auto component = component_named(recorded.stats, "inferred_cumulative");
+            if (! component)
+                fail("a default-constructed presolver did not register a stats block");
+            if (component->summary().empty())
+                fail("the registered block had nothing to say");
+            if (string::npos == component->summary().find("makespan bound of 11"))
+                fail("the registered block was not the one the presolver filled in: " + component->summary());
+
+            println(cerr, "diagnostics: `{}`, {} entries", component->summary(), component->entries().size());
+        }
+
+        // And that a block the *caller* supplied is the one registered, by
+        // identity. Problem::add_presolver stores a clone and run() happens on
+        // that, so a clone allocating its own would leave the caller's handle
+        // reading zero while everything above carried on passing.
+        {
+            auto block = make_shared<InferredCumulativeStats>();
+            Problem p;
+            post(p, lifted_instance(10), Setup{.stats = block});
+            auto recorded = solve_recording(p);
+
+            if (component_named(recorded.stats, "inferred_cumulative").get() != static_cast<const ComponentStats *>(block.get()))
+                fail("the caller's stats block is not the one that was registered");
+            if (block->cuts_posted == 0)
+                fail("the caller's stats block was not the one that was filled in");
+        }
+
+        // A decline: General, naming the constraint it is about, and not
+        // Important --- nothing was limited, and a donor this presolver cannot
+        // bridge across is not a configuration the caller can change. If
+        // everything is Important then nothing is.
+        {
+            Problem p;
+            vector<IntegerVariableID> starts, presences;
+            for (int i = 0; i < 4; ++i) {
+                starts.push_back(p.create_integer_variable(0_i, 3_i));
+                presences.push_back(p.create_integer_variable(0_i, 1_i));
+            }
+            vector<IntegerVariableID> lengths(4, constant_variable(2_i)),
+                heights{constant_variable(5_i), constant_variable(2_i), constant_variable(2_i), constant_variable(2_i)};
+            p.post(Cumulative{starts, lengths, heights, presences, constant_variable(5_i)});
+            p.add_presolver(InferredCumulative{});
+            auto recorded = solve_recording(p);
+
+            auto general = notes_at(recorded, StatsLevel::General);
+            if (general.size() != 1)
+                fail("an optional-task decline reported " + to_string(general.size()) + " General notes, not one");
+            if (! general[0].constraint)
+                fail("the note does not carry the constraint it is about, so nothing can filter on it");
+            if (general[0].component != "inferred_cumulative")
+                fail("the note is not attributed to this presolver");
+            if (string::npos == general[0].text.find("optional"))
+                fail("the note does not say what was wrong: " + general[0].text);
+            if (! notes_at(recorded, StatsLevel::Important).empty())
+                fail("an optional-task decline raised an Important note");
+        }
+
+        // The output budget, which does carry a figure a caller would act on,
+        // reported at both levels: the figures and the option at General, and
+        // what it means at Important.
+        {
+            Problem p;
+            post(p, lifted_instance_with_spare(13), Setup{.max_posted = 0});
+            auto recorded = solve_recording(p);
+
+            auto general = notes_at(recorded, StatsLevel::General);
+            auto has_figures = false;
+            for (const auto & note : general)
+                if (string::npos != note.text.find("output budget of 0") && string::npos != note.text.find("with_budgets"))
+                    has_figures = true;
+            if (! has_figures)
+                fail("the output budget's figures and option are not in any General note");
+
+            auto important = notes_at(recorded, StatsLevel::Important);
+            if (important.size() != 1)
+                fail("an output-budget decline raised " + to_string(important.size()) + " Important notes, not one");
+            if (important[0].constraint)
+                fail("the Important note names a constraint, which is not what it is for");
+            if (string::npos == important[0].text.find("never posted") || string::npos == important[0].text.find("search may be slower"))
+                fail("the Important note does not say what was cut short, or what it costs: " + important[0].text);
+
+            println(cerr, "diagnostics: Important note is `{}`", important[0].text);
+        }
+    }
+    println(cerr, "the report and the notes say what happened, at the level for who is reading");
+
     if (! proofs) {
         println(cerr, "veripb is not available, so the proof-level checks are skipped");
         return EXIT_SUCCESS;

--- a/gcs/presolvers/inferred_disjunctive/inferred_disjunctive.cc
+++ b/gcs/presolvers/inferred_disjunctive/inferred_disjunctive.cc
@@ -13,6 +13,7 @@
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/proofs/proof_scaffolding_scope.hh>
 #include <gcs/innards/proofs/pseudo_boolean.hh>
+#include <gcs/innards/propagators.hh>
 #include <gcs/innards/state.hh>
 #include <gcs/presolvers/inferred_disjunctive/inferred_disjunctive.hh>
 #include <gcs/presolvers/innards/makespan_links.hh>
@@ -30,14 +31,17 @@
 using namespace gcs;
 using namespace gcs::innards;
 
+using std::make_shared;
 using std::make_unique;
 using std::map;
 using std::move;
+using std::nullopt;
 using std::optional;
 using std::pair;
 using std::set;
 using std::shared_ptr;
 using std::size_t;
+using std::string;
 using std::to_string;
 using std::unique_ptr;
 using std::vector;
@@ -118,7 +122,10 @@ namespace
 }
 
 InferredDisjunctive::InferredDisjunctive(shared_ptr<InferredDisjunctiveStats> stats) :
-    _stats(move(stats)), _max_candidates(100), _max_posted(5), _min_clique_size(3),
+    // Always a block, whether or not anyone asked for one: the default
+    // experience was silent because nothing was allocated, not because the
+    // channel was wrong.
+    _stats(stats ? move(stats) : make_shared<InferredDisjunctiveStats>()), _max_candidates(100), _max_posted(5), _min_clique_size(3),
     // Energy only: a conflicting pair is already kept apart by the resource
     // that witnesses it, so an inferred constraint's time-tabling is redundant.
     _rules(CumulativeRules{.time_table = false, .overload = true, .profile_overload = true}), _mutation(inferred_disjunctive_mutation::None{})
@@ -158,10 +165,21 @@ auto InferredDisjunctive::with_rules(CumulativeRules rules) -> InferredDisjuncti
 
 auto InferredDisjunctive::run(Problem & problem, Propagators & propagators, State & state, ProofLogger * const logger) -> bool
 {
-    auto bump = [&](size_t InferredDisjunctiveStats::* field, size_t by = 1) {
-        if (_stats)
-            (*_stats).*field += by;
+    // Before the loop, and unconditionally: a presolver that found no Cumulative
+    // to look at is the case worth being able to see, and it is the one every
+    // other check passes without noticing.
+    propagators.add_component_stats(_stats);
+
+    auto bump = [&](size_t InferredDisjunctiveStats::* field, size_t by = 1) { (*_stats).*field += by; };
+
+    auto note = [&](StatsLevel level, optional<ConstraintID> constraint, string text) {
+        propagators.report(StatsNote{.level = level, .component = _stats->component_name(), .constraint = move(constraint), .text = move(text)});
     };
+
+    // This run's own tally, rather than the block's: a block shared across two
+    // solves would otherwise have the first solve's drops counted into the
+    // second's Important note.
+    size_t pairs_ungrown_this_run = 0, cliques_unposted_this_run = 0;
 
     // What the model says about the makespan, if the caller named one: the rows
     // saying each task finishes by it, which are what a bound on it is derived
@@ -194,8 +212,8 @@ auto InferredDisjunctive::run(Problem & problem, Propagators & propagators, Stat
         // until that has a rule of its own rather than a hopeful `pol`.
         if (! donor.presences().empty()) {
             bump(&InferredDisjunctiveStats::declined_optional);
-            if (logger)
-                logger->emit_proof_comment("presolve disjunctive: declining " + as_string(donor.constraint_id()) + ", optional tasks");
+            note(StatsLevel::General, donor.constraint_id(),
+                "passed over: it has optional tasks, whose presence conjuncts do not yet cancel across a bridge between donors");
             continue;
         }
 
@@ -210,8 +228,8 @@ auto InferredDisjunctive::run(Problem & problem, Propagators & propagators, Stat
         auto view = cumulative_donor_view(donor, state, logger);
         if (! view) {
             bump(&InferredDisjunctiveStats::declined_irreducible_capacity);
-            if (logger)
-                logger->emit_proof_comment("presolve disjunctive: declining " + as_string(donor.constraint_id()) + ", capacity is not reducible");
+            note(StatsLevel::General, donor.constraint_id(),
+                "passed over: its capacity is a view, which cannot be reduced to a number to argue conflicts against");
             continue;
         }
         if (! view->set_aside.empty())
@@ -355,10 +373,11 @@ auto InferredDisjunctive::run(Problem & problem, Propagators & propagators, Stat
     size_t considered = 0;
     for (const auto & [u, v] : candidate_pairs) {
         if (considered >= _max_candidates) {
-            bump(&InferredDisjunctiveStats::dropped_over_candidate_budget, candidate_pairs.size() - considered);
-            if (logger)
-                logger->emit_proof_comment("presolve disjunctive: " + to_string(candidate_pairs.size() - considered) +
-                    " candidate pairs left ungrown, against a budget of " + to_string(_max_candidates));
+            pairs_ungrown_this_run = candidate_pairs.size() - considered;
+            bump(&InferredDisjunctiveStats::dropped_over_candidate_budget, pairs_ungrown_this_run);
+            note(StatsLevel::General, nullopt,
+                to_string(pairs_ungrown_this_run) + " candidate pairs left ungrown, against a budget of " + to_string(_max_candidates) +
+                    ", see with_budgets");
             break;
         }
         ++considered;
@@ -486,9 +505,8 @@ auto InferredDisjunctive::run(Problem & problem, Propagators & propagators, Stat
         }
 
         if (accepted.size() >= _max_posted) {
+            ++cliques_unposted_this_run;
             bump(&InferredDisjunctiveStats::dropped_over_posting_budget);
-            if (logger)
-                logger->emit_proof_comment("presolve disjunctive: a clique beyond the output budget of " + to_string(_max_posted) + " was dropped");
             continue;
         }
 
@@ -505,6 +523,14 @@ auto InferredDisjunctive::run(Problem & problem, Propagators & propagators, Stat
 
         accepted.push_back(move(clique));
     }
+
+    // One note for the lot rather than one per clique: the figure a caller acts
+    // on is how many were dropped, and a dense conflict graph produces enough
+    // of them to bury everything else this presolver has to say.
+    if (0 != cliques_unposted_this_run)
+        note(StatsLevel::General, nullopt,
+            to_string(cliques_unposted_this_run) + " cliques left unposted, against an output budget of " + to_string(_max_posted) +
+                ", see with_budgets");
 
     for (const auto & clique : accepted) {
         // Each member's flags come from its first appearance; the certificate
@@ -593,8 +619,7 @@ auto InferredDisjunctive::run(Problem & problem, Propagators & propagators, Stat
 
                     auto line = recover_conjunction_flag_bridge(recipe_logger, std::get<2>(*from), {std::get<0>(*from), std::get<1>(*from)},
                         std::get<2>(*to), {std::get<0>(*to), std::get<1>(*to)}, ProofLevel::Temporary);
-                    if (stats)
-                        ++stats->bridges_derived;
+                    ++stats->bridges_derived;
                     bridges.emplace(key, line);
                     return line;
                 };
@@ -697,7 +722,7 @@ auto InferredDisjunctive::run(Problem & problem, Propagators & propagators, Stat
             .makespan_links = links,
             .makespan_bound_reached =
                 [stats = _stats](Integer bound) {
-                    if (stats && bound > stats->certified_makespan_bound)
+                    if (bound > stats->certified_makespan_bound)
                         stats->certified_makespan_bound = bound;
                 },
             .makespan_mutation = std::holds_alternative<inferred_disjunctive_mutation::ClaimHigherMakespanBound>(_mutation)
@@ -713,7 +738,7 @@ auto InferredDisjunctive::run(Problem & problem, Propagators & propagators, Stat
         bump(&InferredDisjunctiveStats::cliques_posted);
         bump(&InferredDisjunctiveStats::clique_members_posted, clique.size());
         auto bound = capacity_bound(clique);
-        if (_stats && bound > _stats->largest_capacity_bound)
+        if (bound > _stats->largest_capacity_bound)
             _stats->largest_capacity_bound = bound;
         if (logger)
             logger->emit_proof_comment(
@@ -729,6 +754,23 @@ auto InferredDisjunctive::run(Problem & problem, Propagators & propagators, Stat
             bump(&InferredDisjunctiveStats::cross_donor_pairs);
     }
 
+    // The model-level consequence, for a reader who does not know what this
+    // presolver is: a limit stopped it doing what it was asked to do, so the
+    // configuration being run is not the one that was asked for. The figures
+    // and the option that raises them are in the General notes above; this one
+    // names neither, because naming them is what makes a message unreadable to
+    // the person it is for.
+    if (0 != pairs_ungrown_this_run || 0 != cliques_unposted_this_run) {
+        string what;
+        if (0 != pairs_ungrown_this_run)
+            what = to_string(pairs_ungrown_this_run) + " pairs of tasks were never grown into a clique";
+        if (0 != cliques_unposted_this_run)
+            what += (what.empty() ? string{} : string{", and "}) + to_string(cliques_unposted_this_run) + " cliques were found and not posted";
+        note(StatsLevel::Important, nullopt,
+            "Inferring Disjunctives was cut short because a size limit was reached: " + what +
+                "; answers are still correct, but search may be slower");
+    }
+
     return true;
 }
 
@@ -741,5 +783,55 @@ auto InferredDisjunctive::clone() const -> unique_ptr<Presolver>
     result->with_proof_mutation(_mutation);
     if (_makespan)
         result->with_makespan(*_makespan);
+    return result;
+}
+
+auto InferredDisjunctiveStats::component_name() const -> std::string
+{
+    return "inferred_disjunctive";
+}
+
+auto InferredDisjunctiveStats::summary() const -> std::string
+{
+    if (0 == donors_seen)
+        return "no posted Cumulative to look at";
+
+    if (0 == cliques_posted)
+        return "nothing inferred, of " + to_string(conflicting_pairs) + " conflicting pairs over " + to_string(tasks) + " tasks from " +
+            to_string(donors_seen) + " posted Cumulative" + (1 == donors_seen ? "" : "s") + " looked at";
+
+    return to_string(cliques_posted) + " clique" + (1 == cliques_posted ? "" : "s") + " posted over " + to_string(clique_members_posted) +
+        " task appearances, from " + to_string(donors_seen) + " posted Cumulative" + (1 == donors_seen ? "" : "s") +
+        ", the best of them worth a makespan bound of " + to_string(largest_capacity_bound.raw_value);
+}
+
+auto InferredDisjunctiveStats::entries() const -> vector<StatsEntry>
+{
+    vector<StatsEntry> result;
+    auto add = [&](const char * name, size_t value) { result.push_back(StatsEntry{name, static_cast<long long>(value)}); };
+
+    add("donors_seen", donors_seen);
+    add("tasks", tasks);
+    add("conflicting_pairs", conflicting_pairs);
+    add("cross_donor_pairs", cross_donor_pairs);
+    add("cliques_found", cliques_found);
+    add("cliques_posted", cliques_posted);
+    add("clique_members_posted", clique_members_posted);
+    result.push_back(StatsEntry{"largest_capacity_bound", largest_capacity_bound.raw_value});
+    result.push_back(StatsEntry{"certified_makespan_bound", certified_makespan_bound.raw_value});
+    add("resources_with_set_aside_tasks", resources_with_set_aside_tasks);
+    add("converted_heights", converted_heights);
+    add("bridges_derived", bridges_derived);
+    add("declined_optional", declined_optional);
+    add("declined_irreducible_capacity", declined_irreducible_capacity);
+    add("dropped_too_small", dropped_too_small);
+    add("dropped_subset", dropped_subset);
+    add("dropped_dominated", dropped_dominated);
+    add("dropped_over_candidate_budget", dropped_over_candidate_budget);
+    add("dropped_over_posting_budget", dropped_over_posting_budget);
+    add("dropped_disagreeing_length", dropped_disagreeing_length);
+    add("dropped_duplicate_appearance", dropped_duplicate_appearance);
+    add("declined_by_install", declined_by_install);
+
     return result;
 }

--- a/gcs/presolvers/inferred_disjunctive/inferred_disjunctive.hh
+++ b/gcs/presolvers/inferred_disjunctive/inferred_disjunctive.hh
@@ -5,11 +5,14 @@
 #include <gcs/integer.hh>
 #include <gcs/presolver.hh>
 #include <gcs/presolvers/innards/inferred_disjunctive_mutations.hh>
+#include <gcs/stats.hh>
 
 #include <cstddef>
 #include <memory>
 #include <optional>
+#include <string>
 #include <variant>
+#include <vector>
 
 namespace gcs
 {
@@ -24,9 +27,14 @@ namespace gcs
      * find ones: a budget that silently swallowed every candidate looks exactly
      * like a conflict graph with no cliques in it.
      *
+     * The presolver allocates one of these whether or not a caller asked for
+     * one, so the block reaches Stats::components() --- and, through it,
+     * `%%%mzn-stat` --- and says what happened even when nobody was interested
+     * enough to pass a handle in.
+     *
      * \ingroup Presolvers
      */
-    struct InferredDisjunctiveStats
+    struct InferredDisjunctiveStats final : ComponentStats
     {
         /// Posted Cumulatives the presolver looked at.
         std::size_t donors_seen = 0;
@@ -158,6 +166,10 @@ namespace gcs
         std::size_t dropped_duplicate_appearance = 0;
         std::size_t declined_by_install = 0;
         ///@}
+
+        [[nodiscard]] virtual auto component_name() const -> std::string override;
+        [[nodiscard]] virtual auto summary() const -> std::string override;
+        [[nodiscard]] virtual auto entries() const -> std::vector<StatsEntry> override;
     };
 
     /**

--- a/gcs/presolvers/inferred_disjunctive/inferred_disjunctive_test.cc
+++ b/gcs/presolvers/inferred_disjunctive/inferred_disjunctive_test.cc
@@ -419,6 +419,201 @@ auto main(int argc, char * argv[]) -> int
     }
     println(cerr, "an optional-task donor is declined");
 
+    /* The diagnostics channel (#662, #723). What a counter says is how many,
+     * and what a note says is which one and with what figures --- and a note's
+     * *level* is exactly what rendering throws away, so one drifting from
+     * Important down to Detailed would still appear in a dump, still say the
+     * right words, and be read by nobody. Hence assertions on the notes rather
+     * than on rendered output.
+     */
+    {
+        auto names_of = [](const ComponentStats & block) -> vector<string> {
+            vector<string> result;
+            for (const auto & entry : block.entries())
+                result.push_back(entry.name);
+            return result;
+        };
+
+        auto joined = [](const vector<string> & names) -> string {
+            string result;
+            for (const auto & name : names)
+                result += (result.empty() ? "" : ", ") + name;
+            return result;
+        };
+
+        auto component_named = [](const Stats & stats, const string & name) -> shared_ptr<const ComponentStats> {
+            for (const auto & component : stats.components())
+                if (component->component_name() == name)
+                    return component;
+            return nullptr;
+        };
+
+        struct Recorded
+        {
+            Stats stats;
+            vector<StatsNote> notes;
+        };
+
+        auto solve_recording = [](Problem & p) -> Recorded {
+            auto notes = make_shared<vector<StatsNote>>();
+            auto stats = solve_with(p,
+                SolveCallbacks{.trace = [](const CurrentState &) -> bool { return false; },
+                    .stats_report = [notes](const StatsNote & note) -> void { notes->push_back(note); }},
+                nullopt);
+            return Recorded{move(stats), move(*notes)};
+        };
+
+        auto notes_at = [](const Recorded & recorded, StatsLevel level) -> vector<StatsNote> {
+            vector<StatsNote> result;
+            for (const auto & note : recorded.notes)
+                if (note.level == level)
+                    result.push_back(note);
+            return result;
+        };
+
+        // The flat view's names are public: fzn-glasgow camel-cases
+        // component_name() onto each of them to make a %%%mzn-stat name, so
+        // renaming a field or dropping one from entries() is a user-visible
+        // change to statistics output. Asserted as an ordered list rather than
+        // a count so that a rename fails as a rename.
+        if (InferredDisjunctiveStats{}.component_name() != "inferred_disjunctive")
+            fail("the block calls itself '" + InferredDisjunctiveStats{}.component_name() +
+                "', which is the first half of every %%%mzn-stat name it produces");
+
+        const vector<string> expected_names{"donors_seen", "tasks", "conflicting_pairs", "cross_donor_pairs", "cliques_found", "cliques_posted",
+            "clique_members_posted", "largest_capacity_bound", "certified_makespan_bound", "resources_with_set_aside_tasks", "converted_heights",
+            "bridges_derived", "declined_optional", "declined_irreducible_capacity", "dropped_too_small", "dropped_subset", "dropped_dominated",
+            "dropped_over_candidate_budget", "dropped_over_posting_budget", "dropped_disagreeing_length", "dropped_duplicate_appearance",
+            "declined_by_install"};
+        if (names_of(InferredDisjunctiveStats{}) != expected_names)
+            fail("the flat view is [" + joined(names_of(InferredDisjunctiveStats{})) + "], expected [" + joined(expected_names) +
+                "]. These names are public, so this is a user-visible change and not a tidy-up.");
+
+        // And that the list is all of them. Every field of this block is eight
+        // bytes wide --- a std::size_t or an Integer --- and the only other
+        // thing in the object is the vtable pointer ComponentStats brings, so
+        // sizeof counts the fields. A field added without a matching entries()
+        // line moves one side of this and not the other.
+        if (8 == sizeof(std::size_t)) {
+            auto fields = (sizeof(InferredDisjunctiveStats) - sizeof(void *)) / sizeof(std::size_t);
+            if (expected_names.size() != fields)
+                fail("the block has " + to_string(fields) + " fields and " + to_string(expected_names.size()) +
+                    " of them reach the flat view: add the new one to entries() and to the list here, rather than to neither");
+        }
+
+        // A *default-constructed* presolver --- one nobody passed a block to ---
+        // reaches Stats::components() with the figures in it. That is the
+        // always-allocate path, and the part with no other observable effect:
+        // every other check this presolver has to pass is passed just as well
+        // while its block is invisible.
+        {
+            Problem p;
+            post_family(p, 3, 2, 6, Setup{});
+            auto recorded = solve_recording(p);
+
+            auto component = component_named(recorded.stats, "inferred_disjunctive");
+            if (! component)
+                fail("a default-constructed presolver did not register a stats block");
+            if (component->summary().empty())
+                fail("the registered block had nothing to say");
+            if (string::npos == component->summary().find("1 clique posted"))
+                fail("the registered block was not the one the presolver filled in: " + component->summary());
+
+            println(cerr, "diagnostics: `{}`, {} entries", component->summary(), component->entries().size());
+        }
+
+        // And that a block the *caller* supplied is the one registered, by
+        // identity. Problem::add_presolver stores a clone and run() happens on
+        // that, so a clone allocating its own would leave the caller's handle
+        // reading zero while everything above carried on passing.
+        {
+            auto block = make_shared<InferredDisjunctiveStats>();
+            Problem p;
+            post_family(p, 3, 2, 6, Setup{.stats = block});
+            auto recorded = solve_recording(p);
+
+            if (component_named(recorded.stats, "inferred_disjunctive").get() != static_cast<const ComponentStats *>(block.get()))
+                fail("the caller's stats block is not the one that was registered");
+            if (block->cliques_posted != 1)
+                fail("the caller's stats block was not the one that was filled in");
+        }
+
+        // A decline: General, naming the constraint it is about, and not
+        // Important --- nothing was limited, and a donor this presolver cannot
+        // bridge across is not a configuration the caller can change. If
+        // everything is Important then nothing is.
+        {
+            Problem p;
+            vector<IntegerVariableID> starts, presences;
+            for (int i = 0; i < 3; ++i) {
+                starts.push_back(p.create_integer_variable(0_i, 3_i));
+                presences.push_back(p.create_integer_variable(0_i, 1_i));
+            }
+            vector<IntegerVariableID> lengths{constant_variable(2_i), constant_variable(2_i), constant_variable(2_i)},
+                heights{constant_variable(1_i), constant_variable(1_i), constant_variable(1_i)};
+            p.post(Cumulative{starts, lengths, heights, presences, constant_variable(1_i)});
+            p.add_presolver(InferredDisjunctive{});
+            auto recorded = solve_recording(p);
+
+            auto general = notes_at(recorded, StatsLevel::General);
+            if (general.size() != 1)
+                fail("an optional-task decline reported " + to_string(general.size()) + " General notes, not one");
+            if (! general[0].constraint)
+                fail("the note does not carry the constraint it is about, so nothing can filter on it");
+            if (general[0].component != "inferred_disjunctive")
+                fail("the note is not attributed to this presolver");
+            if (string::npos == general[0].text.find("optional"))
+                fail("the note does not say what was wrong: " + general[0].text);
+            if (! notes_at(recorded, StatsLevel::Important).empty())
+                fail("an optional-task decline raised an Important note");
+        }
+
+        // The budgets, which do carry a figure a caller would act on, reported
+        // at both levels: the figures and the option at General, and what it
+        // means at Important. The two budgets are separate counters bounding
+        // different costs, so each has to reach the Important note on its own.
+        {
+            Problem p;
+            post_family(p, 3, 2, 6, Setup{.max_candidates = 0});
+            auto recorded = solve_recording(p);
+
+            auto general = notes_at(recorded, StatsLevel::General);
+            if (general.size() != 1 || string::npos == general[0].text.find("against a budget of 0") ||
+                string::npos == general[0].text.find("with_budgets"))
+                fail("the candidate budget's figures and option are not in a General note");
+            if (general[0].constraint)
+                fail("the candidate budget's note names a constraint, and the budget is not about one");
+
+            auto important = notes_at(recorded, StatsLevel::Important);
+            if (important.size() != 1)
+                fail("a candidate-budget decline raised " + to_string(important.size()) + " Important notes, not one");
+            if (important[0].constraint)
+                fail("the Important note names a constraint, which is not what it is for");
+            if (string::npos == important[0].text.find("never grown into a clique") || string::npos == important[0].text.find("search may be slower"))
+                fail("the Important note does not say what was cut short, or what it costs: " + important[0].text);
+
+            println(cerr, "diagnostics: Important note is `{}`", important[0].text);
+        }
+
+        {
+            Problem p;
+            post_family(p, 3, 2, 6, Setup{.max_posted = 0});
+            auto recorded = solve_recording(p);
+
+            auto general = notes_at(recorded, StatsLevel::General);
+            if (general.size() != 1 || string::npos == general[0].text.find("output budget of 0") ||
+                string::npos == general[0].text.find("with_budgets"))
+                fail("the posting budget's figures and option are not in a General note");
+
+            auto important = notes_at(recorded, StatsLevel::Important);
+            if (important.size() != 1)
+                fail("a posting-budget decline raised " + to_string(important.size()) + " Important notes, not one");
+            if (string::npos == important[0].text.find("found and not posted"))
+                fail("the Important note does not say what was cut short: " + important[0].text);
+        }
+    }
+    println(cerr, "the report and the notes say what happened, at the level for who is reading");
+
     /* Variable arguments, which are a restriction on a *task* rather than on a
      * resource. Three tasks of length two, pairwise conflicting on three
      * resources exactly as the family above, but with two things that family

--- a/xcsp/CMakeLists.txt
+++ b/xcsp/CMakeLists.txt
@@ -83,12 +83,21 @@ add_xcsp_test(cumulative_var)
 # the peephole's doing --- without it they would arrive as comparisons
 # over invented auxiliaries instead --- and SKIPPED UNCITABLE ROW 0 says
 # no donor of the right shape was dropped for want of a citable OPB row.
+#
+# These names are also the contract between ComponentStats::entries() and the
+# generic loop in xcsp_glasgow_constraint_solver.cc: each is component_name()
+# and an entry name upper-cased together, so a rename on either side fails here
+# rather than in whatever is parsing the output. DIFFERENCE LOGIC PROPAGATOR
+# INSTALLED is one of the two fields that were filled in and reported to nobody
+# until the loop replaced the hand-written list, and is here so that stays
+# fixed --- as differenceLogicPropagatorInstalled is in minizinc/CMakeLists.txt.
 add_xcsp_test(difference_logic "--difference-logic"
     "^d DIFFERENCE LOGIC EDGES LIFTED 4$"
     "^d DIFFERENCE LOGIC COMPARISON EDGES LIFTED 0$"
     "^d DIFFERENCE LOGIC NODES 4$"
     "^d DIFFERENCE LOGIC SKIPPED NOT TWO TERMS 1$"
     "^d DIFFERENCE LOGIC SKIPPED UNCITABLE ROW 0$"
+    "^d DIFFERENCE LOGIC PROPAGATOR INSTALLED 1$"
     "^d DIFFERENCE LOGIC SIMPLIFY RAN 1$")
 add_xcsp_test(disjunctive)
 add_xcsp_test(no_overlap_var)

--- a/xcsp/xcsp_glasgow_constraint_solver.cc
+++ b/xcsp/xcsp_glasgow_constraint_solver.cc
@@ -10,6 +10,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <cctype>
 #include <chrono>
 #include <condition_variable>
 #include <csignal>
@@ -87,6 +88,19 @@ namespace
 {
     atomic<bool> abort_flag{false};
     atomic<bool> was_terminated{false};
+
+    // A ComponentStats entry's name in the XCSP idiom: `difference_logic` and
+    // `edges_lifted` make `DIFFERENCE LOGIC EDGES LIFTED`, which is exactly
+    // what the hand-written list here used to spell, so nothing parsing this
+    // output sees a name change. fzn_glasgow.cc's mzn_stat_name is the same
+    // function in the MiniZinc idiom.
+    [[nodiscard]] auto xcsp_stat_name(const string & component, const string & entry) -> string
+    {
+        string result;
+        for (auto c : component + "_" + entry)
+            result += ('_' == c) ? ' ' : static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
+        return result;
+    }
 
     auto sig_int_or_term_handler(int) -> void
     {
@@ -2078,25 +2092,16 @@ auto main(int argc, char * argv[]) -> int
     if (options_vars.contains("all"))
         cout << "d FOUND SOLUTIONS " << stats.solutions << endl;
 
-    // A presolver that lifts nothing preserves the solution set, adds no OPB
-    // content and leaves every proof verifying, so these counts are the only way
-    // to tell "it worked" from "it silently did nothing" --- which is why a test
-    // asserts on them.
-    if (difference_logic_stats) {
-        cout << "d DIFFERENCE LOGIC EDGES LIFTED " << difference_logic_stats->edges_lifted << endl;
-        cout << "d DIFFERENCE LOGIC COMPARISON EDGES LIFTED " << difference_logic_stats->comparison_edges_lifted << endl;
-        cout << "d DIFFERENCE LOGIC HALF REIFIED EDGES LIFTED " << difference_logic_stats->half_reified_edges_lifted << endl;
-        cout << "d DIFFERENCE LOGIC NODES " << difference_logic_stats->nodes << endl;
-        cout << "d DIFFERENCE LOGIC SKIPPED NOT TWO TERMS " << difference_logic_stats->skipped_not_two_terms << endl;
-        cout << "d DIFFERENCE LOGIC SKIPPED COEFFICIENTS " << difference_logic_stats->skipped_coefficients << endl;
-        cout << "d DIFFERENCE LOGIC SKIPPED REIFIED " << difference_logic_stats->skipped_reified << endl;
-        cout << "d DIFFERENCE LOGIC SKIPPED NEGATED VIEW " << difference_logic_stats->skipped_negated_view << endl;
-        cout << "d DIFFERENCE LOGIC SKIPPED DEGENERATE " << difference_logic_stats->skipped_degenerate << endl;
-        cout << "d DIFFERENCE LOGIC SKIPPED UNCITABLE ROW " << difference_logic_stats->skipped_uncitable_row << endl;
-        cout << "d DIFFERENCE LOGIC SIMPLIFY RAN " << (difference_simplification_stats->ran ? 1 : 0) << endl;
-        cout << "d DIFFERENCE LOGIC SIMPLIFY REDUNDANT EDGES REMOVED " << difference_simplification_stats->redundant_edges_removed << endl;
-        cout << "d DIFFERENCE LOGIC SIMPLIFY CONDITIONS FIXED " << difference_simplification_stats->conditions_fixed << endl;
-    }
+    // Every component that registered a block, rendered without this file
+    // knowing which components exist. A presolver that lifts nothing preserves
+    // the solution set, adds no OPB content and leaves every proof verifying, so
+    // these counts are the only way to tell "it worked" from "it silently did
+    // nothing" --- and listing them by hand here is how ten of
+    // DifferenceLogicStats' twelve fields, and three of the simplification
+    // block's fourteen, were the whole of what this frontend reported.
+    for (const auto & component : stats.components())
+        for (const auto & entry : component->entries())
+            cout << "d " << xcsp_stat_name(component->component_name(), entry.name) << " " << entry.value << endl;
 
     return actually_aborted ? EXIT_FAILURE : EXIT_SUCCESS;
 }


### PR DESCRIPTION
Closes #723.

## What was still on the old channel

`InferredDisjunctive` and `InferredCumulative` reported their decisions as proof comments — the exact thing #662 was opened about: a decision that is invisible with proofs off, and that nobody reads with proofs on. Neither block was a `ComponentStats`, so after #720 they were also invisible to `%%%mzn-stat` while `cumulative_strengthening`, `auto_table`, `difference_logic` and `difference_logic_simplify` all reported.

## What changed

Both blocks derive from `ComponentStats` with `component_name` / `summary` / `entries`; both presolvers allocate one whether or not a caller asked, and register it before deciding anything; the declines are `StatsNote`s. The successes stay as proof comments, as `CumulativeStrengthening`'s do — what annotates a derivation is not a decision about the model.

```
inferred_disjunctive: 1 clique posted over 3 task appearances, from 3 posted Cumulatives, the best of them worth a makespan bound of 6
inferred_cumulative: 5 constraints inferred from 1 posted Cumulative, 1 of them with a coefficient above one, the best worth a makespan bound of 11
```

Both have the property that made the cumulative case worth an `Important` note — a budget can stop them doing what they were asked, and there is a knob to raise. So the figures and the option are `General` and name the constraint where there is one, and one `Important` note per run says what was cut short and what it costs, naming neither:

```
Inferring Disjunctives was cut short because a size limit was reached: 3 pairs of tasks were never grown into a clique; answers are still correct, but search may be slower
Inferring lifted cover cuts was cut short because a size limit was reached: 11 inferred constraints were never posted; answers are still correct, but search may be slower
```

## Two corrections to the issue's census

- **Seven decision proof comments, not five.** `inferred_disjunctive.cc:360` (the candidate-budget drop) is the same kind of budget decline as `:491`, and `inferred_cumulative.cc:745` (dropping an inferred constraint) is a decision too. Both converted.
- **`:745`'s two halves land on opposite sides of the `Important` rung.** A dynamic programme over its state budget is a limit with a knob (`with_programme_state_budget`), so it counts toward the aggregate note. A cut that does not in fact follow from the rows is not a limit and stays `General` — it is the gap between the published method and what can be certified, which is a fact about the method, not about the configuration.

`derived_cumulative.cc:235` is untouched, per the issue.

## Other decisions

- **The posting-budget note is one note with a total, not one per dropped clique.** A dense conflict graph produces enough of them to bury everything else the presolver has to say. The candidate-budget note already had this shape.
- **No designated-initialiser fallout.** The issue warned to expect the #720 fixture breakage; neither block was ever constructed that way (both test files use `make_shared` and `->field`), so no `Expected` mirror was needed. `examples/rcpsp/rcpsp.cc` uses `make_shared` too and is unchanged.
- The now-dead `if (_stats)` and `if (stats && ...)` guards are gone, since always-allocate makes the block an invariant.

## While in the area (second commit)

`xcsp_glasgow_constraint_solver.cc` still hand-wrote the difference-logic statistics, reporting ten of `DifferenceLogicStats`' twelve fields and three of the simplification block's fourteen. Replaced with the same generic loop `fzn_glasgow.cc` uses, in the XCSP idiom: `component_name()` and the entry name, upper-cased with underscores as spaces — which is *exactly* what the hand-written lines spelled, so every previously-printed line comes out byte for byte identical and nothing parsing this output sees a rename. The six pinned lines in `xcsp/CMakeLists.txt` still match; `DIFFERENCE LOGIC PROPAGATOR INSTALLED` is now pinned too, as `differenceLogicPropagatorInstalled` is on the MiniZinc side.

## Testing

Each presolver's test grows a diagnostics block, mirroring `cumulative_strengthening_test.cc`: a default-constructed presolver registers a block with the figures in it; a caller's block is the one registered, by identity; a decline is `General`, names its constraint, and is *not* `Important`; a budget decline is both, with the option named at `General` and no constraint named at `Important`. Entry names are asserted as **ordered lists** (per the issue) since #720 made them public `%%%mzn-stat` names, plus a field-count check so a field added without an `entries()` line fails.

Full `ctest` 725/725 green, rebased onto current main (post-#764). GCC build warning-free, clang `-fsyntax-only` clean, clang-format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PAZYGJdsP3dmWAepRGi5T5