### PR TITLE
Read multi-mode RCPSP, so a variable duration and demand get measured

### DIFF
--- a/dev_docs/cumulative-proof-logging.md
+++ b/dev_docs/cumulative-proof-logging.md
@@ -419,6 +419,43 @@ The `pin_contributor` / `pin_pushed` helpers in
 and both push inferences share one shape across all constant/variable
 combinations.
 
+### Where a variable length or height can actually be measured
+
+All of the above is certified and fixture-tested, and until #633's
+multi-mode reader landed **none of it had ever run on a benchmark
+instance**. Nothing in the RCPSP collections to hand has a variable
+anything: `examples/rcpsp` builds `std::vector<Integer>` durations and
+demands from every one of them, so the constant path is the only path a
+sweep ever took, and #748 and #749 shipped backed by fixtures alone.
+
+Multi-mode RCPSP is where the case is native rather than contrived. An
+activity chooses a mode; the mode fixes both how long it runs and what it
+takes while it does; a shorter mode generally costs more of something.
+So a duration and a demand are decisions, and they are *linked* decisions
+--- which is the shape the guaranteed-energy accounting was written for.
+`examples/rcpsp --mm` reads the PSPLIB `.mm` sets (`j10` through `j30`),
+posting a mode variable per activity, an element constraint tying each
+duration and demand to it, and one linear inequality per non-renewable
+resource.
+
+Two things to know before taking numbers from it.
+
+**The non-renewable budgets are not decoration.** They are the only
+reason the mode choice does not decompose into "give every activity its
+shortest mode", and they are what make the instances hard. On
+`examples/rcpsp/sample.mm`, raising the budget from 15 to 22 drops the
+optimum from 10 to 6.
+
+**The temporal network is no longer a difference network**, or not all of
+it. A precedence is weighted by the predecessor's duration, so where that
+duration is a decision the constraint is a three-term
+`s_j - s_i - d_i >= 0` and not a difference constraint at all. `--variant`
+still selects how the rest is posted --- the dummy source and sink, and
+any activity whose modes agree on a duration, stay difference-shaped ---
+but a multi-mode instance is not the clean `--variant` comparison a
+single-mode one is.
+
+
 ## Inference 4 — the overload check, and the window-energy lemma
 
 Time-tabling only ever looks at one time point at a time. The overload

--- a/examples/rcpsp/CMakeLists.txt
+++ b/examples/rcpsp/CMakeLists.txt
@@ -127,6 +127,35 @@ add_test(NAME rcpsp_jss_disjunctive COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_
     --disjunctive-edge-finding --disjunctive-not-first-not-last --disjunctive-overload
     --disjunctive-detectable-precedences-set)
 
+# The multi-mode reader, and the only lane anywhere that hands Cumulative
+# variable lengths and heights rather than constants --- which is what #748 and
+# #749 taught it to reason about, and what no single-mode instance can reach. An
+# activity picks a mode, the mode fixes both its duration and its demands, and
+# an element constraint ties them together.
+#
+# sample.mm is built so that both halves of that are load-bearing: the optimum
+# is 10 against a critical path of 5, so the resources decide it rather than the
+# chains, and raising the non-renewable budget on the file's last line from 15 to
+# 22 drops the optimum to 6, so the budget is worth four of those ten units. An
+# instance without that would let every activity take its shortest mode, and
+# would be a plain RCPSP with extra steps.
+add_test(NAME rcpsp_mm COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash --basename rcpsp_mm
+    $<TARGET_FILE:rcpsp> --mm ${CMAKE_CURRENT_SOURCE_DIR}/sample.mm)
+
+# The same instance with the energetic accounting on, so this is the end-to-end
+# proof check for #755's certificate over a *variable* length and height rather
+# than over the constants every other lane gives it. 109 recursions become 107,
+# so the rule is doing something here rather than merely not crashing.
+add_test(NAME rcpsp_mm_energetic COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash --basename rcpsp_mm_energetic
+    $<TARGET_FILE:rcpsp> --mm ${CMAKE_CURRENT_SOURCE_DIR}/sample.mm --cumulative-energetic-edge-finding)
+
+# A deadline one below the optimum, so this reaches UNSATISFIABLE rather than
+# BOUNDS: the refutation has to rule out every mode selection as well as every
+# schedule, which is the conclusion the mode variables and the budget row are
+# jointly responsible for.
+add_test(NAME rcpsp_mm_deadline COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash --basename rcpsp_mm_deadline
+    $<TARGET_FILE:rcpsp> --mm ${CMAKE_CURRENT_SOURCE_DIR}/sample.mm --deadline 9)
+
 # The temporal network through the global propagator, and through the presolver
 # that lifts it back out of the decomposition, on the same maximum-lag instance
 # rcpsp_max_lags posts decomposed. All three reach makespan 14 in 61 recursions

--- a/examples/rcpsp/rcpsp.cc
+++ b/examples/rcpsp/rcpsp.cc
@@ -98,6 +98,7 @@
 #include <gcs/constraints/cumulative.hh>
 #include <gcs/constraints/difference.hh>
 #include <gcs/constraints/disjunctive.hh>
+#include <gcs/constraints/element.hh>
 #include <gcs/constraints/linear.hh>
 #include <gcs/presolvers/difference_logic.hh>
 #include <gcs/presolvers/inferred_cumulative/inferred_cumulative.hh>
@@ -396,6 +397,12 @@ auto main(int argc, char * argv[]) -> int
                 "one, so this is the instance family --unary=disjunctive actually posts a Disjunctive "  //
                 "for; no RCPSP collection has a unary resource at all",                                  //
                 cxxopts::value<string>())                                                                //
