### PR TITLE
Certify Disjunctive's published not-first / not-last (#757)

### DIFF
--- a/dev_docs/disjunctive-proof-logging.md
+++ b/dev_docs/disjunctive-proof-logging.md
@@ -949,10 +949,13 @@ every change is small and they run both ways: the best instance goes to
 0.965x and the worst to 1.060x. On top of edge-finding it is a small
 loss, and the 1.026x is one instance at 4.05x carrying it.
 
-So the certificate is **not built**, and the switch is here as the record
-of why. It throws rather than propagating under `--prove`: a rule that
-quietly weakened itself when proof logging came on would confound exactly
-the comparison it exists to make.
+The switch is here as the record of why, and it was for a long time the
+one rule in the suite that threw rather than propagating under `--prove`.
+That is no longer true. **The certificate is built** (see "The published
+condition's certificate", below): a solver that cannot prove one of its
+own rules is a worse thing to have than a rule that does not pay for its
+sweep, and the measurement above is a reason to leave the switch off by
+default, not a reason to leave it unprovable.
 
 The result is worth more than the propagator would have been. #746 asks,
 on the cumulative side, whether certifying a weaker detection than the
@@ -971,6 +974,63 @@ past everything else running on 2.9% of nodes — a *smaller* gap than the
 one measured here to be worth nothing. That is not a reason to close
 #754, whose gap is against a different rule's fixpoint rather than a
 weaker form of its own, but it is the number to beat before building it.
+
+### The published condition's certificate
+
+The window follows the detection. Ours argues over the window the sweep
+enumerated; the published one argues over a window the negated conclusion
+*derives*, and the certificate is the same shape over that window
+instead:
+
+```
+not-first   [ect_j, lct(Θ))          left edge from the conclusion
+not-last    [est(Θ), ub(s_j))        right edge from the conclusion
+```
+
+Take not-first, and suppose the conclusion `s_j ≥ ECT(Θ)` fails. Then for
+every `k ∈ Θ`, `s_j < ECT(Θ) ≤ ect_k = est_k + p_k ≤ s_k + p_k`, so `k`
+does not run before `j`; the pair's separation clause therefore puts `j`
+before `k`, and `s_k ≥ s_j + p_j ≥ lb(s_j) + p_j = ect_j`. Every contained
+task is inside `[ect_j, lct(Θ))`, which the detection says is too narrow
+to hold them all. The mirror reads the same sentence backwards.
+
+So the rows cited are the **standard contained-task guarded ones** over
+that window — the same `derive_guarded_window_energy` call edge-finding
+makes — and what is new is only how one of each row's two guards is
+discharged: by a *derived two-literal clause* rather than by the reason,
+the clause carrying the conclusion literal at that guard's coefficient so
+the conclusion accumulates across Θ and the summed pol derives it. That
+is #754's mechanism, and this is where it was first worked out; #754
+built it first because it was the rule worth having. Which guard is which
+is the whole difference between the two halves, and it is the **opposite
+way round** from #754's:
+
+| | low guard `[s_k ≥ ·]` | high guard `[s_k < ·]` |
+|---|---|---|
+| not-first | `ect_j`, derived | `lct(Θ) − p_k + 1`, from the reason |
+| not-last | `est(Θ)`, from the reason | `ub(s_j) − p_k + 1`, derived |
+
+**The shortcut, which is not a corner case.** The derived window is
+narrower than the sweep's by construction, so a contained task too long
+to fit inside it at all is common rather than exotic. There the two
+guards on that one task are already contradictory — "starts at or after
+`ect_j`" against the reason's "starts at or before `lct(Θ) − p_k`" — and
+the whole derivation is the clause taken at the task's own far bound plus
+the reason's row for that bound. No energy argument, no at-most-ones, no
+activity flags. It is also the only place the energy path could otherwise
+ask the lemma for a window it cannot fill, so the two paths are exhaustive
+rather than merely convenient.
+
+**What the mutation lanes say.** Six lanes, `emit_nothing` /
+`skip_fold` / `drop_energy` / `drop_clause` / `rup_clause` /
+`one_too_far`. Over 300 generated instances, 172 fired the rule and 24 of
+those rejected every lane. The fragile ones are `skip_fold` (36 of 172)
+and `drop_energy` (58), for this rule family's usual reason — the
+thresholds are `min ect` and `max lst`, quantities pairwise reasoning can
+often reach on its own. The two aimed at what is *new* hold up much
+better: `drop_clause` 127 and `rup_clause` 130. In particular unit
+propagation cannot reach the clause on its own, which is the same
+cross-variable limit `RupOverloadBridge` finds in the bridge.
 
 ## The set-based detectable precedence, measured before it is certified (#754)
 

--- a/examples/rcpsp/rcpsp.cc
+++ b/examples/rcpsp/rcpsp.cc
@@ -457,10 +457,10 @@ auto main(int argc, char * argv[]) -> int
                 "Detect not-first / not-last by the published unary condition rather than by the " //
                 "guarded window-energy one: the published rule argues over a narrower window "     //
                 "whose left edge the negated conclusion derives, and fires 1.6-1.7x as often. "    //
-                "Implies --disjunctive-not-first-not-last. A measurement switch, and the "         //
-                "measurement is made: that detection is worth 0.6% of the summed recursions and "  //
-                "nothing at the median, so it is deliberately uncertified and throws rather than " //
-                "propagating under --prove (#757)")                                                //
+                "Implies --disjunctive-not-first-not-last. Certified over that derived window, "   //
+                "by the same mechanism --disjunctive-detectable-precedences-set uses. Off by "     //
+                "default because the measurement is made: that detection is worth 0.6% of the "    //
+                "summed recursions and nothing at the median (#757)")                              //
             ("disjunctive-detectable-precedences-set",
                 "Push a detectable precedence to the set's earliest completion time rather than " //
                 "to the latest single predecessor's earliest end, and the mirror --- Vilim's "    //

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -291,6 +291,7 @@ if(GCS_BUILD_TESTS)
     add_executable(disjunctive_nfnl_test constraints/disjunctive/disjunctive_nfnl_test.cc)
     add_executable(disjunctive_precedences_test constraints/disjunctive/disjunctive_precedences_test.cc)
     add_executable(disjunctive_set_precedences_test constraints/disjunctive/disjunctive_set_precedences_test.cc)
+    add_executable(disjunctive_published_nfnl_test constraints/disjunctive/disjunctive_published_nfnl_test.cc)
     add_executable(disjunctive_2d_test constraints/disjunctive_2d/disjunctive_2d_test.cc)
     add_executable(divide_modulus_test constraints/divide_modulus/divide_modulus_test.cc)
     add_executable(element_test constraints/element/element_test.cc)
@@ -337,7 +338,7 @@ if(GCS_BUILD_TESTS)
 
     foreach(test_target
             abs_test all_different_test all_different_except_test all_equal_test among_test at_most_one_test bin_packing_test comparison_test
-            count_test cumulative_test cumulative_overload_test cumulative_edge_finding_test cumulative_ttef_test cumulative_nfnl_test cumulative_kaoc_test cumulative_optional_test derived_cumulative_test difference_test disjunctive_test disjunctive_optional_test disjunctive_overload_test disjunctive_edge_finding_test disjunctive_nfnl_test disjunctive_precedences_test disjunctive_set_precedences_test disjunctive_2d_test divide_modulus_test element_test equals_test bounds_global_cardinality_test gac_global_cardinality_test in_test increasing_test inverse_test knapsack_test knapsack_upfront_test lex_test linear_test linear_constant_test
+            count_test cumulative_test cumulative_overload_test cumulative_edge_finding_test cumulative_ttef_test cumulative_nfnl_test cumulative_kaoc_test cumulative_optional_test derived_cumulative_test difference_test disjunctive_test disjunctive_optional_test disjunctive_overload_test disjunctive_edge_finding_test disjunctive_nfnl_test disjunctive_precedences_test disjunctive_set_precedences_test disjunctive_published_nfnl_test disjunctive_2d_test divide_modulus_test element_test equals_test bounds_global_cardinality_test gac_global_cardinality_test in_test increasing_test inverse_test knapsack_test knapsack_upfront_test lex_test linear_test linear_constant_test
             logical_test mdd_test min_distance_test min_distance_matching_test min_max_test mini_linear_test multiply_test n_value_test nogoods_test parity_test
             plus_minus_test power_test product_bounds_test product_justify_test regular_test regular_bacchus_test regular_legacy_test seq_precede_chain_test smart_table_test sort_test arg_sort_test symmetric_all_different_test
             negative_table_test table_test tabulation_test value_precede_test)
@@ -481,6 +482,19 @@ if(GCS_BUILD_TESTS)
         add_test(NAME disjunctive_set_precedences_mutation_${mutation}
             COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_expect_verify_failure.bash
                 --basename disjunctive_set_precedences_mutation_${mutation} $<TARGET_FILE:disjunctive_set_precedences_test> --mutate=${mutation})
+    endforeach()
+    # The rule as published, over the window the negated conclusion derives
+    # (#757). Its own lanes rather than the sweep-window rule's: what is new is
+    # the derived two-literal clause, so `drop_clause` and `rup_clause` are the
+    # ones that matter and the rest check the pieces it is built on.
+    add_test(NAME disjunctive_published_nfnl
+        COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:disjunctive_published_nfnl_test>)
+    add_test(NAME disjunctive_published_nfnl_search
+        COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:disjunctive_published_nfnl_test> --search 28)
+    foreach(mutation emit_nothing skip_fold drop_energy drop_clause rup_clause one_too_far)
+        add_test(NAME disjunctive_published_nfnl_mutation_${mutation}
+            COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_expect_verify_failure.bash
+                --basename disjunctive_published_nfnl_mutation_${mutation} $<TARGET_FILE:disjunctive_published_nfnl_test> --mutate=${mutation})
     endforeach()
     add_test(NAME disjunctive_precedences COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:disjunctive_precedences_test>)
     # Mutation lanes: each writes a deliberately corrupted proof of the

--- a/gcs/constraints/disjunctive/disjunctive.cc
+++ b/gcs/constraints/disjunctive/disjunctive.cc
@@ -1059,6 +1059,215 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                 };
             };
 
