### PR TITLE
Read job shops, so the unary rules have a real instance family

### DIFF
--- a/dev_docs/disjunctive-proof-logging.md
+++ b/dev_docs/disjunctive-proof-logging.md
@@ -35,6 +35,41 @@ interesting part.
 For the constraint itself — semantics, propagator, the strict / non-strict
 flag — read `gcs/constraints/disjunctive/disjunctive.{hh,cc}`.
 
+## Where these rules can actually be measured
+
+Every one of the energetic rules is off by default and justified by a
+measurement, and until #633's job-shop reader landed there was nowhere
+to take one from a real instance. **No RCPSP collection in circulation
+has a capacity-one resource at all**: the smallest capacity across
+`data_bl`, `data_pack`, `data_pack_d` and `data_ksd15_d` is three, the
+MiniZinc Challenge `rcpsp*` instances run 5 to 22, and `la_x` is the
+Lawrence job-shop set with its capacities deliberately *raised* to two
+or three. So `--unary disjunctive` posts no `Disjunctive` whatever on
+any of them, and neither `--dzn` nor `--file` can express the machine
+the generator makes — `Instance::machine_tasks` is only ever filled in
+by `generate()`. Every disjunctive figure quoted in this document was
+therefore taken on **generated** instances.
+
+`examples/rcpsp --jss` reads a job shop in the standard OR-Library
+layout, which is that family: all unary machines, and what the unary
+scheduling literature reports on. No modelling is involved — a machine
+*is* a renewable resource of capacity one, an operation demands one unit
+of the machine it runs on and none of any other, and a job is a chain of
+precedences — so the reader is the whole of the support and the model
+file has no job-shop case in it. `--unary disjunctive` then posts one
+`Disjunctive` per machine, and the default `--unary cumulative` posts
+the capacity-one `Cumulative` saying the same thing, which is the
+control arm.
+
+Two cautions for anyone taking numbers from it. The two globals do
+**not** search alike at their defaults — `Cumulative` has the overload
+check on and `Disjunctive` does not, while `Disjunctive` has detectable
+precedences and `Cumulative` has no such rule — so a
+`Disjunctive`-against-`Cumulative` row has to say which rules were on.
+And the greedy horizon is loose on a job shop (about 1.6× the optimum on
+`la01`), which inflates every start variable's domain and so every
+proof; `--horizon` overrides it where a tighter one is known.
+
 ## The declarative OPB encoding
 
 `define_proof_model` emits exactly one shape: for every unordered pair

--- a/examples/rcpsp/CMakeLists.txt
+++ b/examples/rcpsp/CMakeLists.txt
@@ -101,6 +101,32 @@ add_test(NAME rcpsp_all COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_ver
 add_test(NAME rcpsp_unary COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash --basename rcpsp_unary
     $<TARGET_FILE:rcpsp> --size 10 --seed 4 --resources 1 --capacity 1 --max-demand 1 --unary disjunctive)
 
+# The job-shop reader, where *every* resource has capacity one. This is the only
+# instance format here that posts a Disjunctive per resource, because no RCPSP
+# collection in circulation has a unary resource at all --- which is why the
+# unary rules had no file-read instance to be exercised on before it.
+#
+# This lane takes the default --unary=cumulative, so it covers the reader and
+# the capacity-one Cumulative saying the same thing. It reaches the same optimum
+# of 23 as the lane below but in 153 recursions against 164: the two globals do
+# *not* search alike at their defaults, because Cumulative's overload check is
+# on by default and Disjunctive's is not, while Disjunctive has detectable
+# precedences and Cumulative has no such rule.
+add_test(NAME rcpsp_jss COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash --basename rcpsp_jss
+    $<TARGET_FILE:rcpsp> --jss ${CMAKE_CURRENT_SOURCE_DIR}/sample.jss)
+
+# The same instance with every unary rule on, which is the end-to-end proof
+# check for all four of those certificates over a model read from a file rather
+# than over a propagator fixture. sample.jss is chosen so that each rule
+# actually changes the search --- 164 recursions with none of them, 125 with
+# edge-finding, 144 with not-first/not-last, 132 with the overload check and 125
+# with set-based detectable precedences --- so a rule that stopped inferring
+# would not quietly keep passing here.
+add_test(NAME rcpsp_jss_disjunctive COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash --basename rcpsp_jss_disjunctive
+    $<TARGET_FILE:rcpsp> --jss ${CMAKE_CURRENT_SOURCE_DIR}/sample.jss --unary disjunctive
+    --disjunctive-edge-finding --disjunctive-not-first-not-last --disjunctive-overload
+    --disjunctive-detectable-precedences-set)
+
 # The temporal network through the global propagator, and through the presolver
 # that lifts it back out of the decomposition, on the same maximum-lag instance
 # rcpsp_max_lags posts decomposed. All three reach makespan 14 in 61 recursions

--- a/examples/rcpsp/rcpsp.cc
+++ b/examples/rcpsp/rcpsp.cc
@@ -389,6 +389,13 @@ auto main(int argc, char * argv[]) -> int
                 "rcpsp.mzn (the Pack, Pack_d, PSPLib, la_x, ksd15_d and bl sets), instead of "           //
                 "generating one",                                                                        //
                 cxxopts::value<string>())                                                                //