+            ("mm",                                                                                       //
+                "Read a multi-mode RCPSP instance from PATH, in the PSPLIB .mm format (the j10, j12, "   //
+                "j14, j16, j18, j20 and j30 multi-mode sets). Each activity picks a mode, and the mode " //
+                "fixes both its duration and its demands, so this is the only instance family where "    //
+                "Cumulative is handed variable lengths and heights rather than constants (#748, #749)",  //
+                cxxopts::value<string>())                                                                //
             ("max-lag-density",
                 "Probability that a pair joined by a precedence path also gets a maximum time " //
                 "lag, which is what turns this into an RCPSP/max instance. Zero, the default, " //
@@ -553,15 +560,18 @@ auto main(int argc, char * argv[]) -> int
 
     rcpsp::Instance instance;
     try {
-        auto named = (options_vars.contains("file") ? 1 : 0) + (options_vars.contains("dzn") ? 1 : 0) + (options_vars.contains("jss") ? 1 : 0);
+        auto named = (options_vars.contains("file") ? 1 : 0) + (options_vars.contains("dzn") ? 1 : 0) + (options_vars.contains("jss") ? 1 : 0) +
+            (options_vars.contains("mm") ? 1 : 0);
         if (named > 1)
-            throw std::runtime_error{"--file, --dzn and --jss each name an instance; give only one"};
+            throw std::runtime_error{"--file, --dzn, --jss and --mm each name an instance; give only one"};
         if (options_vars.contains("file"))
             instance = rcpsp::read_file(options_vars["file"].as<string>());
         else if (options_vars.contains("dzn"))
             instance = rcpsp::read_dzn_file(options_vars["dzn"].as<string>());
         else if (options_vars.contains("jss"))
             instance = rcpsp::read_jss_file(options_vars["jss"].as<string>());
+        else if (options_vars.contains("mm"))
+            instance = rcpsp::read_mm_file(options_vars["mm"].as<string>());
         else {
             rcpsp::GeneratorOptions gen_opts;
             gen_opts.n_tasks = options_vars["size"].as<int>();
@@ -606,12 +616,26 @@ auto main(int argc, char * argv[]) -> int
     // Note the fallback is only a *proven* upper bound when there are no maximum
     // lags: RCPSP/max feasibility is NP-hard, and there is no cheap valid
     // horizon. See rcpsp::default_horizon.
-    auto greedy = rcpsp::serial_schedule(instance);
-    auto greedy_makespan = rcpsp::makespan_of(instance, greedy);
-    if (! rcpsp::is_feasible(instance, greedy)) {
-        if (! rcpsp::has_maximum_lags(instance))
-            println(cerr, "Warning: the greedy schedule did not check out, falling back to a serial horizon.");
-        greedy_makespan = rcpsp::default_horizon(instance);
+    //
+    // A multi-mode instance takes neither route. serial_schedule() would have to
+    // pick a mode per activity before it could place anything, and whether *any*
+    // mode selection fits the non-renewable budgets is itself NP-hard --- so a
+    // greedy that ignored the budgets would not have produced a schedule, and
+    // one that respected them could not be trusted to have found the shortest it
+    // could. Running every activity in its longest mode, one after another, is
+    // feasible for the precedences and the renewable resources whatever the
+    // modes turn out to be, and needs no such search. See multi_mode_horizon().
+    long long greedy_makespan = 0;
+    if (rcpsp::is_multi_mode(instance))
+        greedy_makespan = rcpsp::multi_mode_horizon(instance);
+    else {
+        auto greedy = rcpsp::serial_schedule(instance);
+        greedy_makespan = rcpsp::makespan_of(instance, greedy);
+        if (! rcpsp::is_feasible(instance, greedy)) {
+            if (! rcpsp::has_maximum_lags(instance))
+                println(cerr, "Warning: the greedy schedule did not check out, falling back to a serial horizon.");
+            greedy_makespan = rcpsp::default_horizon(instance);
+        }
     }
 
     auto critical_path = rcpsp::critical_path_length(instance);
@@ -644,9 +668,100 @@ auto main(int argc, char * argv[]) -> int
 
     auto makespan = problem.create_integer_variable(0_i, Integer{horizon}, "makespan");
 
+    // Multi-mode: an activity picks one of several modes, and the mode fixes
+    // both how long it runs and how much of each resource it takes while it
+    // does. So a duration and a demand are *decisions* here, tied to the mode
+    // by an element constraint, and what Cumulative is handed is a vector of
+    // variables rather than one of constants --- which is the case #748 and
+    // #749 taught it to reason about, and the one no single-mode instance can
+    // reach.
+    //
+    // Where the mode makes no difference to a figure, the constant goes in
+    // directly: an element over an array of equal values is the same constraint
+    // and a bigger encoding, and the dummy source and sink have one mode at all.
+    vector<IntegerVariableID> mode_vars, duration_vars;
+    vector<vector<IntegerVariableID>> demand_vars, nonrenewable_vars;
+    if (rcpsp::is_multi_mode(instance)) {
+        auto link = [&](const vector<Integer> & vals, IntegerVariableID mode, const string & name) -> IntegerVariableID {
+            if (all_of(vals.begin(), vals.end(), [&](const Integer & v) { return v == vals.front(); }))
+                return constant_variable(vals.front());
+            auto [lo, hi] = minmax_element(vals.begin(), vals.end());
+            auto var = problem.create_integer_variable(*lo, *hi, name);
+            problem.post(ElementConstantArray{var, mode, vals});
+            return var;
+        };
+
+        demand_vars.assign(instance.capacities.size(), {});
+        nonrenewable_vars.assign(instance.nonrenewable_capacities.size(), {});
+        for (int i = 0; i < instance.n_tasks; ++i) {
+            const auto & modes = instance.modes[static_cast<std::size_t>(i)];
+            auto mode = modes.size() == 1
+                ? constant_variable(0_i)
+                : problem.create_integer_variable(0_i, Integer{static_cast<long long>(modes.size()) - 1}, "mode" + to_string(i));
+            mode_vars.push_back(mode);
+
+            vector<Integer> vals;
+            vals.reserve(modes.size());
+            for (const auto & m : modes)
+                vals.push_back(m.duration);
+            duration_vars.push_back(link(vals, mode, "duration" + to_string(i)));
+
+            for (std::size_t r = 0; r < instance.capacities.size(); ++r) {
+                vals.clear();
+                for (const auto & m : modes)
+                    vals.push_back(m.demands[r]);
+                demand_vars[r].push_back(link(vals, mode, "demand" + to_string(r) + "_" + to_string(i)));
+            }
+
+            for (std::size_t k = 0; k < instance.nonrenewable_capacities.size(); ++k) {
+                vals.clear();
+                for (const auto & m : modes)
+                    vals.push_back(m.nonrenewable[k]);
+                nonrenewable_vars[k].push_back(link(vals, mode, "nonrenewable" + to_string(k) + "_" + to_string(i)));
+            }
+        }
+
+        // A non-renewable resource is a budget drawn on once by each activity
+        // and spent over the whole project, not a rate held at each time point,
+        // so it is one linear inequality rather than a Cumulative. It is also
+        // the only thing stopping the mode choice decomposing into "give every
+        // activity its shortest mode", which is why an instance without one is
+        // a plain RCPSP with extra steps.
+        //
+        // A fixed draw comes off the budget rather than into the sum: a
+        // constant term in a linear is just a smaller right-hand side.
+        for (std::size_t k = 0; k < instance.nonrenewable_capacities.size(); ++k) {
+            WeightedSum consumption;
+            auto budget = instance.nonrenewable_capacities[k];
+            for (const auto & v : nonrenewable_vars[k]) {
+                if (is_constant_variable(v))
+                    budget -= constant_value_of(v);
+                else
+                    consumption += 1_i * v;
+            }
+
+            if (budget < 0_i) {
+                println(cerr, "Error: the activities with no choice of mode already exceed non-renewable resource {}.", k);
+                return EXIT_FAILURE;
+            }
+            if (! consumption.terms.empty())
+                problem.post(LinearLessThanEqual{consumption, budget});
+        }
+    }
+
     auto unary_variant = options_vars["unary"].as<string>();
     if (unary_variant != "cumulative" && unary_variant != "disjunctive") {
         println(cerr, "Error: unknown --unary value '{}'. Supported: cumulative, disjunctive.", unary_variant);
+        return EXIT_FAILURE;
+    }
+    // Rejected rather than ignored. Disjunctive carries no demands, so it can
+    // only stand in for a capacity-one resource over the tasks that use it ---
+    // and with a variable demand, whether a task uses one is itself a decision.
+    // Accepting the flag and posting a Cumulative anyway would be a silent
+    // no-op, which is the shape of thing that passes every check.
+    if (unary_variant == "disjunctive" && rcpsp::is_multi_mode(instance)) {
+        println(cerr, "Error: --unary disjunctive cannot be used with --mm: a mode decides whether a task uses a resource,");
+        println(cerr, "       and Disjunctive has no demands to make that conditional on.");
         return EXIT_FAILURE;
     }
 
@@ -675,7 +790,40 @@ auto main(int argc, char * argv[]) -> int
     // The temporal network. --variant decides how it reaches the solver, over
     // the identical edge list in the identical order, so a comparison between
     // the three is between the handling and nothing else.
-    auto edges = model_edges(instance, starts, makespan);
+    // For a multi-mode instance a precedence is *not* a difference constraint:
+    // its weight is the predecessor's duration, and that is a decision. So each
+    // one becomes a three-term linear `s_j - s_i - d_i >= 0` instead, and the
+    // same for the makespan bound --- getting this wrong is not a modelling
+    // preference but a wrong answer, since an edge weighted by the shortest
+    // mode lets a successor start while its predecessor is still running.
+    //
+    // Where the mode makes no difference to a duration it *is* a difference
+    // constraint, and goes into the same edge list every --variant handles;
+    // the dummy source and sink are always in that case. So --variant still
+    // selects how the difference part of the network is posted, over however
+    // much of it stays difference-shaped.
+    vector<ModelEdge> edges;
+    vector<WeightedSum> variable_precedences;
+    if (rcpsp::is_multi_mode(instance)) {
+        auto duration_of = [&](int i) { return duration_vars[static_cast<std::size_t>(i)]; };
+        for (const auto & [i, j] : instance.precedences) {
+            auto d = duration_of(i);
+            if (is_constant_variable(d))
+                edges.push_back(ModelEdge{starts[static_cast<std::size_t>(i)], starts[static_cast<std::size_t>(j)], constant_value_of(d)});
+            else
+                variable_precedences.push_back(
+                    WeightedSum{} + 1_i * starts[static_cast<std::size_t>(j)] + -1_i * starts[static_cast<std::size_t>(i)] + -1_i * d);
+        }
+        for (int i = 0; i < instance.n_tasks; ++i) {
+            auto d = duration_of(i);
+            if (is_constant_variable(d))
+                edges.push_back(ModelEdge{starts[static_cast<std::size_t>(i)], makespan, constant_value_of(d)});
+            else
+                variable_precedences.push_back(WeightedSum{} + 1_i * makespan + -1_i * starts[static_cast<std::size_t>(i)] + -1_i * d);
+        }
+    }
+    else
+        edges = model_edges(instance, starts, makespan);
     auto presolver_stats = std::make_shared<DifferenceLogicStats>();
 
     // --machine=difference puts the machine into that same network, as the
@@ -765,6 +913,13 @@ auto main(int argc, char * argv[]) -> int
         break;
     }
 
+    // The precedences and makespan bounds whose weight is a decision, which no
+    // --variant can take: they are not difference constraints. Posted after the
+    // switch above so that the difference part of the network keeps the posting
+    // order it has always had.
+    for (const auto & sum : variable_precedences)
+        problem.post(LinearGreaterThanEqual{sum, 0_i});
+
     // A .sch instance's dummy source is pinned at time zero: the file's arc
     // weights are all relative to it.
     if (instance.source_task)
@@ -817,6 +972,28 @@ auto main(int argc, char * argv[]) -> int
     }
 
     for (std::size_t r = 0; r < instance.capacities.size(); ++r) {
+        // Multi-mode: the durations and demands are variables, so this resource
+        // gets the element-linked ones rather than the instance's numbers. A
+        // task is left out when *no* mode has it both running and using this
+        // resource --- the same "it can never occupy this" test as the
+        // single-mode case below, which now has to hold across every mode
+        // instead of for the one.
+        if (rcpsp::is_multi_mode(instance)) {
+            vector<IntegerVariableID> task_starts, task_durations, task_demands;
+            for (int i = 0; i < instance.n_tasks; ++i) {
+                const auto & modes = instance.modes[static_cast<std::size_t>(i)];
+                if (any_of(modes.begin(), modes.end(), [&](const rcpsp::Mode & m) { return m.duration > 0_i && m.demands[r] > 0_i; })) {
+                    task_starts.push_back(starts[i]);
+                    task_durations.push_back(duration_vars[static_cast<std::size_t>(i)]);
+                    task_demands.push_back(demand_vars[r][static_cast<std::size_t>(i)]);
+                }
+            }
+            if (! task_starts.empty())
+                problem.post(
+                    Cumulative{task_starts, task_durations, task_demands, constant_variable(instance.capacities[r])}.with_rules(cumulative_rules));
+            continue;
+        }
+
         // A task that runs for no time never occupies a resource, so leaving it
         // out changes nothing but keeps the propagator and the proof smaller.
         // Every generated duration is at least one, so nothing is ever dropped
@@ -936,7 +1113,18 @@ auto main(int argc, char * argv[]) -> int
     // tasks at once. The reified linear forms do infer their condition, which is
     // why --machine=pairwise is sound without them; relying on that here would
     // be relying on the very thing this variant is meant to exercise.
+    // Which mode each activity runs in is half the decision on a multi-mode
+    // instance, and it comes first: fixing the modes leaves a plain RCPSP
+    // behind, where fixing the starts first would leave the solver reporting a
+    // "solution" in which the durations were still a range. The element
+    // constraints then determine every duration and demand from the mode, so
+    // those need no branching of their own --- and if one ever failed to,
+    // reading the solution would throw rather than print a schedule that is not
+    // one.
     auto branch_vars = machine_order_vars;
+    for (const auto & v : mode_vars)
+        if (! is_constant_variable(v))
+            branch_vars.push_back(v);
     branch_vars.insert(branch_vars.end(), starts.begin(), starts.end());
     branch_vars.push_back(makespan);
 
@@ -952,7 +1140,7 @@ auto main(int argc, char * argv[]) -> int
     }
 
     optional<Integer> best_makespan;
-    vector<Integer> best_starts;
+    vector<Integer> best_starts, best_modes, best_durations;
     bool proven = false;
 
     auto stats = bench::solve_with_timeout(options_vars["timeout"].as<double>(), problem,
@@ -961,6 +1149,16 @@ auto main(int argc, char * argv[]) -> int
                            best_starts.clear();
                            for (auto & v : starts)
                                best_starts.push_back(s(v));
+                           // A multi-mode schedule is not checkable from its
+                           // start times alone: which mode each activity ran in
+                           // is half the decision, and is what fixes its
+                           // duration and its demands.
+                           best_modes.clear();
+                           best_durations.clear();
+                           for (auto & v : mode_vars)
+                               best_modes.push_back(s(v));
+                           for (auto & v : duration_vars)
+                               best_durations.push_back(s(v));
                            // Optimising or enumerating, so keep going and let
                            // the solver prove this is the best (or that there
                            // are no more); deciding, so the first schedule that
@@ -1035,6 +1233,18 @@ auto main(int argc, char * argv[]) -> int
         for (auto & v : best_starts)
             print(" {}", v);
         println("");
+        if (rcpsp::is_multi_mode(instance)) {
+            // One-based, as the .mm file numbers them, so that a line here can
+            // be read against the file it came from without arithmetic.
+            print("modes:");
+            for (auto & v : best_modes)
+                print(" {}", v + 1_i);
+            println("");
+            print("durations:");
+            for (auto & v : best_durations)
+                print(" {}", v);
+            println("");
+        }
     }
     println("solutions: {}", stats.solutions);
     println("recursions: {}", stats.recursions);

--- a/examples/rcpsp/rcpsp_instance.hh
+++ b/examples/rcpsp/rcpsp_instance.hh
@@ -67,6 +67,22 @@ namespace rcpsp
         gcs::Integer d;
     };
 
+    /// One execution mode of an activity: how long it takes, and what it needs
+    /// of each renewable and each non-renewable resource while it does. A
+    /// renewable demand is a rate, held for the whole duration; a non-renewable
+    /// one is a lump drawn once from a project-wide budget.
+    struct Mode
+    {
+        gcs::Integer duration;
+
+        /// One per renewable resource, in the same order as Instance::capacities.
+        std::vector<gcs::Integer> demands;
+
+        /// One per non-renewable resource, in the same order as
+        /// Instance::nonrenewable_capacities.
+        std::vector<gcs::Integer> nonrenewable;
+    };
+
     struct Instance
     {
         int n_tasks = 0;
@@ -93,6 +109,26 @@ namespace rcpsp
         /// The tasks that also need the single unary machine, ascending.
         std::vector<int> machine_tasks;
 
+        /// modes[i] is task i's execution modes, in file order. **Empty unless
+        /// the instance is multi-mode**, and everything that special-cases
+        /// multi-mode keys off that emptiness rather than off a flag, exactly
+        /// as `lags` does for RCPSP/max. When it is non-empty there is one
+        /// entry per task and every entry has at least one mode.
+        ///
+        /// `durations[i]` and `demands[r][i]` then hold the *smallest* figure
+        /// over modes[i]. That is what keeps earliest_starts(), tails() and
+        /// critical_path_length() valid: they are lower bounds, and the
+        /// smallest duration is the only one every mode selection admits.
+        /// Anything wanting an upper bound has to ask max_durations().
+        std::vector<std::vector<Mode>> modes;
+
+        /// Capacity of each non-renewable resource: a budget drawn on once by
+        /// each activity and spent over the whole project, rather than a rate
+        /// held at each time point. Only a multi-mode instance has any, and
+        /// they are what makes choosing the modes a problem in its own right
+        /// rather than "give every activity its shortest mode".
+        std::vector<gcs::Integer> nonrenewable_capacities;
+
         /// The task, if any, pinned to time zero. Set for a .sch instance, whose
         /// format carries a dummy source; left unset for a generated one, where
         /// minimising the makespan pins the schedule anyway.
@@ -109,6 +145,48 @@ namespace rcpsp
             if (l.d < gcs::Integer{0})
                 return true;
         return false;
+    }
+
+    /// Whether this instance gives its activities a choice of execution mode.
+    [[nodiscard]] inline auto is_multi_mode(const Instance & inst) -> bool
+    {
+        return ! inst.modes.empty();
+    }
+
+    /// The longest each task can take, over the modes it may be run in. On a
+    /// single-mode instance this is just the durations.
+    [[nodiscard]] inline auto max_durations(const Instance & inst) -> std::vector<gcs::Integer>
+    {
+        if (! is_multi_mode(inst))
+            return inst.durations;
+
+        std::vector<gcs::Integer> longest;
+        longest.reserve(inst.modes.size());
+        for (const auto & task_modes : inst.modes) {
+            auto d = task_modes.front().duration;
+            for (const auto & m : task_modes)
+                d = std::max(d, m.duration);
+            longest.push_back(d);
+        }
+        return longest;
+    }
+
+    /// A horizon for a multi-mode instance: run every activity in its longest
+    /// mode, one after another. That is feasible for the *precedences and the
+    /// renewable resources* whatever modes are chosen, so it is a genuine upper
+    /// bound on the optimal makespan of any mode selection.
+    ///
+    /// It does not depend on finding a mode selection the non-renewable budgets
+    /// allow, which is why this is used rather than a greedy schedule: deciding
+    /// whether any such selection exists is itself NP-hard, so a greedy that
+    /// went looking for one could not be trusted to have found the best it
+    /// could, and one that ignored the budgets would not be a schedule.
+    [[nodiscard]] inline auto multi_mode_horizon(const Instance & inst) -> long long
+    {
+        long long total = 0;
+        for (const auto & d : max_durations(inst))
+            total += d.raw_value;
+        return total;
     }
 
     /// Parameters for generate(). The defaults are the small instance the
@@ -634,6 +712,265 @@ namespace rcpsp
                 throw std::runtime_error{"malformed .sch file: a negative capacity"};
 
         return inst;
+    }
+
+    /// Read a multi-mode RCPSP instance in the PSPLIB `.mm` format, the one the
+    /// `j10`, `j12`, `j14`, `j16`, `j18`, `j20` and `j30` multi-mode sets are
+    /// distributed in.
+    ///
+    /// The file is a sequence of `****`-separated sections. Three are read: the
+    /// resource counts, `PRECEDENCE RELATIONS:` (one line per job, giving its
+    /// mode count and its one-based successors) and `REQUESTS/DURATIONS:` (one
+    /// line per *mode*, giving its duration and its demand on each renewable and
+    /// each non-renewable resource, with the job number written only on the
+    /// first of a job's modes). `RESOURCEAVAILABILITIES:` closes it with one
+    /// capacity per resource, renewables first. Job 1 is a dummy source and job
+    /// n a dummy sink, both single-mode and of zero duration.
+    ///
+    /// \par What multi-mode adds, and why it is the point
+    ///
+    /// An activity chooses one of several modes, and the mode fixes both how
+    /// long it runs and how much of each resource it takes while it does. So a
+    /// task's duration and its demands are **decisions**, not data --- which is
+    /// exactly the case #748 and #749 taught `Cumulative` to reason about, and
+    /// the case no single-mode instance can exercise. A shorter mode generally
+    /// costs more of some resource, so the trade-off is real.
+    ///
+    /// **Non-renewable resources** are what stop the answer being "give every
+    /// activity its shortest mode". A renewable resource is a rate, capped at
+    /// each time point, and is what a `Cumulative` says; a non-renewable one is
+    /// a lump sum drawn once per activity from a project-wide budget, and is one
+    /// linear inequality over the whole instance. Without them the mode choice
+    /// would decompose and the instance would be a plain RCPSP with extra steps.
+    ///
+    /// \par Modes that cannot run
+    ///
+    /// A mode whose renewable demand exceeds that resource's capacity, or whose
+    /// non-renewable demand exceeds that budget on its own, can never be
+    /// selected in any feasible schedule, so it is dropped as the file is read.
+    /// This is what the literature does and it keeps the mode variables' domains
+    /// honest. An activity all of whose modes go that way makes the instance
+    /// infeasible for a reason that has nothing to do with scheduling, and is
+    /// reported as a malformed instance rather than passed on to the solver.
+    [[nodiscard]] inline auto read_mm_stream(std::istream & in, const std::string & description) -> Instance
+    {
+        std::vector<std::string> lines;
+        for (std::string line; std::getline(in, line);)
+            lines.push_back(line);
+
+        // A data line in this format is digits, space and sign and nothing
+        // else. That is what tells the numbers apart from the column headings
+        // and the rows of dashes that sit above them, without this reader having
+        // to know how many heading lines each section has: a row of dashes
+        // carries no digit, so it is not a data line whether or not a sign is
+        // allowed in one.
+        //
+        // Signs are allowed here precisely so that a file with a negative
+        // duration in it is *read* and then rejected by the check that says so.
+        // Treating that line as a heading instead would skip it, shift every
+        // number after it by one, and report whatever the shifted stream
+        // happened to violate first.
+        auto numeric_line = [](const std::string & line) {
+            bool any_digit = false;
+            for (auto & c : line) {
+                if (c >= '0' && c <= '9')
+                    any_digit = true;
+                else if (c != ' ' && c != '\t' && c != '\r' && c != '-' && c != '+')
+                    return false;
+            }
+            return any_digit;
+        };
+
+        // The integer at the end of a `name : value` line, which is how the
+        // counts at the top of the file are written.
+        auto field = [&](const std::string & name) -> long long {
+            for (const auto & line : lines) {
+                auto at = line.find(name);
+                if (at == std::string::npos)
+                    continue;
+                auto colon = line.find(':', at);
+                if (colon == std::string::npos)
+                    continue;
+                std::istringstream vs{line.substr(colon + 1)};
+                long long v = 0;
+                if (vs >> v)
+                    return v;
+            }
+            throw std::runtime_error{"not a PSPLIB .mm file: no '" + name + "' line"};
+        };
+
+        // Every number in the section a marker opens, up to the `****` that
+        // closes it.
+        auto section = [&](const std::string & marker) -> std::vector<long long> {
+            std::size_t at = 0;
+            while (at != lines.size() && lines[at].find(marker) == std::string::npos)
+                ++at;
+            if (at == lines.size())
+                throw std::runtime_error{"not a PSPLIB .mm file: no '" + marker + "' section"};
+
+            std::vector<long long> out;
+            for (++at; at != lines.size() && lines[at].find("***") == std::string::npos; ++at) {
+                if (! numeric_line(lines[at]))
+                    continue;
+                std::istringstream ls{lines[at]};
+                for (long long v; ls >> v;)
+                    out.push_back(v);
+            }
+            return out;
+        };
+
+        auto n_tasks = field("jobs (incl. supersource/sink )");
+        auto n_renewable = field("- renewable");
+        auto n_nonrenewable = field("- nonrenewable");
+        if (field("- doubly constrained") != 0)
+            throw std::runtime_error{"unsupported .mm instance: doubly-constrained resources are not modelled here"};
+        if (n_tasks < 2 || n_tasks > 1000000)
+            throw std::runtime_error{"not a PSPLIB .mm file: implausible job count"};
+        if (n_renewable < 0 || n_nonrenewable < 0 || n_renewable > 1000 || n_nonrenewable > 1000)
+            throw std::runtime_error{"not a PSPLIB .mm file: implausible resource count"};
+
+        Instance inst;
+        inst.n_tasks = static_cast<int>(n_tasks);
+        auto un = static_cast<std::size_t>(n_tasks);
+        auto ur = static_cast<std::size_t>(n_renewable), uk = static_cast<std::size_t>(n_nonrenewable);
+
+        // A cursor over a section's numbers, so that a file which ends early
+        // says so rather than reading zeroes.
+        struct Cursor
+        {
+            const std::vector<long long> & vals;
+            std::size_t at = 0;
+            const char * what;
+            auto next() -> long long
+            {
+                if (at == vals.size())
+                    throw std::runtime_error{std::string{"malformed .mm file: the "} + what + " section ended early"};
+                return vals[at++];
+            }
+        };
+
+        auto precedence_vals = section("PRECEDENCE RELATIONS:");
+        Cursor prec{precedence_vals, 0, "precedence"};
+        std::vector<long long> mode_counts;
+        mode_counts.reserve(un);
+        for (std::size_t i = 0; i != un; ++i) {
+            if (prec.next() != static_cast<long long>(i) + 1)
+                throw std::runtime_error{"malformed .mm file: the precedence block's jobs are out of order"};
+            auto n_modes = prec.next();
+            if (n_modes < 1 || n_modes > 1000)
+                throw std::runtime_error{"malformed .mm file: job " + std::to_string(i + 1) + " has an implausible mode count"};
+            mode_counts.push_back(n_modes);
+
+            auto n_successors = prec.next();
+            if (n_successors < 0 || n_successors > static_cast<long long>(un))
+                throw std::runtime_error{"malformed .mm file: job " + std::to_string(i + 1) + " has an implausible successor count"};
+            for (long long s = 0; s != n_successors; ++s) {
+                auto j = static_cast<int>(prec.next()) - 1;
+                if (j < 0 || j >= inst.n_tasks)
+                    throw std::runtime_error{"malformed .mm file: a precedence to a nonexistent job"};
+                // earliest_starts(), tails() and longest_paths() all walk the
+                // tasks in index order and need that to be topological. PSPLIB
+                // numbers its jobs that way; a file that did not would give
+                // silently wrong bounds rather than an error, so check it.
+                if (j <= static_cast<int>(i))
+                    throw std::runtime_error{"malformed .mm file: job " + std::to_string(j + 1) + " is a successor of job " + std::to_string(i + 1) +
+                        ", so the jobs are not in topological order; this reader needs them to be"};
+                inst.precedences.emplace_back(static_cast<int>(i), j);
+            }
+        }
+
+        auto capacity_vals = section("RESOURCEAVAILABILITIES:");
+        Cursor caps{capacity_vals, 0, "resource availabilities"};
+        for (std::size_t r = 0; r != ur; ++r) {
+            auto c = caps.next();
+            if (c < 0)
+                throw std::runtime_error{"malformed .mm file: a negative renewable capacity"};
+            inst.capacities.push_back(gcs::Integer{c});
+        }
+        for (std::size_t k = 0; k != uk; ++k) {
+            auto c = caps.next();
+            if (c < 0)
+                throw std::runtime_error{"malformed .mm file: a negative non-renewable capacity"};
+            inst.nonrenewable_capacities.push_back(gcs::Integer{c});
+        }
+
+        // The job number is written only on the first of a job's modes, so the
+        // records are not all the same width. Knowing each job's mode count from
+        // the precedence block above is what makes a flat stream unambiguous.
+        auto request_vals = section("REQUESTS/DURATIONS:");
+        Cursor req{request_vals, 0, "requests/durations"};
+        inst.modes.assign(un, {});
+        for (std::size_t i = 0; i != un; ++i) {
+            for (long long m = 0; m != mode_counts[i]; ++m) {
+                if (m == 0 && req.next() != static_cast<long long>(i) + 1)
+                    throw std::runtime_error{"malformed .mm file: the requests block's jobs are out of order"};
+                if (req.next() != m + 1)
+                    throw std::runtime_error{"malformed .mm file: job " + std::to_string(i + 1) + "'s modes are not numbered 1 upwards"};
+
+                auto duration = req.next();
+                if (duration < 0)
+                    throw std::runtime_error{"malformed .mm file: job " + std::to_string(i + 1) + " has a negative duration"};
+                Mode mode{gcs::Integer{duration}, {}, {}};
+
+                bool possible = true;
+                for (std::size_t r = 0; r != ur; ++r) {
+                    auto d = req.next();
+                    if (d < 0)
+                        throw std::runtime_error{"malformed .mm file: a negative renewable demand"};
+                    if (gcs::Integer{d} > inst.capacities[r])
+                        possible = false;
+                    mode.demands.push_back(gcs::Integer{d});
+                }
+                for (std::size_t k = 0; k != uk; ++k) {
+                    auto d = req.next();
+                    if (d < 0)
+                        throw std::runtime_error{"malformed .mm file: a negative non-renewable demand"};
+                    if (gcs::Integer{d} > inst.nonrenewable_capacities[k])
+                        possible = false;
+                    mode.nonrenewable.push_back(gcs::Integer{d});
+                }
+
+                if (possible)
+                    inst.modes[i].push_back(std::move(mode));
+            }
+
+            if (inst.modes[i].empty())
+                throw std::runtime_error{
+                    "job " + std::to_string(i + 1) + " has no mode a resource capacity allows, so the instance is infeasible before any scheduling"};
+        }
+
+        // The smallest figure over the modes, which is what every bound derived
+        // from `durations` and `demands` is allowed to assume. See Instance::modes.
+        inst.durations.reserve(un);
+        inst.demands.assign(ur, std::vector<gcs::Integer>(un, gcs::Integer{0}));
+        for (std::size_t i = 0; i != un; ++i) {
+            auto shortest = inst.modes[i].front().duration;
+            for (const auto & m : inst.modes[i])
+                shortest = std::min(shortest, m.duration);
+            inst.durations.push_back(shortest);
+
+            for (std::size_t r = 0; r != ur; ++r) {
+                auto least = inst.modes[i].front().demands[r];
+                for (const auto & m : inst.modes[i])
+                    least = std::min(least, m.demands[r]);
+                inst.demands[r][i] = least;
+            }
+        }
+
+        std::size_t total_modes = 0;
+        for (const auto & task_modes : inst.modes)
+            total_modes += task_modes.size();
+        inst.description = description + " n=" + std::to_string(inst.n_tasks) + " renewable=" + std::to_string(n_renewable) +
+            " nonrenewable=" + std::to_string(n_nonrenewable) + " modes=" + std::to_string(total_modes);
+        return inst;
+    }
+
+    [[nodiscard]] inline auto read_mm_file(const std::string & path) -> Instance
+    {
+        std::ifstream in{path};
+        if (! in)
+            throw std::runtime_error{"could not open instance file: " + path};
+        return read_mm_stream(in, "mm " + path);
     }
 
     /// Read a job-shop scheduling instance in the standard OR-Library layout,