+            // --- #757: the published not-first / not-last condition ----------
+            //
+            // `not_first_not_last` above asks whether the window the sweep
+            // enumerated is overfilled by the contained set plus whatever of
+            // `j` must lie in it under the negated conclusion. The rule as
+            // published (Baptiste, Le Pape and Nuijten; Vilim's Theta-tree
+            // presentation) argues over a window the negated conclusion
+            // *derives* instead:
+            //
+            //     p(Theta) > lct(Theta) - ect_j      not-first
+            //     p(Theta) > ub(s_j) - est(Theta)    not-last, the mirror
+            //
+            // and the certificate follows the window. For not-first it is
+            // `[ect_j, lct(Theta))`, whose *left* edge the conclusion supplies;
+            // for not-last `[est(Theta), ub(s_j))`, whose *right* edge it does.
+            // Either way the rows cited are the standard contained-task guarded
+            // ones over that window, and what is new --- exactly as in #754,
+            // whose mechanism this is --- is that one of each row's two guards
+            // is discharged by a *derived two-literal clause* rather than by
+            // the reason, the clause carrying the conclusion literal along at
+            // that guard's coefficient so the conclusion accumulates across
+            // Theta and the summed pol derives it.
+            //
+            // Which guard is which is the whole difference between the two
+            // halves, and it is the opposite way round from #754's:
+            //
+            //     not-first  low guard  [s_k >= ect_j]      derived
+            //                high guard [s_k < b - p_k + 1] from the reason
+            //     not-last   low guard  [s_k >= est(Theta)] from the reason
+            //                high guard [s_k < ub(s_j) - p_k + 1] derived
+            //
+            // Why the derived guard follows. Take not-first, and suppose the
+            // conclusion `s_j >= ECT(Theta)` fails. Then for every k in Theta,
+            // `s_j < ECT(Theta) <= ect_k = est_k + p_k <= s_k + p_k`, so k does
+            // not run before j; the pair's separation clause therefore puts j
+            // before k, and `s_k >= s_j + p_j >= lb(s_j) + p_j = ect_j`. Every
+            // contained task is in `[ect_j, lct(Theta))`, which the detection
+            // says is too narrow to hold them. The mirror reads the same
+            // sentence backwards.
+            //
+            // As everywhere else here, every bound the arithmetic reads is one
+            // the *caller* captured at detection time. By the time a
+            // justification runs an earlier push has landed, and the state
+            // holds a bound the reason does not support.
+            struct PublishedTask
+            {
+                std::size_t task;
+                Integer duration, lb, ub;
+            };
+
+            // The two-literal clause. `conclusion` is the threshold being
+            // derived --- `[s_j >= conclusion]` for not-first and
+            // `[s_j < conclusion]` for not-last --- and `edge` the guard
+            // literal's own threshold, which is the derived window edge for the
+            // main path and the task's own far bound for the shortcut below.
+            auto published_clause = [&](const PublishedTask & k, std::size_t j, Integer j_lb, Integer j_ub, Integer p_j, Integer conclusion,
+                                        Integer edge, bool not_first, const ReasonLiterals & reason) -> ProofLine {
+                if (std::holds_alternative<disjunctive_proof_mutation::RupPublishedClause>(mutation)) {
+                    // Can unit propagation reach the clause on its own? If it
+                    // can, the pairwise pols below are decoration.
+                    auto lit = not_first ? (starts[j] >= conclusion) : (starts[j] < conclusion);
+                    auto other = not_first ? (starts[k.task] >= edge) : (starts[k.task] < edge);
+                    return logger->emit_rup_proof_line(WPBSum{} + 1_i * lit + 1_i * other >= 1_i, ProofLevel::Temporary);
+                }
+
+                // 1. The ordering the negated conclusion rules out, refuted by
+                // #734's own pol --- except that here one of the two bounds it
+                // resolves against is the negated conclusion rather than the
+                // reason, so that literal is *kept* rather than discharged.
+                // That is the whole of what makes the window derived.
+                //
+                // Divided rather than merely saturated, because this row is
+                // going to be added to another.
+                auto [refuted_from, refuted_to] = not_first ? pair{k.task, j} : pair{j, k.task};
+                auto from_lit = not_first ? (starts[k.task] >= k.lb) : (starts[j] >= conclusion);
+                auto to_lit = not_first ? (starts[j] < conclusion) : (starts[k.task] < k.ub + 1_i);
+                auto degree = not_first ? k.duration + k.lb - conclusion + 1_i : p_j + conclusion - k.ub;
+                if (degree <= 0_i)
+                    throw ProofError{"disjunctive published not-first / not-last: the negated conclusion does not refute the ordering"};
+                PolBuilder refute;
+                refute.add(emit_before_pol(refuted_from, refuted_to, from_lit, to_lit, nullopt, degree));
+                // Only the reason's half is discharged. The conclusion's stays
+                // in, and is what the guarded row will eventually be paid with.
+                auto kept_side_is_from = ! not_first;
+                if (! kept_side_is_from && ! is_constant_variable(starts[refuted_from]))
+                    refute.add(logger->emit_rup_proof_line_under_reason(reason, WPBSum{} + 1_i * from_lit >= 1_i, ProofLevel::Temporary));
+                if (kept_side_is_from && ! is_constant_variable(starts[refuted_to]))
+                    refute.add(logger->emit_rup_proof_line_under_reason(reason, WPBSum{} + 1_i * to_lit >= 1_i, ProofLevel::Temporary));
+                auto refutation = refute.saturate().emit(*logger, ProofLevel::Temporary);
+
+                // 2. The pair's separation clause then forces the other
+                // ordering, still carrying the conclusion literal.
+                PolBuilder forced;
+                forced.add(clause_lines.at(make_pair(min(j, k.task), max(j, k.task))));
+                forced.add(refutation);
+                for (auto r : {j, k.task})
+                    if (auto row = escape_is_false(r))
+                        forced.add(*row);
+                auto ordering = forced.saturate().emit(*logger, ProofLevel::Temporary);
+
+                // 3. That ordering's own arithmetic against the window edge
+                // comes out at degree exactly one, and 4. discharging the
+                // ordering leaves the two-literal clause the guarded row wants.
+                PolBuilder clause;
+                if (not_first) {
+                    clause.add(emit_before_pol(j, k.task, starts[j] >= j_lb, starts[k.task] < edge));
+                    if (! is_constant_variable(starts[j]))
+                        clause.add(
+                            logger->emit_rup_proof_line_under_reason(reason, WPBSum{} + 1_i * (starts[j] >= j_lb) >= 1_i, ProofLevel::Temporary));
+                }
+                else {
+                    clause.add(emit_before_pol(k.task, j, starts[k.task] >= edge, starts[j] < j_ub + 1_i));
+                    if (! is_constant_variable(starts[j]))
+                        clause.add(logger->emit_rup_proof_line_under_reason(
+                            reason, WPBSum{} + 1_i * (starts[j] < j_ub + 1_i) >= 1_i, ProofLevel::Temporary));
+                }
+                clause.add(ordering);
+                return clause.saturate().emit(*logger, ProofLevel::Temporary);
+            };
+
+            // One published-condition push. `[lo, hi)` is the derived window
+            // and `omega` the contained set, whose whole duration the detection
+            // says will not fit in it.
+            auto published_justification = [&](Integer lo, Integer hi, const vector<PublishedTask> & omega, std::size_t j, Integer j_lb, Integer j_ub,
+                                               Integer p_j, Integer conclusion, bool not_first) {
+                return [&, lo, hi, omega, j, j_lb, j_ub, p_j, conclusion, not_first](const ReasonLiterals & reason) -> void {
+                    logger->emit_proof_comment("disjunctive published not-" + string{not_first ? "first" : "last"} +
+                        " w=" + std::to_string(omega.size()) + " span=" + std::to_string((hi - lo).raw_value));
+                    if (std::holds_alternative<disjunctive_proof_mutation::PublishedEmitNothing>(mutation))
+                        return;
+
+                    // A contained task with no room for itself in the derived
+                    // window needs no energy argument: its two guards are
+                    // already contradictory, so the clause taken at the task's
+                    // own far bound plus the reason's row for that bound is the
+                    // whole derivation. This is not a corner case bolted on ---
+                    // it is where the published condition fires hardest, the
+                    // window being narrower than the sweep's by construction,
+                    // and it is also the only place the energy path could ask
+                    // the lemma for a window it cannot fill.
+                    for (const auto & k : omega)
+                        if (lo + k.duration > hi) {
+                            auto edge = not_first ? hi - k.duration + 1_i : lo;
+                            PolBuilder pol;
+                            pol.add(published_clause(k, j, j_lb, j_ub, p_j, conclusion, edge, not_first, reason));
+                            pol.add(logger->emit_rup_proof_line_under_reason(reason,
+                                WPBSum{} + 1_i * (not_first ? (starts[k.task] < edge) : (starts[k.task] >= edge)) >= 1_i, ProofLevel::Temporary));
+                            pol.saturate().emit(*logger, ProofLevel::Temporary);
+                            return;
+                        }
+
+                    vector<std::size_t> members;
+                    for (const auto & k : omega)
+                        members.push_back(k.task);
+                    auto tasks = members;
+                    tasks.push_back(j);
+                    pin_escapes(reason, tasks);
+
+                    // As edge-finding: a Temporary vocabulary does not outlive
+                    // the firing that made it, so what the caches hold has been
+                    // deleted and citing it would be citing a dead row.
+                    if (ProofLevel::Top != rules.overload_vocabulary_at) {
+                        activity->clear();
+                        bridge->clear();
+                        floors->clear();
+                        escapes->clear();
+                        guarded->clear();
+                    }
+
+                    for (auto i : members)
+                        for (Integer t = lo; t < hi; ++t)
+                            (void)activity_flag(i, t);
+
+                    PolBuilder total;
+                    // j is not in this window --- it is what the window is
+                    // derived *from* --- so the at-most-ones are over the
+                    // contained set alone, as #754's are over its cut.
+                    for (auto line :
+                        fold_at_most_ones(members, lo, hi, std::holds_alternative<disjunctive_proof_mutation::SkipPublishedFold>(mutation)))
+                        total.add(line);
+
+                    for (const auto & k : omega) {
+                        if (std::holds_alternative<disjunctive_proof_mutation::DropPublishedEnergy>(mutation) && k.task == omega.front().task)
+                            continue;
+                        const auto & row = guarded_energy(k.task, lo, hi, lo, hi - k.duration + 1_i);
+                        total.add(row.line);
+                        auto drop_clause = std::holds_alternative<disjunctive_proof_mutation::DropPublishedClause>(mutation);
+                        if (not_first) {
+                            if (row.low_coeff > 0_i && ! drop_clause)
+                                total.add(published_clause(k, j, j_lb, j_ub, p_j, conclusion, row.low_guard, true, reason), row.low_coeff);
+                            if (row.bound > 0_i)
+                                total.add(logger->emit_rup_proof_line_under_reason(
+                                              reason, WPBSum{} + 1_i * (starts[k.task] < row.high_guard) >= 1_i, ProofLevel::Temporary),
+                                    row.bound);
+                        }
+                        else {
+                            if (row.low_coeff > 0_i)
+                                total.add(logger->emit_rup_proof_line_under_reason(
+                                              reason, WPBSum{} + 1_i * (starts[k.task] >= row.low_guard) >= 1_i, ProofLevel::Temporary),
+                                    row.low_coeff);
+                            if (row.bound > 0_i && ! drop_clause)
+                                total.add(published_clause(k, j, j_lb, j_ub, p_j, conclusion, row.high_guard, false, reason), row.bound);
+                        }
+                    }
+
+                    total.emit(*logger, ProofLevel::Temporary);
+                };
+            };
+
             // Time-table consistency, specialised to heights = 1 and
             // capacity = 1. Mandatory part of task i is [lst_i, eet_i)
             // where lst_i = ub(s_i) and eet_i = lb(s_i) + l_i: the slice it
