### PR TITLE
One sweep harness for the scheduling rules

### DIFF
--- a/dev_docs/README.md
+++ b/dev_docs/README.md
@@ -42,6 +42,12 @@ library. For an introduction to *using* the solver, start with the top-level
   instances: the `XCSPCallbacks` class, the intension tree walker, the
   cache-based test harness with ACE cross-checking, and the recipe for
   adding a new constraint binding.
+- [Running the scheduling experiments elsewhere](cluster-experiments.md) —
+  the runbook for producing the certified-scheduling measurements on a
+  machine that has only this repository and a network connection: build,
+  fetch the three instance families from their upstreams, check the build
+  against published optima before spending anything, then the sweeps.
+  Start here rather than at the sweep harness.
 - [Per-rule firing counters](rule-counters.md) — what
   `GCS_SCHEDULING_RULE_STATS` prints for each `Cumulative` and
   `Disjunctive` propagation rule, what the four numbers mean, and the one

--- a/dev_docs/cluster-experiments.md
+++ b/dev_docs/cluster-experiments.md
@@ -1,0 +1,226 @@
+# Running the scheduling experiments elsewhere
+
+A runbook for producing the measurements the certified-scheduling work needs, on
+a machine that has nothing but this repository and a network connection. It
+assumes no local state: every instance family is fetched from its upstream, and
+every command below is meant to be run as written.
+
+Read this top to bottom before starting anything long. Steps 1-4 take under an
+hour; step 5 is the part that takes real time, and steps 1-4 exist to stop you
+spending it on a build that was going to produce wrong numbers.
+
+## What this is for
+
+Every energetic rule in `Cumulative` and `Disjunctive` is off by default and the
+reason is always a measurement. The point of a sweep is to produce, per rule:
+
+- what the rule does to the **search** (recursions, and how many instances it
+  closes),
+- what it **costs** (`calls` against `firings`, and how much of its reach was
+  already true),
+- what it does to the **proof** (`.pbp` size and VeriPB checking time).
+
+Three instance families, because no one of them exercises the whole rule set:
+
+| family | why it is here |
+|---|---|
+| RCPSP (`.dzn`) | the cumulative rules' home ground |
+| job shop (`.jss`) | **the only family with unary machines.** No RCPSP collection in circulation has a capacity-one resource --- the smallest across `data_bl`, `data_pack`, `data_pack_d` and `data_ksd15_d` is three --- so without this the disjunctive rules measure nothing at all |
+| multi-mode (`.mm`) | **the only family with variable durations and demands.** An activity picks a mode and the mode fixes both, which is the case `Cumulative` was taught to reason about and that no single-mode instance reaches |
+
+## 1. Build
+
+Needs a C++23 compiler (GCC 13 on Ubuntu 24.04 is the oldest tested; GCC 15 and
+Clang 21 are the development compilers), CMake 3.21+, Python 3.10+, and `veripb`
+3.0.2 or later on `PATH` for anything involving proofs. The top-level `README`
+has the full list and the FetchContent dependencies.
+
+```shell
+cmake --preset release -B build
+cmake --build build --parallel
+ctest --test-dir build --parallel
+```
+
+All tests must pass before going further. **Do not pin your own expectations to
+the exact figures quoted in this repository's comments**: recursion counts and
+rule counters are stable for a given build but differ between toolchains, so a
+number here that your machine does not reproduce is not necessarily a fault.
+Test *failures* are.
+
+### If the work is still on branches
+
+At the time of writing four branches carry this, and `main` may or may not have
+them yet. Check first:
+
+```shell
+./build/rcpsp --help | grep -cE '^\s+--(jss|mm)'          # 2 if the readers are in
+./build/rcpsp --help >/dev/null && ls tools/scheduling_sweep.py   # the harness
+```
+
+If they are missing, combine them --- they merge cleanly apart from one conflict
+that is two branches appending test blocks to the same file, where the
+resolution is to keep both:
+
+```shell
+git checkout -b experiments main
+git merge jobshop-reader          # --jss
+git merge multi-mode-reader       # --mm
+git merge scheduling-rule-counters   # conflict in examples/rcpsp/CMakeLists.txt: keep both blocks
+git merge scheduling-sweep-harness   # tools/scheduling_sweep.py
+```
+
+756 tests pass with all four applied. If a flag is missing the sweep harness
+says so and skips what depends on it rather than failing obscurely, so a partial
+combination still runs --- it just measures less.
+
+## 2. Fetch the instances
+
+```shell
+tools/fetch_scheduling_instances.bash scheduling-instances
+```
+
+Public sources, ~100 MB, a few minutes. **Needs network access, so on a cluster
+run this on a login node rather than inside a batch job.** It is idempotent:
+re-run it if it is interrupted. It prints what it got and what to expect
+(`data_bl` 40, `jobshop` 82, `multimode/j10` 536, and so on).
+
+## 3. Check the build against published answers
+
+```shell
+tools/check_scheduling_readers.py --binary build/rcpsp --instances scheduling-instances
+```
+
+This solves instances whose optimal makespans other people have published ---
+PSPLIB ships a table of them for the multi-mode sets, and `ft06` and `la01` are
+settled job-shop optima --- and compares. It exits non-zero on any disagreement.
+
+**Do not skip this and do not proceed past a disagreement.** A reader that is
+subtly wrong does not crash: it produces a slightly *better* optimum, which is
+the one thing nobody double-checks. Both bugs found in the multi-mode support
+while it was being written showed up only this way, and neither was visible to a
+unit test.
+
+## 4. A smoke run
+
+```shell
+tools/scheduling_sweep.py --list-arms
+
+tools/scheduling_sweep.py --binary build/rcpsp --out smoke.jsonl \
+    --dzn-dir scheduling-instances/rcpsp --collections data_bl \
+    --arms ef,ttef --timeout 10 --jobs 4
+```
+
+Expect 80 rows, each carrying `recursions` and a `rules` object with 21 counter
+entries. If `rules` is missing, the counters are not in this build.
+
+## 5. The sweeps
+
+Each writes one JSONL row per (instance, arm). `--resume` skips rows already
+present, so a killed job is restarted by re-running the same command. Rough
+costs assume ~16 cores; scale accordingly.
+
+### 5a. Cumulative, search shape (~2-4 hours)
+
+```shell
+tools/scheduling_sweep.py --binary build/rcpsp --out cumulative-shape.jsonl \
+    --dzn-dir scheduling-instances/rcpsp --collections data_bl,data_pack,data_pack_d \
+    --arms off,ef,ttef,energetic,nfnl,nfnlpub,ttef+nfnl,ttef+nfnlpub,elastic,kaoc \
+    --timeout 60 --jobs 16 --resume
+```
+
+### 5b. Disjunctive on job shops (~2-4 hours)
+
+The family that makes these rules measurable at all. Expect a low closed count:
+job shop is hard and the branching here is basic, so compare on the instances
+every arm closes.
+
+```shell
+tools/scheduling_sweep.py --binary build/rcpsp --out disjunctive-shape.jsonl \
+    --jss-dir scheduling-instances/jobshop \
+    --arms dj-off,dj-ef,dj-ef-lb,dj-ef-ub,dj-nfnl,dj-nfnlpub,dj-dps,dj-overload,dj-ef+nfnl,dj-ef+dps \
+    --timeout 60 --jobs 16 --resume
+```
+
+### 5c. Multi-mode, variable durations and demands (~1-2 hours)
+
+```shell
+tools/scheduling_sweep.py --binary build/rcpsp --out multimode-shape.jsonl \
+    --mm-dir scheduling-instances/multimode/j10 \
+    --arms off,ef,ttef,energetic,nfnl --timeout 60 --jobs 16 --resume
+```
+
+### 5d. Proof size and verification time (hours to days)
+
+Much the most expensive: every run writes a proof and then checks it. Start
+small and grow. The cap is not optional --- an uncapped proving run on a real
+instance has written 128 GB in ten minutes.
+
+```shell
+tools/scheduling_sweep.py --binary build/rcpsp --out proofs-generated.jsonl \
+    --mode prove --generated 'size=10,12,14;seed=1..10;capacity=3,4,6' \
+    --arms off,ef,ttef,energetic,nfnl --timeout 60 --proof-cap-mb 4000 --jobs 8 --resume
+```
+
+Then, if there is time, the same over `--dzn-dir ... --collections data_bl` and
+over `--jss-dir`. Watch the disk: `--jobs 8` at a 4 GB cap can want 32 GB at
+once, and rows come back as `proof-too-big` rather than as failures when they
+hit it.
+
+### 5e. Closed counts, serially (long)
+
+Only if a table is going to report *how many instances an arm closed*. Those
+counts depend on machine load in a way that recursion ratios do not, so they
+need a quiet machine and one run at a time.
+
+```shell
+tools/scheduling_sweep.py --binary build/rcpsp --out closed-serial.jsonl \
+    --dzn-dir scheduling-instances/rcpsp --collections data_bl \
+    --arms off,ef,ttef,energetic --timeout 60 --serial --resume
+```
+
+## 6. What to bring back
+
+Every `.jsonl` file, plus:
+
+```shell
+git rev-parse HEAD > provenance.txt
+{ echo; c++ --version; cmake --version | head -1; veripb --version; uname -a; nproc; } >> provenance.txt
+```
+
+The rows already record the timeout, the arm and how parallel the sweep was;
+`provenance.txt` supplies the rest. **A table of these figures has to name the
+build that produced it**, because the counts are not portable across toolchains.
+
+## Traps
+
+**Snapshot the binary before a long sweep, and never rebuild into the tree a
+sweep is running from.** A rebuild mid-sweep silently mixes two binaries across
+rows, or removes the binary and kills the run. `cp build/rcpsp ./rcpsp-snapshot`
+and point `--binary` at that.
+
+**`already_true` does not mean the same thing on every row.** Each rule tests the
+live bound and evaluates its own condition in whichever order is cheaper, which
+differs between the encodings: on `Disjunctive` edge-finding `firings +
+already_true` is a detection count, and everywhere else `already_true` counts
+candidates the rule passed over. `dev_docs/rule-counters.md` has the table.
+
+**A simulated firing count and one of these are not the same measurement.**
+Figures quoted from standalone simulations of these rules count *detections* on
+small random draws; `firings` counts *bound moves* on a benchmark instance. Both
+are useful and they are not two halves of one thing.
+
+**An incomplete proof is not a rejected one.** `proof-too-big` and `timeout` mean
+the run did not finish, not that VeriPB refused anything. Only `REJECTED` is a
+finding --- and it is a serious one, so report it rather than filtering it out.
+
+**Filter on `result` and `status`, not on the presence of a makespan.** A row can
+be a clean run of an instance that timed out.
+
+## One thing worth knowing before you start
+
+On `ft06` --- a 6x6 job shop, the smallest real instance in the set --- the
+solver closes the instance in **55 recursions** with `--disjunctive-edge-finding`
+and has not closed it after **29.6 million** without. That is the same rule that
+looks marginal on generated instances, and it is the reason the job-shop family
+was added. Expect the disjunctive arms to separate much more sharply here than
+any earlier measurement suggested.