--- a/examples/rcpsp/sample.mm
+++ b/examples/rcpsp/sample.mm
@@ -1,0 +1,78 @@
+A hand-written multi-mode RCPSP instance in the PSPLIB .mm format, for the --mm
+reader. Written here rather than taken from a benchmark set, so it is small
+enough to prove quickly and there is no licence question about redistributing
+it. Everything above the first row of stars is ignored by the reader, which
+finds each section by its heading.
+
+Five real activities between a dummy source and sink, each with three modes,
+two resources that are capped at every time point and one budget spent over the
+whole project.
+
+Chosen to be discriminating rather than merely valid, on the two things that
+make this format worth reading at all:
+
+  * A mode fixes both a duration and the demands that go with it, so the
+    trade-off is real. The optimum is 10 against a critical path of 5, so the
+    resources decide the answer and not the chains.
+
+  * The budget binds, and hard. Raise the 15 on the last line to 22 and the
+    optimum drops from 10 to 6: four of the ten time units are there because
+    the cheap modes cannot all be afforded together. Without that, every
+    activity would take its shortest mode and this would be a plain RCPSP with
+    extra steps.
+
+Every energetic rule that reads a variable length or height changes the search
+on it --- 109 recursions with none of them, 107 with edge-finding, with the
+time-table and energetic strengthenings, and with not-first / not-last --- so a
+rule that stopped reasoning about variable arguments would show up here.
+************************************************************************
+file with basedata            : sample.bas
+initial value random generator: 0
+************************************************************************
+projects                      :  1
+jobs (incl. supersource/sink ):  7
+horizon                       :  0
+RESOURCES
+  - renewable                 :  2   R
+  - nonrenewable              :  1   N
+  - doubly constrained        :  0   D
+************************************************************************
+PROJECT INFORMATION:
+pronr.  #jobs rel.date duedate tardcost  MPM-Time
+    1     5      0       0        0       0
+************************************************************************
+PRECEDENCE RELATIONS:
+jobnr.    #modes  #successors   successors
+    1        1        2        2  3
+    2        3        3        3  5  6
+    3        3        2        4  6
+    4        3        1        6
+    5        3        1        6
+    6        3        1        7
+    7        1        0        
+************************************************************************
+REQUESTS/DURATIONS:
+jobnr. mode duration  R 1  R 2  N 1
+------------------------------------------------------------------------
+    1      1       0     0    0     0
+    2      1       2     5    1     5
+           2       4     5    5     2
+           3       5     0    1     3
+    3      1       1     6    3     2
+           2       5     0    4     4
+           3       5     5    2     1
+    4      1       1     6    0     6
+           2       4     5    2     6
+           3       4     2    5     3
+    5      1       2     2    2     4
+           2       2     0    4     5
+           3       3     0    4     6
+    6      1       1     0    5     2
+           2       2     4    2     1
+           3       3     2    3     2
+    7      1       0     0    0     0
+************************************************************************
+RESOURCEAVAILABILITIES:
+  R 1  R 2  N 1
+    6    5   15
+************************************************************************


