### PR TITLE
Certify Cumulative's published not-first / not-last (#746)

### DIFF
--- a/dev_docs/cumulative-proof-logging.md
+++ b/dev_docs/cumulative-proof-logging.md
@@ -1526,11 +1526,10 @@ depend on the unclamped end. Two further numbers shape the work item:
   derived-window mechanism. The residue is reachable by no window and no task
   set at all.
 
-### And what the gap is worth, which is why it stays open
+### And what the gap is worth
 
 `CumulativeRules::not_first_not_last_published` fires the published condition
-verbatim, uncertified, so the difference can be priced the way #757 priced its
-own. Over `data_bl` + `data_pack` at 60 s, the same 37 instances:
+verbatim, so the difference can be priced the way #757 priced its own. Over `data_bl` + `data_pack` at 60 s, the same 37 instances:
 
 | arm | vs the detection we certify | better | worse |
 |---|---|---|---|
@@ -1548,6 +1547,63 @@ against plain edge-finding's 39.
 **That is the paper claim, now on both encodings.** Where a rule certifies a
 weaker detection than the literature states, the gap is priced rather than
 confessed: 0.6% of the search on `Disjunctive`, under 1% here.
+
+### Certifying the published condition, by contiguity (#746)
+
+The measurement above is a reason to leave the switch off by default, not a
+reason to leave it unprovable, so the certificate is built. It is not the
+window-energy lemma's --- §"#746, settled" above is the proof that it cannot
+be --- and what it is instead is the contiguity argument written down there,
+turned into rows.
+
+Over the contained set's own window `[est(Ω), lct(Ω))`, and for not-first:
+
+```
+active_{k,u}  ⟹  active_{k,v}        for k ∈ Ω and u ≤ v < ECT(Ω)
+```
+
+because `before` is monotone in the model and `after_{k,v}` follows from the
+reason's `s_k ≥ est_k` and `l_k ≥ p_k`, `ect_k` reaching `ECT(Ω)` by definition
+of `Ω`. So Ω's whole load over the prefix is capped by its load at one time
+point, and if the pushed task is running *there* the capacity row at that point
+caps the prefix at `C − c_j` rather than `C`. Summed over the window that is
+exactly the published inequality.
+
+The pushed task is running at `v` when `s_j ≤ v` — the negated conclusion,
+which reaches `ECT(Ω) − 1` — and `s_j + l_j ≥ v + 1`, which the reason reaches
+at `ect_j`. Both hold at `v = ECT(Ω) − 1` exactly when `ect_j ≥ ECT(Ω)`, and
+then **one pol does the whole rule**. Where `ect_j < ECT(Ω)` no fixed time
+point works: the meeting point is `s_j` itself, a variable. The derivation
+becomes a **chain**, walking the bound up `p_j` at a time in the way the
+time-table push already does, each rung weakened by its own conclusion and
+deposited under the reason for the next rung's unit propagation. Every rung
+charges the window at least what the detection counted --- rung `i` caps
+`[est(Ω), min(r_i + p_j, lct(Ω)))` and `r_i ≥ lb(s_j)` --- so the first already
+suffices and the rest only carry the bound the rest of the way. The chain stops
+at the target or at a running bound the reason already contradicts, whichever
+comes first; walking past the pushed task's own domain was a real bug the
+`--random` lane found.
+
+Not-last is the same sentence backwards: Ω's activity is monotone *down* from
+`LST(Ω)`, the suffix rather than the prefix is capped, and it is the pushed
+task's own upper bound rather than its lower one that puts it beside them.
+
+Everything is stated in **activity** space rather than in the bit-linearised
+contribution space the capacity rows use, because contiguity is a statement
+about activity. A variable-height task's capacity term is converted back with
+the same `guaranteed_contribution` line `energy_contribution` would have used to
+convert the other way, so the line count is the same either way.
+
+**What the mutation lanes say, and what they cannot.** `emit_nothing` is
+rejected on 171 of 238 firing instances, so the derivation is load-bearing;
+`drop_pin`, `drop` and `toofar` all bite. Dropping the *contiguity rows* does
+not, in either a one-row or an every-row form, on any of ~1,700 instances: the
+detection's own margin absorbs `lb(h_k)` units per row, and what the pol no
+longer reaches the wrapping RUP finishes. `cumulative_mutations.hh` records
+that as deliberately absent rather than shipping a lane that always passes. The
+rows stay because without them the pol's arithmetic cannot reach the published
+threshold at all, and a proof whose pol stops short of its own claim is not a
+certificate of the published rule however VeriPB finishes it.
 
 Testing is `cumulative_nfnl_test`, whose fixtures were searched the same way
 TTEF's were and against the same two conditions --- the rule must move a bound