--- a/dev_docs/rule-counters.md
+++ b/dev_docs/rule-counters.md
@@ -99,6 +99,12 @@ one) already had. On the instance above, edge-finding's lb half passes over
 412: the two halves do very different amounts of redundant work, which is
 invisible in a recursion count and is why the halves have a row each.
 
+## Reading them off a sweep
+
+`tools/scheduling_sweep.py` collects these alongside the search shape, one JSONL
+row per (instance, arm), and because they are inert it is the same run that
+gives the recursion count. See `tools/README.md`.
+
 ## Adding a rule
 
 `gcs/constraints/innards/rule_counters.hh`. Add an entry to the constraint's

--- a/tools/README.md
+++ b/tools/README.md
@@ -111,3 +111,22 @@ how the flags work and how a row has to be read. Disjunctive arms have to carry
 `--unary disjunctive --machine disjunctive` themselves --- without them nothing
 posts a `Disjunctive` on a file-read instance, and the arm would measure an
 unchanged model very convincingly.
+
+## fetch_scheduling_instances.bash and check_scheduling_readers.py
+
+The two steps that come before a sweep on a machine with no local instance data.
+The first fetches the three families from their upstreams (MiniZinc benchmarks,
+the OR-Library, PSPLIB) into a directory; the second solves instances whose
+optimal makespans other people have published and compares, exiting non-zero on
+any disagreement.
+
+```shell
+tools/fetch_scheduling_instances.bash scheduling-instances
+tools/check_scheduling_readers.py --binary build/rcpsp --instances scheduling-instances
+```
+
+Run the check every time before a long sweep. A reader that is subtly wrong does
+not crash --- it produces a slightly *better* optimum, which is the one thing
+nobody double-checks, and every number the sweep goes on to produce inherits it.
+
+`dev_docs/cluster-experiments.md` is the runbook these two belong to.

--- a/tools/README.md
+++ b/tools/README.md
@@ -40,3 +40,74 @@ Run from the repository root after a build:
 ```shell
 python3 tools/capture_encodings.py
 ```