@@ -1808,11 +2017,21 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                         // task holding it need not be contained.
                         Integer energy = 0_i, min_ect = 0_i, max_lst = 0_i, min_est = 0_i;
                         vector<size_t> inside;
+                        // The same set again, with the bounds the published
+                        // condition's certificate argues about, and only
+                        // collected when something asks for them. Captured here
+                        // rather than read back out of `state` in the
+                        // justification: by then an earlier push has landed and
+                        // the state holds a bound the reason does not support.
+                        vector<PublishedTask> inside_published;
                         for (size_t c = 0; c < candidates.size(); ++c) {
                             if (candidates[c].est < a)
                                 continue;
                             energy += candidates[c].duration;
                             inside.push_back(candidates[c].task);
+                            if (rules.not_first_not_last_published)
+                                inside_published.push_back(PublishedTask{
+                                    candidates[c].task, candidates[c].duration, candidates[c].est, candidates[c].lct - candidates[c].duration});
                             min_ect = inside.size() == 1 ? candidates[c].est + candidates[c].duration
                                                          : min(min_ect, candidates[c].est + candidates[c].duration);
                             max_lst = inside.size() == 1 ? candidates[c].lct - candidates[c].duration
@@ -1927,16 +2146,17 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                                         // [ect_j, lct(Theta)): under the
                                         // negated conclusion j is before every
                                         // contained task, so all of Theta lies
-                                        // in it. Measurement only, hence the
-                                        // throw --- see
-                                        // DisjunctiveRules::not_first_not_last_published.
+                                        // in it. Certified over that derived
+                                        // window --- see `published_justification`
+                                        // and DisjunctiveRules::not_first_not_last_published.
                                         if (rules.not_first_not_last_published) {
-                                            if (logger)
-                                                throw UnimplementedException{
-                                                    "disjunctive not-first by the published condition has no certificate yet (#757)"};
-                                            if (energy > b - (s_lo + p_j))
+                                            auto ect_j = s_lo + p_j;
+                                            if (energy > b - ect_j) {
+                                                auto justify =
+                                                    published_justification(ect_j, b, inside_published, j.task, s_lo, s_hi, p_j, min_ect, true);
                                                 inference.infer_greater_than_or_equal(logger, starts[j.task], one_too_far ? min_ect + 1_i : min_ect,
-                                                    JustifyUsingRUP{hints::Disjunctive{owner}}, reason_over(reason_vars));
+                                                    JustifyExplicitly{justify, ThenRUP::Yes, hints::Disjunctive{owner}}, reason_over(reason_vars));
+                                            }
                                         }
                                         else {
                                             auto low_guard = min(s_lo, a);
@@ -1963,14 +2183,16 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                                         auto low_guard = max_lst - p_j + 1_i;
                                         // The mirror, over [est(Theta), ub(s_j)):
                                         // under the negated conclusion every
-                                        // contained task ends by s_j.
+                                        // contained task ends by s_j, so this
+                                        // time it is the window's *right* edge
+                                        // the conclusion supplies.
                                         if (rules.not_first_not_last_published) {
-                                            if (logger)
-                                                throw UnimplementedException{
-                                                    "disjunctive not-last by the published condition has no certificate yet (#757)"};
-                                            if (energy > s_hi - min_est)
+                                            if (energy > s_hi - min_est) {
+                                                auto justify = published_justification(
+                                                    min_est, s_hi, inside_published, j.task, s_lo, s_hi, p_j, low_guard, false);
                                                 inference.infer_less_than(logger, starts[j.task], one_too_far ? low_guard - 1_i : low_guard,
-                                                    JustifyUsingRUP{hints::Disjunctive{owner}}, reason_over(reason_vars));
+                                                    JustifyExplicitly{justify, ThenRUP::Yes, hints::Disjunctive{owner}}, reason_over(reason_vars));
+                                            }
                                         }
                                         else {
                                             auto clipped = window_energy::window_energy_bound(

--- a/gcs/constraints/disjunctive/disjunctive.hh
+++ b/gcs/constraints/disjunctive/disjunctive.hh
@@ -84,7 +84,7 @@ namespace gcs
         ///
         /// Measured before being certified, the way
         /// \ref not_first_not_last_published was, and unlike that one **this
-        /// was worth building**: on its own it is 0.386x the median recursions
+        /// pays for itself**: on its own it is 0.386x the median recursions
         /// and closes three more instances, and on top of \ref edge_finding it
         /// is better on 23 of 36 at a median of 0.941x, closing one instance no
         /// other arm closes. Set that against not-first/not-last's 1 of 36.
@@ -198,24 +198,38 @@ namespace gcs
         /// four and five tasks the published condition fires 1.7x and 1.6x as
         /// often (#757).
         ///
-        /// **Deliberately uncertified**, and it throws rather than
-        /// propagating when proof logging is on: a rule that quietly weakened
-        /// itself under `--prove` would confound the very comparison this
-        /// switch exists to make. The certificate is settled in simulation ---
-        /// it is \ref edge_finding's, with the low guard discharged by a
-        /// derived two-literal clause rather than by the reason --- and was
-        /// **not built**, because this switch is what decided that:
+        /// **Certified**, over the window the negated conclusion derives:
+        /// `[ect_j, lct(Theta))` for not-first, whose *left* edge the
+        /// conclusion supplies, and `[est(Theta), ub(s_j))` for not-last,
+        /// whose right edge it does. Either way the rows cited are the
+        /// standard contained-task guarded ones, and what is new --- exactly
+        /// as in \ref detectable_precedences_set, whose mechanism this is ---
+        /// is that one of each row's two guards is discharged by a *derived
+        /// two-literal clause* rather than by the reason, the clause carrying
+        /// the conclusion literal at that guard's coefficient so the
+        /// conclusion accumulates across Theta and the summed pol derives it.
+        /// Which guard is which is the whole difference between the halves,
+        /// and it is the opposite way round from #754's.
+        ///
+        /// A contained task too long for the derived window --- which the
+        /// narrower window makes common rather than exotic --- takes a
+        /// shortcut instead: its two guards are already contradictory, so the
+        /// clause plus the reason's row for the bound it contradicts is the
+        /// whole derivation, with no energy argument at all.
+        ///
+        /// Off by default because it is measurably not worth running, which is
+        /// what this switch established before it was certified:
         /// **1.6-1.7x the detection is worth 0.6% of the summed recursions and
         /// nothing at the median**, and a little worse than nothing on top of
         /// edge-finding. Not for want of firing --- propagation counts differ
         /// on 64 of 68 instances. See `dev_docs/disjunctive-proof-logging.md`.
         ///
-        /// So this exists to reproduce a measurement, in the way
-        /// \ref overload_max_window does, and not because it is expected to
-        /// pay. What it establishes is worth more than the propagator would
-        /// have been: it prices, on the encoding where the gap is cleanest,
-        /// what #746 asks and cannot answer --- how much certifying a weaker
-        /// detection than the literature states actually costs.
+        /// That measurement is what the switch was built for, and it prices,
+        /// on the encoding where the gap is cleanest, what #746 asks and
+        /// cannot answer: how much certifying a weaker detection than the
+        /// literature states actually costs. The certificate came afterwards,
+        /// because a solver that cannot prove one of its own rules is a worse
+        /// thing to have than a rule that does not pay for its sweep.
         bool not_first_not_last_published = false;
 
         /// Refuse an overload conflict whose smallest window holds more than

--- a/gcs/constraints/disjunctive/disjunctive_published_nfnl_test.cc
+++ b/gcs/constraints/disjunctive/disjunctive_published_nfnl_test.cc
@@ -1,0 +1,399 @@
+/* The published not-first / not-last condition for Disjunctive, and its
+ * certificate (#757).
+ *
+ * `disjunctive_nfnl_test.cc` covers the detection the window-energy lemma can
+ * derive over the window the sweep enumerated. This one covers the rule as the
+ * literature states it, which argues over a window the negated conclusion
+ * *derives* instead --- `[ect_j, lct(Theta))` for not-first, and
+ * `[est(Theta), ub(s_j))` for not-last. The two detections are incomparable, so
+ * neither test's fixtures serve the other.
+ *
+ * What is new in the certificate, and so what this test is mostly about, is the
+ * derived two-literal clause that puts the contained set inside that window: it
+ * carries the conclusion literal at the guard's own coefficient, so the
+ * conclusion accumulates across Theta and the summed pol derives it. That is
+ * #754's mechanism, and the `drop_clause` / `rup_clause` mutation lanes are
+ * aimed straight at it.
+ *
+ * The certificate has two paths and both are fixtured. Where every contained
+ * task fits inside the derived window it is an energy argument, the same shape
+ * edge-finding's is (`sharp`, `mirror`). Where one does not --- which the
+ * narrower window makes common, not exotic --- the two guards on that one task
+ * are already contradictory and the whole derivation is the clause plus the
+ * reason's row for the bound it contradicts (`shortcut_nf`, `shortcut_nl`).
+ *
+ * `--search` generates random unary instances, verifies a proof per instance,
+ * and checks the rule removes no solutions.
+ */
+
+#include <gcs/constraints/disjunctive.hh>
+#include <gcs/constraints/innards/constraints_test_utils.hh>
+#include <gcs/problem.hh>
+#include <gcs/solve.hh>
+
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <optional>
+#include <random>
+#include <string>
+#include <utility>
+#include <variant>
+#include <vector>
+#include <version>
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+#include <print>
+#else
+#include <fmt/core.h>
+#include <fmt/ostream.h>
+#endif
+
+using std::cerr;
+using std::make_optional;
+using std::mt19937;
+using std::nullopt;
+using std::optional;
+using std::pair;
+using std::string;
+using std::to_string;
+using std::uniform_int_distribution;
+using std::vector;
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+using std::println;
+#else
+using fmt::println;
+#endif
+
+using namespace gcs;
+using namespace gcs::innards;
+
+namespace
+{
+    struct Instance
+    {
+        vector<pair<int, int>> start_ranges;
+        vector<int> lengths;
+    };
+
+    auto fail(const string & message) -> void
+    {
+        println(cerr, "disjunctive_published_nfnl_test: {}", message);
+        exit(EXIT_FAILURE);
+    }
+
+    auto post(Problem & p, const Instance & inst, DisjunctiveRules rules, DisjunctiveProofMutation mutation) -> vector<IntegerVariableID>
+    {
+        vector<IntegerVariableID> starts;
+        vector<Integer> lengths;
+        for (const auto & [lo, hi] : inst.start_ranges)
+            starts.push_back(p.create_integer_variable(Integer{lo}, Integer{hi}));
+        for (auto l : inst.lengths)
+            lengths.push_back(Integer{l});
+        p.post(Disjunctive{starts, lengths}.with_rules(rules).with_proof_mutation(mutation));
+        return starts;
+    }
+
+    struct Probe
+    {
+        vector<pair<int, int>> root_bounds;
+        int markers = 0;
+        int solutions = 0;
+    };
+
+    auto count_markers(const string & basename, const string & marker) -> int
+    {
+        std::ifstream f{basename + ".pbp"};
+        string line;
+        auto count = 0;
+        while (getline(f, line))
+            if (line.find(marker) != string::npos)
+                ++count;
+        return count;
+    }
+
+    auto probe(const Instance & inst, DisjunctiveRules rules, const optional<string> & proof_name,
+        DisjunctiveProofMutation mutation = disjunctive_proof_mutation::None{}, bool enumerate = false,
+        const string & marker = "disjunctive published not-") -> Probe
+    {
+        Problem p;
+        auto starts = post(p, inst, rules, mutation);
+        Probe result;
+        auto reached_a_node = false;
+        solve_with(p,
+            SolveCallbacks{.solution = [&](const CurrentState &) -> bool {
+                               ++result.solutions;
+                               return enumerate;
+                           },
+                .trace = [&](const CurrentState & s) -> bool {
+                    if (! reached_a_node) {
+                        reached_a_node = true;
+                        for (const auto & v : starts)
+                            result.root_bounds.emplace_back(
+                                static_cast<int>(s.lower_bound(v).raw_value), static_cast<int>(s.upper_bound(v).raw_value));
+                    }
+                    return enumerate;
+                }},
+            proof_name ? make_optional<ProofOptions>(ProofFileNames{*proof_name}) : nullopt);
+        if (proof_name)
+            result.markers = count_markers(*proof_name, marker);
+        return result;
+    }
+
+    /// The published condition replaces the certifiable detection rather than
+    /// strengthening it, so it needs the sweep the other rule owns: setting it
+    /// without `not_first_not_last` would run nothing at all, which is what
+    /// `rcpsp` does too.
+    const DisjunctiveRules published{.not_first_not_last = true, .not_first_not_last_published = true};
+    const DisjunctiveRules nothing{};
+
+    /// The shortcut fixtures' rules. A contained task too long for the derived
+    /// window is one whose earliest end is past the pushed task's whole range,
+    /// which at two tasks is also a detectable precedence --- so the pairwise
+    /// rules have to be off for this rule to be the one making the push.
+    /// Nothing about the certificate depends on them: the mandatory-overlap
+    /// check that makes the propagator a *checker* is unconditional.
+    const DisjunctiveRules shortcut_rules{
+        .time_table = false, .detectable_precedences = false, .not_first_not_last = true, .not_first_not_last_published = true};
+
+    auto generate(mt19937 & rnd, int n) -> Instance
+    {
+        Instance inst;
+        uniform_int_distribution<int> dur{1, 4}, slack{0, 6};
+        auto total = 0;
+        for (auto i = 0; i < n; ++i) {
+            auto l = dur(rnd);
+            inst.lengths.push_back(l);
+            total += l;
+        }
+        for (auto i = 0; i < n; ++i) {
+            auto lo = uniform_int_distribution<int>{0, total / 2}(rnd);
+            inst.start_ranges.emplace_back(lo, lo + inst.lengths[i] + slack(rnd));
+        }
+        return inst;
+    }
+}
+
+auto main(int argc, char * argv[]) -> int
+{
+    auto proofs = gcs::test_innards::can_run_veripb();
+
+    // The energy path, not-first. Window [5, 8) holds Theta = {1, 2}, two units
+    // in three, which fits --- so the sweep's own detection has nothing to say
+    // over it. The published one argues over [ect_0, 8) = [7, 8) instead: if
+    // task 0 started before ect(Theta) = 6 then both contained tasks would have
+    // to start at or after task 0's earliest end, and two unit tasks do not fit
+    // in one time point. So task 0's lower bound rises to 6.
+    const Instance sharp{{{3, 9}, {5, 7}, {6, 7}}, {4, 1, 1}};
+
+    // The mirror, and the half a test measuring only not-first would miss.
+    // Theta = {1, 2} sits in [8, 10) and task 0 spans it; the derived window is
+    // [est(Theta), ub(s_0)) = [8, 9), and two units do not fit in one, so task
+    // 0's upper bound drops to max lst(Theta) - p_0 = 6.
+    const Instance mirror{{{2, 9}, {8, 9}, {8, 9}}, {3, 1, 1}};
+
+    // The shortcut path. Theta = {1} carries three units and the derived window
+    // [ect_0, lct(Theta)) = [7, 9) is two wide, so task 1 cannot be in it at
+    // all: its guard "starts at or after 7" and the reason's "starts at or
+    // before 6" are contradictory on their own, and the certificate is the
+    // clause plus that one row. Task 0's lower bound goes to ect_1 = 8, which
+    // is where enumeration puts it.
+    const Instance shortcut_nf{{{3, 12}, {5, 6}}, {4, 3}};
+
+    // Its mirror, reflected in time: the derived window [11, 13) is two wide
+    // and task 1 needs three, so task 0's upper bound drops to
+    // lst(Theta) - p_0 = 8. Also the bound enumeration gives.
+    const Instance shortcut_nl{{{4, 13}, {11, 12}}, {4, 3}};
+
+    // One more unit of room in the window and the condition has nothing to
+    // claim, so neither fixture above is firing on a technicality.
+    const Instance loose{{{3, 9}, {5, 8}, {6, 7}}, {4, 1, 1}};
+
+    // The mutation fixture, generated rather than hand-built for the reason
+    // `disjunctive_nfnl_test.cc` records: on a small fixture the closing RUP
+    // finishes the job from whatever a corrupted derivation left behind, which
+    // is sound and VeriPB is right to accept.
+    //
+    // Scanning generated instances for one where all six lanes are rejected
+    // found this at the eighth try. Over 300 instances, 172 fired the rule at
+    // all and 24 of those rejected every lane; the two most fragile are
+    // `skip_fold` (36 of 172) and `drop_energy` (58), for the same reason
+    // not-first / not-last's own lanes are fragile --- the thresholds are
+    // `min ect` and `max lst`, which pairwise reasoning can often reach on its
+    // own. The two aimed at what is new here hold up much better:
+    // `drop_clause` 127 and `rup_clause` 130.
+    const Instance mutating{{{6, 14}, {9, 13}, {6, 14}, {0, 4}, {3, 11}, {5, 11}, {2, 11}}, {3, 1, 2, 3, 4, 3, 3}};
+
+    // Mutation mode: emit one deliberately corrupted proof and stop, for
+    // run_test_and_expect_verify_failure.bash to hand to veripb.
+    {
+        optional<DisjunctiveProofMutation> mutation;
+        string proof_basename = "disjunctive_published_nfnl_mutation";
+        for (auto a = 1; a < argc; ++a) {
+            string arg = argv[a];
+            if (arg == "--mutate=emit_nothing")
+                mutation = disjunctive_proof_mutation::PublishedEmitNothing{};
+            else if (arg == "--mutate=skip_fold")
+                mutation = disjunctive_proof_mutation::SkipPublishedFold{};
+            else if (arg == "--mutate=drop_energy")
+                mutation = disjunctive_proof_mutation::DropPublishedEnergy{};
+            else if (arg == "--mutate=drop_clause")
+                mutation = disjunctive_proof_mutation::DropPublishedClause{};
+            else if (arg == "--mutate=rup_clause")
+                mutation = disjunctive_proof_mutation::RupPublishedClause{};
+            else if (arg == "--mutate=one_too_far")
+                mutation = disjunctive_proof_mutation::EdgeFindingOneTooFar{};
+            else if (arg == "--proof-files-basename" && a + 1 < argc)
+                proof_basename = argv[++a];
+        }
+
+        if (mutation) {
+            auto result = probe(mutating, published, make_optional(proof_basename), *mutation);
+            if (result.markers == 0)
+                fail("mutation mode: no published push was justified, so the proof is empty");
+            println(cerr, "wrote a deliberately corrupted proof to {}.pbp", proof_basename);
+            return EXIT_SUCCESS;
+        }
+    }
+
+    // --search: generated instances, a proof verified per instance, and a
+    // solution count against the rule off.
+    if (argc > 1 && string{argv[1]} == "--search") {
+        auto seed = argc > 2 ? static_cast<unsigned>(std::stoul(argv[2])) : 0u;
+        mt19937 rnd{seed};
+        auto fired = 0, checked = 0;
+        for (auto attempt = 0; attempt < 60; ++attempt) {
+            auto inst = generate(rnd, 4 + static_cast<int>(attempt % 3));
+            auto name = "disjunctive_published_nfnl_gen_" + to_string(attempt);
+            auto on = probe(inst, published, proofs ? make_optional(name) : nullopt, disjunctive_proof_mutation::None{}, true);
+            auto off = probe(inst, nothing, nullopt, disjunctive_proof_mutation::None{}, true);
+            if (on.solutions != off.solutions)
+                fail("generated instance " + to_string(attempt) + ": " + to_string(on.solutions) + " solutions with the rule on against " +
+                    to_string(off.solutions) + " with it off");
+            if (proofs) {
+                ++checked;
+                if (on.markers > 0)
+                    ++fired;
+                if (! gcs::test_innards::run_veripb(name + ".opb", name + ".pbp"))
+                    fail("generated instance " + to_string(attempt) + ": veripb rejected the proof");
+            }
+        }
+        println(cerr, "checked {} generated proofs, {} of them carrying a published not-first / not-last push", checked, fired);
+        if (proofs && fired == 0)
+            fail("--search: no generated instance fired the rule, so nothing was tested");
+        return EXIT_SUCCESS;
+    }
+
+    // The energy path, and --- the half that makes a fixture worth having ---
+    // that nothing else makes the push.
+    {
+        auto on = probe(sharp, published, proofs ? make_optional("disjunctive_published_nfnl_sharp") : nullopt);
+        if (on.root_bounds.at(0).first < 6)
+            fail("sharp: expected the pushed task's lower bound at 6 or better, got " + to_string(on.root_bounds.at(0).first));
+        if (proofs && on.markers == 0)
+            fail("sharp: no published marker, so the fixture says nothing about the rule");
+        if (proofs && ! gcs::test_innards::run_veripb("disjunctive_published_nfnl_sharp.opb", "disjunctive_published_nfnl_sharp.pbp"))
+            fail("sharp: veripb rejected the certificate");
+
+        auto off = probe(sharp, nothing, nullopt);
+        if (off.root_bounds.at(0).first >= 6)
+            fail("sharp: the bound moved with the rule off, so the fixture says nothing about the rule");
+    }
+
+    // The mirror, which is the same certificate with the derived edge on the
+    // other side of the window.
+    {
+        auto on = probe(mirror, published, proofs ? make_optional("disjunctive_published_nfnl_mirror") : nullopt);
+        if (on.root_bounds.at(0).second > 6)
+            fail("mirror: expected the pushed task's upper bound at 6 or better, got " + to_string(on.root_bounds.at(0).second));
+        if (proofs && on.markers == 0)
+            fail("mirror: no published marker, so the fixture says nothing about the rule");
+        if (proofs && ! gcs::test_innards::run_veripb("disjunctive_published_nfnl_mirror.opb", "disjunctive_published_nfnl_mirror.pbp"))
+            fail("mirror: veripb rejected the certificate");
+
+        auto off = probe(mirror, nothing, nullopt);
+        if (off.root_bounds.at(0).second <= 6)
+            fail("mirror: the bound moved with the rule off, so the fixture says nothing about the rule");
+    }
+
+    // Each half makes its own fixture's push and neither makes the other's. A
+    // symmetric rule measured in one direction only is the mistake this exists
+    // to prevent.
+    {
+        auto first_only = published;
+        first_only.not_last = false;
+        auto last_only = published;
+        last_only.not_first = false;
+
+        if (probe(sharp, first_only, nullopt).root_bounds.at(0).first < 6)
+            fail("not-first alone did not make the sharp fixture's push");
+        if (probe(sharp, last_only, nullopt).root_bounds.at(0).first >= 6)
+            fail("not-last made the sharp fixture's push, so the halves are not what they say");
+        if (probe(mirror, last_only, nullopt).root_bounds.at(0).second > 6)
+            fail("not-last alone did not make the mirror fixture's push");
+        if (probe(mirror, first_only, nullopt).root_bounds.at(0).second <= 6)
+            fail("not-first made the mirror fixture's push, so the halves are not what they say");
+    }
+
+    // The shortcut path, both ways round, and in each case the push lands
+    // exactly where enumeration puts the bound.
+    {
+        auto nf = probe(shortcut_nf, shortcut_rules, proofs ? make_optional("disjunctive_published_nfnl_shortcut_nf") : nullopt);
+        if (nf.root_bounds.at(0).first != 8)
+            fail("shortcut_nf: expected the pushed task's lower bound at 8, got " + to_string(nf.root_bounds.at(0).first));
+        if (proofs && nf.markers == 0)
+            fail("shortcut_nf: no published marker");
+        if (proofs && ! gcs::test_innards::run_veripb("disjunctive_published_nfnl_shortcut_nf.opb", "disjunctive_published_nfnl_shortcut_nf.pbp"))
+            fail("shortcut_nf: veripb rejected the certificate");
+
+        auto nl = probe(shortcut_nl, shortcut_rules, proofs ? make_optional("disjunctive_published_nfnl_shortcut_nl") : nullopt);
+        if (nl.root_bounds.at(0).second != 8)
+            fail("shortcut_nl: expected the pushed task's upper bound at 8, got " + to_string(nl.root_bounds.at(0).second));
+        if (proofs && nl.markers == 0)
+            fail("shortcut_nl: no published marker");
+        if (proofs && ! gcs::test_innards::run_veripb("disjunctive_published_nfnl_shortcut_nl.opb", "disjunctive_published_nfnl_shortcut_nl.pbp"))
+            fail("shortcut_nl: veripb rejected the certificate");
+    }
+
+    // The margin of one: a single unit more room and there is nothing to claim.
+    {
+        auto result = probe(loose, published, proofs ? make_optional("disjunctive_published_nfnl_loose") : nullopt);
+        if (proofs && result.markers != 0)
+            fail("loose: a push was claimed where the work fits");
+        if (proofs && ! gcs::test_innards::run_veripb("disjunctive_published_nfnl_loose.opb", "disjunctive_published_nfnl_loose.pbp"))
+            fail("loose: veripb rejected the proof");
+    }
+
+    // Both vocabulary placements certify the same push: they differ only in
+    // whether the flags and the guarded rows outlive the firing that made them.
+    if (proofs)
+        for (auto at : {ProofLevel::Top, ProofLevel::Temporary}) {
+            auto rules = published;
+            rules.overload_vocabulary_at = at;
+            auto name = string{"disjunctive_published_nfnl_"} + (at == ProofLevel::Top ? "top" : "temporary");
+            auto result = probe(sharp, rules, make_optional(name));
+            if (result.root_bounds.at(0).first < 6)
+                fail(name + ": the push did not land");
+            if (! gcs::test_innards::run_veripb(name + ".opb", name + ".pbp"))
+                fail(name + ": veripb rejected the certificate");
+        }
+
+    // Alongside edge-finding, the set-based precedences and the overload check,
+    // which share every piece of the vocabulary with it and reach the guarded
+    // rows at different guards. Running them together is what would catch a
+    // cache keyed on too little.
+    if (proofs) {
+        auto rules = published;
+        rules.edge_finding = true;
+        rules.detectable_precedences_set = true;
+        rules.overload = true;
+        auto result = probe(sharp, rules, make_optional("disjunctive_published_nfnl_with_everything"));
+        if (result.root_bounds.at(0).first < 6)
+            fail("with_everything: the push did not land");
+        if (! gcs::test_innards::run_veripb("disjunctive_published_nfnl_with_everything.opb", "disjunctive_published_nfnl_with_everything.pbp"))
+            fail("with_everything: veripb rejected the certificate");
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/gcs/constraints/innards/disjunctive_mutations.hh
+++ b/gcs/constraints/innards/disjunctive_mutations.hh
@@ -191,6 +191,46 @@ namespace gcs::innards
         {
         };
 
+        /// Emit no certificate at all for the *published* not-first / not-last
+        /// condition, leaving the push to the framework's wrapping RUP. The
+        /// control for that rule.
+        struct PublishedEmitNothing
+        {
+        };
+
+        /// Leave the per-time at-most-ones out of the published rule's endgame,
+        /// so nothing says the derived window can hold only one task at a time
+        /// and the contained set's duration has no supply to exceed.
+        struct SkipPublishedFold
+        {
+        };
+
+        /// Leave one contained task's guarded energy row out of the published
+        /// rule's endgame, so the derived window is charged less work than
+        /// `p(Theta)` puts in it.
+        struct DropPublishedEnergy
+        {
+        };
+
+        /// Leave out the derived two-literal clause that puts the contained set
+        /// inside the *derived* window. **The mutation for what is new in this
+        /// rule**: the published condition's window has an edge the negated
+        /// conclusion supplies rather than one the sweep enumerated, and this
+        /// clause is the only thing that supplies it. Without it the guarded
+        /// rows are guarded by something nothing discharges and the conclusion
+        /// never enters the sum.
+        struct DropPublishedClause
+        {
+        };
+
+        /// Conclude that clause by bare `rup` rather than by the pairwise pols,
+        /// as \ref RupSetPrecedenceClause does for #754's. The same question,
+        /// asked where the derived edge comes from the pushed task's own bound
+        /// rather than from a cut's.
+        struct RupPublishedClause
+        {
+        };
+
         // Deliberately absent: citing the pushed task's row at the *unclipped*
         // threshold, as if the window contained it. It was written, and it
         // verified. A row derived at a threshold the reason still entails is a
@@ -212,7 +252,10 @@ namespace gcs::innards
         disjunctive_proof_mutation::DropContainedEnergy, disjunctive_proof_mutation::EdgeFindingOneTooFar,
         disjunctive_proof_mutation::DropPushedEnergy, disjunctive_proof_mutation::SetPrecedenceEmitNothing,
         disjunctive_proof_mutation::SkipSetPrecedenceFold, disjunctive_proof_mutation::DropSetPrecedenceEnergy,
-        disjunctive_proof_mutation::DropSetPrecedenceClause, disjunctive_proof_mutation::RupSetPrecedenceClause>;
+        disjunctive_proof_mutation::DropSetPrecedenceClause, disjunctive_proof_mutation::RupSetPrecedenceClause,
+        disjunctive_proof_mutation::PublishedEmitNothing, disjunctive_proof_mutation::SkipPublishedFold,
+        disjunctive_proof_mutation::DropPublishedEnergy, disjunctive_proof_mutation::DropPublishedClause,
+        disjunctive_proof_mutation::RupPublishedClause>;
 
     /**
      * \brief Deliberate corruptions of the presence-falsification derivation,


### PR DESCRIPTION
`DisjunctiveRules::not_first_not_last_published` was the one rule in the suite that threw `UnimplementedException` rather than propagating under `--prove`. It went into the tree to price what certifying a weaker detection than the literature states actually costs, and that measurement is made: 1.6-1.7x the detection buys 0.6% of the summed recursions and nothing at the median. A measurement is a reason to leave a switch off by default, not a reason to leave it unprovable.

## The certificate

The window follows the detection. Ours argues over the window the sweep enumerated; the published one argues over a window the negated conclusion *derives*:

```
not-first   [ect_j, lct(Theta))     left edge from the conclusion
not-last    [est(Theta), ub(s_j))   right edge from the conclusion
```

Suppose the not-first conclusion `s_j >= ECT(Theta)` fails. Then for every `k` in Theta, `s_j < ECT(Theta) <= ect_k <= s_k + p_k`, so `k` does not run before `j`; the pair's separation clause puts `j` before `k`, and `s_k >= s_j + p_j >= ect_j`. Every contained task is inside `[ect_j, lct(Theta))`, which the detection says is too narrow to hold them.

So the rows cited are the **standard contained-task guarded ones** over that window — the same `derive_guarded_window_energy` call edge-finding makes — and what is new is only how one of each row's two guards is discharged: by a **derived two-literal clause** rather than by the reason, the clause carrying the conclusion literal at that guard's coefficient so the conclusion accumulates across Theta and the summed pol derives it.

That is #754's mechanism, which is where the header said this certificate had been settled in simulation but not built. The roles are the opposite way round from #754's: not-first derives the low guard and takes the high one from the reason, not-last the mirror.

## The shortcut, which is not a corner case

The derived window is narrower than the sweep's by construction, so a contained task too long to fit inside it at all is common. There its two guards are already contradictory, and the whole derivation is the clause at the task's own far bound plus the reason's row for that bound — no energy argument, no at-most-ones, no activity flags. It is also the only place the energy path could ask the lemma for a window it cannot fill, so the two paths are exhaustive rather than merely convenient.

## Testing

New `disjunctive_published_nfnl_test`, with fixtures for both halves of both paths, controls that nothing else makes each push, a `loose` margin-of-one fixture, both vocabulary placements, and one run alongside edge-finding, set-based precedences and the overload check.

Six mutation lanes — `emit_nothing` / `skip_fold` / `drop_energy` / `drop_clause` / `rup_clause` / `one_too_far` — all rejected by VeriPB. Over 300 generated instances, 172 fired the rule and 24 rejected every lane; the two aimed at the new clause hold up best (127 and 130 against `skip_fold`'s 36), and in particular unit propagation cannot reach the clause on its own.

360 generated instances verify across six seeds, about 83% of them carrying a push, with solution counts checked against the rule off.

Part of the wider "no rule in the solver refuses proof logging" sweep; the two `Cumulative` refusals (#755, #746) follow separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PAZYGJdsP3dmWAepRGi5T5