### PR DESCRIPTION
**Stacked on #774** (`jobshop-reader`) — both touch the same three files. Review that one first; this diff is against it.

#748 and #749 taught `Cumulative` to count the guaranteed energy of a variable length and a variable height, and both shipped **backed by fixtures alone**. Nothing in any RCPSP collection to hand has a variable anything — `examples/rcpsp` builds `std::vector<Integer>` durations and demands from every instance it can read — so the constant path is the only path a sweep has ever taken, and the strength claim has never met a benchmark.

Multi-mode RCPSP is where that case is native rather than contrived: an activity chooses a mode, the mode fixes both how long it runs and what it takes while it does, and a shorter mode generally costs more of something. So a duration and a demand are decisions, and they are *linked* decisions — the shape the guaranteed-energy accounting was written for.

## What it posts

`--mm` reads the PSPLIB `.mm` format (`j10`–`j30`): a mode variable per activity, an `ElementConstantArray` tying its duration and each of its demands to that mode, and `Cumulative` handed vectors of variables. Where the mode makes no difference to a figure the constant goes in directly — an element over equal values is the same constraint and a bigger encoding — so the dummy source and sink cost nothing.

**Non-renewable resources are modelled, and are not decoration.** A renewable resource is a rate capped at each time point, which is what a `Cumulative` says; a non-renewable one is a lump drawn once per activity from a project-wide budget, which is one linear inequality. They are the only reason the mode choice does not decompose into "give every activity its shortest mode". On `sample.mm`, raising the budget from 15 to 22 drops the optimum from 10 to 6.