+
+## scheduling_sweep.py
+
+The sweep harness for the `Cumulative` and `Disjunctive` propagation rules: one
+script, an arm table, four instance sources and two modes. It replaces a family
+of per-issue scripts that each hardcoded their own arms and answered one
+question --- measuring a scheduling rule needs an arm to switch it on, an
+instance family it actually fires on, a search-shape number and a proof number,
+and each of those scripts had two of the four.
+
+```shell
+tools/scheduling_sweep.py --list-arms
+
+tools/scheduling_sweep.py --binary build/rcpsp --out shape.jsonl \
+    --dzn-dir ~/mzn-bench/rcpsp --collections data_bl,data_pack \
+    --arms ef,ttef,energetic,nfnl --timeout 60 --jobs 8
+
+tools/scheduling_sweep.py --binary build/rcpsp --out proofs.jsonl --mode prove \
+    --generated 'size=10,12;seed=1..10;capacity=3,4' --arms ef,ttef
+```
+
+One JSONL row per (instance, arm), holding the search shape, every per-rule
+counter row (see `dev_docs/rule-counters.md`), and in `--mode prove` the `.opb`
+and `.pbp` sizes, the line count, the verification time and the verdict.
+
+**Shape and counters come off one run.** The counters are inert --- they change
+no inference and no proof byte --- so this replaces the `STATS=0` / `STATS=1`
+two-pass split the older harnesses needed, and a timing column and a counter
+column can be read from the same row.
+
+### Things it does that are easy to get wrong by hand
+
+**An arm the binary cannot run is skipped and said to be skipped.** Point it at
+a build from before half the stack merged and it tells you which arms and which
+instance sources it dropped, rather than failing every run identically or ---
+worse --- appearing to measure something. An arm silently dropped looks exactly
+like an arm that made no difference.
+
+**An incomplete proof is not a rejected one.** A run killed by the file-size cap
+leaves a truncated `.pbp`; a run that hits its own `--timeout` leaves one with no
+conclusion. Both are non-empty, both make `veripb` exit non-zero, and neither
+says anything about the solver. They come back as `proof-too-big` and `timeout`,
+and are never handed to `veripb` at all. A harness that cried `REJECTED` at those
+would do it on every large instance.
+
+**Every proving run is capped** (`--proof-cap-mb`, default 4000). An uncapped
+`rcpsp --prove` on a real Pack instance has written 128 GB in ten minutes and
+taken a machine's disk with it.
+
+**Each run gets its own scratch directory**, because proof files are named after
+the run and a parallel sweep would otherwise have several runs writing one set.
+
+**Every row records how parallel the sweep was.** Recursion ratios over
+instances every arm closed are load-independent; *closed counts* are not --- "38
+against 39" at a 60 s timeout is a statement about one machine under one load.
+`--serial` is there for when the closed counts are what is being reported, and
+the `parallel` field is there so that a row whose provenance is a 12-way sweep
+cannot be quoted as though it were not.
+
+**`--resume` skips rows already in the output**, so a killed cluster job can be
+restarted without redoing what landed. `--print-jobs` emits one command line per
+run instead of running them, for a scheduler that wants to fan out itself.
+
+### Adding an arm
+
+One line in `ARMS`. Name it after the configuration rather than the rule: several
+arms are a rule plus the strengthening that *replaces* its detection, which is
+how the flags work and how a row has to be read. Disjunctive arms have to carry
+`--unary disjunctive --machine disjunctive` themselves --- without them nothing
+posts a `Disjunctive` on a file-read instance, and the arm would measure an
+unchanged model very convincingly.