--- a/examples/rcpsp/rcpsp.cc
+++ b/examples/rcpsp/rcpsp.cc
@@ -366,8 +366,8 @@ auto main(int argc, char * argv[]) -> int
                 "--cumulative-edge-finding",                                                             //
                 cxxopts::value<bool>()->default_value("false"))                                          //
             ("cumulative-not-first-not-last-published",                                                  //
-                "Run the published not-first / not-last detection instead of the one we certify, to "    //
-                "price the difference (#746). Deliberately uncertified, so a run with --prove refuses. " //
+                "Run the published not-first / not-last detection instead of the window-energy one, "    //
+                "to price the difference (#746). Certified by contiguity rather than by that lemma. "    //
                 "Implies --cumulative-not-first-not-last, which it replaces",                            //
                 cxxopts::value<bool>()->default_value("false"))                                          //
             ("mutate-makespan-bound",                                                                    //

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -281,6 +281,7 @@ if(GCS_BUILD_TESTS)
     add_executable(cumulative_ttef_test constraints/cumulative/cumulative_ttef_test.cc)
     add_executable(cumulative_energetic_test constraints/cumulative/cumulative_energetic_test.cc)
     add_executable(cumulative_nfnl_test constraints/cumulative/cumulative_nfnl_test.cc)
+    add_executable(cumulative_published_nfnl_test constraints/cumulative/cumulative_published_nfnl_test.cc)
     add_executable(cumulative_kaoc_test constraints/cumulative/cumulative_kaoc_test.cc)
     add_executable(derived_cumulative_test constraints/cumulative/derived_cumulative_test.cc)
     add_executable(cumulative_optional_test constraints/cumulative/cumulative_optional_test.cc)
@@ -339,7 +340,7 @@ if(GCS_BUILD_TESTS)
 
     foreach(test_target
             abs_test all_different_test all_different_except_test all_equal_test among_test at_most_one_test bin_packing_test comparison_test
-            count_test cumulative_test cumulative_overload_test cumulative_edge_finding_test cumulative_ttef_test cumulative_energetic_test cumulative_nfnl_test cumulative_kaoc_test cumulative_optional_test derived_cumulative_test difference_test disjunctive_test disjunctive_optional_test disjunctive_overload_test disjunctive_edge_finding_test disjunctive_nfnl_test disjunctive_precedences_test disjunctive_set_precedences_test disjunctive_published_nfnl_test disjunctive_2d_test divide_modulus_test element_test equals_test bounds_global_cardinality_test gac_global_cardinality_test in_test increasing_test inverse_test knapsack_test knapsack_upfront_test lex_test linear_test linear_constant_test
+            count_test cumulative_test cumulative_overload_test cumulative_edge_finding_test cumulative_ttef_test cumulative_energetic_test cumulative_nfnl_test cumulative_published_nfnl_test cumulative_kaoc_test cumulative_optional_test derived_cumulative_test difference_test disjunctive_test disjunctive_optional_test disjunctive_overload_test disjunctive_edge_finding_test disjunctive_nfnl_test disjunctive_precedences_test disjunctive_set_precedences_test disjunctive_published_nfnl_test disjunctive_2d_test divide_modulus_test element_test equals_test bounds_global_cardinality_test gac_global_cardinality_test in_test increasing_test inverse_test knapsack_test knapsack_upfront_test lex_test linear_test linear_constant_test
             logical_test mdd_test min_distance_test min_distance_matching_test min_max_test mini_linear_test multiply_test n_value_test nogoods_test parity_test
             plus_minus_test power_test product_bounds_test product_justify_test regular_test regular_bacchus_test regular_legacy_test seq_precede_chain_test smart_table_test sort_test arg_sort_test symmetric_all_different_test
             negative_table_test table_test tabulation_test value_precede_test)
@@ -383,6 +384,19 @@ if(GCS_BUILD_TESTS)
         add_test(NAME cumulative_nfnl_mutation_${mutation}
             COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_expect_verify_failure.bash
                 --basename cumulative_nfnl_mutation_${mutation} $<TARGET_FILE:cumulative_nfnl_test> --mutate=${mutation})
+    endforeach()
+    # The detection as published (#746), certified by contiguity rather than by
+    # the window-energy lemma. `emit_nothing` is the control and `drop_pin` the
+    # lane aimed at what is new; dropping the contiguity rows themselves cannot
+    # be caught, and cumulative_mutations.hh records why.
+    add_test(NAME cumulative_published_nfnl
+        COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_published_nfnl_test>)
+    add_test(NAME cumulative_published_nfnl_random
+        COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_published_nfnl_test> --random 7)
+    foreach(mutation emit_nothing drop_pin drop toofar roomy_toofar roomy_drop_pin)
+        add_test(NAME cumulative_published_nfnl_mutation_${mutation}
+            COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_expect_verify_failure.bash
+                --basename cumulative_published_nfnl_mutation_${mutation} $<TARGET_FILE:cumulative_published_nfnl_test> --mutate=${mutation})
     endforeach()
     foreach(mutation pins pin drop toofar mirror_pins mirror_pin mirror_toofar)
         add_test(NAME cumulative_ttef_mutation_${mutation}

--- a/gcs/constraints/cumulative/cumulative.cc
+++ b/gcs/constraints/cumulative/cumulative.cc
@@ -42,6 +42,7 @@ using std::make_unique;
 using std::max;
 using std::min;
 using std::move;
+using std::nullopt;
 using std::optional;
 using std::pair;
 using std::size_t;
@@ -349,11 +350,6 @@ auto gcs::innards::prepare_cumulative_overload_check(const vector<IntegerVariabl
 
 auto Cumulative::define_proof_model(ProofModel & model, const State &) -> void
 {
-    // A propagator that infers what it cannot justify is worse than one that
-    // declines: refuse here rather than emit a proof VeriPB will reject.
-    if (_rules.not_first_not_last_published)
-        throw UnimplementedException{"the published not-first / not-last detection is not certified: see #746"};
-
     // Time-table OPB encoding:
     //   for each task i and each time point t in its possible-active range:
     //     before_{i,t}  ⇔  starts[i] ≤ t
@@ -1049,6 +1045,255 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
         return {contrib_line, 1_i};
     };
 
+    // --- #746: the published not-first / not-last detection -----------------
+    //
+    // `not_first_not_last` above asks what the guarded window-energy lemma can
+    // *derive*: the least overlap the pushed task can have with the window over
+    // the negated conclusion's whole start range. Schutt & Wolf (CP 2010,
+    // Proposition 1) and Kameugne et al. (CPAIOR 2018, rule (NF)) charge the
+    // overlap at *one end* of that range instead, over the contained set's own
+    // window `[est(Omega), lct(Omega))`:
+    //
+    //     e(Omega) + c_j * (min(ect_j, lct(Omega)) - est(Omega))
+    //         > C * (lct(Omega) - est(Omega))         =>  s_j >= ECT(Omega)
+    //
+    // and the mirror. That is more than the lemma derives, so it is not a
+    // window-energy argument at all, and this is what it is instead.
+    //
+    // **Contiguity.** Every task in Omega has `ect_k >= ECT(Omega)`, so it
+    // cannot finish before `ECT(Omega)`: if it is running at any time in
+    // `[est(Omega), ECT(Omega))` it is still running at the end of that
+    // interval. In the encoding that is one line per (task, time),
+    //
+    //     active_{k,u}  =>  active_{k,v}      for  u <= v < ECT(Omega)
+    //
+    // since `before` is monotone in the model and `after_{k,v}` follows from
+    // the reason's `s_k >= est_k` and `l_k >= p_k`. So the whole prefix's load
+    // from Omega is capped by the load at one time point --- and if the pushed
+    // task is running *there*, the capacity row at that one point caps the
+    // prefix at `C - c_j` rather than `C`. Summed over the window that is
+    // exactly the published inequality, which is #746's answer to why the rule
+    // is sound: contiguity plus `ECT` at a single time point, not window
+    // energy.
+    //
+    // **Where the pushed task is running.** It is running at `v` when
+    // `s_j <= v` (the negated conclusion, which gives `s_j <= ECT(Omega) - 1`)
+    // and `s_j + l_j >= v + 1` (the reason's `s_j >= lb(s_j)`, which reaches
+    // `ect_j`). Both hold at `v = ECT(Omega) - 1` exactly when
+    // `ect_j >= ECT(Omega)`, and then one pol does the whole rule. When
+    // `ect_j < ECT(Omega)` no single time point works --- the meeting point is
+    // `s_j` itself, which is a variable --- so the derivation becomes a chain,
+    // walking the bound up `p_j` at a time in the way the time-table push
+    // already does, each rung's row weakened by that rung's own conclusion and
+    // deposited under the reason for the next rung's unit propagation. Every
+    // rung charges the window at least what the detection counted, so the first
+    // one already suffices and the rest only carry the bound the rest of the
+    // way.
+    //
+    // Everything is stated in *activity* space rather than in the
+    // bit-linearised contribution space the capacity rows use, because
+    // contiguity is a statement about activity. A variable-height task's
+    // capacity term is converted back with the same `guaranteed_contribution`
+    // line `energy_contribution` would have used to convert the other way; the
+    // count is the same either way.
+    struct PublishedTask
+    {
+        std::size_t task;
+        Integer est, ub, length;
+    };
+
+    // active_{k,v} >= active_{k,u}: task k, running at u, is still running at
+    // v. `forward` is not-first's direction (u <= v, the far end pinned by
+    // `after`); its mirror pins `before` instead. nullopt when one of the two
+    // times is outside k's flag range, where there is no activity term to
+    // bound and nothing to say.
+    auto contiguity_applies = [&](const PublishedTask & k, Integer u, Integer v) {
+        auto t_lo = per_task_t_lo[k.task], t_hi = per_task_t_hi[k.task];
+        return u >= t_lo && u <= t_hi && v >= t_lo && v <= t_hi;
+    };
+    auto published_contiguity = [&](const ReasonLiterals & reason, const PublishedTask & k, Integer u, Integer v, bool forward) -> ProofLine {
+        auto t_lo = per_task_t_lo[k.task];
+        auto fu = static_cast<size_t>((u - t_lo).raw_value), fv = static_cast<size_t>((v - t_lo).raw_value);
+        if (forward) {
+            // s_k + l_k >= est_k + p_k = ect_k >= ECT(Omega) > v.
+            materialise_after_sum(k.task, k.est);
+            logger->emit_rup_proof_line_under_reason(reason, WPBSum{} + 1_i * after_flags[k.task][fv] >= 1_i, ProofLevel::Temporary);
+        }
+        else
+            // s_k <= ub(s_k) <= LST(Omega) <= v.
+            logger->emit_rup_proof_line_under_reason(reason, WPBSum{} + 1_i * before_flags[k.task][fv] >= 1_i, ProofLevel::Temporary);
+        return logger->emit_rup_proof_line_under_reason(
+            reason, WPBSum{} + 1_i * active_flags[k.task][fv] + 1_i * ! active_flags[k.task][fu] >= 1_i, ProofLevel::Temporary);
+    };
+
+    // The pushed task pinned active at t, in activity space: `pin_pushed`'s
+    // three lines, but returning the `active` one rather than the contribution
+    // one, since this rule's capacity rows have been converted to match.
+    auto published_pin = [&](const ReasonLiterals & reason, size_t j_idx, Integer t, const ExtLits & ext, Integer s_lo_after) -> ProofLine {
+        // The chain's own stop rules keep every rung inside the pushed task's
+        // flag range, so a time outside it means the rung arithmetic and the
+        // flags have come apart. Worth saying here rather than as a rejected
+        // proof, or a flag lookup that reads past the end.
+        if (t < per_task_t_lo[j_idx] || t > per_task_t_hi[j_idx])
+            throw ProofError{
+                "cumulative published not-first / not-last: task " + std::to_string(j_idx) + " has no flag at time " + std::to_string(t.raw_value)};
+        auto fj = static_cast<size_t>((t - per_task_t_lo[j_idx]).raw_value);
+        logger->emit_rup_proof_line_under_reason(reason, plus_ext(WPBSum{} + 1_i * before_flags[j_idx][fj], ext, 1_i) >= 1_i, ProofLevel::Temporary);
+        materialise_after_sum(j_idx, s_lo_after);
+        logger->emit_rup_proof_line_under_reason(reason, plus_ext(WPBSum{} + 1_i * after_flags[j_idx][fj], ext, 1_i) >= 1_i, ProofLevel::Temporary);
+        return logger->emit_rup_proof_line_under_reason(
+            reason, plus_ext(WPBSum{} + 1_i * active_flags[j_idx][fj], ext, 1_i) >= 1_i, ProofLevel::Temporary);
+    };
+
+    auto published_nfnl_justification = [&](Integer a2, Integer b, const vector<PublishedTask> & theta, size_t j, Integer j_lb, Integer j_ub,
+                                            Integer boundary, bool not_first) {
+        return [&, a2, b, theta, j, j_lb, j_ub, boundary, not_first](const ReasonLiterals & reason) -> void {
+            if (! logger)
+                return;
+            logger->emit_proof_comment("cumulative published not-" + string{not_first ? "first" : "last"} + " w=" + std::to_string(theta.size()) +
+                " span=" + std::to_string((b - a2).raw_value));
+
+            if (std::holds_alternative<cumulative_proof_mutation::PublishedEmitNothing>(mutation))
+                return;
+
+            auto p_j = llb(j), h_j = hlb(j);
+            auto drop_pin = std::holds_alternative<cumulative_proof_mutation::DropPublishedPin>(mutation);
+            auto drop_task = std::holds_alternative<cumulative_proof_mutation::DropContainedTask>(mutation);
+            auto omit_capacity = std::holds_alternative<cumulative_proof_mutation::OmitCapacityLine>(mutation);
+
+            // A capacity line with the contained set's and the pushed task's
+            // contributions converted back into activity, so contiguity has
+            // something to cancel against. Any other task's ride through as the
+            // negative terms they already are.
+            auto capacity_at = [&](PolBuilder & pol, Integer t, Integer coeff) {
+                if (omit_capacity && t == b - 1_i)
+                    return;
+                auto line = capacity_lines.find(t);
+                if (line == capacity_lines.end())
+                    return;
+                pol.add(line->second, coeff);
+                auto convert = [&](size_t i) {
+                    if (h_is_var(i) && t >= per_task_t_lo[i] && t <= per_task_t_hi[i])
+                        pol.add(guaranteed_contribution(reason, i, t), coeff);
+                };
+                for (const auto & k : theta)
+                    convert(k.task);
+                convert(j);
+            };
+
+            // The contained set's energy over [a2, b), in activity space: the
+            // same guarded rows edge-finding cites, at the same guards, over a
+            // window keyed on est(Omega) rather than on the swept one.
+            auto add_theta_energy = [&](PolBuilder & pol) {
+                for (const auto & k : theta) {
+                    if (drop_task && k.task == theta.front().task)
+                        continue;
+                    const auto & row =
+                        guarded_energy(k.task, a2, b, clipped_window_start(k.task, a2), clipped_window_end(k.task, b) - k.length + 1_i);
+                    pol.add(row.line, hlb(k.task));
+                    if (row.low_coeff > 0_i)
+                        pol.add(logger->emit_rup_proof_line_under_reason(
+                                    reason, WPBSum{} + 1_i * (starts[k.task] >= row.low_guard) >= 1_i, ProofLevel::Temporary),
+                            hlb(k.task) * row.low_coeff);
+                    if (row.bound > 0_i)
+                        pol.add(logger->emit_rup_proof_line_under_reason(
+                                    reason, WPBSum{} + 1_i * (starts[k.task] < row.high_guard) >= 1_i, ProofLevel::Temporary),
+                            hlb(k.task) * row.bound);
+                    if (row.length_coeff > 0_i)
+                        pol.add(logger->emit_rup_proof_line_under_reason(
+                                    reason, WPBSum{} + 1_i * (lengths_var[k.task] >= row.length_guard) >= 1_i, ProofLevel::Temporary),
+                            hlb(k.task) * row.length_coeff);
+                }
+            };
+
+            // The published charge. Non-positive means the detection fired on
+            // the contained set alone overflowing the window, where there is no
+            // pushed task to place and the energy rows against the capacity
+            // rows are the whole argument.
+            auto charge = not_first ? min(j_lb + p_j, b) - a2 : b - max(j_ub, a2);
+            if (charge <= 0_i) {
+                PolBuilder pol;
+                add_theta_energy(pol);
+                for (Integer t = a2; t < b; ++t)
+                    capacity_at(pol, t, 1_i);
+                pol.emit(*logger, ProofLevel::Temporary);
+                return;
+            }
+
+            // One rung of the chain. `meet` is the time point the capped range
+            // is compared against, `capped` the half-open range the rung caps
+            // at `C - c_j`, and `ext` the rung's own conclusion, which every
+            // line it lays down is weakened by.
+            auto rung = [&](Integer meet, Integer capped_lo, Integer capped_hi, const ExtLits & ext, Integer s_lo_after) {
+                PolBuilder pol;
+                add_theta_energy(pol);
+
+                auto multiplicity = not_first ? meet + 1_i - a2 : b - meet;
+                capacity_at(pol, meet, multiplicity);
+                if (! drop_pin)
+                    pol.add(published_pin(reason, j, meet, ext, s_lo_after), multiplicity * h_j);
+
+                for (const auto & k : theta) {
+                    auto from = not_first ? a2 : meet + 1_i, to = not_first ? meet : b;
+                    for (Integer u = from; u < to; ++u)
+                        // A time outside the task's flag range has no activity
+                        // term in the capacity row either, so there is nothing
+                        // to bound and nothing to say.
+                        if (contiguity_applies(k, u, meet))
+                            pol.add(published_contiguity(reason, k, u, meet, not_first), hlb(k.task));
+                }
+
+                // The times the rung does not reach through `meet`: the pushed
+                // task is running at each of them under the rung's own case, so
+                // each is capped directly.
+                for (Integer u = not_first ? meet + 1_i : capped_lo; u < (not_first ? capped_hi : meet); ++u) {
+                    capacity_at(pol, u, 1_i);
+                    if (! drop_pin)
+                        pol.add(published_pin(reason, j, u, ext, s_lo_after), h_j);
+                }
+
+                // And the rest of the window, at the full capacity.
+                for (Integer u = a2; u < b; ++u)
+                    if (not_first ? u >= capped_hi : u < capped_lo)
+                        capacity_at(pol, u, 1_i);
+
+                pol.emit(*logger, ProofLevel::Temporary);
+            };
+
+            // The chain, walking the bound `p_j` at a time. It stops on
+            // whichever comes first: the target, or a running bound the reason
+            // already contradicts --- the deposits and the reason are then
+            // jointly unsatisfiable, so the framework's wrapping RUP has
+            // everything it needs and a further rung would be asking for an
+            // order literal outside the task's own domain.
+            if (not_first) {
+                auto running = j_lb;
+                while (true) {
+                    auto meet = min(running + p_j - 1_i, boundary - 1_i);
+                    auto next = meet + 1_i;
+                    rung(meet, a2, min(running + p_j, b), ExtLits{starts[j] >= next}, running);
+                    if (next >= boundary || next > j_ub)
+                        break;
+                    logger->emit_rup_proof_line_under_reason(reason, WPBSum{} + 1_i * (starts[j] >= next) >= 1_i, ProofLevel::Temporary);
+                    running = next;
+                }
+            }
+            else {
+                auto running = j_ub;
+                auto target = boundary - p_j + 1_i;
+                while (true) {
+                    auto meet = max(running, boundary);
+                    auto next = meet - p_j + 1_i;
+                    rung(meet, max(a2, running), b, ExtLits{starts[j] < next}, next);
+                    if (next <= target || next <= j_lb)
+                        break;
+                    logger->emit_rup_proof_line_under_reason(reason, WPBSum{} + 1_i * (starts[j] < next) >= 1_i, ProofLevel::Temporary);
+                    running = next - 1_i;
+                }
+            }
+        };
+    };
+
     // Time-table consistency. The mandatory part of task i is the
     // half-open interval [lst_i, eet_i) where lst_i = ub(s_i) and
     // eet_i = lb(s_i) + l_i. Summing heights over mandatory parts
@@ -1347,12 +1592,20 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
             // the same growing contained set the energy accumulates over.
             Integer energy = 0_i, inside_mandatory = 0_i, min_ect = 0_i, max_lst = 0_i, min_est = 0_i;
             vector<size_t> inside_tasks;
+            // The same set again, with the bounds the published condition's
+            // certificate argues about, and only collected when something asks
+            // for them. Captured here rather than read back out of `state` in
+            // the justification: by then an earlier push has landed, and the
+            // state holds a bound the reason does not support.
+            vector<PublishedTask> published_theta;
             for (const auto & c : candidates) {
                 if (c.est < a)
                     continue;
                 energy += c.energy;
                 inside_mandatory += c.mandatory;
                 inside_tasks.push_back(c.task);
+                if (rules.not_first_not_last_published && logger)
+                    published_theta.push_back(PublishedTask{c.task, c.est, c.lct - c.length, c.length});
                 if (elastic_rules)
                     join_elastic(c);
                 min_ect = inside_tasks.size() == 1 ? c.est + c.length : min(min_ect, c.est + c.length);
@@ -1584,19 +1837,25 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
                         // term is the overlap at one end of the negated
                         // conclusion's start range, unclamped against j's far
                         // bound, so it is neither above nor below what the
-                        // lemma derives. Measurement only, hence the refusal in
-                        // define_proof_model --- see
-                        // CumulativeRules::not_first_not_last_published, which
-                        // carries both why it is sound and what it is worth.
+                        // lemma derives --- and it is certified by contiguity
+                        // rather than by that lemma. See
+                        // `published_nfnl_justification`, and
+                        // CumulativeRules::not_first_not_last_published for
+                        // both why it is sound and what it is worth.
                         if (rules.not_first_not_last_published) {
                             auto ect_j = s_lo + p_j, lst_j = j.lct - p_j;
                             auto span = b - min_est;
-                            if (s_lo < min_ect && energy + h_j * (min(ect_j, b) - min_est) > capacity * span)
-                                inference.infer_greater_than_or_equal(
-                                    logger, starts[j.task], min_ect, JustifyUsingRUP{hints::Cumulative{owner}}, reason_with_presence());
-                            if (max_lst < j.lct && energy + h_j * (b - max(lst_j, min_est)) > capacity * span)
-                                inference.infer_less_than(
-                                    logger, starts[j.task], max_lst - p_j + 1_i, JustifyUsingRUP{hints::Cumulative{owner}}, reason_with_presence());
+                            auto one_too_far = std::holds_alternative<cumulative_proof_mutation::PushOneTooFar>(mutation);
+                            if (s_lo < min_ect && energy + h_j * (min(ect_j, b) - min_est) > capacity * span) {
+                                auto justify = published_nfnl_justification(min_est, b, published_theta, j.task, s_lo, s_hi, min_ect, true);
+                                inference.infer_greater_than_or_equal(logger, starts[j.task], one_too_far ? min_ect + 1_i : min_ect,
+                                    JustifyExplicitly{justify, ThenRUP::Yes, hints::Cumulative{owner}}, reason_with_presence());
+                            }
+                            if (max_lst < j.lct && energy + h_j * (b - max(lst_j, min_est)) > capacity * span) {
+                                auto justify = published_nfnl_justification(min_est, b, published_theta, j.task, s_lo, s_hi, max_lst, false);
+                                inference.infer_less_than(logger, starts[j.task], one_too_far ? max_lst - p_j : max_lst - p_j + 1_i,
+                                    JustifyExplicitly{justify, ThenRUP::Yes, hints::Cumulative{owner}}, reason_with_presence());
+                            }
                             continue;
                         }
 

--- a/gcs/constraints/cumulative/cumulative.hh
+++ b/gcs/constraints/cumulative/cumulative.hh
@@ -176,12 +176,9 @@ namespace gcs
         /// **incomparable** --- each fires where the other does not --- so this
         /// replaces the rule rather than strengthening it.
         ///
-        /// **Deliberately uncertified**, and \ref Cumulative::define_proof_model
-        /// throws rather than propagating when it is set: the published
-        /// condition is sound (see below), but its argument is not one
-        /// `derive_guarded_window_energy` can make, and a rule that quietly
-        /// weakened itself under `--prove` would confound the comparison this
-        /// switch exists to make.
+        /// **Certified, and not by the window-energy lemma.** Its argument is
+        /// not one `derive_guarded_window_energy` can make --- which is what
+        /// #746 asked --- and what it is instead is contiguity.
         ///
         /// **Why it is sound, which is #746's answer.** Suppose the not-first
         /// conclusion fails, so some schedule has `s_i < ECT(Omega)`. Every
@@ -205,7 +202,18 @@ namespace gcs
         /// and the certifiable one is worth **under 1% of the search**, which
         /// is what #757 found on the disjunctive encoding by a different route.
         /// Neither detection pays for its own sweep: at 60 s both close fewer
-        /// instances than leaving the rule off.
+        /// instances than leaving the rule off --- which is why this is off by
+        /// default, and the only reason it is.
+        ///
+        /// **What the certificate costs.** One row per (contained task, prefix
+        /// time) saying a task running earlier is still running at the meeting
+        /// point, plus a pin putting the pushed task there beside it. Where
+        /// `ect_j >= ECT(Omega)` one pol does the whole rule. Where it does
+        /// not, no single time point is where both are running --- the meeting
+        /// point is `s_j` itself, which is a variable --- and the derivation
+        /// becomes a chain walking the bound up `p_j` at a time, in the way the
+        /// time-table push already does. The mirror reads the same sentence
+        /// backwards, over `LST(Omega)` and the suffix.
         bool not_first_not_last_published = false;
     };
 

--- a/gcs/constraints/cumulative/cumulative.hh
+++ b/gcs/constraints/cumulative/cumulative.hh
@@ -250,9 +250,9 @@ namespace gcs
      * horizontally elastic overload rungs, edge-finding, its time-table and
      * energetic forms, and not-first / not-last --- is behind the flags in
      * \ref CumulativeRules, off by default because each costs a sweep that a
-     * solve never firing it still pays. Whether a rule is certified is stated
-     * on its own flag, and one that is not refuses to run against a proof
-     * logger rather than emit a proof VeriPB would reject.
+     * solve never firing it still pays. What each rule's certificate rests on
+     * --- and, where that is not the window-energy lemma, what it is instead
+     * --- is stated on its own flag.
      *
      * A task whose presence is still undecided is left out of the profile and
      * out of the overload check's energy set entirely, and its own start bounds

--- a/gcs/constraints/cumulative/cumulative_published_nfnl_test.cc
+++ b/gcs/constraints/cumulative/cumulative_published_nfnl_test.cc
@@ -1,0 +1,486 @@
+/* The published not-first / not-last detection for Cumulative, and its
+ * certificate (#746).
+ *
+ * `cumulative_nfnl_test.cc` covers the detection the guarded window-energy
+ * lemma can derive. This one covers the rule as Schutt & Wolf and Kameugne et
+ * al. state it, which charges the pushed task's overlap at *one end* of the
+ * negated conclusion's start range and argues over the contained set's own
+ * window rather than the swept one. The two are incomparable, so neither
+ * test's fixtures serve the other.
+ *
+ * The certificate is not a window-energy one at all. It is contiguity: every
+ * task in Omega has `ect_k >= ECT(Omega)`, so one running in the prefix is
+ * still running at the end of it, and the capacity row at that one time point
+ * --- where the pushed task is running too --- caps the whole prefix at
+ * `C - c_j`. `drop_contiguity` and `drop_pin` are the mutation lanes aimed at
+ * exactly that, and are what a lane inherited from the window-energy rule
+ * could not test.
+ *
+ * Where `ect_j >= ECT(Omega)` one pol does the whole rule. Where it does not,
+ * no single time point is where both the contained set and the pushed task are
+ * running, and the derivation becomes a chain that walks the bound up `p_j` at
+ * a time. Both are fixtured.
+ */
+
+#include <gcs/constraints/cumulative.hh>
+#include <gcs/constraints/innards/constraints_test_utils.hh>
+#include <gcs/problem.hh>
+#include <gcs/solve.hh>
+
+#include <algorithm>
+#include <climits>
+#include <cstdlib>
+#include <iostream>
+#include <optional>
+#include <random>
+#include <set>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+#include <version>
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+#include <print>
+#else
+#include <fmt/core.h>
+#include <fmt/ostream.h>
+#include <fmt/ranges.h>
+#endif
+
+using std::cerr;
+using std::flush;
+using std::make_optional;
+using std::max;
+using std::min;
+using std::nullopt;
+using std::optional;
+using std::pair;
+using std::set;
+using std::string;
+using std::tuple;
+using std::vector;
+using std::ranges::any_of;
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+using std::print;
+using std::println;
+#else
+using fmt::print;
+using fmt::println;
+#endif
+
+using namespace gcs;
+using namespace gcs::innards;
+using namespace gcs::test_innards;
+
+namespace
+{
+    struct Instance
+    {
+        vector<pair<int, int>> start_ranges;
+        vector<int> lengths;
+        vector<int> heights;
+        int capacity;
+    };
+
+    auto is_satisfying(const Instance & inst, const vector<int> & starts) -> bool
+    {
+        auto n = inst.start_ranges.size();
+        int t_lo = INT_MAX, t_hi = INT_MIN;
+        for (size_t i = 0; i < n; ++i) {
+            t_lo = min(t_lo, starts[i]);
+            t_hi = max(t_hi, starts[i] + inst.lengths[i] - 1);
+        }
+        for (int t = t_lo; t <= t_hi; ++t) {
+            int load = 0;
+            for (size_t i = 0; i < n; ++i)
+                if (starts[i] <= t && t < starts[i] + inst.lengths[i])
+                    load += inst.heights[i];
+            if (load > inst.capacity)
+                return false;
+        }
+        return true;
+    }
+
+    auto post(Problem & p, const Instance & inst, CumulativeRules rules, CumulativeProofMutation mutation = cumulative_proof_mutation::None{})
+        -> vector<IntegerVariableID>
+    {
+        vector<IntegerVariableID> starts;
+        vector<Integer> lengths, heights;
+        for (size_t i = 0; i < inst.start_ranges.size(); ++i) {
+            starts.push_back(
+                p.create_integer_variable(Integer{inst.start_ranges[i].first}, Integer{inst.start_ranges[i].second}, "start" + std::to_string(i)));
+            lengths.push_back(Integer{inst.lengths[i]});
+            heights.push_back(Integer{inst.heights[i]});
+        }
+        p.post(Cumulative{starts, lengths, heights, Integer{inst.capacity}}.with_rules(rules).with_proof_mutation(mutation));
+        return starts;
+    }
+
+    /// The bounds each start is left with once root propagation has run. TTEF
+    /// moves bounds rather than reporting conflicts, so this is where it has to
+    /// be measured: an enumeration test alone cannot tell whether it fired.
+    auto root_bounds(const Instance & inst, CumulativeRules rules, CumulativeProofMutation mutation, const optional<string> & proof_name)
+        -> optional<vector<pair<int, int>>>
+    {
+        Problem p;
+        auto starts = post(p, inst, rules, mutation);
+
+        optional<vector<pair<int, int>>> bounds;
+        solve_with(p,
+            SolveCallbacks{.solution = [&](const CurrentState & s) -> bool {
+                               if (! bounds) {
+                                   bounds.emplace();
+                                   for (const auto & v : starts)
+                                       bounds->emplace_back(static_cast<int>(s(v).raw_value), static_cast<int>(s(v).raw_value));
+                               }
+                               return false;
+                           },
+                .trace = [&](const CurrentState & s) -> bool {
+                    if (! bounds) {
+                        bounds.emplace();
+                        for (const auto & v : starts)
+                            bounds->emplace_back(static_cast<int>(s.lower_bound(v).raw_value), static_cast<int>(s.upper_bound(v).raw_value));
+                    }
+                    return false;
+                }},
+            proof_name ? make_optional<ProofOptions>(ProofFileNames{*proof_name}) : nullopt);
+        return bounds;
+    }
+
+    auto fail(const string & message) -> void
+    {
+        println(cerr, "cumulative published nfnl: {}", message);
+        exit(EXIT_FAILURE);
+    }
+
+    /// "starts lo:hi,... / lengths / heights / capacity", so that a fixture
+    /// found by --search can be handed straight back in.
+    auto parse_instance(const string & spec) -> Instance
+    {
+        vector<string> parts;
+        for (size_t at = 0, next; at <= spec.size(); at = next + 1) {
+            next = spec.find('/', at);
+            if (next == string::npos)
+                next = spec.size();
+            parts.push_back(spec.substr(at, next - at));
+            if (next == spec.size())
+                break;
+        }
+        if (parts.size() != 4)
+            fail("instance spec wants four /-separated parts, got " + std::to_string(parts.size()));
+
+        auto split = [](const string & s) {
+            vector<string> out;
+            for (size_t at = 0, next; at <= s.size(); at = next + 1) {
+                next = s.find(',', at);
+                if (next == string::npos)
+                    next = s.size();
+                out.push_back(s.substr(at, next - at));
+                if (next == s.size())
+                    break;
+            }
+            return out;
+        };
+
+        Instance inst{{}, {}, {}, std::stoi(parts[3])};
+        for (const auto & r : split(parts[0])) {
+            auto colon = r.find(':');
+            inst.start_ranges.emplace_back(std::stoi(r.substr(0, colon)), std::stoi(r.substr(colon + 1)));
+        }
+        for (const auto & l : split(parts[1]))
+            inst.lengths.push_back(std::stoi(l));
+        for (const auto & h : split(parts[2]))
+            inst.heights.push_back(std::stoi(h));
+        return inst;
+    }
+
+    auto show_instance(const Instance & inst) -> string
+    {
+        string out;
+        for (size_t i = 0; i < inst.start_ranges.size(); ++i)
+            out += (i ? "," : "") + std::to_string(inst.start_ranges[i].first) + ":" + std::to_string(inst.start_ranges[i].second);
+        out += "/";
+        for (size_t i = 0; i < inst.lengths.size(); ++i)
+            out += (i ? "," : "") + std::to_string(inst.lengths[i]);
+        out += "/";
+        for (size_t i = 0; i < inst.heights.size(); ++i)
+            out += (i ? "," : "") + std::to_string(inst.heights[i]);
+        return out + "/" + std::to_string(inst.capacity);
+    }
+
+    /// A fixture is only a test of the *claim* if the claim is tight: a push to
+    /// v that a solution with the pushed task at v−1 would refute. Where the
+    /// push is merely valid, "one too far" is valid too, and VeriPB verifies the
+    /// corrupted proof --- which is a fact about the fixture, not about the
+    /// rule. So: TTEF must move a bound edge-finding does not, and some solution
+    /// must sit exactly on the bound it moves to.
+    auto search_for_fixture(
+        const CumulativeRules & without_rule, const CumulativeRules & with_rule, unsigned long long seed_from, unsigned long long candidates) -> void
+    {
+        std::mt19937 rand(static_cast<unsigned>(seed_from));
+        for (unsigned long long attempt = 0; attempt < candidates; ++attempt) {
+            auto n = 3 + static_cast<size_t>(rand() % 3);
+            auto capacity = 2 + static_cast<int>(rand() % 3);
+            Instance inst{{}, {}, {}, capacity};
+            for (size_t i = 0; i < n; ++i) {
+                auto len = 1 + static_cast<int>(rand() % 5);
+                auto lo = static_cast<int>(rand() % 6);
+                auto slack = static_cast<int>(rand() % 7);
+                inst.start_ranges.emplace_back(lo, lo + slack);
+                inst.lengths.push_back(len);
+                inst.heights.push_back(1 + static_cast<int>(rand() % capacity));
+            }
+
+            auto without = root_bounds(inst, without_rule, cumulative_proof_mutation::None{}, nullopt);
+            auto with = root_bounds(inst, with_rule, cumulative_proof_mutation::None{}, nullopt);
+            if (! without || ! with)
+                continue;
+
+            set<vector<int>> solutions;
+            build_expected(solutions, [&](const vector<int> & starts) { return is_satisfying(inst, starts); }, inst.start_ranges);
+            if (solutions.empty())
+                continue;
+
+            for (size_t i = 0; i < n; ++i) {
+                auto raises = (*with)[i].first > (*without)[i].first;
+                auto lowers = (*with)[i].second < (*without)[i].second;
+                if (! raises && ! lowers)
+                    continue;
+                auto landed = raises ? (*with)[i].first : (*with)[i].second;
+                auto tight = any_of(solutions, [&](const vector<int> & s) { return s[i] == landed; });
+                if (! tight)
+                    continue;
+                println(cerr, "candidate {} task {} {} -> {} tight, {} solutions", show_instance(inst), i, raises ? "lb" : "ub", landed,
+                    solutions.size());
+                break;
+            }
+        }
+    }
+
+    /// Every rule setting must find exactly the same solutions: TTEF is a
+    /// propagation strength, not a change of constraint. This is the net for an
+    /// over-firing push, which removes solutions.
+    auto check_enumeration(const string & what, const Instance & inst, CumulativeRules rules, const optional<string> & proof_name) -> void
+    {
+        print(cerr, "cumulative published nfnl {} starts={} lens={} hts={} c={}{}", what, inst.start_ranges, inst.lengths, inst.heights,
+            inst.capacity, proof_name ? " with proofs:" : ":");
+        cerr << flush;
+
+        set<vector<int>> expected, actual;
+        build_expected(expected, [&](const vector<int> & starts) { return is_satisfying(inst, starts); }, inst.start_ranges);
+        println(cerr, " expecting {} solutions", expected.size());
+
+        Problem p;
+        auto starts = post(p, inst, rules);
+        solve_for_tests(p, proof_name, actual, tuple{starts});
+        check_results(proof_name, expected, actual);
+    }
+}
+
+auto main(int argc, char * argv[]) -> int
+{
+    establish_and_announce_seed(argc, argv);
+
+    // The baseline is everything else that is certified, so a fixture here has
+    // to show not-first / not-last inferring something time-tabling, the
+    // overload check, edge-finding and TTEF together do not.
+    const CumulativeRules without_rule{
+        .time_table = true, .overload = true, .profile_overload = true, .edge_finding = true, .time_table_edge_finding = true};
+    const CumulativeRules with_rule{.time_table = true,
+        .overload = true,
+        .profile_overload = true,
+        .edge_finding = true,
+        .time_table_edge_finding = true,
+        .not_first_not_last = true,
+        .not_first_not_last_published = true};
+
+    auto proofs = can_run_veripb();
+
+    // What a fixture here has to do, and why hand-building one does not work.
+    //
+    // Not-first / not-last only ever adds an inference on a task that SPANS the
+    // window: where a task has one end inside, edge-finding's threshold is the
+    // furthest an energy argument over that window can reach, so its push
+    // subsumes this rule's and the live-bound test drops the duplicate. A
+    // fixture therefore needs a spanning task whose guaranteed energy, once its
+    // start is restricted to one side of the contained set's `min ect` or
+    // `max lst`, is enough to overflow a window that does not otherwise
+    // overflow --- while the contained tasks keep mandatory parts small enough
+    // that time-tabling sees nothing. Two hand-built attempts had time-tabling
+    // making the same push on its own.
+    //
+    // And the push has to be TIGHT --- some solution must sit exactly on the
+    // bound --- or "one too far" is valid too and VeriPB verifies the corrupted
+    // proof. Both were found by --search, which keeps random instances where
+    // the rule moves a bound the other rules do not and a solution sits on it,
+    // then vetted against every mutation with an honest control. --describe
+    // prints the numbers written down here.
+    //
+    // Capacity three, four tasks. Task 0's lower bound rises 5 -> 6, over 6
+    // solutions, and the push is the published detection's alone: everything
+    // else certified --- time-tabling, the overload check, edge-finding and
+    // TTEF --- leaves it at 5.
+    const Instance sharp{{{2, 7}, {1, 5}, {4, 6}, {5, 7}}, {5, 4, 1, 2}, {2, 2, 3, 1}, 3};
+
+    // The mirror, where task 0's upper bound falls 5 -> 1 over 2 solutions, so
+    // the argument runs backwards: the contained set's activity is monotone
+    // *down* from `max lst` rather than up to `min ect`, and it is the pushed
+    // task's own upper bound rather than its lower one that puts it beside them.
+    const Instance sharp_mirror{{{1, 5}, {3, 9}, {3, 6}}, {5, 3, 2}, {3, 2, 2}, 3};
+
+    // A roomier one, 20 solutions, so the enumeration check has something to
+    // enumerate. Task 1's upper bound falls 6 -> 4.
+    const Instance roomy{{{1, 4}, {0, 6}, {1, 7}}, {1, 3, 5}, {1, 2, 2}, 2};
+
+    // Describe one instance: what edge-finding leaves, what TTEF leaves, and
+    // whether the bound it moves to is one a solution sits on. This is how a
+    // fixture found by --search gets turned into the numbers written down
+    // beside it below.
+    for (int a = 1; a < argc; ++a)
+        if (string{argv[a]}.starts_with("--describe=")) {
+            string arg = argv[a];
+            auto inst = parse_instance(arg.substr(arg.find('=') + 1));
+            auto without = root_bounds(inst, without_rule, cumulative_proof_mutation::None{}, nullopt);
+            auto with = root_bounds(inst, with_rule, cumulative_proof_mutation::None{}, nullopt);
+            if (! without || ! with)
+                fail("describe: nothing was reached at the root");
+            set<vector<int>> solutions;
+            build_expected(solutions, [&](const vector<int> & starts) { return is_satisfying(inst, starts); }, inst.start_ranges);
+            println(cerr, "{} solutions {}", show_instance(inst), solutions.size());
+            for (size_t i = 0; i < inst.start_ranges.size(); ++i) {
+                auto tight = [&](int v) { return any_of(solutions, [&](const vector<int> & s) { return s[i] == v; }); };
+                println(cerr, "  task {}: without_rule [{}, {}] with_rule [{}, {}]{}{}", i, (*without)[i].first, (*without)[i].second,
+                    (*with)[i].first, (*with)[i].second, (*with)[i].first > (*without)[i].first ? " lb MOVED" : "",
+                    (*with)[i].second < (*without)[i].second ? " ub MOVED" : "");
+                println(cerr, "           lb tight {} ub tight {}", tight((*with)[i].first), tight((*with)[i].second));
+            }
+            return EXIT_SUCCESS;
+        }
+
+    // Fixture search: print instances on which TTEF moves a bound
+    // edge-finding does not, and moves it somewhere a solution actually sits.
+    for (int a = 1; a < argc; ++a)
+        if (string{argv[a]} == "--search") {
+            unsigned long long from = 1, count = 2000;
+            auto number = [&](int at) { return at < argc && argv[at][0] >= '0' && argv[at][0] <= '9'; };
+            if (number(a + 1))
+                from = std::stoull(argv[a + 1]);
+            if (number(a + 2))
+                count = std::stoull(argv[a + 2]);
+            search_for_fixture(without_rule, with_rule, from, count);
+            return EXIT_SUCCESS;
+        }
+
+    // --random: generated instances, each enumerated against a pure C++ oracle
+    // and each proof verified. The fixtures below are picked for what they
+    // demonstrate; this is the net under them, and it is where the chain would
+    // show up --- a rung walking past the pushed task's own domain is not
+    // something a hand-built fixture reaches, and was a real bug this lane
+    // found.
+    for (int a = 1; a < argc; ++a)
+        if (string{argv[a]} == "--random") {
+            std::mt19937 rand(a + 1 < argc ? static_cast<unsigned>(std::stoul(argv[a + 1])) : 1u);
+            for (auto attempt = 0; attempt < 40; ++attempt) {
+                auto n = 3 + static_cast<size_t>(rand() % 4);
+                auto capacity = 2 + static_cast<int>(rand() % 4);
+                Instance inst{{}, {}, {}, capacity};
+                for (size_t i = 0; i < n; ++i) {
+                    inst.lengths.push_back(1 + static_cast<int>(rand() % 6));
+                    auto lo = static_cast<int>(rand() % 8);
+                    inst.start_ranges.emplace_back(lo, lo + static_cast<int>(rand() % 8));
+                    inst.heights.push_back(1 + static_cast<int>(rand() % capacity));
+                }
+                check_enumeration("random " + std::to_string(attempt), inst, with_rule,
+                    proofs ? make_optional("cumulative_published_nfnl_random_" + std::to_string(attempt)) : nullopt);
+            }
+            return EXIT_SUCCESS;
+        }
+
+    // Mutation mode: emit one deliberately corrupted proof and stop, for
+    // run_test_and_expect_verify_failure.bash to hand to veripb.
+    {
+        optional<CumulativeProofMutation> mutation;
+        const Instance * fixture = &sharp;
+        optional<Instance> from_spec;
+        string proof_basename = "cumulative_published_nfnl_mutation";
+        for (int a = 1; a < argc; ++a) {
+            string arg = argv[a];
+            if (arg.starts_with("--instance=")) {
+                from_spec = parse_instance(arg.substr(arg.find('=') + 1));
+                fixture = &*from_spec;
+            }
+            else if (arg == "--mutate=none")
+                mutation = cumulative_proof_mutation::None{};
+            else if (arg == "--mutate=emit_nothing")
+                mutation = cumulative_proof_mutation::PublishedEmitNothing{};
+            else if (arg == "--mutate=drop_pin")
+                mutation = cumulative_proof_mutation::DropPublishedPin{};
+            else if (arg == "--mutate=drop")
+                mutation = cumulative_proof_mutation::DropContainedTask{};
+            else if (arg == "--mutate=toofar")
+                mutation = cumulative_proof_mutation::PushOneTooFar{};
+            else if (arg == "--mutate=capacity")
+                mutation = cumulative_proof_mutation::OmitCapacityLine{};
+            else if (arg == "--mutate=roomy_toofar") {
+                mutation = cumulative_proof_mutation::PushOneTooFar{};
+                fixture = &roomy;
+            }
+            else if (arg == "--mutate=roomy_drop_pin") {
+                mutation = cumulative_proof_mutation::DropPublishedPin{};
+                fixture = &roomy;
+            }
+            else if (arg == "--proof-files-basename" && a + 1 < argc)
+                proof_basename = argv[++a];
+        }
+
+        if (mutation) {
+            auto bounds = root_bounds(*fixture, with_rule, *mutation, make_optional(proof_basename));
+            // Unlike the other two mutation harnesses, this one does not insist
+            // that the root was reached. A push corrupted one step too far can
+            // empty a domain outright, and then there is no root to report ---
+            // but the proof of that emptying is exactly the corrupted step, and
+            // veripb is the thing that judges it. Where a mutation is instead a
+            // no-op, the root *is* reached, veripb accepts, and the lane fails,
+            // which is the verdict wanted either way.
+            if (! bounds)
+                println(cerr, "the corrupted inference left nothing at the root, which is itself the corruption");
+            println(cerr, "wrote a deliberately corrupted proof to {}.pbp", proof_basename);
+            return EXIT_SUCCESS;
+        }
+    }
+
+    // The rule fires, pushes exactly as far as the energy supports, and does so
+    // where edge-finding on its own does not. `raises` says which bound the
+    // fixture is about, and `task` which task it is about.
+    for (const auto & [name, inst, task, raises, expected] : vector<tuple<string, Instance, size_t, bool, int>>{
+             {"sharp", sharp, 0, true, 6}, {"sharp_mirror", sharp_mirror, 0, false, 1}, {"roomy", roomy, 1, false, 4}}) {
+        auto off = root_bounds(inst, without_rule, cumulative_proof_mutation::None{}, nullopt);
+        auto on =
+            root_bounds(inst, with_rule, cumulative_proof_mutation::None{}, proofs ? make_optional("cumulative_published_nfnl_" + name) : nullopt);
+        if (! off || ! on)
+            fail(name + ": nothing was reached at the root");
+
+        auto pick = [&, task = task, raises = raises](const vector<pair<int, int>> & b) { return raises ? b[task].first : b[task].second; };
+        if (raises ? pick(*off) >= expected : pick(*off) <= expected)
+            fail(name + ": edge-finding alone already reaches the push, so this fixture measures nothing");
+        if (pick(*on) != expected)
+            fail(name + ": expected the pushed task's bound to reach " + std::to_string(expected) + ", got " + std::to_string(pick(*on)));
+        println(cerr, "cumulative published nfnl {}: task {} {} {} -> {}", name, task, raises ? "lb" : "ub", pick(*off), pick(*on));
+        if (proofs)
+            verify_proof_and_clean_up("cumulative_published_nfnl_" + name);
+    }
+
+    // Soundness, over instances small enough to enumerate: the rule may not
+    // lose a solution, with or without a proof being written.
+    for (const auto & [name, inst] : vector<pair<string, Instance>>{{"sharp", sharp}, {"sharp_mirror", sharp_mirror}, {"roomy", roomy},
+             {"tight", Instance{{{0, 3}, {0, 3}, {1, 2}, {0, 5}}, {2, 2, 3, 2}, {1, 1, 1, 1}, 2}},
+             {"mixed_heights", Instance{{{0, 4}, {0, 4}, {1, 2}, {0, 6}}, {3, 2, 4, 2}, {2, 1, 1, 2}, 3}}}) {
+        check_enumeration(name, inst, with_rule, nullopt);
+        if (proofs)
+            check_enumeration(name, inst, with_rule, make_optional("cumulative_published_nfnl_enum_" + name));
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/gcs/constraints/innards/cumulative_mutations.hh
+++ b/gcs/constraints/innards/cumulative_mutations.hh
@@ -119,13 +119,52 @@ namespace gcs::innards
         {
         };
 
+        /// The published not-first / not-last detection: emit no certificate
+        /// at all, leaving the push to the framework's wrapping RUP. Not a
+        /// corruption but a control: if VeriPB accepts this, the derivation is
+        /// decoration and no mutation of it can be caught.
+        struct PublishedEmitNothing
+        {
+        };
+
+        /// The published not-first / not-last detection: leave out the pin
+        /// that says the pushed task is running at the time the prefix is
+        /// compared against. Contiguity caps the prefix by what runs at that
+        /// one point, and this is what puts the pushed task there beside it ---
+        /// so this is the half of that argument a mutation can reach.
+        struct DropPublishedPin
+        {
+        };
+
+        // Deliberately absent: dropping the published rule's *contiguity* rows,
+        // the other half of that argument. It was written, in both a one-row
+        // and an every-row form, and neither can be made to fail. Two reasons,
+        // and the second is the interesting one:
+        //
+        //   * the detection's own margin absorbs them. Dropping a contiguity
+        //     row costs the pol lb(h_k) units of degree, and a rule firing at
+        //     `> supply` has at least one to spare and usually many more;
+        //   * what the pol no longer reaches, the framework's wrapping RUP
+        //     finishes, which is the same finding `dev_docs` records elsewhere
+        //     as "a pol only has to get close".
+        //
+        // Measured over roughly 1,700 firing instances, in neither form, on
+        // none of them --- while `PublishedEmitNothing` is rejected on 171 of
+        // 238, so the derivation as a whole is load-bearing and it is this one
+        // corruption that cannot be caught. The contiguity rows stay because
+        // without them the pol's arithmetic cannot reach the published
+        // threshold at all, and a proof whose *pol* stops short of its own
+        // claim is not a certificate of the published rule however VeriPB
+        // finishes it.
+
     }
 
     using CumulativeProofMutation = std::variant<cumulative_proof_mutation::None, cumulative_proof_mutation::OverstateWindowEnergy,
         cumulative_proof_mutation::OmitCapacityLine, cumulative_proof_mutation::ShrinkLemmaWindow, cumulative_proof_mutation::DropContainedTask,
         cumulative_proof_mutation::PushOneTooFar, cumulative_proof_mutation::DropProfilePin, cumulative_proof_mutation::DropProfilePins,
         cumulative_proof_mutation::ClaimOneBetterAvailability, cumulative_proof_mutation::StrengthenOneFewer,
-        cumulative_proof_mutation::DropEnergeticContributor>;
+        cumulative_proof_mutation::DropEnergeticContributor, cumulative_proof_mutation::PublishedEmitNothing,
+        cumulative_proof_mutation::DropPublishedPin>;
 
     /**
      * \brief Deliberate corruptions of the presence-falsification derivation,


### PR DESCRIPTION
The last rule in the suite that threw `UnimplementedException` rather than propagating under `--prove`. It went into the tree to price what certifying a weaker detection than the literature states costs, and that measurement is made: the published condition is worth under 1% of the search. A measurement is a reason to leave a switch off by default, not a reason to leave it unprovable.

## The certificate is contiguity, not window energy

#746 is itself the finding that `derive_guarded_window_energy` cannot make this argument. What can is the contiguity argument the issue already wrote down. Over the contained set's own window `[est(Ω), lct(Ω))`, for not-first:

```
active_{k,u}  ⟹  active_{k,v}        for k ∈ Ω and u ≤ v < ECT(Ω)
```

because `before` is monotone in the model and `after_{k,v}` follows from the reason's `s_k ≥ est_k` and `l_k ≥ p_k`, `ect_k` reaching `ECT(Ω)` by definition of Ω. So Ω's whole prefix load is capped by its load at one time point — and if the pushed task is running *there*, the capacity row at that point caps the prefix at `C − c_j` rather than `C`. Summed over the window, that is exactly the published inequality.

## One pol, or a chain

The pushed task is running at `v` when `s_j ≤ v` (the negated conclusion, which reaches `ECT(Ω) − 1`) and `s_j + l_j ≥ v + 1` (the reason, which reaches `ect_j`). Both hold at `v = ECT(Ω) − 1` exactly when `ect_j ≥ ECT(Ω)`, and then **one pol does the whole rule**.

Where `ect_j < ECT(Ω)`, no fixed time point is where both are running — the meeting point is `s_j` itself, a variable — and the derivation becomes a **chain**, walking the bound up `p_j` at a time in the way the time-table push already does, each rung weakened by its own conclusion and deposited under the reason for the next rung's unit propagation. Every rung charges the window at least what the detection counted, so the first already suffices and the rest only carry the bound the rest of the way.

Not-last reads the same sentence backwards: Ω's activity is monotone *down* from `LST(Ω)`, the suffix is capped rather than the prefix, and it is the pushed task's own upper bound that puts it beside them.

Everything is in **activity** space rather than the bit-linearised contribution space the capacity rows use, because contiguity is a statement about activity; a variable height is converted back with the same `guaranteed_contribution` line `energy_contribution` would have used to convert the other way, so the line count is unchanged.

## Testing

New `cumulative_published_nfnl_test`: three fixtures found by `--search` and vetted against every lane, plus a `--random` lane that enumerates 40 generated instances against a C++ oracle and verifies each proof. That lane earned its place — it found a chain that could walk a rung past the pushed task's own domain.

Six mutation lanes, all rejected by VeriPB.

**Dropping the contiguity rows is deliberately *not* a lane**, and this is worth reading before adding one. It was written in both a one-row and an every-row form, and cannot be made to fail on any of ~1,700 firing instances: dropping a row costs the pol `lb(h_k)` units of degree, and a rule firing at `> supply` has at least one to spare; and what the pol no longer reaches, the wrapping RUP finishes — the same finding the docs record elsewhere as "a pol only has to get close". `emit_nothing` *is* rejected on 171 of 238, so the derivation as a whole is load-bearing and it is this one corruption that cannot be caught. The rows stay because without them the pol's arithmetic cannot reach the published threshold at all, and a proof whose pol stops short of its own claim is not a certificate of the published rule however VeriPB finishes it.

Third of three. #770 did the disjunctive published not-first/not-last, #771 the energetic edge-finding; with all three merged, no rule in `Cumulative` or `Disjunctive` refuses proof logging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PAZYGJdsP3dmWAepRGi5T5