### PR TITLE
Certify Cumulative's energetic edge-finding (#755)

### DIFF
--- a/dev_docs/cumulative-proof-logging.md
+++ b/dev_docs/cumulative-proof-logging.md
@@ -1360,10 +1360,51 @@ are fixed by `(task, time)` alone, which is why the reuse is so high.
 `CumulativeRules::energetic_edge_finding` is the same rule with every task's
 *guaranteed* energy in the window in place of contained-energy-plus-profile.
 That is what `window_energy_bound` computes anyway, so it needs no pins at all,
-and it is stronger. It is **not certified** — `define_proof_model` refuses a
-logger while it is set — and it is in the tree to be measured, not to be used:
-the row above is what it buys, and the propagation cost of recomputing the sum
-per window is not paid for on this family.
+and it is stronger. The row above is what it buys, and the propagation cost of
+recomputing the sum per window is not paid for on this family, so it stays off
+by default.
+
+### Certifying it: the same certificate, a different set of rows (#755)
+
+It is edge-finding's certificate with the cited rows swapped, and nothing else
+changes: the same capacity lines over the window, the same closing pol, the
+same negated-conclusion guard on the pushed task's row. What differs is which
+rows go in.
+
+| arm | rows cited | pins |
+|---|---|---|
+| edge-finding | one per contained task, guarded by the *window* | none |
+| TTEF | the same, plus the profile term | 2.93 per firing |
+| energetic | one per candidate, guarded by the task's *own bounds* | none |
+
+The guards a non-contained task's row carries are exactly the start bounds
+`guaranteed()` asked `window_energy_bound` about, so the row establishes
+neither more nor less than the detection counted — which is the invariant that
+keeps the propagator honest here, as it does everywhere else in this rule
+family. Both guards are discharged by the reason, because the reason carries
+every task's bounds whether or not the window contains it. That is why the
+profile term's pins have no counterpart: a pin exists to say "this task is
+*here*, at this time point", and a guarded energy row says the same thing about
+a whole window in one line.
+
+The bounds cited are the ones the sweep captured when it built its candidates,
+not the live ones. An earlier push in the same sweep may have tightened them,
+and a guard at a stale bound is one the reason still entails — and it is also
+the bound the detection's arithmetic used, so the two cannot drift apart.
+
+**What is left open, and it is the cache key.** A contained task's guards come
+from the window, so its row is the same at every node and is cited over and
+over. A non-contained task's come from bounds that move, so its row is derived
+far more often than it is reused. Weakening those guards deliberately — buying
+reuse at the price of a looser bound — is the experiment, and it is not made
+here.
+
+**Mutation lanes.** `drop_energetic` is the one this rule needs: it leaves out
+the row of a task the window does *not* contain, which is the only energy plain
+edge-finding would not have cited. `drop` removes a contained task's row and so
+says nothing about what is new, which is why the two are separate lanes rather
+than one. Both are rejected on the fixtures, along with `toofar` and
+`capacity`.
 
 ## Not-first / not-last: the same certificate, different thresholds (PR #745)
 
@@ -1695,12 +1736,12 @@ per time point. Same trade as #742 for edge-finding's scan, and the same answer
   alone, so it would cache the way the contained rows do --- and the same row
   would amortise `(TTOC)`'s pins, which the merged overload check also
   re-derives every firing.