--- a/tools/check_scheduling_readers.py
+++ b/tools/check_scheduling_readers.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Pre-flight: does this build get the published answers?
+
+Reading an instance format is easy to get subtly wrong in a way that no crash
+and no test reveals --- a duration read into the wrong mode, a precedence
+weighted by the wrong figure --- and the failure looks like a slightly better
+optimum, which is exactly what nobody double-checks. Both of the bugs that
+existed in the multi-mode support when it was written showed up only as a
+makespan *below* the published one.
+
+So before a long sweep, check the build against numbers other people published:
+
+    tools/check_scheduling_readers.py --binary build/rcpsp \\
+        --instances scheduling-instances
+
+Multi-mode is compared against PSPLIB's own optimal-makespan table, which the
+fetch script downloads alongside the instances. Job shop is compared against two
+optima famous enough to hardcode. Anything that disagrees is a finding about
+this build, not about the instance.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# ft06 and la01 from the Lawrence and Fisher-Thompson sets. Both are settled and
+# have been for forty years; if this build disagrees, this build is wrong.
+JOBSHOP_OPTIMA = {"ft06": 55, "la01": 666}
+
+# The mode/instance columns are 1-based and a makespan of 16384 is the table's
+# way of saying "no feasible schedule". PSPLIB ships no file for those, so they
+# never come up here, but read the sentinel rather than trusting that.
+INFEASIBLE = 16384
+
+
+def solve(binary: str, flags: list[str], timeout: float) -> tuple[str, int | None]:
+    out = subprocess.run([binary, *flags, "--stats", "--timeout", str(timeout)],
+                         capture_output=True, text=True, timeout=timeout * 6).stdout
+    status = re.search(r"^status: (\S+)$", out, re.M)
+    makespan = re.search(r"^makespan: (\d+)$", out, re.M)
+    return (status.group(1) if status else "?",
+            int(makespan.group(1)) if makespan else None)
+
+
+def check_jobshop(binary: str, root: Path, timeout: float) -> tuple[int, int, int]:
+    agree = disagree = unresolved = 0
+    for name, want in JOBSHOP_OPTIMA.items():
+        found = list(root.rglob(f"{name}.jss"))
+        if not found:
+            print(f"  {name}: no instance file, skipped")
+            continue
+        # Edge-finding is off by default and a job shop is where that shows:
+        # ft06 is 55 recursions with it and had not closed after 29.6 million
+        # without. A pre-flight wants the configuration that finishes.
+        status, got = solve(binary, ["--jss", str(found[0]), "--unary", "disjunctive",
+                                     "--disjunctive-edge-finding",
+                                     "--branch", "dom-then-deg", "--value-order", "split"], timeout)
+        if status != "optimal":
+            print(f"  {name}: {status} within {timeout:g}s, wanted {want}")
+            unresolved += 1
+        elif got == want:
+            print(f"  {name}: {got} as published")
+            agree += 1
+        else:
+            print(f"  {name}: got {got}, PUBLISHED OPTIMUM IS {want}  <-- disagreement")
+            disagree += 1
+    return agree, disagree, unresolved
+
+
+def published_optima(opt_file: Path, prefix: str) -> dict[str, int]:
+    table: dict[str, int] = {}
+    for line in opt_file.read_text(errors="replace").splitlines():
+        f = line.split()
+        if len(f) >= 3 and f[0].isdigit() and f[1].isdigit():
+            try:
+                table[f"{prefix}{f[0]}_{f[1]}.mm"] = int(f[2])
+            except ValueError:
+                pass
+    return table
+
+
+def check_multimode(binary: str, root: Path, timeout: float, limit: int) -> tuple[int, int, int]:
+    agree = disagree = unresolved = 0
+    for opt_file in sorted(root.glob("*.opt")):
+        setname = opt_file.stem
+        table = published_optima(opt_file, setname)
+        files = sorted((root / setname).rglob("*.mm"))[:limit]
+        if not files:
+            continue
+        print(f"  {setname}: checking {len(files)} of {len(list((root / setname).rglob('*.mm')))}")
+        for path in files:
+            want = table.get(path.name)
+            if want is None or want == INFEASIBLE:
+                continue
+            status, got = solve(binary, ["--mm", str(path)], timeout)
+            if status != "optimal":
+                unresolved += 1
+            elif got == want:
+                agree += 1
+            else:
+                disagree += 1
+                print(f"    {path.name}: got {got}, published {want}  <-- disagreement")
+    return agree, disagree, unresolved
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--binary", default="build/rcpsp")
+    p.add_argument("--instances", default="scheduling-instances",
+                   help="the directory tools/fetch_scheduling_instances.bash filled")
+    p.add_argument("--timeout", type=float, default=30.0)
+    p.add_argument("--limit", type=int, default=40, help="multi-mode instances per set")
+    args = p.parse_args()
+
+    root = Path(args.instances).expanduser()
+    binary = str(Path(args.binary).expanduser().resolve())
+    help_text = subprocess.run([binary, "--help"], capture_output=True, text=True).stdout
+
+    total_disagree = total_unresolved = 0
+
+    if "--jss" not in help_text:
+        print("job shop: this binary has no --jss, skipping")
+    elif not (root / "jobshop").is_dir():
+        print("job shop: no instances fetched, skipping")
+    else:
+        print("job shop, against published optima:")
+        a, d, u = check_jobshop(binary, root / "jobshop", args.timeout)
+        total_disagree += d
+        total_unresolved += u
+
+    if "--mm" not in help_text:
+        print("multi-mode: this binary has no --mm, skipping")
+    elif not (root / "multimode").is_dir():
+        print("multi-mode: no instances fetched, skipping")
+    else:
+        print("multi-mode, against PSPLIB's optimal-makespan table:")
+        a, d, u = check_multimode(binary, root / "multimode", args.timeout, args.limit)
+        total_disagree += d
+        total_unresolved += u
+        print(f"  {a} agree, {d} disagree, {u} unresolved within {args.timeout:g}s")
+
+    print()
+    if total_disagree:
+        print(f"{total_disagree} DISAGREEMENTS. Do not sweep with this build: a makespan that "
+              f"differs from a published optimum is a bug in the reader or the model, and every "
+              f"number the sweep produces would inherit it.")
+        return 1
+    print("no disagreements with any published optimum.")
+    if total_unresolved:
+        print(f"{total_unresolved} did not resolve in {args.timeout:g}s, which is a statement "
+              f"about the timeout rather than about the build; raise --timeout to shrink it.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/fetch_scheduling_instances.bash
+++ b/tools/fetch_scheduling_instances.bash
@@ -1,0 +1,148 @@
+#!/bin/bash
+# Fetch the instance families the scheduling sweeps need, from their upstream
+# sources. Everything here is public and freely redistributable; none of it is
+# kept in this repository, which is why this script exists.
+#
+#   tools/fetch_scheduling_instances.bash [DEST] [family ...]
+#
+# DEST defaults to ./scheduling-instances. With no families named it fetches all
+# three. Re-running skips what is already there, so an interrupted fetch is
+# restarted by running it again.
+#
+# Needs network access. On a cluster that usually means running this on a login
+# node, not inside a batch job.
+
+set -eu
+
+DEST="${1:-scheduling-instances}"
+shift || true
+FAMILIES=("$@")
+[[ ${#FAMILIES[@]} -eq 0 ]] && FAMILIES=(rcpsp jobshop multimode)
+
+# PSPLIB multi-mode sets to take. j10 and j20 are the ones with published
+# optimal makespans for every instance; j30 is bigger and harder.
+MM_SETS="${MM_SETS:-j10 j20}"
+
+mkdir -p "$DEST"
+DEST="$(cd "$DEST" && pwd)"
+
+have() { command -v "$1" >/dev/null 2>&1; }
+for tool in curl git python3 unzip; do
+    have "$tool" || { echo "need $tool on PATH" >&2; exit 1; }
+done
+
+note() { printf '\n=== %s\n' "$*"; }
+
+# --- RCPSP, as MiniZinc .dzn -------------------------------------------------
+#
+# From the MiniZinc benchmark suite (MIT). A blob-filtered sparse clone of just
+# the rcpsp directory is ~19 MB against a very large repository.
+fetch_rcpsp() {
+    local dir="$DEST/rcpsp"
+    if [[ -d "$dir/data_bl" ]]; then
+        echo "rcpsp: already present"
+        return
+    fi
+    note "rcpsp: sparse-cloning the MiniZinc benchmark suite"
+    rm -rf "$dir.tmp"
+    git clone --filter=blob:none --no-checkout --depth 1 \
+        https://github.com/MiniZinc/minizinc-benchmarks.git "$dir.tmp"
+    git -C "$dir.tmp" sparse-checkout init --cone
+    git -C "$dir.tmp" sparse-checkout set rcpsp
+    git -C "$dir.tmp" checkout
+    mv "$dir.tmp/rcpsp" "$dir"
+    rm -rf "$dir.tmp"
+}
+
+# --- Job shop ----------------------------------------------------------------
+#
+# The OR-Library ships all 82 instances as one file; the sweep wants one file
+# each. Everything between an `instance <name>` line and the next one is that
+# instance, blurb included --- the reader skips down to the first line that is
+# numeric throughout.
+fetch_jobshop() {
+    local dir="$DEST/jobshop"
+    if [[ -d "$dir" ]] && [[ $(find "$dir" -name '*.jss' | wc -l) -ge 82 ]]; then
+        echo "jobshop: already present"
+        return
+    fi
+    note "jobshop: fetching the OR-Library set"
+    mkdir -p "$dir"
+    curl -sSLf -o "$dir/jobshop1.txt" \
+        "http://people.brunel.ac.uk/~mastjjb/jeb/orlib/files/jobshop1.txt"
+    python3 - "$dir" <<'PY'
+import re, sys, pathlib
+d = pathlib.Path(sys.argv[1])
+lines = (d / "jobshop1.txt").read_text().splitlines()
+starts = [(i, m.group(1)) for i, l in enumerate(lines)
+          if (m := re.match(r'\s*instance\s+(\S+)\s*$', l))]
+for k, (i, name) in enumerate(starts):
+    end = starts[k + 1][0] if k + 1 < len(starts) else len(lines)
+    (d / f"{name}.jss").write_text("\n".join(lines[i:end]).rstrip() + "\n")
+print(f"split into {len(starts)} instances")
+PY
+}
+
+# --- Multi-mode RCPSP --------------------------------------------------------
+#
+# PSPLIB, with the published optimal makespans alongside. The .opt table is what
+# makes this family worth having twice over: it is the only one of the three
+# that can tell you the solver's answer is not merely self-consistent but right.
+#
+# Note the shipped set holds only the feasible instances --- the 104
+# (parameter, instance) rows the table marks 16384 have no file --- so this
+# family never exercises infeasibility detection.
+fetch_multimode() {
+    local dir="$DEST/multimode"
+    mkdir -p "$dir"
+    for set in $MM_SETS; do
+        if [[ -d "$dir/$set" ]]; then
+            echo "multimode $set: already present"
+            continue
+        fi
+        note "multimode: fetching PSPLIB $set"
+        curl -sSLf -o "$dir/$set.zip" \
+            "https://www.om-db.wi.tum.de/psplib/download_dataset.php?set=$set&mode=mm&format=zip"
+        mkdir -p "$dir/$set"
+        unzip -q -o "$dir/$set.zip" -d "$dir/$set"
+        rm -f "$dir/$set.zip"
+        curl -sSLf -o "$dir/$set.opt" \
+            "https://www.om-db.wi.tum.de/psplib/download_solution.php?set=$set&mode=mm&type=opt" \
+            || echo "  (no published optima for $set)"
+    done
+}
+
+for family in "${FAMILIES[@]}"; do
+    case "$family" in
+        rcpsp) fetch_rcpsp ;;
+        jobshop) fetch_jobshop ;;
+        multimode) fetch_multimode ;;
+        *) echo "unknown family: $family (want rcpsp, jobshop or multimode)" >&2; exit 1 ;;
+    esac
+done
+
+note "what is in $DEST"
+for d in "$DEST"/rcpsp/data_*; do
+    [[ -d "$d" ]] || continue
+    n=$(find "$d" -name '*.dzn' | wc -l)
+    printf '  %-28s %5d .dzn\n' "rcpsp/$(basename "$d")" "$n"
+done
+[[ -d "$DEST/jobshop" ]] && printf '  %-28s %5d .jss\n' "jobshop" "$(find "$DEST/jobshop" -name '*.jss' | wc -l)"
+for d in "$DEST"/multimode/*/; do
+    [[ -d "$d" ]] || continue
+    printf '  %-28s %5d .mm\n' "multimode/$(basename "$d")" "$(find "$d" -name '*.mm' | wc -l)"
+done
+
+cat <<'EOF'
+
+Expected, if the upstreams have not changed under us:
+  rcpsp/data_bl 40, data_pack 55, data_pack_d 55, data_ksd15_d 480, data_la_x 80
+  jobshop 82
+  multimode/j10 536, multimode/j20 554
+
+data_at and data_psplib hold their instances in subdirectories rather than
+directly, so they read as zero above and want --dzn-dir pointing a level deeper.
+
+None of these has a capacity-one resource, which is why the job shops are here:
+see dev_docs/cluster-experiments.md.
+EOF

--- a/tools/scheduling_sweep.py
+++ b/tools/scheduling_sweep.py
@@ -1,0 +1,400 @@
+#!/usr/bin/env python3
+"""One sweep harness for the Cumulative and Disjunctive propagation rules.
+
+Replaces a family of per-issue scripts that each hardcoded their own arm list
+and answered one question. What made them proliferate is that measuring a
+scheduling rule needs four things at once --- an arm to switch it on, an
+instance family it actually fires on, a search-shape number and a proof number
+--- and each script had two of the four.
+
+Two modes:
+
+  shape   solve and record search shape *and* the per-rule counters. One pass:
+          the counters are inert (they change no inference and no proof byte),
+          so unlike the STATS=0 / STATS=1 split this replaces, a counter run and
+          a timing run are the same run.
+
+  prove   solve with --prove, then run veripb, and record proof size and
+          verification time.
+
+Four instance sources --- a directory of MiniZinc .dzn RCPSP data, job shops,
+multi-mode .mm files, and the generator --- because no single family exercises
+the whole rule set. Every RCPSP collection in circulation has capacities of
+three and up, so none of them posts a Disjunctive at all; none has a variable
+duration, so none exercises the variable-argument accounting.
+
+Arms are a table, one line each, so adding a rule is adding a line. Arms whose
+flags this binary does not have are skipped and *said to be skipped*, which is
+what makes it safe to point at an older build or at one built before half the
+stack merged.
+
+Examples:
+
+    tools/scheduling_sweep.py --list-arms
+    tools/scheduling_sweep.py --binary build/rcpsp --out shape.jsonl \\
+        --dzn-dir ~/mzn-bench/rcpsp --collections data_bl,data_pack \\
+        --arms ef,ttef,energetic,nfnl --timeout 60 --jobs 8
+    tools/scheduling_sweep.py --binary build/rcpsp --out proofs.jsonl \\
+        --mode prove --generated 'size=10,12;seed=1..10;capacity=3,4' \\
+        --arms ef,ttef --proof-cap-mb 4000
+    tools/scheduling_sweep.py ... --print-jobs > jobs.txt   # for a cluster
+
+See dev_docs/rule-counters.md for what the counter columns mean, and
+tools/README.md for the traps.
+"""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import json
+import os
+import re
+import resource
+import shlex
+import shutil
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+# --- the arm table ---------------------------------------------------------
+#
+# name -> flags. An arm is a *configuration of the solver*, not a rule: several
+# name a rule plus the strengthening that replaces its detection, because that
+# is how the flags work and how a row has to be read.
+#
+# The disjunctive arms carry --unary/--machine themselves. Without them nothing
+# posts a Disjunctive at all on a file-read instance, and the arm would measure
+# an unchanged model very convincingly.
+
+ARMS: dict[str, list[str]] = {
+    # Cumulative. The baseline is time-tabling plus the overload check, both on
+    # by default; "off" therefore means "no energetic rule", not "no rules".
+    "off": [],
+    "elastic": ["--cumulative-elastic-overload"],
+    "kaoc": ["--cumulative-knapsack-overload"],
+    "ef": ["--cumulative-edge-finding"],
+    "ttef": ["--cumulative-time-table-edge-finding"],
+    "energetic": ["--cumulative-energetic-edge-finding"],
+    "nfnl": ["--cumulative-not-first-not-last"],
+    "nfnlpub": ["--cumulative-not-first-not-last-published"],
+    "ttef+nfnl": ["--cumulative-time-table-edge-finding", "--cumulative-not-first-not-last"],
+    "ttef+nfnlpub": ["--cumulative-time-table-edge-finding", "--cumulative-not-first-not-last-published"],
+    "energetic+nfnl": ["--cumulative-energetic-edge-finding", "--cumulative-not-first-not-last"],
+
+    # Disjunctive. Every one of these needs a unary resource to exist.
+    "dj-off": ["--unary", "disjunctive", "--machine", "disjunctive"],
+    "dj-ef": ["--unary", "disjunctive", "--machine", "disjunctive", "--disjunctive-edge-finding"],
+    "dj-ef-lb": ["--unary", "disjunctive", "--machine", "disjunctive", "--disjunctive-edge-finding",
+                 "--disjunctive-edge-finding-lb-only"],
+    "dj-ef-ub": ["--unary", "disjunctive", "--machine", "disjunctive", "--disjunctive-edge-finding",
+                 "--disjunctive-edge-finding-ub-only"],
+    "dj-nfnl": ["--unary", "disjunctive", "--machine", "disjunctive", "--disjunctive-not-first-not-last"],
+    "dj-nfnlpub": ["--unary", "disjunctive", "--machine", "disjunctive",
+                   "--disjunctive-not-first-not-last-published"],
+    "dj-dps": ["--unary", "disjunctive", "--machine", "disjunctive",
+               "--disjunctive-detectable-precedences-set"],
+    "dj-overload": ["--unary", "disjunctive", "--machine", "disjunctive", "--disjunctive-overload"],
+    "dj-overload-ti": ["--unary", "disjunctive", "--machine", "disjunctive", "--disjunctive-overload",
+                       "--disjunctive-overload-certificate", "time-indexed"],
+    "dj-overload-sn": ["--unary", "disjunctive", "--machine", "disjunctive", "--disjunctive-overload",
+                       "--disjunctive-overload-certificate", "sorting-network"],
+    "dj-ef+nfnl": ["--unary", "disjunctive", "--machine", "disjunctive", "--disjunctive-edge-finding",
+                   "--disjunctive-not-first-not-last"],
+    "dj-ef+dps": ["--unary", "disjunctive", "--machine", "disjunctive", "--disjunctive-edge-finding",
+                  "--disjunctive-detectable-precedences-set"],
+}
+
+COUNTER_LINE = re.compile(r"^(cumulative|disjunctive)_([a-z_]+): "
+                          r"calls=(\d+) firings=(\d+) already_true=(\d+) contradictions=(\d+)\s*$")
+STAT_LINE = re.compile(r"^([a-z_ ]+): (.*)$")
+
+# Whole-solve fields worth keeping from --stats, in the order rcpsp prints them.
+WANTED_STATS = ["status", "makespan", "recursions", "propagations", "wall_time_s",
+                "solutions", "critical path", "horizon"]
+
+
+def binary_flags(binary: str) -> set[str]:
+    """Every long option this binary's help mentions."""
+    try:
+        out = subprocess.run([binary, "--help"], capture_output=True, text=True, timeout=60).stdout
+    except (OSError, subprocess.SubprocessError) as e:
+        sys.exit(f"could not run {binary} --help: {e}")
+    return set(re.findall(r"--[a-z0-9-]+", out))
+
+
+def usable_arms(names: list[str], have: set[str]) -> tuple[list[str], dict[str, list[str]]]:
+    """Split the requested arms into the ones this binary can run and the rest.
+
+    Skipping is reported rather than silent: an arm quietly dropped looks
+    exactly like an arm that made no difference.
+    """
+    ok, skipped = [], {}
+    for name in names:
+        missing = [f for f in ARMS[name] if f.startswith("--") and f not in have]
+        if missing:
+            skipped[name] = missing
+        else:
+            ok.append(name)
+    return ok, skipped
+
+
+def instance_jobs(args) -> list[tuple[str, str, list[str]]]:
+    """(source, label, flags naming the instance)."""
+    jobs: list[tuple[str, str, list[str]]] = []
+
+    if args.dzn_dir:
+        root = Path(args.dzn_dir).expanduser()
+        colls = args.collections.split(",") if args.collections else [d.name for d in root.iterdir() if d.is_dir()]
+        for coll in colls:
+            for f in sorted((root / coll).glob("*.dzn")):
+                jobs.append(("dzn", f"{coll}/{f.stem}", ["--dzn", str(f)]))
+
+    for flag, source, pattern in (("--jss", "jss", "*.jss"), ("--mm", "mm", "*.mm")):
+        d = getattr(args, f"{source}_dir")
+        if not d:
+            continue
+        # An instance source is a flag too, and a binary built before the reader
+        # landed would fail every run of it with the same unhelpful message.
+        if flag not in args.have:
+            print(f"skipping --{source}-dir: this binary has no {flag}", file=sys.stderr)
+            continue
+        for f in sorted(Path(d).expanduser().rglob(pattern)):
+            jobs.append((source, f.stem, [flag, str(f)]))
+
+    if args.generated:
+        grid: dict[str, list[str]] = {}
+        for part in args.generated.split(";"):
+            if not part.strip():
+                continue
+            key, _, spec = part.partition("=")
+            values: list[str] = []
+            for piece in spec.split(","):
+                if ".." in piece:
+                    lo, _, hi = piece.partition("..")
+                    values += [str(v) for v in range(int(lo), int(hi) + 1)]
+                else:
+                    values.append(piece)
+            grid[key.strip()] = values
+        keys = sorted(grid)
+
+        def expand(at: int, chosen: list[tuple[str, str]]) -> None:
+            if at == len(keys):
+                label = " ".join(f"{k}={v}" for k, v in chosen)
+                flags: list[str] = []
+                for k, v in chosen:
+                    flags += [f"--{k}", v]
+                jobs.append(("generated", label, flags))
+                return
+            for v in grid[keys[at]]:
+                expand(at + 1, chosen + [(keys[at], v)])
+
+        expand(0, [])
+
+    return jobs
+
+
+def parse_output(text: str) -> tuple[dict, dict]:
+    stats: dict[str, str] = {}
+    rules: dict[str, dict[str, int]] = {}
+    for line in text.splitlines():
+        m = COUNTER_LINE.match(line)
+        if m:
+            which, rule, calls, firings, already, contra = m.groups()
+            rules[f"{which}_{rule}"] = {"calls": int(calls), "firings": int(firings),
+                                        "already_true": int(already), "contradictions": int(contra)}
+            continue
+        m = STAT_LINE.match(line)
+        if m and m.group(1) in WANTED_STATS and m.group(1) not in stats:
+            stats[m.group(1)] = m.group(2).strip()
+    return stats, rules
+
+
+def run_one(args, source: str, label: str, instance_flags: list[str], arm: str) -> dict:
+    scratch = tempfile.mkdtemp(prefix="sweep-")
+    row: dict = {"source": source, "instance": label, "arm": arm, "mode": args.mode,
+                 "timeout_s": args.timeout, "parallel": 1 if args.serial else args.jobs}
+    try:
+        cmd = [os.path.abspath(args.binary), *instance_flags, *ARMS[arm], "--stats",
+               "--timeout", str(args.timeout)]
+        if args.mode == "prove":
+            cmd += ["--prove", "--proof-files-basename", os.path.join(scratch, "p")]
+
+        env = dict(os.environ, GCS_SCHEDULING_RULE_STATS="1")
+        cap = args.proof_cap_mb * 1024 * 1024
+
+        def limit() -> None:
+            # A proof that runs away takes the disk with it: an uncapped rcpsp
+            # --prove on a real Pack instance has written 128 GB in ten minutes.
+            # The run dies with a write error and everything before the cap is
+            # still readable, which is what makes this a cap and not a loss.
+            if args.mode == "prove":
+                resource.setrlimit(resource.RLIMIT_FSIZE, (cap, cap))
+            os.setpgrp()
+
+        started = time.monotonic()
+        try:
+            done = subprocess.run(cmd, capture_output=True, text=True, env=env,
+                                  preexec_fn=limit, timeout=args.timeout * 6)
+            row["solve_wall_s"] = round(time.monotonic() - started, 3)
+            out = done.stdout + done.stderr
+            row["exit"] = done.returncode
+        except subprocess.TimeoutExpired:
+            row["result"] = "harness-timeout"
+            return row
+
+        stats, rules = parse_output(out)
+        row.update({k.replace(" ", "_"): v for k, v in stats.items()})
+        if rules:
+            row["rules"] = rules
+
+        if args.mode == "prove":
+            opb, pbp = Path(scratch, "p.opb"), Path(scratch, "p.pbp")
+
+            # An incomplete proof is not a rejected one, and this is the whole
+            # difference between a harness that reports a finding and one that
+            # cries wolf. A run killed by the file-size cap leaves a truncated
+            # .pbp behind, and a run that hit its own --timeout leaves one with
+            # no conclusion: both are non-empty, both make veripb exit non-zero,
+            # and neither says anything about the solver. Classify them from how
+            # the run ended, and do not check them.
+            if row.get("exit", 0) < 0:
+                killed = -row["exit"]
+                row["result"] = "proof-too-big" if killed == int(signal.SIGXFSZ) else f"killed-by-signal-{killed}"
+                return row
+            if stats.get("status") not in ("optimal", "infeasible", "unsatisfiable", "satisfiable-complete"):
+                row["result"] = stats.get("status", "no-status")
+                return row
+            if not pbp.exists() or pbp.stat().st_size == 0:
+                row["result"] = "no-proof"
+                return row
+            row["opb_bytes"] = opb.stat().st_size
+            row["pbp_bytes"] = pbp.stat().st_size
+            with pbp.open("rb") as fh:
+                row["pbp_lines"] = sum(1 for _ in fh)
+            started = time.monotonic()
+            try:
+                check = subprocess.run([args.veripb, str(opb), str(pbp)], capture_output=True,
+                                       text=True, timeout=args.verify_timeout)
+                row["verify_s"] = round(time.monotonic() - started, 3)
+                row["result"] = "verified" if check.returncode == 0 else "REJECTED"
+                if check.returncode != 0:
+                    row["verify_says"] = (check.stdout + check.stderr).strip()[-400:]
+            except subprocess.TimeoutExpired:
+                row["verify_s"] = round(time.monotonic() - started, 3)
+                row["result"] = "verify-timeout"
+        elif row.get("exit") != 0:
+            row["result"] = "solver-error"
+        else:
+            # A solve that ran out of time ran cleanly; saying "ok" for it would
+            # be true of the process and misleading about the row. Anything
+            # summing these has to filter on one field, so make it this one.
+            row["result"] = stats.get("status", "ok") if stats.get("status") != "optimal" else "ok"
+        return row
+    finally:
+        shutil.rmtree(scratch, ignore_errors=True)
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--binary", default="build/rcpsp", help="the rcpsp example to sweep")
+    p.add_argument("--out", help="JSONL output; appended to, and re-runnable (see --resume)")
+    p.add_argument("--arms", help="comma-separated arm names; default every arm the binary supports")
+    p.add_argument("--list-arms", action="store_true", help="print the arm table and what this binary supports")
+    p.add_argument("--dzn-dir", help="directory of RCPSP .dzn collections")
+    p.add_argument("--collections", help="comma-separated subdirectories of --dzn-dir")
+    p.add_argument("--jss-dir", help="directory of job-shop instances (searched recursively)")
+    p.add_argument("--mm-dir", help="directory of multi-mode .mm instances (searched recursively)")
+    p.add_argument("--generated", help="generator grid, e.g. 'size=10,12;seed=1..10;capacity=3,4'")
+    p.add_argument("--mode", choices=["shape", "prove"], default="shape")
+    p.add_argument("--timeout", type=float, default=60.0, help="solver timeout in seconds")
+    p.add_argument("--verify-timeout", type=float, default=3600.0)
+    p.add_argument("--proof-cap-mb", type=int, default=4000, help="per-run proof file size cap")
+    p.add_argument("--veripb", default="veripb")
+    p.add_argument("--jobs", type=int, default=8)
+    p.add_argument("--serial", action="store_true",
+                   help="one run at a time. Closed counts under a timeout are load-dependent, "
+                        "so a table that reports them wants this; ratios over instances every arm "
+                        "closed do not.")
+    p.add_argument("--resume", action="store_true", help="skip rows already in --out")
+    p.add_argument("--print-jobs", action="store_true",
+                   help="print one command line per run instead of running them, for a cluster scheduler")
+    args = p.parse_args()
+
+    have = args.have = binary_flags(args.binary)
+    requested = args.arms.split(",") if args.arms else list(ARMS)
+    unknown = [a for a in requested if a not in ARMS]
+    if unknown:
+        sys.exit(f"unknown arm(s): {', '.join(unknown)}\nknown: {', '.join(ARMS)}")
+    arms, skipped = usable_arms(requested, have)
+
+    if args.list_arms:
+        for name, flags in ARMS.items():
+            mark = "  " if name in arms else ("--" if name in skipped else "  ")
+            note = f"   [skipped: {' '.join(skipped[name])} not in this binary]" if name in skipped else ""
+            print(f"{mark} {name:18s} {' '.join(flags) or '(defaults only)'}{note}")
+        return 0
+
+    if not args.out:
+        sys.exit("--out is required unless --list-arms is given")
+    for name, missing in skipped.items():
+        print(f"skipping arm {name}: this binary has no {', '.join(missing)}", file=sys.stderr)
+    if not arms:
+        sys.exit("no requested arm is supported by this binary")
+
+    jobs = instance_jobs(args)
+    if not jobs:
+        sys.exit("no instances: give at least one of --dzn-dir, --jss-dir, --mm-dir, --generated")
+
+    done: set[tuple] = set()
+    if args.resume and os.path.exists(args.out):
+        with open(args.out) as fh:
+            for line in fh:
+                try:
+                    r = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                done.add((r.get("source"), r.get("instance"), r.get("arm"), r.get("mode")))
+
+    work = [(s, label, flags, arm) for (s, label, flags) in jobs for arm in arms
+            if (s, label, arm, args.mode) not in done]
+    print(f"{len(work)} runs ({len(jobs)} instances x {len(arms)} arms, {len(done)} already done)",
+          file=sys.stderr)
+
+    if args.print_jobs:
+        for s, label, flags, arm in work:
+            cmd = [os.path.abspath(args.binary), *flags, *ARMS[arm], "--stats", "--timeout", str(args.timeout)]
+            print(f"GCS_SCHEDULING_RULE_STATS=1 {' '.join(shlex.quote(c) for c in cmd)}")
+        return 0
+
+    written = 0
+    with open(args.out, "a", buffering=1) as fh:
+        def emit(row: dict) -> None:
+            nonlocal written
+            fh.write(json.dumps(row) + "\n")
+            written += 1
+
+        if args.serial:
+            for s, label, flags, arm in work:
+                emit(run_one(args, s, label, flags, arm))
+        else:
+            with concurrent.futures.ThreadPoolExecutor(max_workers=args.jobs) as pool:
+                futures = [pool.submit(run_one, args, s, label, flags, arm) for s, label, flags, arm in work]
+                try:
+                    for fut in concurrent.futures.as_completed(futures):
+                        emit(fut.result())
+                except KeyboardInterrupt:
+                    for fut in futures:
+                        fut.cancel()
+                    raise
+
+    print(f"wrote {written} rows to {args.out}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    signal.signal(signal.SIGINT, signal.default_int_handler)
+    sys.exit(main())


### PR DESCRIPTION
**Rebased onto `main` at `58fad258` (2026-09-19)** with the rest of the stack; no conflicts in this PR's own files, and every commit now carries its `Co-Authored-By` trailer. Two statements below were overtaken by the first campaign and are corrected in #840 rather than here: the `ft06` figure needs a branching this PR's arms do not use (see the last section), and the "756 passing tests" count is now 873 with all five branches on current `main`.

**Stacked on #776** (`scheduling-rule-counters`). Review that one first.

Two things: one harness for the sweeps, and a runbook that makes the whole programme runnable on a machine that has nothing but this repository.

## The harness

Measuring one of these rules needs four things at once — an arm to switch it on, an instance family it actually fires on, a search-shape number and a proof number — and the scripts that have accumulated each have two of the four: search shape with arms in a hardcoded `case` that has no entry for the energetic accounting and **none at all for `Disjunctive`**; proof size and verify time with two arms and generated instances only; and neither can read a job shop or a multi-mode instance.

`tools/scheduling_sweep.py` is one harness: an arm table (one line per arm, 23 of them across both globals), four instance sources, and `--mode shape` or `--mode prove`. One JSONL row per (instance, arm) with the search shape, all 21 per-rule counter rows, and for a proving run the `.opb`/`.pbp` sizes, line count, verification time and verdict.

**Shape and counters come off one run**, because the counters are inert — that retires the `STATS=0`/`STATS=1` split.

Four things it does that are easy to get wrong by hand:

- **An arm the binary cannot run is skipped and *said* to be skipped**, so a build from before half the stack merged still runs and reports what it dropped. An arm silently dropped looks exactly like an arm that made no difference.
- **An incomplete proof is not a rejected one.** A run killed by the size cap leaves a truncated `.pbp`; one that hits its timeout leaves one with no conclusion. Both are non-empty and both make `veripb` exit non-zero. They come back as `proof-too-big` and `timeout` and are never checked. *The first cut reported `REJECTED` for a capped run — found by testing it.*
- **Every row records how parallel the sweep was**, since closed counts are load-dependent and ratios are not. `--serial` for when those are the point.
- **Capped proofs and per-run scratch directories**, plus `--resume` for killed cluster jobs and `--print-jobs` for a scheduler.

## The runbook

`dev_docs/cluster-experiments.md` — build, fetch, check, smoke, sweep, what to bring back. Written to be followed start to finish with no access to the machine any of this was developed on, which mattered more than expected: the instance data is not in this repository and should not be, so "run the sweep" was not a runnable instruction anywhere else.

- `tools/fetch_scheduling_instances.bash` — fetches all three families from their upstreams (MiniZinc benchmarks, OR-Library, PSPLIB). Idempotent, prints what it got against what to expect, takes the RCPSP set as a blob-filtered sparse clone (19 MB against a very large repo).
- `tools/check_scheduling_readers.py` — a pre-flight that solves instances with published optima and exits non-zero on disagreement. The runbook says not to skip it: a subtly wrong reader does not crash, it produces a slightly *better* optimum, and both bugs in the multi-mode support showed up only that way.

It also carries the traps that are not obvious from `--help`: `already_true` means different things on different rows; a simulated firing count and a counted one are not the same measurement; the counts are not portable across toolchains, so a table has to name its build; and rebuilding into the tree a sweep is running from mixes two binaries across rows.

## Verified by doing it

Every mode and classification exercised: shape over `data_bl` (80 rows, 21 counter rows each), prove over a generated grid (all `verified`), the cap (`proof-too-big`), a solve timeout in prove mode (`timeout`, not a rejection), `--resume`, `--serial`, `--print-jobs`, and a missing instance source on a binary without `--jss`.

End to end for real: the four branches merge (one conflict — two branches appending test blocks, keep both) giving **756 passing tests**; the fetch script pulls 82 job shops and 1,090 multi-mode instances; the checker agrees with every published optimum it was pointed at.

## One number worth having in advance

`ft06` is the smallest real job shop in the set. Under `--branch dom-then-deg --value-order split` the solver closes it in **55 recursions** with `--disjunctive-edge-finding` and in **35,142,089** without. That is the same rule that looks marginal on generated instances, and it is why the job-shop family was added.

**Corrected after the first campaign:** that pair needs the branching named above, and every arm in this PR's harness runs the default `in-order`/`smallest`, under which the same pair is **1,588** against **5,465,061**. So as written here the headline figure is not reproducible from the harness. #840 adds a `-dd` twin of every arm and puts both pairs in the runbook; all four figures re-measured on current `main` with the harness, exact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