+            ("jss",                                                                                      //
+                "Read a job-shop instance from PATH, in the standard OR-Library layout (the ft, la, "    //
+                "abz, orb, swv and ta sets): a jobs-and-machines line, then one line per job of "        //
+                "machine/duration pairs in processing order. Every machine is a resource of capacity "   //
+                "one, so this is the instance family --unary=disjunctive actually posts a Disjunctive "  //
+                "for; no RCPSP collection has a unary resource at all",                                  //
+                cxxopts::value<string>())                                                                //
             ("max-lag-density",
                 "Probability that a pair joined by a precedence path also gets a maximum time " //
                 "lag, which is what turns this into an RCPSP/max instance. Zero, the default, " //
@@ -546,12 +553,15 @@ auto main(int argc, char * argv[]) -> int
 
     rcpsp::Instance instance;
     try {
-        if (options_vars.contains("file") && options_vars.contains("dzn"))
-            throw std::runtime_error{"--file and --dzn both name an instance; give only one"};
+        auto named = (options_vars.contains("file") ? 1 : 0) + (options_vars.contains("dzn") ? 1 : 0) + (options_vars.contains("jss") ? 1 : 0);
+        if (named > 1)
+            throw std::runtime_error{"--file, --dzn and --jss each name an instance; give only one"};
         if (options_vars.contains("file"))
             instance = rcpsp::read_file(options_vars["file"].as<string>());
         else if (options_vars.contains("dzn"))
             instance = rcpsp::read_dzn_file(options_vars["dzn"].as<string>());
+        else if (options_vars.contains("jss"))
+            instance = rcpsp::read_jss_file(options_vars["jss"].as<string>());
         else {
             rcpsp::GeneratorOptions gen_opts;
             gen_opts.n_tasks = options_vars["size"].as<int>();

--- a/examples/rcpsp/rcpsp_instance.hh
+++ b/examples/rcpsp/rcpsp_instance.hh
@@ -1,9 +1,9 @@
 #ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_EXAMPLES_RCPSP_INSTANCE_HH
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_EXAMPLES_RCPSP_INSTANCE_HH
 
-// Instance model, random generator, .sch reader and schedule utilities for the
-// RCPSP example. Kept separate from the model itself (rcpsp.cc) so that the
-// model file reads as a model.
+// Instance model, random generator, .sch / .dzn / job-shop readers and schedule
+// utilities for the RCPSP example. Kept separate from the model itself
+// (rcpsp.cc) so that the model file reads as a model.
 //
 // An instance has n tasks, indexed 0..n-1. Task i has an integer duration
 // d_i >= 1 and, for each of the renewable resources, a demand q_{r,i} >= 0
@@ -23,6 +23,15 @@
 // *maximum* time lag, which is a backward arc, so the network of lags may have
 // cycles. That is what makes the problem RCPSP/max rather than plain RCPSP, and
 // it changes what the horizon machinery can promise --- see default_horizon().
+//
+// \par Job shops
+//
+// A job-shop instance is an RCPSP instance and needs no separate model: each
+// machine is a renewable resource of capacity one, each operation demands one
+// unit of the machine it runs on and none of any other, and each job is a chain
+// of precedences. read_jss_stream() below is the whole of the support, and
+// `--unary disjunctive` is what turns those capacity-one resources into
+// Disjunctives.
 //
 // A plain RCPSP instance has an empty lag list, and everything below then
 // behaves exactly as it did before generalised lags existed. That is deliberate:
@@ -625,6 +634,144 @@ namespace rcpsp
                 throw std::runtime_error{"malformed .sch file: a negative capacity"};
 
         return inst;
+    }
+
+    /// Read a job-shop scheduling instance in the standard OR-Library layout,
+    /// the one the `ft`, `la`, `abz`, `orb`, `swv` and `ta` sets are distributed
+    /// in.
+    ///
+    /// After any amount of leading blurb --- the bundled `jobshop1.txt` puts an
+    /// `instance <name>` line and a free-text description between rows of `+`
+    /// signs --- the file is
+    ///
+    ///     J  M                                   job count, machine count
+    ///     m_1 p_1  m_2 p_2  ..  m_M p_M          one line per job
+    ///
+    /// where job `j` occupies machine `m_1` for `p_1` time units, then `m_2` for
+    /// `p_2`, and so on. The pairs are in *processing order*, and the machine
+    /// indices are zero-based and a permutation of `0..M-1`: every job visits
+    /// every machine exactly once, which is what makes this a job shop rather
+    /// than a general shop, and this reader insists on it rather than guessing
+    /// what a repeated or missing machine was meant to mean.
+    ///
+    /// \par How a job shop lands in an RCPSP Instance
+    ///
+    /// Operations are numbered job-major --- job `j`'s `k`th operation is task
+    /// `j * M + k` --- so index order is a topological order of the job chains,
+    /// which earliest_starts(), tails() and longest_paths() all require. The
+    /// chain itself is an ordinary finish-to-start precedence per consecutive
+    /// pair, so there are no time lags and this is plain RCPSP, not RCPSP/max.
+    ///
+    /// A machine is a **capacity-one renewable resource** that its own
+    /// operations demand one unit of and every other operation demands none of.
+    /// That is not a re-modelling of the problem: it is what a machine is, and
+    /// it is why rcpsp.cc needs no job-shop case at all. `--unary disjunctive`
+    /// then posts one Disjunctive per machine over exactly that machine's
+    /// operations, and the default `--unary cumulative` posts the capacity-one
+    /// Cumulative saying the same thing, which is the control arm.
+    ///
+    /// \par What this is for
+    ///
+    /// Every RCPSP collection to hand has capacities of three and up, so none of
+    /// them posts a Disjunctive at all, and the unary propagation rules have had
+    /// no real instance family to be measured on. A job shop is that family: it
+    /// is all unary machines, it is what the unary scheduling literature reports
+    /// on, and the `la_x` RCPSP set is these instances with their capacities
+    /// raised to two or three.
+    ///
+    /// Taillard's own distribution format is a different layout --- named header
+    /// fields, then the durations and the machine assignments as two separate
+    /// matrices --- and is not read here. A file holding several instances is
+    /// not read here either: this takes the first one it finds.
+    [[nodiscard]] inline auto read_jss_stream(std::istream & in, const std::string & description) -> Instance
+    {
+        // Leading blurb is anything that is not a row of numbers: the bundled
+        // file's `instance <name>` line, its rows of `+` signs, and the prose
+        // between them. The dimensions are the first line that is numeric
+        // throughout, which no line of blurb is.
+        auto numeric_line = [](const std::string & line) {
+            bool any_digit = false;
+            for (auto & c : line) {
+                if (c >= '0' && c <= '9')
+                    any_digit = true;
+                else if (c != ' ' && c != '\t' && c != '\r')
+                    return false;
+            }
+            return any_digit;
+        };
+
+        std::string dims_line;
+        while (std::getline(in, dims_line))
+            if (numeric_line(dims_line))
+                break;
+
+        long long n_jobs = 0, n_machines = 0;
+        {
+            std::istringstream ds{dims_line};
+            long long extra = 0;
+            if (! (ds >> n_jobs >> n_machines))
+                throw std::runtime_error{"not a job-shop instance: no line giving a job count and a machine count"};
+            if (ds >> extra)
+                throw std::runtime_error{"not a job-shop instance: the first numeric line has more than a job count and a machine count"};
+        }
+        if (n_jobs < 1 || n_machines < 1 || n_jobs > 100000 || n_machines > 100000)
+            throw std::runtime_error{"not a job-shop instance: implausible job or machine count"};
+        // Bound the product too, not just the factors: the operation count is
+        // what gets cast to int and what sizes every array below, and a header
+        // of two plausible-looking factors can still ask for more operations
+        // than an int holds.
+        if (n_jobs * n_machines > 1000000)
+            throw std::runtime_error{"not a job-shop instance: " + std::to_string(n_jobs) + " jobs of " + std::to_string(n_machines) +
+                " operations each is more than this reader will build"};
+
+        auto next = [&](const char * what) -> long long {
+            long long v = 0;
+            if (! (in >> v))
+                throw std::runtime_error{std::string{"job-shop instance ended while reading "} + what};
+            return v;
+        };
+
+        Instance inst;
+        auto uj = static_cast<std::size_t>(n_jobs), um = static_cast<std::size_t>(n_machines);
+        inst.n_tasks = static_cast<int>(n_jobs * n_machines);
+        inst.durations.assign(static_cast<std::size_t>(inst.n_tasks), gcs::Integer{0});
+        inst.capacities.assign(um, gcs::Integer{1});
+        inst.demands.assign(um, std::vector<gcs::Integer>(static_cast<std::size_t>(inst.n_tasks), gcs::Integer{0}));
+
+        for (std::size_t j = 0; j != uj; ++j) {
+            std::vector<char> visited(um, 0);
+            for (std::size_t k = 0; k != um; ++k) {
+                auto machine = next("a machine index");
+                auto duration = next("a duration");
+                if (machine < 0 || machine >= n_machines)
+                    throw std::runtime_error{"malformed job-shop instance: job " + std::to_string(j) + " names machine " + std::to_string(machine) +
+                        ", which is outside 0.." + std::to_string(n_machines - 1)};
+                if (duration < 0)
+                    throw std::runtime_error{"malformed job-shop instance: job " + std::to_string(j) + " has a negative duration"};
+                if (visited[static_cast<std::size_t>(machine)])
+                    throw std::runtime_error{"malformed job-shop instance: job " + std::to_string(j) + " visits machine " + std::to_string(machine) +
+                        " twice, so it is not a job shop as this reader understands one"};
+                visited[static_cast<std::size_t>(machine)] = 1;
+
+                auto task = j * um + k;
+                inst.durations[task] = gcs::Integer{duration};
+                inst.demands[static_cast<std::size_t>(machine)][task] = gcs::Integer{1};
+                if (k > 0)
+                    inst.precedences.emplace_back(static_cast<int>(task - 1), static_cast<int>(task));
+            }
+        }
+
+        inst.description = description + " jobs=" + std::to_string(n_jobs) + " machines=" + std::to_string(n_machines) +
+            " operations=" + std::to_string(inst.n_tasks);
+        return inst;
+    }
+
+    [[nodiscard]] inline auto read_jss_file(const std::string & path) -> Instance
+    {
+        std::ifstream in{path};
+        if (! in)
+            throw std::runtime_error{"could not open instance file: " + path};
+        return read_jss_stream(in, "jss " + path);
     }
 
     [[nodiscard]] inline auto read_file(const std::string & path) -> Instance

--- a/examples/rcpsp/sample.jss
+++ b/examples/rcpsp/sample.jss
@@ -1,0 +1,27 @@
+ instance sample4x4
++++++++++++++++++++++++++++++
+A hand-written four-job, four-machine job shop, in the standard OR-Library
+layout that the ft, la, abz, orb, swv and ta sets are distributed in. Written
+here rather than taken from a benchmark set, so it is small enough to prove
+quickly and there is no licence question about redistributing it.
+
+The optimum is 23, and neither kind of reasoning reaches it alone: the busiest
+machine (machine 0) carries 19 units of work and the longest job (job 3) is 17
+long, so both of the easy bounds are slack and the machines and the chains have
+to be reasoned about together.
+
+Chosen to be discriminating rather than merely valid. Every unary rule changes
+the search on it, and by different amounts, so a rule that silently stopped
+inferring would show up here: against 164 recursions with none of them on,
+--disjunctive-edge-finding gives 125, --disjunctive-not-first-not-last 144,
+--disjunctive-overload 132 and --disjunctive-detectable-precedences-set 125.
+
+This blurb is also the reader's test that it skips a header: the bundled
+jobshop1.txt puts an `instance` line and a description between rows of plus
+signs, and everything down to the dimensions line has to be ignored.
++++++++++++++++++++++++++++++
+ 4 4
+ 2 2  1 3  0 5  3 2
+ 1 5  0 5  2 3  3 3
+ 0 4  1 1  2 1  3 6
+ 2 5  0 5  1 2  3 5


### PR DESCRIPTION
Every energetic rule on `Disjunctive` — edge-finding (#751), not-first / not-last (#752, #757), set-based detectable precedences (#754) and the overload check (#730) — is off by default and justified by a measurement, and **every one of those measurements was taken on generated instances**. Not by preference:

- No RCPSP collection in circulation has a capacity-one resource. The smallest capacity across `data_bl`, `data_pack`, `data_pack_d` and `data_ksd15_d` is three; the MiniZinc Challenge `rcpsp*` instances run 5 to 22; and `la_x` is the Lawrence job-shop set with its capacities deliberately *raised* to two or three.
- Neither reader can express the machine the generator makes. `Instance::machine_tasks` is only ever filled in by `generate()`, so a file-read instance prints `machine tasks: 0` and posts no `Disjunctive` at all.

So the cumulative half of the suite has ~2,600 real instances to hand and the unary half has none. This adds the family that fixes that.

## No new model

A job shop *is* an RCPSP instance: a machine is a renewable resource of capacity one, an operation demands one unit of the machine it runs on and none of any other, and a job is a chain of precedences. So this is a reader and nothing else — `rcpsp.cc` gains an option and a call, and no job-shop case.

`--unary disjunctive` posts one `Disjunctive` per machine over exactly that machine's operations; the default `--unary cumulative` posts the capacity-one `Cumulative` saying the same thing, which is the control arm.

## The format

The OR-Library layout the `ft`, `la`, `abz`, `orb`, `swv` and `yn` sets are distributed in: leading blurb, a jobs-and-machines line, then one line per job of machine/duration pairs in processing order. Operations are numbered job-major so index order is a topological order of the chains, which `earliest_starts()`, `tails()` and `longest_paths()` all require. Taillard's own layout is a different format and is not read here; neither is a file holding several instances.

## Checked against the real thing

- All **82** instances of the OR-Library bundle parse.
- Every operation's duration and machine assignment **round-trips against an independent parse** of the same files — zero mismatches. That is the check that the machine assignments are self-consistent.
- `ft06` solves to **55** and `la01` to **666**, both the published optima. That is the check that they are also *right*.
- Setup stays at 0.1 s up to `swv20`'s 50 × 10.
- Every malformed input gives a specific error: bad machine index, repeated machine, negative duration, truncated stream, missing or over-long dimensions line, implausible size.

## The fixture is discriminating

`sample.jss` is hand-written rather than taken from a set, so there is no redistribution question, and it is chosen so that every rule changes the search on it: against **164** recursions with none on, edge-finding gives **125**, not-first / not-last **144**, the overload check **132**, set-based detectable precedences **125**. A rule that stopped inferring would show up in that lane rather than quietly keep passing.

Two ctest entries: `rcpsp_jss` (the reader at default settings, so the capacity-one `Cumulative` path) and `rcpsp_jss_disjunctive` (every unary rule on, which is the end-to-end proof check for all four certificates over a model read from a file rather than over a propagator fixture).

## One trap, now documented

**The two globals do not search alike at their defaults.** `Cumulative`'s overload check is on by default and `Disjunctive`'s is not, while `Disjunctive` has detectable precedences and `Cumulative` has no such rule — 153 recursions against 164 on the fixture. A `Disjunctive`-against-`Cumulative` row has to say which rules were on. `dev_docs/disjunctive-proof-logging.md` now says so, along with the fact that the greedy horizon is loose on a job shop (~1.6× the optimum on `la01`), which inflates every start domain and so every proof.

Part of #633, and what unblocks the experimental section for the unary half of the suite.

## Testing

751/751 pass. GCC `-Werror` clean on the changed translation unit; clang builds clean with no warning in the changed files, and its binary agrees on the fixture.


*Updated 2026-09-19: the commit now carries its `Co-Authored-By` trailer, which it was missing. Nothing else changed — same tree, same parent, same author date.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