## Two things this could not reuse

- **A precedence stops being a difference constraint.** Its weight is the predecessor's duration, so where that is a decision it becomes a three-term `s_j - s_i - d_i >= 0`, and so does the makespan bound. Where a duration is fixed the edge stays difference-shaped and goes into the list `--variant` handles, so that comparison still means something over the part of the network that is still a network.
- **The greedy horizon cannot be used.** It would have to pick modes first, and whether *any* selection fits the budgets is itself NP-hard — so a greedy ignoring the budgets would not have produced a schedule, and one respecting them could not be trusted to have found the shortest it could. Running everything in its longest mode, one after another, is feasible for the precedences and the renewables whatever the modes turn out to be.

## Validated against published optima — which is what caught the bugs

- **534 of the 536 `j10` instances reach exactly the makespan PSPLIB publishes as optimal.** Zero disagreements; two unresolved at a 20 s timeout.
- **150 solutions re-checked from the raw file by an independent script**: modes against durations, precedences, renewable load at every time point, non-renewable totals. Zero invalid.

Both bugs showed up only as makespans *below* the published optimum, and neither would have shown up against a fixture:

1. The mode variables were not in the branch list, so the solver reported "solutions" in which the durations were still a range.
2. The precedences were weighted by each activity's *shortest* mode, letting a successor start while its predecessor was still running.

Error paths are covered too: doubly-constrained resources, a wrong job count, a missing section, mis-numbered modes, a negative duration, a back edge, a budget no mode fits, and junk each give a specific message.

## The single-mode path is untouched

Not only by inspection — `rcpsp --size 12 --seed 3 --max-lag-density 0.3 --prove` produces a **byte-identical `.opb` and `.pbp`** to the parent commit.

## Tests

`sample.mm` is hand-written so it can be redistributed, and is discriminating on both counts: the optimum is 10 against a critical path of 5, so the resources decide it rather than the chains, and the budget is worth four of those ten units. Three lanes — the reader, the energetic accounting over a variable length and height (**#755's certificate meeting a variable argument outside a fixture for the first time**), and a deadline one below the optimum for the UNSATISFIABLE conclusion.

754/754 pass. GCC `-Werror` clean on the changed translation unit; clang builds clean with no warning in the changed files.

Closes the C2 half of the experimental-section gap; part of #633.


*Updated 2026-09-19: the commit now carries its `Co-Authored-By` trailer, which it was missing. Nothing else changed — same tree, same parent, same author date.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