-- **Certifying the energetic form.** `energetic_edge_finding` measures better
-  than TTEF and needs *no* pins, since every task's contribution is a guarded
-  window-energy row. What is unresolved is the cache key: a contained task's
-  guards come from the window, a non-contained one's from its current bounds, so
-  the rows would repeat far less. Weakening the guards deliberately, to buy
-  reuse at the price of a looser bound, is the experiment.
+- **The energetic form's cache key.** `energetic_edge_finding` is certified now
+  (#755) and needs no pins, since every task's contribution is a guarded
+  window-energy row. What is still unresolved is the cache key: a contained
+  task's guards come from the window, a non-contained one's from its current
+  bounds, so the latter repeat far less. Weakening the guards deliberately, to
+  buy reuse at the price of a looser bound, is the experiment.
 - **Edge-finding's scan (#742).** The rule is certified and its inferences cost
   nothing measurable, but the window x task sweep that finds them is O(n^3) and
   taxes the solve about 1.5x at identical search. Propagation performance, not

--- a/examples/rcpsp/rcpsp.cc
+++ b/examples/rcpsp/rcpsp.cc
@@ -358,7 +358,8 @@ auto main(int argc, char * argv[]) -> int
             ("cumulative-energetic-edge-finding",                                                        //
                 "Strengthen edge-finding with every task's guaranteed energy inside the window, rather " //
                 "than only the contained tasks' whole energy (subsumes TTEF). Implies "                  //
-                "--cumulative-edge-finding. Not certified yet, so a run with --prove will refuse it",    //
+                "--cumulative-edge-finding. Certified, and unlike TTEF it needs no pins: every "         //
+                "contribution is a guarded window-energy row (#755)",                                    //
                 cxxopts::value<bool>()->default_value("false"))                                          //
             ("cumulative-not-first-not-last",                                                            //
                 "Run not-first / not-last on every posted Cumulative, alongside edge-finding. Implies "  //

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -279,6 +279,7 @@ if(GCS_BUILD_TESTS)
     add_executable(cumulative_overload_test constraints/cumulative/cumulative_overload_test.cc)
     add_executable(cumulative_edge_finding_test constraints/cumulative/cumulative_edge_finding_test.cc)
     add_executable(cumulative_ttef_test constraints/cumulative/cumulative_ttef_test.cc)
+    add_executable(cumulative_energetic_test constraints/cumulative/cumulative_energetic_test.cc)
     add_executable(cumulative_nfnl_test constraints/cumulative/cumulative_nfnl_test.cc)
     add_executable(cumulative_kaoc_test constraints/cumulative/cumulative_kaoc_test.cc)
     add_executable(derived_cumulative_test constraints/cumulative/derived_cumulative_test.cc)
@@ -338,7 +339,7 @@ if(GCS_BUILD_TESTS)
 
     foreach(test_target
             abs_test all_different_test all_different_except_test all_equal_test among_test at_most_one_test bin_packing_test comparison_test
-            count_test cumulative_test cumulative_overload_test cumulative_edge_finding_test cumulative_ttef_test cumulative_nfnl_test cumulative_kaoc_test cumulative_optional_test derived_cumulative_test difference_test disjunctive_test disjunctive_optional_test disjunctive_overload_test disjunctive_edge_finding_test disjunctive_nfnl_test disjunctive_precedences_test disjunctive_set_precedences_test disjunctive_published_nfnl_test disjunctive_2d_test divide_modulus_test element_test equals_test bounds_global_cardinality_test gac_global_cardinality_test in_test increasing_test inverse_test knapsack_test knapsack_upfront_test lex_test linear_test linear_constant_test
+            count_test cumulative_test cumulative_overload_test cumulative_edge_finding_test cumulative_ttef_test cumulative_energetic_test cumulative_nfnl_test cumulative_kaoc_test cumulative_optional_test derived_cumulative_test difference_test disjunctive_test disjunctive_optional_test disjunctive_overload_test disjunctive_edge_finding_test disjunctive_nfnl_test disjunctive_precedences_test disjunctive_set_precedences_test disjunctive_published_nfnl_test disjunctive_2d_test divide_modulus_test element_test equals_test bounds_global_cardinality_test gac_global_cardinality_test in_test increasing_test inverse_test knapsack_test knapsack_upfront_test lex_test linear_test linear_constant_test
             logical_test mdd_test min_distance_test min_distance_matching_test min_max_test mini_linear_test multiply_test n_value_test nogoods_test parity_test
             plus_minus_test power_test product_bounds_test product_justify_test regular_test regular_bacchus_test regular_legacy_test seq_precede_chain_test smart_table_test sort_test arg_sort_test symmetric_all_different_test
             negative_table_test table_test tabulation_test value_precede_test)
@@ -387,6 +388,20 @@ if(GCS_BUILD_TESTS)
         add_test(NAME cumulative_ttef_mutation_${mutation}
             COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_expect_verify_failure.bash
                 --basename cumulative_ttef_mutation_${mutation} $<TARGET_FILE:cumulative_ttef_test> --mutate=${mutation})
+    endforeach()
+    # The energetic form (#755), which charges every task its guaranteed energy
+    # rather than a contained one's whole energy plus a non-contained one's
+    # mandatory part. `drop_energetic` is the lane that matters: it removes the
+    # row of a task the window does not contain, which is the only energy plain
+    # edge-finding would not have cited.
+    add_test(NAME cumulative_energetic
+        COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_energetic_test>)
+    add_test(NAME cumulative_energetic_random
+        COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_energetic_test> --random 17)
+    foreach(mutation drop_energetic drop toofar capacity mirror_drop_energetic mirror_toofar)
+        add_test(NAME cumulative_energetic_mutation_${mutation}
+            COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_expect_verify_failure.bash
+                --basename cumulative_energetic_mutation_${mutation} $<TARGET_FILE:cumulative_energetic_test> --mutate=${mutation})
     endforeach()
     add_test(NAME derived_cumulative COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:derived_cumulative_test>)
     # Mutation lanes: each writes a deliberately corrupted proof of the

--- a/gcs/constraints/cumulative/cumulative.cc
+++ b/gcs/constraints/cumulative/cumulative.cc
@@ -351,8 +351,6 @@ auto Cumulative::define_proof_model(ProofModel & model, const State &) -> void
 {
     // A propagator that infers what it cannot justify is worse than one that
     // declines: refuse here rather than emit a proof VeriPB will reject.
-    if (_rules.energetic_edge_finding)
-        throw UnimplementedException{"energetic edge-finding is not yet certified"};
     if (_rules.not_first_not_last_published)
         throw UnimplementedException{"the published not-first / not-last detection is not certified: see #746"};
 
@@ -861,6 +859,26 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
         High
     };
 
+    // What the energetic form charges a window with: one task, and the two
+    // guards its own bounds put on the row that says how much of it the window
+    // must contain. Unlike the contained-task rows the other forms cite, these
+    // are keyed on bounds that move --- a contained task's guards come from the
+    // window and are the same at every node, a non-contained one's do not ---
+    // which is the reuse question #755 leaves open and this deliberately does
+    // not try to answer. Correctness first: the guards are exactly the start
+    // bounds `guaranteed()` asked `window_energy_bound` about, so the row
+    // establishes exactly the energy the detection counted.
+    struct EnergeticContributor
+    {
+        std::size_t task;
+        Integer low_guard, high_guard;
+        /// Whether the window contains this task, which is what tells the two
+        /// mutation lanes apart: dropping a contained task's row corrupts a
+        /// row plain edge-finding would have cited too, and dropping a
+        /// non-contained one corrupts the only energy this rule adds.
+        bool contained;
+    };
+
     // Edge-finding's certificate, in both directions. It is the overload
     // check's, emitted under the negated conclusion: the contained tasks'
     // energy, plus what the pushed task must still occupy if the conclusion
@@ -872,8 +890,9 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
     // bounds and is cited rather than re-derived. What a firing pays is the
     // guard discharges and one pol.
     auto edge_finding_justification = [&](Integer a, Integer b, const vector<size_t> & inside_tasks, size_t pushed, Integer pushed_low_guard,
-                                          Integer pushed_high_guard, GuardToDischarge discharge) {
-        return [&, a, b, inside_tasks, pushed, pushed_low_guard, pushed_high_guard, discharge](const ReasonLiterals & reason) -> void {
+                                          Integer pushed_high_guard, GuardToDischarge discharge,
+                                          const vector<EnergeticContributor> & energetic = {}) {
+        return [&, a, b, inside_tasks, pushed, pushed_low_guard, pushed_high_guard, discharge, energetic](const ReasonLiterals & reason) -> void {
             if (! logger)
                 return;
 
@@ -909,18 +928,46 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
                         hlb(i) * row.length_coeff);
             };
 
-            // A contained task is inside the window whichever way the push
-            // goes, so both its guards are refuted by the reason. Its high
-            // guard is the first start that would take it out of the window,
-            // stated against the *clipped* window since that is where the
-            // lemma's sum stops; where the two differ the guard is refuted by
-            // the task's declared bounds rather than by the search, and the RUP
-            // closes on those just the same.
-            for (auto i : inside_tasks) {
-                if (std::holds_alternative<cumulative_proof_mutation::DropContainedTask>(mutation) && i == inside_tasks.front())
-                    continue;
-                cite(i, clipped_window_start(i, a), clipped_window_end(i, b) - llb(i) + 1_i, true, true);
+            // The energetic form charges the window every task's guaranteed
+            // energy, so it cites a row per candidate rather than a row per
+            // contained task plus a pin per profile time point. Both of each
+            // row's guards are the task's own current bounds, which the reason
+            // carries whether or not the window contains it --- so unlike
+            // TTEF's profile term this needs no pins at all, which is what
+            // #755 said it would not.
+            //
+            // The bounds are the ones the sweep captured when it built its
+            // candidates, not the live ones: an earlier push in the same sweep
+            // may have tightened them, and a guard at the stale bound is one
+            // the reason still entails. It is also the bound the detection's
+            // arithmetic used, so the row establishes neither more nor less
+            // than was counted.
+            if (! energetic.empty()) {
+                auto skip_outside = std::holds_alternative<cumulative_proof_mutation::DropEnergeticContributor>(mutation);
+                auto skip_inside = std::holds_alternative<cumulative_proof_mutation::DropContainedTask>(mutation);
+                for (const auto & e : energetic) {
+                    if (e.task == pushed)
+                        continue;
+                    if (e.contained ? skip_inside : skip_outside) {
+                        (e.contained ? skip_inside : skip_outside) = false;
+                        continue;
+                    }
+                    cite(e.task, e.low_guard, e.high_guard, true, true);
+                }
             }
+            else
+                // A contained task is inside the window whichever way the push
+                // goes, so both its guards are refuted by the reason. Its high
+                // guard is the first start that would take it out of the
+                // window, stated against the *clipped* window since that is
+                // where the lemma's sum stops; where the two differ the guard
+                // is refuted by the task's declared bounds rather than by the
+                // search, and the RUP closes on those just the same.
+                for (auto i : inside_tasks) {
+                    if (std::holds_alternative<cumulative_proof_mutation::DropContainedTask>(mutation) && i == inside_tasks.front())
+                        continue;
+                    cite(i, clipped_window_start(i, a), clipped_window_end(i, b) - llb(i) + 1_i, true, true);
+                }
 
             // TTEF: the tasks the window does not contain still put their
             // mandatory-part load into it, and that load is pinned exactly the
@@ -934,7 +981,7 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
             // the sweep pushes bounds around, so the pins claim at least what
             // the firing's arithmetic counted, and a pol carrying more energy
             // than it needs closes just the same.
-            if (rules.time_table_edge_finding) {
+            if (rules.time_table_edge_finding && energetic.empty()) {
                 vector<bool> contained(starts.size(), false);
                 for (auto i : inside_tasks)
                     contained[i] = true;
@@ -1371,6 +1418,25 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
                                                         : 0_i;
                 };
 
+                // The rows the energetic certificate cites, one per candidate
+                // the window can reach. Built once per window rather than once
+                // per push: every push over this window cites the same set,
+                // minus the task it is pushing.
+                //
+                // A task with a non-positive bound is left out rather than
+                // cited at zero, which is the same clamp `guaranteed` applies:
+                // the lemma has nothing to derive for a task the window cannot
+                // reach, and would decline to emit a row at all.
+                vector<EnergeticContributor> energetic_contributors;
+                if (rules.energetic_edge_finding && logger)
+                    for (const auto & c2 : candidates) {
+                        auto low_guard = c2.est, high_guard = c2.lct - c2.length + 1_i;
+                        if (window_energy::window_energy_bound(
+                                c2.length, per_task_t_lo[c2.task], active_flag_count(c2.task), a, b, pair{low_guard, high_guard - 1_i}) <= 0_i)
+                            continue;
+                        energetic_contributors.push_back(EnergeticContributor{c2.task, low_guard, high_guard, c2.est >= a && c2.lct <= b});
+                    }
+
                 // Edge-finding. A task j that starts inside [a, b) but is not
                 // contained in it can be pushed when the window has no room
                 // left: if everything contained plus the whole of j cannot fit,
@@ -1475,8 +1541,8 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
                             continue;
 
                         auto one_too_far = std::holds_alternative<cumulative_proof_mutation::PushOneTooFar>(mutation);
-                        auto justify = edge_finding_justification(
-                            a, b, inside_tasks, j.task, low_guard, high_guard, starts_inside ? GuardToDischarge::Low : GuardToDischarge::High);
+                        auto justify = edge_finding_justification(a, b, inside_tasks, j.task, low_guard, high_guard,
+                            starts_inside ? GuardToDischarge::Low : GuardToDischarge::High, energetic_contributors);
                         if (starts_inside) {
                             inference.infer_greater_than_or_equal(logger, starts[j.task], one_too_far ? high_guard + 1_i : high_guard,
                                 JustifyExplicitly{justify, ThenRUP::Yes, hints::Cumulative{owner}}, reason_with_presence());
@@ -1552,7 +1618,8 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
                                 p_j, per_task_t_lo[j.task], active_flag_count(j.task), a, b, pair{low_guard, min_ect - 1_i});
                             if (clipped > 0_i && other_energy + h_j * clipped > supply) {
                                 auto one_too_far = std::holds_alternative<cumulative_proof_mutation::PushOneTooFar>(mutation);
-                                auto justify = edge_finding_justification(a, b, inside_tasks, j.task, low_guard, min_ect, GuardToDischarge::Low);
+                                auto justify = edge_finding_justification(
+                                    a, b, inside_tasks, j.task, low_guard, min_ect, GuardToDischarge::Low, energetic_contributors);
                                 inference.infer_greater_than_or_equal(logger, starts[j.task], one_too_far ? min_ect + 1_i : min_ect,
                                     JustifyExplicitly{justify, ThenRUP::Yes, hints::Cumulative{owner}}, reason_with_presence());
                             }
@@ -1568,7 +1635,8 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
                                 p_j, per_task_t_lo[j.task], active_flag_count(j.task), a, b, pair{low_guard, s_hi});
                             if (clipped > 0_i && other_energy + h_j * clipped > supply) {
                                 auto one_too_far = std::holds_alternative<cumulative_proof_mutation::PushOneTooFar>(mutation);
-                                auto justify = edge_finding_justification(a, b, inside_tasks, j.task, low_guard, s_hi + 1_i, GuardToDischarge::High);
+                                auto justify = edge_finding_justification(
+                                    a, b, inside_tasks, j.task, low_guard, s_hi + 1_i, GuardToDischarge::High, energetic_contributors);
                                 inference.infer_less_than(logger, starts[j.task], one_too_far ? low_guard - 1_i : low_guard,
                                     JustifyExplicitly{justify, ThenRUP::Yes, hints::Cumulative{owner}}, reason_with_presence());
                             }

--- a/gcs/constraints/cumulative/cumulative.hh
+++ b/gcs/constraints/cumulative/cumulative.hh
@@ -118,8 +118,25 @@ namespace gcs
         /// and a variable height at its guaranteed contribution. Takes
         /// precedence over \ref time_table_edge_finding when both are set.
         ///
-        /// \warning Not yet certified. A propagator with this set refuses to
-        /// run against a proof logger.
+        /// **Certified**, and more cheaply than \ref time_table_edge_finding:
+        /// every contribution is one guarded window-energy row, guarded by the
+        /// task's own bounds, which the reason carries whether or not the
+        /// window contains the task. Where TTEF pays 2.93 reason-backed pin
+        /// lines per firing for its profile term, this pays none.
+        ///
+        /// The rows it cites for a task the window does *not* contain are
+        /// keyed on bounds that move, where a contained task's guards come
+        /// from the window and are the same at every node. So they are derived
+        /// far more often than they are reused, and whether weakening them
+        /// deliberately --- buying reuse at the price of a looser bound --- is
+        /// worth it is the experiment #755 leaves open.
+        ///
+        /// Off by default because it is a sweep a solve that never fires it
+        /// still pays, not because it is weak: on `data_bl` + `data_pack` it
+        /// is the strongest arm in the table at **0.667x** edge-finding's
+        /// recursions against TTEF's 0.749x. Those are recursions rather than
+        /// wall times, and `dev_docs/cumulative-proof-logging.md` records that
+        /// recomputing the sum per window is not paid for on that family.
         bool energetic_edge_finding = false;
 
         /// Not-first / not-last: a task that cannot start before every task the

--- a/gcs/constraints/cumulative/cumulative_energetic_test.cc
+++ b/gcs/constraints/cumulative/cumulative_energetic_test.cc
@@ -1,0 +1,504 @@
+/* Energetic edge-finding for Cumulative, and its certificate (#755).
+ *
+ * `cumulative_ttef_test.cc` covers the time-table form, which charges a window
+ * a contained task's whole energy plus a non-contained one's mandatory part in
+ * it. This one covers the energetic form, which charges *every* task its
+ * guaranteed energy --- the least overlap its execution interval can have with
+ * the window over the starts its bounds still allow. That subsumes both: a
+ * contained task's guaranteed energy is its whole energy, and a non-contained
+ * one's is at least its mandatory part and usually more.
+ *
+ * The certificate is edge-finding's with a different set of rows cited, and
+ * what makes it cheap is that the extra energy needs no pins: the guaranteed
+ * figure is exactly what `derive_guarded_window_energy` establishes, guarded by
+ * the task's own bounds, which the reason carries whether or not the window
+ * contains the task. Where TTEF pays 2.93 reason-backed pin lines per firing
+ * for its profile term, this pays none.
+ *
+ * So the mutation lane that matters is `drop_energetic`, which leaves out the
+ * row of a task the window does *not* contain: `drop` removes a row plain
+ * edge-finding would have cited anyway and says nothing about what is new here.
+ */
+
+#include <gcs/constraints/cumulative.hh>
+#include <gcs/constraints/innards/constraints_test_utils.hh>
+#include <gcs/problem.hh>
+#include <gcs/solve.hh>
+
+#include <algorithm>
+#include <climits>
+#include <cstdlib>
+#include <iostream>
+#include <optional>
+#include <random>
+#include <set>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <variant>
+#include <vector>
+#include <version>
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+#include <print>
+#else
+#include <fmt/core.h>
+#include <fmt/ostream.h>
+#include <fmt/ranges.h>
+#endif
+
+using std::cerr;
+using std::flush;
+using std::make_optional;
+using std::max;
+using std::min;
+using std::nullopt;
+using std::optional;
+using std::pair;
+using std::set;
+using std::string;
+using std::tuple;
+using std::vector;
+using std::ranges::any_of;
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+using std::print;
+using std::println;
+#else
+using fmt::print;
+using fmt::println;
+#endif
+
+using namespace gcs;
+using namespace gcs::innards;
+using namespace gcs::test_innards;
+
+namespace
+{
+    struct Instance
+    {
+        vector<pair<int, int>> start_ranges;
+        vector<int> lengths;
+        vector<int> heights;
+        int capacity;
+    };
+
+    auto is_satisfying(const Instance & inst, const vector<int> & starts) -> bool
+    {
+        auto n = inst.start_ranges.size();
+        int t_lo = INT_MAX, t_hi = INT_MIN;
+        for (size_t i = 0; i < n; ++i) {
+            t_lo = min(t_lo, starts[i]);
+            t_hi = max(t_hi, starts[i] + inst.lengths[i] - 1);
+        }
+        for (int t = t_lo; t <= t_hi; ++t) {
+            int load = 0;
+            for (size_t i = 0; i < n; ++i)
+                if (starts[i] <= t && t < starts[i] + inst.lengths[i])
+                    load += inst.heights[i];
+            if (load > inst.capacity)
+                return false;
+        }
+        return true;
+    }
+
+    auto post(Problem & p, const Instance & inst, CumulativeRules rules, CumulativeProofMutation mutation = cumulative_proof_mutation::None{})
+        -> vector<IntegerVariableID>
+    {
+        vector<IntegerVariableID> starts;
+        vector<Integer> lengths, heights;
+        for (size_t i = 0; i < inst.start_ranges.size(); ++i) {
+            starts.push_back(
+                p.create_integer_variable(Integer{inst.start_ranges[i].first}, Integer{inst.start_ranges[i].second}, "start" + std::to_string(i)));
+            lengths.push_back(Integer{inst.lengths[i]});
+            heights.push_back(Integer{inst.heights[i]});
+        }
+        p.post(Cumulative{starts, lengths, heights, Integer{inst.capacity}}.with_rules(rules).with_proof_mutation(mutation));
+        return starts;
+    }
+
+    /// The bounds each start is left with once root propagation has run. TTEF
+    /// moves bounds rather than reporting conflicts, so this is where it has to
+    /// be measured: an enumeration test alone cannot tell whether it fired.
+    auto root_bounds(const Instance & inst, CumulativeRules rules, CumulativeProofMutation mutation, const optional<string> & proof_name)
+        -> optional<vector<pair<int, int>>>
+    {
+        Problem p;
+        auto starts = post(p, inst, rules, mutation);
+
+        optional<vector<pair<int, int>>> bounds;
+        solve_with(p,
+            SolveCallbacks{.solution = [&](const CurrentState & s) -> bool {
+                               if (! bounds) {
+                                   bounds.emplace();
+                                   for (const auto & v : starts)
+                                       bounds->emplace_back(static_cast<int>(s(v).raw_value), static_cast<int>(s(v).raw_value));
+                               }
+                               return false;
+                           },
+                .trace = [&](const CurrentState & s) -> bool {
+                    if (! bounds) {
+                        bounds.emplace();
+                        for (const auto & v : starts)
+                            bounds->emplace_back(static_cast<int>(s.lower_bound(v).raw_value), static_cast<int>(s.upper_bound(v).raw_value));
+                    }
+                    return false;
+                }},
+            proof_name ? make_optional<ProofOptions>(ProofFileNames{*proof_name}) : nullopt);
+        return bounds;
+    }
+
+    auto fail(const string & message) -> void
+    {
+        println(cerr, "cumulative energetic: {}", message);
+        exit(EXIT_FAILURE);
+    }
+
+    /// "starts lo:hi,... / lengths / heights / capacity", so that a fixture
+    /// found by --search can be handed straight back in.
+    auto parse_instance(const string & spec) -> Instance
+    {
+        vector<string> parts;
+        for (size_t at = 0, next; at <= spec.size(); at = next + 1) {
+            next = spec.find('/', at);
+            if (next == string::npos)
+                next = spec.size();
+            parts.push_back(spec.substr(at, next - at));
+            if (next == spec.size())
+                break;
+        }
+        if (parts.size() != 4)
+            fail("instance spec wants four /-separated parts, got " + std::to_string(parts.size()));
+
+        auto split = [](const string & s) {
+            vector<string> out;
+            for (size_t at = 0, next; at <= s.size(); at = next + 1) {
+                next = s.find(',', at);
+                if (next == string::npos)
+                    next = s.size();
+                out.push_back(s.substr(at, next - at));
+                if (next == s.size())
+                    break;
+            }
+            return out;
+        };
+
+        Instance inst{{}, {}, {}, std::stoi(parts[3])};
+        for (const auto & r : split(parts[0])) {
+            auto colon = r.find(':');
+            inst.start_ranges.emplace_back(std::stoi(r.substr(0, colon)), std::stoi(r.substr(colon + 1)));
+        }
+        for (const auto & l : split(parts[1]))
+            inst.lengths.push_back(std::stoi(l));
+        for (const auto & h : split(parts[2]))
+            inst.heights.push_back(std::stoi(h));
+        return inst;
+    }
+
+    auto show_instance(const Instance & inst) -> string
+    {
+        string out;
+        for (size_t i = 0; i < inst.start_ranges.size(); ++i)
+            out += (i ? "," : "") + std::to_string(inst.start_ranges[i].first) + ":" + std::to_string(inst.start_ranges[i].second);
+        out += "/";
+        for (size_t i = 0; i < inst.lengths.size(); ++i)
+            out += (i ? "," : "") + std::to_string(inst.lengths[i]);
+        out += "/";
+        for (size_t i = 0; i < inst.heights.size(); ++i)
+            out += (i ? "," : "") + std::to_string(inst.heights[i]);
+        return out + "/" + std::to_string(inst.capacity);
+    }
+
+    /// A fixture is only a test of the *claim* if the claim is tight: a push to
+    /// v that a solution with the pushed task at v−1 would refute. Where the
+    /// push is merely valid, "one too far" is valid too, and VeriPB verifies the
+    /// corrupted proof --- which is a fact about the fixture, not about the
+    /// rule. So: TTEF must move a bound edge-finding does not, and some solution
+    /// must sit exactly on the bound it moves to.
+    auto search_for_fixture(
+        const CumulativeRules & weaker, const CumulativeRules & stronger, unsigned long long seed_from, unsigned long long candidates) -> void
+    {
+        std::mt19937 rand(static_cast<unsigned>(seed_from));
+        for (unsigned long long attempt = 0; attempt < candidates; ++attempt) {
+            auto n = 3 + static_cast<size_t>(rand() % 3);
+            auto capacity = 2 + static_cast<int>(rand() % 3);
+            Instance inst{{}, {}, {}, capacity};
+            for (size_t i = 0; i < n; ++i) {
+                auto len = 1 + static_cast<int>(rand() % 5);
+                auto lo = static_cast<int>(rand() % 6);
+                auto slack = static_cast<int>(rand() % 7);
+                inst.start_ranges.emplace_back(lo, lo + slack);
+                inst.lengths.push_back(len);
+                inst.heights.push_back(1 + static_cast<int>(rand() % capacity));
+            }
+
+            auto without = root_bounds(inst, weaker, cumulative_proof_mutation::None{}, nullopt);
+            auto with = root_bounds(inst, stronger, cumulative_proof_mutation::None{}, nullopt);
+            if (! without || ! with)
+                continue;
+
+            set<vector<int>> solutions;
+            build_expected(solutions, [&](const vector<int> & starts) { return is_satisfying(inst, starts); }, inst.start_ranges);
+            if (solutions.empty())
+                continue;
+
+            for (size_t i = 0; i < n; ++i) {
+                auto raises = (*with)[i].first > (*without)[i].first;
+                auto lowers = (*with)[i].second < (*without)[i].second;
+                if (! raises && ! lowers)
+                    continue;
+                auto landed = raises ? (*with)[i].first : (*with)[i].second;
+                auto tight = any_of(solutions, [&](const vector<int> & s) { return s[i] == landed; });
+                if (! tight)
+                    continue;
+                println(cerr, "candidate {} task {} {} -> {} tight, {} solutions", show_instance(inst), i, raises ? "lb" : "ub", landed,
+                    solutions.size());
+                break;
+            }
+        }
+    }
+
+    /// Every rule setting must find exactly the same solutions: TTEF is a
+    /// propagation strength, not a change of constraint. This is the net for an
+    /// over-firing push, which removes solutions.
+    auto check_enumeration(const string & what, const Instance & inst, CumulativeRules rules, const optional<string> & proof_name) -> void
+    {
+        print(cerr, "cumulative energetic {} starts={} lens={} hts={} c={}{}", what, inst.start_ranges, inst.lengths, inst.heights, inst.capacity,
+            proof_name ? " with proofs:" : ":");
+        cerr << flush;
+
+        set<vector<int>> expected, actual;
+        build_expected(expected, [&](const vector<int> & starts) { return is_satisfying(inst, starts); }, inst.start_ranges);
+        println(cerr, " expecting {} solutions", expected.size());
+
+        Problem p;
+        auto starts = post(p, inst, rules);
+        solve_for_tests(p, proof_name, actual, tuple{starts});
+        check_results(proof_name, expected, actual);
+    }
+}
+
+auto main(int argc, char * argv[]) -> int
+{
+    establish_and_announce_seed(argc, argv);
+
+    const CumulativeRules ttef{.time_table = true, .overload = true, .profile_overload = true, .edge_finding = true, .time_table_edge_finding = true};
+    const CumulativeRules energetic{.time_table = true,
+        .overload = true,
+        .profile_overload = true,
+        .edge_finding = true,
+        .time_table_edge_finding = false,
+        .energetic_edge_finding = true};
+
+    auto proofs = can_run_veripb();
+
+    // The fixtures, and what it takes to be one. Two things have to hold at
+    // once, and hand-picking gets at most one:
+    //
+    //   * the push must be TIGHT --- some solution must sit exactly on the
+    //     bound it lands on. Where the push is merely valid, "one too far" is
+    //     valid too and VeriPB verifies the corrupted proof, which is a fact
+    //     about the fixture rather than about the rule;
+    //   * the non-contained tasks' rows must be LOAD-BEARING. They usually are
+    //     not: the guaranteed energy the energetic form adds over TTEF's
+    //     profile term is often small enough that the wrapping RUP closes
+    //     without it.
+    //
+    // All three below were found by --search, which generates random instances
+    // and keeps the ones where the energetic form moves a bound TTEF does not
+    // and a solution sits on it, followed by vetting each candidate against
+    // every mutation with an honest control. --describe prints the numbers
+    // written down here.
+    //
+    // Task 1's lower bound moves 3 -> 9, over 5 solutions. The only fixture on
+    // which the `capacity` lane bites as well.
+    const Instance sharp{{{1, 7}, {3, 9}, {1, 6}, {0, 6}, {1, 5}}, {1, 1, 3, 3, 4}, {3, 3, 1, 2, 3}, 3};
+
+    // Its mirror, where task 0's upper bound falls 3 -> 1 over 2 solutions, so
+    // the negated conclusion lands on the guarded row's low guard instead of
+    // its high one. Three other bounds move here too, which is what an
+    // instance this tight looks like.
+    const Instance sharp_mirror{{{0, 3}, {4, 6}, {3, 6}, {2, 7}}, {2, 1, 3, 4}, {2, 3, 2, 3}, 3};
+
+    // A roomier one: task 1's lower bound moves 5 -> 6 over 42 solutions, so
+    // the enumeration check below has something to enumerate and the push is
+    // still the energetic form's alone.
+    const Instance roomy{{{3, 6}, {5, 8}, {2, 6}, {0, 2}}, {2, 5, 2, 1}, {2, 2, 1, 1}, 2};
+
+    // Describe one instance: what edge-finding leaves, what TTEF leaves, and
+    // whether the bound it moves to is one a solution sits on. This is how a
+    // fixture found by --search gets turned into the numbers written down
+    // beside it below.
+    for (int a = 1; a < argc; ++a)
+        if (string{argv[a]}.starts_with("--describe=")) {
+            string arg = argv[a];
+            auto inst = parse_instance(arg.substr(arg.find('=') + 1));
+            auto without = root_bounds(inst, ttef, cumulative_proof_mutation::None{}, nullopt);
+            auto with = root_bounds(inst, energetic, cumulative_proof_mutation::None{}, nullopt);
+            if (! without || ! with)
+                fail("describe: nothing was reached at the root");
+            set<vector<int>> solutions;
+            build_expected(solutions, [&](const vector<int> & starts) { return is_satisfying(inst, starts); }, inst.start_ranges);
+            println(cerr, "{} solutions {}", show_instance(inst), solutions.size());
+            for (size_t i = 0; i < inst.start_ranges.size(); ++i) {
+                auto tight = [&](int v) { return any_of(solutions, [&](const vector<int> & s) { return s[i] == v; }); };
+                println(cerr, "  task {}: ttef [{}, {}] energetic [{}, {}]{}{}", i, (*without)[i].first, (*without)[i].second, (*with)[i].first,
+                    (*with)[i].second, (*with)[i].first > (*without)[i].first ? " lb MOVED" : "",
+                    (*with)[i].second < (*without)[i].second ? " ub MOVED" : "");
+                println(cerr, "           lb tight {} ub tight {}", tight((*with)[i].first), tight((*with)[i].second));
+            }
+            return EXIT_SUCCESS;
+        }
+
+    // Fixture search: print instances on which TTEF moves a bound
+    // edge-finding does not, and moves it somewhere a solution actually sits.
+    for (int a = 1; a < argc; ++a)
+        if (string{argv[a]} == "--search") {
+            unsigned long long from = 1, count = 2000;
+            auto number = [&](int at) { return at < argc && argv[at][0] >= '0' && argv[at][0] <= '9'; };
+            if (number(a + 1))
+                from = std::stoull(argv[a + 1]);
+            if (number(a + 2))
+                count = std::stoull(argv[a + 2]);
+            search_for_fixture(ttef, energetic, from, count);
+            return EXIT_SUCCESS;
+        }
+
+    // --random: generated instances, each enumerated against a pure C++ oracle
+    // and each proof verified. The fixtures above are picked for what they
+    // demonstrate; this is the net under them, and it is where a rule that
+    // charges a window energy its certificate cannot carry would show up ---
+    // the guards on a non-contained task's row come from bounds that move,
+    // which no hand-built fixture exercises many of.
+    for (int a = 1; a < argc; ++a)
+        if (string{argv[a]} == "--random") {
+            std::mt19937 rand(a + 1 < argc ? static_cast<unsigned>(std::stoul(argv[a + 1])) : 1u);
+            for (auto attempt = 0; attempt < 40; ++attempt) {
+                auto n = 3 + static_cast<size_t>(rand() % 3);
+                auto capacity = 2 + static_cast<int>(rand() % 3);
+                Instance inst{{}, {}, {}, capacity};
+                for (size_t i = 0; i < n; ++i) {
+                    inst.lengths.push_back(1 + static_cast<int>(rand() % 5));
+                    auto lo = static_cast<int>(rand() % 6);
+                    inst.start_ranges.emplace_back(lo, lo + static_cast<int>(rand() % 7));
+                    inst.heights.push_back(1 + static_cast<int>(rand() % capacity));
+                }
+                check_enumeration("random " + std::to_string(attempt), inst, energetic,
+                    proofs ? make_optional("cumulative_energetic_random_" + std::to_string(attempt)) : nullopt);
+            }
+            return EXIT_SUCCESS;
+        }
+
+    // Mutation mode: emit one deliberately corrupted proof and stop, for
+    // run_test_and_expect_verify_failure.bash to hand to veripb.
+    {
+        optional<CumulativeProofMutation> mutation;
+        const Instance * fixture = &sharp;
+        optional<Instance> from_spec;
+        string proof_basename = "cumulative_energetic_mutation";
+        for (int a = 1; a < argc; ++a) {
+            string arg = argv[a];
+            if (arg.starts_with("--instance=")) {
+                from_spec = parse_instance(arg.substr(arg.find('=') + 1));
+                fixture = &*from_spec;
+            }
+            else if (arg == "--mutate=none")
+                mutation = cumulative_proof_mutation::None{};
+            else if (arg == "--mutate=drop_energetic")
+                mutation = cumulative_proof_mutation::DropEnergeticContributor{};
+            else if (arg == "--mutate=drop")
+                mutation = cumulative_proof_mutation::DropContainedTask{};
+            else if (arg == "--mutate=toofar")
+                mutation = cumulative_proof_mutation::PushOneTooFar{};
+            else if (arg == "--mutate=capacity")
+                mutation = cumulative_proof_mutation::OmitCapacityLine{};
+            else if (arg == "--mutate=mirror_drop_energetic") {
+                mutation = cumulative_proof_mutation::DropEnergeticContributor{};
+                fixture = &sharp_mirror;
+            }
+            else if (arg == "--mutate=mirror_toofar") {
+                mutation = cumulative_proof_mutation::PushOneTooFar{};
+                fixture = &sharp_mirror;
+            }
+            else if (arg == "--proof-files-basename" && a + 1 < argc)
+                proof_basename = argv[++a];
+        }
+
+        if (mutation) {
+            auto bounds = root_bounds(*fixture, energetic, *mutation, make_optional(proof_basename));
+            // A push deliberately taken one unit past the truth can empty the
+            // pushed task's domain at the root, so no node is ever traced ---
+            // which is itself evidence the corruption fired, and the proof it
+            // wrote is the one veripb has to reject. Every other lane leaves
+            // the inference alone, so nothing reached there really would mean
+            // an empty proof.
+            if (! bounds && ! std::holds_alternative<cumulative_proof_mutation::PushOneTooFar>(*mutation))
+                fail("mutation mode: nothing was reached, so the proof is empty");
+            println(cerr, "wrote a deliberately corrupted proof to {}.pbp", proof_basename);
+            return EXIT_SUCCESS;
+        }
+    }
+
+    // The rule fires, pushes exactly as far as the energy supports, and does so
+    // where edge-finding on its own does not. `raises` says which bound the
+    // fixture is about, and `task` which task it is about.
+    for (const auto & [name, inst, task, raises, expected] : vector<tuple<string, Instance, size_t, bool, int>>{
+             {"sharp", sharp, 1, true, 9}, {"sharp_mirror", sharp_mirror, 0, false, 1}, {"roomy", roomy, 1, true, 6}}) {
+        auto off = root_bounds(inst, ttef, cumulative_proof_mutation::None{}, nullopt);
+        auto on = root_bounds(inst, energetic, cumulative_proof_mutation::None{}, proofs ? make_optional("cumulative_energetic_" + name) : nullopt);
+        if (! off || ! on)
+            fail(name + ": nothing was reached at the root");
+
+        auto pick = [&, task = task, raises = raises](const vector<pair<int, int>> & b) { return raises ? b[task].first : b[task].second; };
+        if (raises ? pick(*off) >= expected : pick(*off) <= expected)
+            fail(name + ": TTEF alone already reaches the push, so this fixture measures nothing");
+        if (pick(*on) != expected)
+            fail(name + ": expected the pushed task's bound to reach " + std::to_string(expected) + ", got " + std::to_string(pick(*on)));
+        println(cerr, "cumulative energetic {}: task {} {} {} -> {}", name, task, raises ? "lb" : "ub", pick(*off), pick(*on));
+        if (proofs)
+            verify_proof_and_clean_up("cumulative_energetic_" + name);
+    }
+
+    // Alongside the rules that share the sweep and the guarded rows with it.
+    // Not-first / not-last reads the same `window_total` and takes the same
+    // task's contribution back out of it, so its certificate has to cite the
+    // energetic rows too --- a lane worth having, because a rule that quietly
+    // cited the contained-task set instead would fire on energy its proof did
+    // not carry. The elastic rungs are here because they share the sweep's
+    // supply figure and nothing else, and running them together is what would
+    // catch a guarded-row cache keyed on too little.
+    if (proofs)
+        for (const auto & [name, extra] : vector<pair<string, CumulativeRules>>{{"nfnl",
+                                                                                    [&] {
+                                                                                        auto r = energetic;
+                                                                                        r.not_first_not_last = true;
+                                                                                        return r;
+                                                                                    }()},
+                 {"everything", [&] {
+                      auto r = energetic;
+                      r.not_first_not_last = true;
+                      r.elastic_overload = true;
+                      r.knapsack_overload = true;
+                      return r;
+                  }()}}) {
+            for (const auto & [what, inst] : vector<pair<string, Instance>>{{"sharp", sharp}, {"sharp_mirror", sharp_mirror}, {"roomy", roomy}}) {
+                auto basename = "cumulative_energetic_" + name + "_" + what;
+                if (! root_bounds(inst, extra, cumulative_proof_mutation::None{}, make_optional(basename)))
+                    fail(name + " " + what + ": nothing was reached at the root");
+                verify_proof_and_clean_up(basename);
+            }
+            println(cerr, "cumulative energetic with {}: certified on every fixture", name);
+        }
+
+    // Soundness, over instances small enough to enumerate: the rule may not
+    // lose a solution, with or without a proof being written.
+    for (const auto & [name, inst] : vector<pair<string, Instance>>{{"sharp", sharp}, {"sharp_mirror", sharp_mirror}, {"roomy", roomy},
+             {"tight", Instance{{{0, 3}, {0, 3}, {1, 2}, {0, 5}}, {2, 2, 3, 2}, {1, 1, 1, 1}, 2}},
+             {"mixed_heights", Instance{{{0, 4}, {0, 4}, {1, 2}, {0, 6}}, {3, 2, 4, 2}, {2, 1, 1, 2}, 3}}}) {
+        check_enumeration(name, inst, energetic, nullopt);
+        if (proofs)
+            check_enumeration(name, inst, energetic, make_optional("cumulative_energetic_enum_" + name));
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/gcs/constraints/innards/cumulative_mutations.hh
+++ b/gcs/constraints/innards/cumulative_mutations.hh
@@ -107,12 +107,25 @@ namespace gcs::innards
         {
         };
 
+        /// Energetic edge-finding: leave out the guarded energy row of one task
+        /// the window does *not* contain. **The mutation this rule exists for**
+        /// --- charging a window every task's guaranteed energy rather than a
+        /// contained task's whole energy plus a non-contained one's mandatory
+        /// part is the whole of what makes the rule stronger, and this is the
+        /// only lane that can tell whether that extra energy is in the proof or
+        /// only in the propagator. \ref DropContainedTask drops a row plain
+        /// edge-finding would have cited too, so it says nothing about this.
+        struct DropEnergeticContributor
+        {
+        };
+
     }
 
     using CumulativeProofMutation = std::variant<cumulative_proof_mutation::None, cumulative_proof_mutation::OverstateWindowEnergy,
         cumulative_proof_mutation::OmitCapacityLine, cumulative_proof_mutation::ShrinkLemmaWindow, cumulative_proof_mutation::DropContainedTask,
         cumulative_proof_mutation::PushOneTooFar, cumulative_proof_mutation::DropProfilePin, cumulative_proof_mutation::DropProfilePins,
-        cumulative_proof_mutation::ClaimOneBetterAvailability, cumulative_proof_mutation::StrengthenOneFewer>;
+        cumulative_proof_mutation::ClaimOneBetterAvailability, cumulative_proof_mutation::StrengthenOneFewer,
+        cumulative_proof_mutation::DropEnergeticContributor>;
 
     /**
      * \brief Deliberate corruptions of the presence-falsification derivation,


### PR DESCRIPTION
`CumulativeRules::energetic_edge_finding` charges a window every task's *guaranteed* energy — the least overlap its execution interval can have with the window, over the starts its bounds still allow — rather than a contained task's whole energy plus a non-contained one's mandatory part. It is the strongest arm in the edge-finding table:

| arm | recursions | vs ef |
|---|---|---|
| edge-finding | 2,359,885 | 1.000x |
| TTEF | 1,768,271 | 0.749x |
| **energetic** | **1,573,267** | **0.667x** |

and it was the one `define_proof_model` threw `UnimplementedException` for.

## The certificate

Edge-finding's, with the cited rows swapped. Same capacity lines over the window, same closing pol, same negated-conclusion guard on the pushed task's row.

| arm | rows cited | pins |
|---|---|---|
| edge-finding | one per contained task, guarded by the *window* | none |
| TTEF | the same, plus the profile term | 2.93 per firing |
| energetic | one per candidate, guarded by the task's *own bounds* | none |

The guards a non-contained task's row carries are exactly the start bounds `guaranteed()` asked `window_energy_bound` about, so the row establishes neither more nor less than the detection counted. Both guards are discharged by the reason, which carries every task's bounds whether or not the window contains it — which is why TTEF's profile pins have no counterpart here: a pin says "this task is *here*, at this time point", and a guarded energy row says the same of a whole window in one line. #755 predicted this would be the cheap one, and it is.

The bounds cited are the ones the sweep captured when it built its candidates, not the live ones. An earlier push in the same sweep may have tightened them, and a guard at a stale bound is one the reason still entails — and it is the bound the detection's arithmetic used, so the two cannot drift apart.

Not-first / not-last reads the same window total and takes the same task's contribution back out of it, so it cites the energetic rows too; a version that quietly cited the contained-task set instead would fire on energy its proof did not carry. There is a test lane for that.

## Left open

The cache key, which is what #755 says is the real question. A contained task's guards come from the window and are the same at every node; a non-contained one's are not, so those rows are derived far more often than they are reused. Weakening them deliberately — buying reuse at the price of a looser bound — is the experiment, and it is not made here.

## Testing

New `cumulative_energetic_test`, modelled on the TTEF one: three fixtures found by `--search` and vetted against every mutation lane, a `--random` lane that enumerates 40 generated instances against a C++ oracle and verifies each proof, and runs alongside not-first/not-last and the elastic rungs.

Six mutation lanes, all rejected by VeriPB. `drop_energetic` is the one this rule needs — it removes the row of a task the window does *not* contain, the only energy plain edge-finding would not have cited — so it is a separate lane from `drop`, which removes a contained task's and says nothing about what is new.

Second of three; #770 did the disjunctive published not-first/not-last, and Cumulative's published detection (#746) follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PAZYGJdsP3dmWAepRGi5T5