### PR TITLE
Cumulative: a horizon-free start-checkpoint OPB encoding (#780)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@ Doxyfile
 *.corepb
 # ... except the curated workflow-2 regression cases, which are source, not generated:
 !verified_encodings/scp_cases/*.scp
+# ... and #780's leak-check model, which is source too: it lives beside the
+# recovery it checks rather than in scp_cases, since it drives no cake chain.
+!gcs/constraints/cumulative/*.scp
 # ... and the committed VeriPB smoke fixture used by the Windows CI lane:
 !.github/veripb_smoke/*.opb
 !.github/veripb_smoke/*.pbp

--- a/dev_docs/cumulative-proof-logging.md
+++ b/dev_docs/cumulative-proof-logging.md
@@ -1989,19 +1989,26 @@ recovery is on and can speak about the constraint, and the model's own row
 otherwise --- a variable height or an optional task still falls back, which is
 why the two live side by side rather than one replacing the other.
 
-The time-table overflow contradiction is the first and so far only citer
-through it. On two tasks that must overlap and do not fit, the refutation
-cites the per-time capacity row **once** under `Both` and **not at all** under
-`BothRecovering` --- and the whole proof then verifies against an OPB with
-every `cap_t` row deleted. That is `cumulative_checkpoint_recovery_whole_proof`,
-and it is the first thing in this project to check *sufficiency* rather than
-soundness: what it says is that for that model the certificate stands on the
-start-checkpoint rows alone, which is the end state #780 is walking towards.
+The whole time-table family goes through it: the overflow contradiction and
+both bound pushes. On two tasks that must overlap and do not fit, the
+refutation cites a per-time capacity row **once** under `Both` and **not at
+all** under `BothRecovering` --- and the whole proof then verifies against an
+OPB with every `cap_t` row deleted.
 
-The lane is deliberately narrow. It refuses any model whose proof still cites a
-per-time row, so it can only be pointed at models firing rules that have moved
-over --- today, that rule and no other. Each further citer moved across is
-another model that can be listed there, and when the last one is, that lane is
+That is the `whole` mode of the leak-check lanes, and it is the first thing in
+this project to check *sufficiency* rather than soundness. Everything before it
+asked whether the checkpoint rows say too much, which solution checking
+answers; nothing asked whether they say enough, because nothing derived
+anything from them.
+
+The mode is deliberately narrow: it refuses any model whose proof still cites a
+per-time row, so a model can only go in it once every rule it fires has moved
+over. Two are there --- the minimal two-task overflow, and four tasks with four
+different durations, which fires both bound pushes and exercises the weakening
+path where the candidate set changes from one time point to the next. The third
+case, three tasks whose mandatory parts are all empty so that the overload
+check is what refutes them, stays in `prefix` until the overload certificate
+moves across. When the last citer moves, every case is `whole`, and that is
 what says the time-indexed block can go.
 
 **Transitivity is load-bearing**, which #780 predicted and this confirms:

--- a/dev_docs/cumulative-proof-logging.md
+++ b/dev_docs/cumulative-proof-logging.md
@@ -2358,6 +2358,123 @@ The last row is the case for the whole exercise: 25 MB of per-time
 block, emitted unconditionally, next to 39 lines that say the same
 thing.
 
+### What `StartCheckpoint` saves today, and why the default cannot flip yet
+
+That table is the cost of *adding* the checkpoint block. The question the
+default flip asks is a different one --- what does `StartCheckpoint` save,
+against `TimeIndexed`, on the same model --- and measured, the answer is
+**nothing, until the horizon reaches about `6n^2`**.
+
+Swept with `examples/cumulative --variant`, one generated instance per row,
+counting OPB lines:
+
+| | `H = n` | `H = 2n` | `H = 4n` | `H = 8n` |
+|---|---|---|---|---|
+| `n = 5` | 268 / 384 (1.43x) | 423 / 534 (1.26x) | 733 / 834 (1.14x) | 1,353 / 1,434 (1.06x) |
+| `n = 10` | 809 / 1,345 (1.66x) | 1,419 / 1,945 (1.37x) | 2,639 / 3,145 (1.19x) | 5,079 / 5,545 (1.09x) |
+| `n = 20` | 2,803 / 5,079 (1.81x) | 5,223 / 7,479 (1.43x) | 10,063 / 12,279 (1.22x) | 19,743 / 21,879 (1.11x) |
+| `n = 40` | 10,415 / 19,771 (1.90x) | 20,055 / 29,371 (1.46x) | 39,335 / 48,571 (1.23x) | 77,895 / 86,971 (1.12x) |
+
+(time-indexed / start-checkpoint, and the ratio.) Every entry is above one,
+and the ratio falls towards one as the horizon grows rather than crossing it.
+Pushing the horizon far past anything a real instance would carry finds the
+crossing exactly where the arithmetic says it is:
+
+| | `H` | time-indexed | start-checkpoint | delta | `6n^2` |
+|---|---|---|---|---|---|
+| `n = 10` | 400 | 24,599 | 24,745 | +146 | 600 |
+| `n = 10` | 600 | 36,799 | 36,745 | **-54** | 600 |
+| `n = 20` | 2,400 | 290,783 | 290,679 | **-104** | 2,400 |
+
+**The reason is that the arm does not remove the `O(n x horizon)` part.**
+Decomposing one model by row kind (`n = 20`, `H = 40`) says it plainly:
+
+| | time-indexed | start-checkpoint |
+|---|---|---|
+| `cb` / `ca` / `cact` rows (per `(i, t)`) | 3,396 / 3,396 / 1,742 | 3,396 / 3,396 / 1,698 |
+| `cap_<t>` rows | 44 | **0** |
+| `sb` / `sa` / `sact` rows (per `(i, j)`) | 0 | 1,520 / 1,520 / 780 |
+| `scap_<j>` rows | 0 | 20 |
+
+The per-`(i, t)` flag family is untouched, and it is where essentially all of
+the `O(n x horizon)` lines live: three fully reified flags per task and time
+point, at two reification halves each, is `6nH` rows against the block's `H`
+capacity rows. `StartCheckpoint` drops those `H` rows and adds `6n(n-1) + n`,
+so
+
+    lines(StartCheckpoint) - lines(TimeIndexed)  ~=  6n^2 - H
+
+which is why the delta above is flat in `H` at a fixed `n`, and why the
+crossing sits at `H ~= 6n^2` --- for `n = 40`, a horizon of about 9,600. No
+scheduling instance looks like that: `H` is normally a small multiple of `n`,
+which is the left-hand column of the first table, where the arm is *worst*.
+
+So **flipping the default today would make almost every real model larger**,
+by up to 1.9x at `H = n`. The flip is not blocked on anything about the
+capacity rows --- those are converted, and the progress bar is empty --- it is
+blocked on the per-`(i, t)` flags still being model objects. Minting them
+lazily, under the same keys and labels, is the step that removes the `6nH`
+term and makes the encoding horizon-free in fact rather than only in its
+capacity rows.
+
+### And the proof costs more than the model saves
+
+The OPB is the smaller half of the question, and the answer on the other half
+is worse. The encoding is proof-only --- at every point in the sweep below the
+two arms report *identical* recursions, failures and propagations, as they
+must --- so the whole difference in proof size is proof-logging cost:
+
+| | `H = n` | `H = 2n` | `H = 4n` |
+|---|---|---|---|
+| `n = 5` | 3,827 / 5,275 (1.38x) | 6,947 / 9,109 (1.31x) | 7,627 / 9,789 (1.28x) |
+| `n = 10` | 14,335 / 29,280 (2.04x) | 15,749 / 35,853 (2.28x) | 17,989 / 38,093 (2.12x) |
+| `n = 20` | 3,265 / 206,019 (**63x**) | 367,991 / 683,552 (1.86x) | 377,151 / 692,712 (1.84x) |
+
+(time-indexed / start-checkpoint `.pbp` lines.) This is the `~2m^3` per time
+point from the table above, showing up at the scale of a whole solve for the
+first time. The cache is per *install* --- one `CheckpointRecoveryCache` made
+in `install_propagators` and shared by every citer for the rest of the solve
+--- so a point is recovered once, not once per firing, and this is already the
+amortised figure. What it amortises over is the number of *distinct time
+points cited*, which grows with `H`, so the recovery bill grows about as
+`H * n^3` while the model saving grows as `H - 6n^2`.
+
+The `n = 20`, `H = n` cell is the shape of the problem in one instance rather
+than a freak. That instance is infeasible and refuted at the root in a single
+propagation: time-indexed cites one model capacity row and writes 3,265 lines;
+start-checkpoint has to *derive* that row first, and writes 206,019. Nothing is
+wrong there --- it is `2m^3` at `m = 20`, plus the time-free transitivity pool,
+for a proof that needed one row. It is a reminder that the recovery's cost is
+paid per cited point regardless of how much proof the search itself generates,
+so the ratio is worst exactly where the solver does best.
+
+The doc's original cost argument --- "at `n = 6` over the 60 points a complete
+refutation cites, this is under 30k lines against a 6.7M-line proof" --- holds
+at `n = 6` and does not survive `n = 10`. `2m^3` is not negligible against a
+real proof once `m` is into double figures.
+
+### What the flip actually needs
+
+Three things, and only the first is currently on the plan:
+
+1. The per-`(i, t)` flags minted lazily, which removes the `6nH` term. Without
+   it there is no model saving to weigh against anything.
+2. A cheaper recovery, or a reason to believe the `H * n^3` bill is affordable
+   for the instances that matter. Emitting only the triples the scan resolves
+   against would take a constant factor off; the `m^3` itself is structural.
+3. A rule for *when* to use it, rather than a global default. The encoding wins
+   on the model only at `H >~ 6n^2` and loses on the proof roughly everywhere,
+   so "always" is not the answer that measurement supports, and the shape gate
+   added for declined shapes is already the precedent for choosing per
+   constraint.
+
+None of that reopens what `StartCheckpoint` is for: the 25 MB case above is
+real, and a horizon-free encoding is the only answer to it. It says the flip is
+a measurement to re-take after step 1, not a milestone to tick off after the
+progress bar empties. `examples/cumulative --variant` is how to re-take it ---
+`--tasks` and `--horizon` move `n` and `H` independently, and the search is
+identical across arms, so any difference is the encoding's.
+
 ## Open follow-ups
 - **Cloutier & Quimper's Profile.** The doubly linked list over time points,
   which collapses the runs where the profile is constant and takes the sweep

--- a/dev_docs/cumulative-proof-logging.md
+++ b/dev_docs/cumulative-proof-logging.md
@@ -2453,6 +2453,29 @@ refutation cites, this is under 30k lines against a 6.7M-line proof" --- holds
 at `n = 6` and does not survive `n = 10`. `2m^3` is not negligible against a
 real proof once `m` is into double figures.
 
+### The same thing on real instances
+
+Both tables above are generated instances from `examples/cumulative`, so the
+conclusion is worth a second opinion from a model nobody wrote for this
+measurement. `GCS_CUMULATIVE_ENCODING` applies to any binary, so `examples/rcpsp`
+needs no changes:
+
+| `--size` / `--seed` / `--horizon` | OPB | `.pbp` |
+|---|---|---|
+| 8 / 0 / auto | 1,026 -> 1,597 (1.56x) | 2,044 -> 6,383 (3.12x) |
+| 10 / 0 / auto | 1,462 -> 2,304 (1.58x) | 1,610 -> 5,020 (3.12x) |
+| 12 / 3 / auto | 932 -> 1,528 (1.64x) | 3,549 -> 9,951 (2.80x) |
+| 14 / 0 / auto | 2,660 -> 4,113 (1.55x) | 226,985 -> 282,243 (1.24x) |
+| 10 / 0 / 60 | 5,862 -> 6,624 (1.13x) | 6,322 -> 18,709 (2.96x) |
+| 10 / 0 / 120 | 12,462 -> 13,104 (1.05x) | 12,622 -> 25,009 (1.98x) |
+
+Worse than the generated instances on both counts, and for a reason the
+generated ones cannot show: an RCPSP has *one Cumulative per resource*, so the
+`6n^2` is paid per constraint while the horizon they would each save is shared.
+Several small Cumulatives over a long horizon is the case the checkpoint
+encoding handles least well, and it is also the common one. Even at `H = 12n`
+the model is still 1.05x larger and the proof twice the size.
+
 ### What the flip actually needs
 
 Three things, and only the first is currently on the plan:
@@ -2466,7 +2489,8 @@ Three things, and only the first is currently on the plan:
    on the model only at `H >~ 6n^2` and loses on the proof roughly everywhere,
    so "always" is not the answer that measurement supports, and the shape gate
    added for declined shapes is already the precedent for choosing per
-   constraint.
+   constraint. Note the rule has to be per *constraint* and not per problem:
+   an RCPSP pays the `6n^2` once per resource over one shared horizon.
 
 None of that reopens what `StartCheckpoint` is for: the 25 MB case above is
 real, and a horizon-free encoding is the only answer to it. It says the flip is

--- a/dev_docs/cumulative-proof-logging.md
+++ b/dev_docs/cumulative-proof-logging.md
@@ -2112,9 +2112,11 @@ Run against the bare cumulative lanes, the arm reports the remaining work
 exactly. It began at 11 genuine failures; `cumulative_kaoc` came off when the
 availability lines moved, and `cumulative_edge_finding`, `cumulative_ttef`,
 `cumulative_energetic{,_random}` and `cumulative_nfnl` came off together when
-edge-finding's window rows did. `cumulative_published_nfnl` and its random twin followed.
-What is left is `derived_cumulative` and the two presolver lanes that reach it
---- and see the note below about those failing softly rather than loudly. That list
+edge-finding's window rows did. `cumulative_published_nfnl` and its random twin followed,
+and `derived_cumulative` with the presolver lanes that reach it went last.
+**The list is empty**: every rule is converted, and every lane that exercises one
+runs with the per-time block deleted from the model. That is the condition for
+deleting the block, which is the next step and not this one. That list
 lives in `gcs/CMakeLists.txt` and is #780's progress bar: **when it is empty, the
 time-indexed block can go.**
 
@@ -2254,6 +2256,71 @@ consequences. First, `derived_cumulative`, `inferred_cumulative_presolver` and
 step 9 moves that lookup onto the recovery like every other citer. Second, this
 is a good argument for those lanes keeping assertions about what they infer, and
 not only about whether the proof checks.
+
+### Citing the recovered row: derived Cumulatives, and how a constraint asks another
+
+The last citer, and the only one outside `cumulative.cc`. A derived Cumulative
+adds nothing to the OPB; it establishes its own per-time rows inside the proof,
+from its donors', by a recipe. It found those donors' rows by *label* --- and
+under the start-checkpoint encoding a donor has none, so the recipe declined and
+the whole derived constraint was never installed.
+
+**Why this one needed a mechanism and the others did not.** Every citer so far
+was inside the donor's own propagator, where `capacity_row(t)` closes over the
+constraint's `CumulativeInputs` and recovery cache. A derived Cumulative is set
+up by a presolver, which reaches its donors as `ConstraintID`s and a
+`CumulativeDonorView`, and has no route to either. So the donor has to be able
+to *publish* the ability to derive a row, and the consumer to ask for one by
+constraint identity.
+
+`NamesAndIDsTracker::publish_derived_line_family` /
+`find_or_derive_line_in_family` are that: a constraint registers a deriver for an
+integer-indexed family of lines, a consumer asks for member `t`, and the tracker
+memoises. Cumulative publishes one from an install initialiser --- the earliest
+point with a logger, and before presolvers run (#658) --- over a copy of its
+inputs sharing the same `CheckpointRecoveryCache`, so a row derived through the
+family and one derived by the propagator are the same row, paid for once.
+`derived_cumulative.cc` tries the label first, since where it exists it costs
+nothing and a derivation is `O(n^3)` lines.
+
+**What kind of state this is, since it was worth getting right.** Not
+"constraint data preserved across `clone()`", which is for posted arguments;
+not backtrackable state either. It is the constraint's own mutable,
+non-backtrackable, **per-install** state, made reachable from outside the
+propagator by constraint identity. Per-install is load-bearing rather than
+incidental: everything in it is a position in *one particular proof file*, so
+hanging it off the `Cumulative` object and carrying it across `clone()` --- the
+first design tried here --- would have promoted it to per-*Problem*, and under
+parallel search two threads would then share one memo and cite one proof's line
+numbers in another's. Install runs once per `create_propagators`, so per-install
+is per-solve is per-proof, and both parallel search and an LNS restart with a
+fresh proof get fresh state by construction.
+
+The publication carries one invariant nothing checks: **whatever the deriver
+emits must live at `ProofLevel::Top`.** The memo hands the same line number out
+for the rest of the proof, and a line emitted lower is deleted on backtracking,
+after which the memo is a dangling reference.
+
+**A known wart, recorded rather than fixed.** This is the third variation on "a
+per-solve, constraint-keyed memo of proof lines" in the tracker, beside
+`publish_derived_line` and `boundary_pin_line`, and each arrived for one caller.
+The tracker is meant to provide general facilities rather than a drawer of
+specific ones. #780's step 10 wants a fourth --- the same thing for *flags*
+rather than lines --- and the deliberate decision is to let that one arrive
+before generalising, on the grounds that three examples are what tells you what
+the fourth needs.
+
+**What it costs, which is the real trade.** A derived Cumulative resolves a row
+for every time point in its window up front, so that it can decline cleanly
+rather than install a propagator whose inferences it cannot justify. Each
+recovery is `~2m^3` lines against the per-time block's `O(n)` rows per point, so
+on a wide horizon the derivations can cost more lines than the block they
+replace. Three things bound it: the donor's cache is shared with its own
+propagation, so points it cites anyway are paid once; the window is the derived
+constraint's, not the donor's horizon; and a donor with a variable height or an
+optional task does not qualify for the recovery at all, keeps its block, and is
+found by label as before. Making the resolution lazy would avoid paying for
+points never cited, but would cost the clean decline, which is deliberate.
 
 ### What it costs in lines
 

--- a/dev_docs/cumulative-proof-logging.md
+++ b/dev_docs/cumulative-proof-logging.md
@@ -2110,10 +2110,11 @@ falls back fails it by name.
 
 Run against the bare cumulative lanes, the arm reports the remaining work
 exactly. It began at 11 genuine failures; `cumulative_kaoc` came off when the
-availability lines moved (above), leaving `cumulative_edge_finding`,
-`cumulative_ttef`, `cumulative_energetic{,_random}` (edge-finding's window rows),
-`cumulative_nfnl`, `cumulative_published_nfnl{,_random}` (not-first / not-last),
-and `derived_cumulative` with the two presolver lanes that reach it. That list
+availability lines moved, and `cumulative_edge_finding`, `cumulative_ttef`,
+`cumulative_energetic{,_random}` and `cumulative_nfnl` came off together when
+edge-finding's window rows did. What is left is `cumulative_published_nfnl` and
+its random twin, and `derived_cumulative` with the two presolver lanes that reach
+it. That list
 lives in `gcs/CMakeLists.txt` and is #780's progress bar: **when it is empty, the
 time-indexed block can go.**
 
@@ -2178,6 +2179,43 @@ code is shared, and the non-strengthened per-point branch is exercised whenever 
 coverage rather than in the certificate's. The `elastic` rule set in
 `cumulative_kaoc_test.cc` is used for decline-checks, which is why the fixtures
 there all go on to fire `kaoc` instead. Worth a fixture; nobody has written one.
+
+### Citing the recovered row: edge-finding's window rows
+
+The smallest change of the lot, and the one that bought the most. Edge-finding's
+certificate opens exactly as the overload check's does --- a capacity row summed
+at every time point of the window, against which the contained tasks' guarded
+energy cancels --- so it is the same one-line swap, and it moved five lanes at
+once: `cumulative_edge_finding`, `cumulative_ttef`, `cumulative_energetic` and
+its random twin, and `cumulative_nfnl`. The last of those is not an accident:
+our not-first / not-last is certified by edge-finding's certificate unchanged,
+so converting one converted both. (The *published* detection is not, and is
+still outstanding --- it has its own citer.)
+
+Worth recording, because the handoff for this step said otherwise:
+`window_energy::WindowRows` has nothing to do with it. That structure's
+`std::function<Integer -> ProofLine>` hands back a *task's activity* rows, for a
+caller minting its own, and Disjunctive is its only user. Edge-finding's capacity
+supply is a plain loop over `capacity_lines` like every other citer, and wants
+the same treatment as the rest.
+
+**Four mutation lanes stop discriminating and stay off the arm**, checked one at
+a time: `cumulative_ttef_mutation_{pin,mirror_pin}`,
+`cumulative_nfnl_mutation_roomy_drop` and
+`cumulative_energetic_mutation_mirror_drop_energetic`. All four drop a single row
+or pin, and with the per-time block gone the checkpoint rows relate the starts
+directly --- enough for the wrapping RUP to close without what was dropped, so
+veripb accepts the corrupted proof. They still say what they always said about
+the other encodings, and they are not part of the progress bar. The forward
+`drop_energetic` lane, which is the one #755 cares about, does still
+discriminate and is on the arm.
+
+That is the same hazard the `Both` arm has, arriving now in a place worth
+noticing: the arm that best checks *sufficiency* is also the arm that most
+weakens the mutation lanes, because both effects come from having more in the
+database for unit propagation to reach. Neither arm dominates the other, which is
+why every lane is registered on the arms it still discriminates under, one at a
+time, on evidence.
 
 ### What it costs in lines
 

--- a/dev_docs/cumulative-proof-logging.md
+++ b/dev_docs/cumulative-proof-logging.md
@@ -1885,6 +1885,77 @@ the solver's proof against *cake's* OPB, which has no checkpoint rows
 in it at all --- but that also means they give the new encoding no
 coverage of its own.
 
+### Recovering `C_t` from the checkpoints
+
+The derivation below has been run against real OPBs, with **every `cap_t` row
+deleted from the model**, for `n = 3` to `6` and at every time point the
+encoding writes a row for. That deletion is the point: nothing in it can lean
+on a row the encoding is meant to lose. It is not yet in the solver ---
+`tmp/issue780-recovery/` outside the repo holds the generator that produced
+the proofs, and is the executable spec for the C++.
+
+Fix a time point `t` and let the *candidates* be the tasks with flags at `t`
+(their possible-active windows differ, so this is not every task; a task with
+no flag at `t` is not in `C_t` and takes no part). Write `cb_i`, `ca_i`,
+`cact_i` for the per-time flags and `sb`, `sa`, `sact` for the pairwise ones.
+
+**The argument.** Let `j` be the candidate with the largest start among those
+that have started by `t`. Every candidate `i` active at `t` has `s_i <= t <=
+s_j`, so `sb_{i,j}`; and `s_i + l_i >= t + 1 >= s_j + 1`, so `sa_{i,j}`; so
+`sact_{i,j}`. `C^start_j` then caps exactly the load at `t`. Note `j` need not
+itself be *active* at `t` --- only started --- which is what keeps the case
+split over "started by `t`" rather than over the active set, and it is why the
+walk below never has to know which tasks are running.
+
+**The steps.** Reason-free, at `Top`, all of them:
+
+| step | shape | count | cacheable on |
+|---|---|---|---|
+| totality `sb_{i,j} \/ sb_{j,i}` | one `pol`: the two `[f]` halves, starts cancelling, divide by 2, saturate | `m(m-1)/2` | nothing, time-free |
+| transitivity | one `pol`: two `[r]` halves and one `[f]`, all three starts cancelling | `m(m-1)(m-2)` | nothing, time-free |
+| `ca_{i,t} /\ cb_{j,t} -> sa_{i,j}` | one `pol`: `ca[r] + cb[r] + sa[f]`, saturate at degree 1 | `m(m-1)` | `t` |
+| `e_{i,j} <-> (~cb_{i,t} \/ sb_{i,j})` | two `red` | `m(m-1)` | `t` |
+| `e_{i,j} /\ sb_{j,k} -> e_{i,k}` | one `rup`, on transitivity | `m(m-1)(m-2)` | `t` |
+| `N_k`, `W_{j,k}` | two `red` each | `O(m^2)` | `t` |
+| the scan `A_k` | `rup` per step, resolved by `pol` | `O(m^2)` | `t` |
+| `W_j -> C_t` | `rup` per pair, then one `pol` on `C^start_j` | `O(m^2)` | `t` |
+
+`W_{j,k}` says "`j` has started by `t` and is the latest to have done so among
+the first `k+1` candidates"; `N_k` says none of the first `k+1` has started.
+`A_k : \/_{j<=k} W_{j,k} \/ N_k` is carried up the scan one candidate at a
+time, each step one `rup` per live `W` plus one for `N`, resolved together by a
+single `pol`. `A_{m-1}` is then resolved against the per-case clauses, and the
+target row comes out from behind the fully reified `F_t` the cases were routed
+through --- the issue's guard-relativized rendering of a case split whose
+target is a row rather than a clause.
+
+**Measured**, lines per time point, at every non-trivial `t`:
+
+| `m` | 3 | 4 | 5 | 6 |
+|---|---|---|---|---|
+| lines | 74 | 153 | 280 | 467 |
+
+That is `~2m^3`, against #780's estimate of `4-5 m^2`. Half of it --- the
+transitivity pool --- is time-free and shared by every point; the other half,
+the `e`-lifting rups, is per point because `e` mentions `cb_{i,t}`. Emitting
+only the triples the scan actually resolves against would take a constant
+factor off it. Even unoptimised the cost argument holds with room to spare: at
+`n = 6` over the 60 points a complete refutation cites, this is under 30k lines
+against a 6.7M-line proof.
+
+**Transitivity is load-bearing**, which #780 predicted and this confirms:
+dropping the transitivity pols makes the `e`-lifting rups fail, and with them
+the whole scan. The cyclic tournament is real, and no amount of pairwise
+reasoning gets past it.
+
+**The differential.** The last line of the derivation is a syntactic
+implication check (`ia`) of the model's own `cap_t` row against the recovered
+line. It is what catches a recovery that derived the *wrong* row rather than an
+invalid one: citing `C^start_{j+1}` where the case wanted `C^start_j` still
+produces a valid line, and the implication check is what rejects it. Both that
+corruption and a recovered row claimed one tighter than `cap_t` are caught
+there; only dropping transitivity fails earlier, as an invalid rup.
+
 ### What it costs in lines
 
 The checkpoint block is `6n(n-1) + n` lines --- six per ordered pair

--- a/dev_docs/cumulative-proof-logging.md
+++ b/dev_docs/cumulative-proof-logging.md
@@ -2363,6 +2363,12 @@ The last row is the case for the whole exercise: 25 MB of per-time
 block, emitted unconditionally, next to 39 lines that say the same
 thing.
 
+One correction to how that reads, from the long-task measurements below: the
+25 MB is *not* the per-time capacity rows. It is the per-`(i, t)` flag family,
+which those 39 lines do not replace and which `StartCheckpoint` does not touch.
+The capacity rows are about 9% of such a file. The exercise is still the right
+one; the line it deletes is not the line that makes the file big.
+
 ### Every shape, and what each one took
 
 The recovery was written for constant lengths, heights and capacity and no
@@ -2467,8 +2473,21 @@ illustration: the `_startcheckpoint` lanes stayed green right through it.
 
 That table is the cost of *adding* the checkpoint block. The question the
 default flip asks is a different one --- what does `StartCheckpoint` save,
-against `TimeIndexed`, on the same model --- and measured, the answer is
-**nothing, until the horizon reaches about `6n^2`**.
+against `TimeIndexed`, on the same model.
+
+**Read the next three subsections together, and note which regime each is in.**
+The first two sweep instances whose tasks are short, and find no saving until
+the horizon reaches about `6n^2`. That is a real result about that family, and
+it is *not* the family this encoding exists for --- which is a handful of tasks
+of very long duration, exactly the instances nobody could write an OPB for, and
+so exactly the instances no test or example covered. The third measures that
+regime, and the answer there differs in direction and, far more importantly, in
+what it implicates.
+
+#### Short tasks: no saving until `H ~= 6n^2`
+
+Measured, the answer in this family is **nothing, until the horizon reaches
+about `6n^2`**.
 
 Swept with `examples/cumulative --variant`, one generated instance per row,
 counting OPB lines:
@@ -2514,15 +2533,20 @@ crossing sits at `H ~= 6n^2` --- for `n = 40`, a horizon of about 9,600. No
 scheduling instance looks like that: `H` is normally a small multiple of `n`,
 which is the left-hand column of the first table, where the arm is *worst*.
 
-So **flipping the default today would make almost every real model larger**,
-by up to 1.9x at `H = n`. The flip is not blocked on anything about the
-capacity rows --- those are converted, and the progress bar is empty --- it is
-blocked on the per-`(i, t)` flags still being model objects. Minting them
-lazily, under the same keys and labels, is the step that removes the `6nH`
-term and makes the encoding horizon-free in fact rather than only in its
-capacity rows.
+So **flipping the default would make every model in this family larger**, by up
+to 1.9x at `H = n`. The flip is not blocked on anything about the capacity rows
+--- those are converted, and the progress bar is empty --- it is blocked on the
+per-`(i, t)` flags still being model objects. Minting them lazily, under the
+same keys and labels, is the step that removes the `6nH` term and makes the
+encoding horizon-free in fact rather than only in its capacity rows.
 
-### And the proof costs more than the model saves
+Every instance in that sweep has task lengths drawn from `1 .. 4`, which is the
+bias to hold on to: short tasks are what was solvable under the time-indexed
+encoding, and so the only thing anything in this repository measured, and they
+are not what #780 was opened for. `--max-length` and `--max-start` exist on
+`examples/cumulative` so that the other family can be reached at all.
+
+#### The proof, in that same family
 
 The OPB is the smaller half of the question, and the answer on the other half
 is worse. The encoding is proof-only --- at every point in the sweep below the
@@ -2558,7 +2582,7 @@ refutation cites, this is under 30k lines against a 6.7M-line proof" --- holds
 at `n = 6` and does not survive `n = 10`. `2m^3` is not negligible against a
 real proof once `m` is into double figures.
 
-### The same thing on real instances
+#### The same thing on real instances
 
 Both tables above are generated instances from `examples/cumulative`, so the
 conclusion is worth a second opinion from a model nobody wrote for this
@@ -2581,28 +2605,107 @@ Several small Cumulatives over a long horizon is the case the checkpoint
 encoding handles least well, and it is also the common one. Even at `H = 12n`
 the model is still 1.05x larger and the proof twice the size.
 
+#### Long tasks: the regime this encoding exists for
+
+The instances above are short-tasked because those are the ones that were
+solvable under the time-indexed encoding, which is a selection every measurement
+in this repository inherited. #780 was opened for the opposite case: a few tasks
+of very long duration, where the per-time block is linear in the duration and
+nobody could write the OPB at all, let alone compare anything.
+
+`--max-length` draws the lengths from a wider range and `--max-start` keeps the
+start domain small, which is what separates "expensive to encode" from
+"expensive to solve": a task of duration `D` has a possible-active window of
+about `D` however few start times it can take, so the per-time block is linear
+in `D` while the search stays trivial. Three tasks, nine possible starts,
+`--seed 7`:
+
+| `D` | time-indexed | start-checkpoint | ratio |
+|---|---|---|---|
+| 100 | 1,027 | 980 | 0.954 |
+| 1,000 | 8,725 | 7,976 | 0.914 |
+| 10,000 | 85,663 (8.3 MB) | 77,894 (7.8 MB) | 0.909 |
+| 100,000 | 854,945 (86 MB) | 776,984 (81 MB) | 0.909 |
+| 1,000,000 | 8,547,916 (**881 MB**) | 7,768,028 (**831 MB**) | 0.909 |
+
+**So the encoding is directionally right here and the sweep above does not
+generalise to it** --- `H` is enormous against `6n^2 = 54`, and start-checkpoint
+wins. And it wins by 9%. An 881 MB file becomes an 831 MB file. Whatever made
+the first unwritable makes the second unwritable.
+
+The row-kind decomposition says why, at `D = 10,000`:
+
+| | time-indexed | start-checkpoint |
+|---|---|---|
+| `cb` / `ca` / `cact`, per `(i, t)` | 51,892 / 51,892 / 33,754 | 51,892 / 51,892 / 25,946 |
+| `cap_<t>` | 7,808 | **0** |
+| the entire checkpoint block (`sb`, `sa`, `sact`, `scap_`) | 0 | **66** |
+
+Counting *defining lines* rather than mentions: of the 77,894 lines
+`StartCheckpoint` writes, **77,838 are per-`(i, t)` flag definitions and 56 are
+everything else** --- the whole checkpoint block, the makespan bounds, the lot.
+The flags are **99.9% of the file**.
+
+That is the number to carry. The per-time capacity rows that `StartCheckpoint`
+removes are the 9%; the per-`(i, t)` flags it leaves behind are the 99.9%. In
+general the saving is
+
+    (H - 6n^2) / (6nH + H)  ~=  1/(6n)   for large H
+
+so it is bounded by about `1/(6n)` however long the tasks get, and it *shrinks*
+as tasks are added. The horizon-freedom the encoding was designed for is real
+and is entirely in the 56 lines; none of it has been collected yet, because the
+`6nH` term was never in the capacity rows.
+
+**What step 10 is worth, then, is not a marginal flip.** Minting the per-`(i, t)`
+flags lazily takes the 77,838 out of the model and leaves them to be created in
+the proof only for the `(i, t)` pairs something actually reasons about --- a
+number bounded by search effort rather than by the horizon. Projected on the
+table above, the 831 MB OPB becomes a few kilobytes. That is the whole of #780's
+motivating case, and it is one step away.
+
+(The proof, in this regime, is not the constraint: at `D = 10,000` these solves
+write 42 lines under `TimeIndexed` and 115 under `StartCheckpoint`. The `~2m^3`
+recovery cost is paid per *cited* time point, and an easy instance cites almost
+none. The 2x proof ratios in the short-task family come from search-heavy
+instances, and neither figure generalises to the other regime.)
+
 ### What the flip actually needs
 
-Three things, and only the first is currently on the plan:
+**One thing above all others.** The per-`(i, t)` flags have to stop being model
+objects. They are 99.9% of the OPB in the regime the encoding exists for, and
+until they move, `StartCheckpoint` collects about `1/(6n)` of a win that is
+otherwise nearly total. Every other question below is secondary to it, and two
+of the three are questions only about the short-task family.
 
-1. The per-`(i, t)` flags minted lazily, which removes the `6nH` term. Without
-   it there is no model saving to weigh against anything.
-2. A cheaper recovery, or a reason to believe the `H * n^3` bill is affordable
-   for the instances that matter. Emitting only the triples the scan resolves
-   against would take a constant factor off; the `m^3` itself is structural.
-3. A rule for *when* to use it, rather than a global default. The encoding wins
-   on the model only at `H >~ 6n^2` and loses on the proof roughly everywhere,
-   so "always" is not the answer that measurement supports, and the shape gate
-   added for declined shapes is already the precedent for choosing per
-   constraint. Note the rule has to be per *constraint* and not per problem:
-   an RCPSP pays the `6n^2` once per resource over one shared horizon.
+1. **The per-`(i, t)` flags minted lazily**, which removes the `6nH` term. This
+   is not a prerequisite for a marginal flip --- it is where the benefit is.
+   831 MB to a few kilobytes, projected on the long-task table above.
+2. A rule for *when* to use it, rather than a global default. On short tasks the
+   encoding wins on the model only at `H >~ 6n^2` and loses on the proof; on
+   long ones it wins outright. So "always" is not what today's measurement
+   supports, and the shape gate is already the precedent for choosing per
+   constraint --- and per *constraint*, not per problem, an RCPSP paying the
+   `6n^2` once per resource over one shared horizon. **Re-take this after (1):**
+   the flags dominate both arms today, so every ratio measured now is mostly
+   measuring something neither encoding is responsible for.
+3. A cheaper recovery, if the `~2m^3` per cited point turns out to bite. It does
+   in the short-task family (2x proofs at `n = 10`), and it does not in the
+   long-task one (42 lines against 115), because the bill is per *cited* time
+   point and an easy instance cites almost none. Emitting only the triples the
+   scan resolves against would take a constant factor off; the `m^3` is
+   structural.
 
-None of that reopens what `StartCheckpoint` is for: the 25 MB case above is
-real, and a horizon-free encoding is the only answer to it. It says the flip is
-a measurement to re-take after step 1, not a milestone to tick off after the
-progress bar empties. `examples/cumulative --variant` is how to re-take it ---
-`--tasks` and `--horizon` move `n` and `H` independently, and the search is
-identical across arms, so any difference is the encoding's.
+None of this reopens what `StartCheckpoint` is for --- it sharpens it. The 25 MB
+case is real, a horizon-free encoding is the only answer to it, and the work so
+far has correctly moved every *rule* and every *shape* off the per-time capacity
+rows. What it has not yet done is make a single unwritable OPB writable, because
+the capacity rows were never where the size was.
+
+`examples/cumulative --variant` is how to re-take any of it. `--tasks` and
+`--horizon` move `n` and `H`; `--max-length` and `--max-start` reach the
+long-task family and keep it solvable while doing so. The search is identical
+across arms, so any difference is the encoding's.
 
 ## Open follow-ups
 - **Cloutier & Quimper's Profile.** The doubly linked list over time points,

--- a/dev_docs/cumulative-proof-logging.md
+++ b/dev_docs/cumulative-proof-logging.md
@@ -2109,13 +2109,17 @@ that the OPB contains *no* `cap_` row and does contain `scap_` ones. A model tha
 falls back fails it by name.
 
 Run against the bare cumulative lanes, the arm reports the remaining work
-exactly: 57 of 70 pass, and the 11 genuine failures are `cumulative_kaoc`
-(the knapsack / elastic availability lines), `cumulative_edge_finding`,
+exactly. It began at 11 genuine failures; `cumulative_kaoc` came off when the
+availability lines moved (above), leaving `cumulative_edge_finding`,
 `cumulative_ttef`, `cumulative_energetic{,_random}` (edge-finding's window rows),
 `cumulative_nfnl`, `cumulative_published_nfnl{,_random}` (not-first / not-last),
 and `derived_cumulative` with the two presolver lanes that reach it. That list
 lives in `gcs/CMakeLists.txt` and is #780's progress bar: **when it is empty, the
 time-indexed block can go.**
+
+Those lanes fail by *aborting*, not by a quiet mismatch: they verify inline, so
+the harness throws `UnexpectedException{"veripb verification failed"}` the moment
+a pol comes up short of supply. Loud, and with the offending proof line named.
 
 Two lanes are off the arm for a different reason and are not part of the bar:
 `cumulative_optional_mutation_wrong_task` and
@@ -2126,6 +2130,54 @@ propagation to reach. They are not unconverted; the arm just cannot hold them.
 The arm is not vacuous on the lanes that are on it: under it, 59 of
 `cumulative_test`'s 77 proofs and 37 of `cumulative_overload_test`'s 115 contain
 no `cap_` row at all.
+
+### Citing the recovered row: the elastic and knapsack availability lines
+
+`(TTHE-OC)` and `(KAOC)` cap what a window supplies one time point at a time,
+which is why their certificate sums a *line per time point* rather than one bulk
+supply term. Each of those lines is built from the capacity row at `t`, with
+every compulsory contribution pinned off it and every term that is not a
+contained task's optional one weakened away, and then --- where the conflict
+needs it --- put through the subset-sum strengthening.
+
+So unlike the overload check, which sums rows straight into one pol, this uses
+the row as the *base of a per-point sub-derivation*. That turns out not to
+matter: a recovered row is the same inequality as the model's, over the same
+candidates at `t` and the same activity flags, so the pins land on the same terms
+and the weakenings remove the same ones. The change is the same one-line swap.
+
+Two things about the loop are worth writing down, because both are easy to get
+wrong in the direction of "tidier but different".
+
+**The row lookup is also the "does the encoding say anything about `t`" test**,
+and it has to stay above the horizontally elastic branch even though that branch
+does not use the row. Moving it below --- which is tempting, since under the
+recovery *asking is what derives the row*, and a point that takes the elastic
+branch has then paid for a row it never cites --- would let a time point with no
+row take that branch, where today it is skipped outright. That changes what
+`pol_supply` accumulates. The cost of leaving it where it is is bounded: rows are
+cached per time point for the whole constraint. It was not worth changing
+behaviour on a branch no fixture currently reaches.
+
+**`pol_supply` is cross-checked against what the detection computed**, and
+throws a `ProofError` if they disagree. That is the backstop that makes the
+paragraph above a matter of tidiness rather than of soundness --- but it is a
+backstop, not a reason to lean on it.
+
+All nine `cumulative_kaoc_mutation_*` lanes still discriminate under the
+start-checkpoint arm and are registered there. `capacity` is the one that earns
+it: it omits a row from a per-time availability line, which on that arm is a
+recovered row, so it is the negative test over exactly the path this moved.
+
+**A coverage gap this turned up, which predates it.** `(TTHE-OC)` --- the
+elastic cap with *no* time point strengthened --- is never fired by any lane in
+the suite, under any encoding: sweeping every cumulative test binary for the
+rule label finds `oc`, `ttoc` and `kaoc` and never `ttheoc`. The certificate
+code is shared, and the non-strengthened per-point branch is exercised whenever a
+`kaoc` firing leaves some points unstrengthened, so this is a gap in *detection*
+coverage rather than in the certificate's. The `elastic` rule set in
+`cumulative_kaoc_test.cc` is used for decline-checks, which is why the fixtures
+there all go on to fire `kaoc` instead. Worth a fixture; nobody has written one.
 
 ### What it costs in lines
 

--- a/dev_docs/cumulative-proof-logging.md
+++ b/dev_docs/cumulative-proof-logging.md
@@ -2475,6 +2475,12 @@ That table is the cost of *adding* the checkpoint block. The question the
 default flip asks is a different one --- what does `StartCheckpoint` save,
 against `TimeIndexed`, on the same model.
 
+> **All of the model measurements below were taken while the per-`(i, t)` flags
+> were still OPB rows, and step 10 has since moved them into the proof. They are
+> kept because the reasoning is what led to step 10 and the failure mode is worth
+> recognising --- but for what the encoding costs *now*, skip to "After step 10:
+> no crossover left". The proof measurements still stand.**
+
 **Read the next three subsections together, and note which regime each is in.**
 The first two sweep instances whose tasks are short, and find no saving until
 the horizon reaches about `6n^2`. That is a real result about that family, and
@@ -2484,7 +2490,7 @@ so exactly the instances no test or example covered. The third measures that
 regime, and the answer there differs in direction and, far more importantly, in
 what it implicates.
 
-#### Short tasks: no saving until `H ~= 6n^2`
+#### Short tasks: no saving until `H ~= 6n^2` (superseded)
 
 Measured, the answer in this family is **nothing, until the horizon reaches
 about `6n^2`**.
@@ -2760,6 +2766,41 @@ sign bit in and shifts every weight. That keeps the three-row form and makes the
 recovery decline; `prepare()` decides it once for the whole constraint, a
 mixture not being available.
 
+#### After step 10: no crossover left
+
+With the per-`(i, t)` flags out of the model the whole picture changes, and the
+two subsections above are superseded on the model side. Re-taken on the same
+instances, OPB lines, time-indexed against start-checkpoint:
+
+| | `H = n` | `H = 2n` | `H = 4n` | `H = 8n` |
+|---|---|---|---|---|
+| `n = 5` | 268 / 150 (0.56) | 423 / 150 (0.35) | 733 / 150 (0.20) | 1,353 / 150 (0.11) |
+| `n = 10` | 809 / 595 (0.74) | 1,419 / 595 (0.42) | 2,639 / 595 (0.23) | 5,079 / 595 (0.12) |
+| `n = 20` | 2,803 / 2,385 (0.85) | 5,223 / 2,385 (0.46) | 10,063 / 2,385 (0.24) | 19,743 / 2,385 (0.12) |
+| `n = 40` | 10,415 / 9,565 (0.92) | 20,055 / 9,565 (0.48) | 39,335 / 9,565 (0.24) | 77,895 / 9,565 (0.12) |
+
+**Smaller at every point, and the start-checkpoint column is constant in `H`**,
+which is what an `O(n^2)` encoding is supposed to look like and what it never
+looked like while the flags were still model objects. The `6n^2 - H` arithmetic
+above was correct about the encoding as it then stood, and it was measuring a
+term that belonged to neither encoding's capacity rows.
+
+On the long-task instances both halves are now flat:
+
+| `D` | time-indexed opb / pbp | start-checkpoint opb / pbp |
+|---|---|---|
+| 1,000 | 8,725 / 42 | 56 / 133 |
+| 10,000 | 85,663 / 42 | 56 / 133 |
+| 100,000 | 854,945 / 42 | 56 / 133 |
+| 1,000,000 | 8,547,916 (881 MB) / 42 | **56 / 133** |
+
+**What has not changed is the proof on search-heavy instances.** Where rules
+fire at nearly every time point the ratio is what it was --- 1.36 at `n = 5`,
+2.36 at `n = 10`, 1.87 at `n = 20` --- because those proofs are dominated by
+the recovery's `~2m^3` per cited point and never were dominated by flag
+definitions. That is the one cost the encoding still carries, and the one open
+question for the flip.
+
 ### What the flip actually needs
 
 **One thing above all others.** The per-`(i, t)` flags have to stop being model
@@ -2768,22 +2809,22 @@ until they move, `StartCheckpoint` collects about `1/(6n)` of a win that is
 otherwise nearly total. Every other question below is secondary to it, and two
 of the three are questions only about the short-task family.
 
-1. **The per-`(i, t)` flags out of the model**, which removes the `6nH` term.
-   Done: 881 MB to 12 KB, measured, in "Step 10" above. What is left of it is
-   making the definitions *lazy* so the proof does not inherit the cost.
-2. A rule for *when* to use it, rather than a global default. On short tasks the
-   encoding wins on the model only at `H >~ 6n^2` and loses on the proof; on
-   long ones it wins outright. So "always" is not what today's measurement
-   supports, and the shape gate is already the precedent for choosing per
-   constraint --- and per *constraint*, not per problem, an RCPSP paying the
-   `6n^2` once per resource over one shared horizon. **Re-take this after (1):**
-   the flags dominate both arms today, so every ratio measured now is mostly
-   measuring something neither encoding is responsible for.
-3. A cheaper recovery, if the `~2m^3` per cited point turns out to bite. It does
-   in the short-task family (2x proofs at `n = 10`), and it does not in the
-   long-task one (42 lines against 115), because the bill is per *cited* time
-   point and an easy instance cites almost none. Emitting only the triples the
-   scan resolves against would take a constant factor off; the `m^3` is
+1. ~~The per-`(i, t)` flags out of the model~~ --- **done**, definitions and
+   all. 881 MB of OPB to 56 lines, and the proof flat too: see "After step 10"
+   above. There is no crossover left on the model side.
+2. A rule for *when* to use it, rather than a global default --- **if one is
+   still wanted**. Re-taken after (1), the model answer is "always": smaller at
+   every point measured, and constant in the horizon. What is left to weigh is
+   the proof, which is 1.3-2.4x on search-heavy short-task instances and flat on
+   long ones. If that is judged acceptable the flip is unconditional; if not,
+   the rule has to be per *constraint* rather than per problem, an RCPSP paying
+   the `6n^2` once per resource over one shared horizon.
+3. A cheaper recovery, if the `~2m^3` per cited point turns out to bite. **This
+   is now the only cost the encoding still carries**, step 10 having removed the
+   other. It bites in the short-task family (2.4x proofs at `n = 10`) and not in
+   the long-task one (42 lines against 133), because the bill is per *cited*
+   time point and an easy instance cites almost none. Emitting only the triples
+   the scan resolves against would take a constant factor off; the `m^3` is
    structural.
 
 None of this reopens what `StartCheckpoint` is for --- it sharpens it. The 25 MB

--- a/dev_docs/cumulative-proof-logging.md
+++ b/dev_docs/cumulative-proof-logging.md
@@ -2003,13 +2003,12 @@ anything from them.
 
 The mode is deliberately narrow: it refuses any model whose proof still cites a
 per-time row, so a model can only go in it once every rule it fires has moved
-over. Two are there --- the minimal two-task overflow, and four tasks with four
-different durations, which fires both bound pushes and exercises the weakening
-path where the candidate set changes from one time point to the next. The third
-case, three tasks whose mandatory parts are all empty so that the overload
-check is what refutes them, stays in `prefix` until the overload certificate
-moves across. When the last citer moves, every case is `whole`, and that is
-what says the time-indexed block can go.
+over. Two went in with the time-table family --- the minimal two-task overflow,
+and four tasks with four different durations, which fires both bound pushes and
+exercises the weakening path where the candidate set changes from one time point
+to the next --- and the third, three tasks whose mandatory parts are all empty so
+that the overload check is what refutes them, joined them when that check moved
+across (below).
 
 **Transitivity is load-bearing**, which #780 predicted and this confirms:
 dropping the transitivity pols makes the `e`-lifting rups fail, and with them
@@ -2023,6 +2022,66 @@ invalid one: citing `C^start_{j+1}` where the case wanted `C^start_j` still
 produces a valid line, and the implication check is what rejects it. Both that
 corruption and a recovered row claimed one tighter than `cap_t` are caught
 there; only dropping transitivity fails earlier, as an invalid rup.
+
+### Citing the recovered row: the overload check's window
+
+The overload check's `(OC)`/`(TTOC)` certificate opens by summing a capacity row
+at *every time point of the window* before the contained tasks' energy cancels
+against it. Moving it over is the same one-line change as the time-table
+family's --- it reads `capacity_row(t)` instead of `capacity_lines` --- but it is
+the first citer that wants a row at more than one point, and so the first place
+the recovery is asked for many rows at once.
+
+Two things make that cheaper than the per-point cost suggests. The rows are
+keyed on `t` alone and cached for the constraint, so overlapping windows share
+them: three firings on `cumulative_overload_enum_f1_twin` over `[2,7)`, `[1,6)`
+and `[1,5)` are fourteen row citations across six distinct time points, and only
+the first citation of each point pays anything. And the rows live at
+`ProofLevel::Top`, so backtracking does not lose them and a window re-derived at
+another node pays nothing either.
+
+The cancellation is unaffected by which of the two produced the row, because a
+recovered row is the *same inequality* as the model's: the encoding writes
+`Sum_i h_i * cact_{i,t} <= capacity` over the tasks with a flag at `t`, and the
+recovery's target is built over exactly that candidate set, from exactly those
+flags. Where the model writes no row at all --- no task can be active at `t` ---
+the recovery returns nullopt on the same condition, so the two agree on the
+empty case too.
+
+`checkpoint_recovery_overload.scp` is `whole` from here, and a fourth case,
+`checkpoint_recovery_ttoc.scp`, goes in beside it for the other arm. That one is
+built so that `(OC)` alone cannot refute it: capacity 3 over `[0,4)`, contained
+tasks carrying `6 + 6 = 12` against a supply of `12`, and a task the window does
+not contain whose mandatory part `[3,4)` at height 2 is what tips it to `14 >
+12`. So it fires `(TTOC)` and nothing weaker, and it passes `whole` --- the
+profile-strengthened certificate, too, stands with every `cap_t` row deleted.
+
+All four registered cases are now `whole`, which says something narrower than it
+looks: the *default* rule set --- time-tabling, the overload check, and its
+`(TTOC)` strengthening --- is fully converted, and a default-rules model's whole
+refutation now stands with every `cap_t` row deleted. It does not say the
+time-indexed block can go.
+
+The three overload mutation lanes (`energy`, `capacity`, `window`) are twinned
+onto the recovering arm at the same time, having been checked one at a time to
+still fail there. `capacity` is the one that matters for this step: it omits a
+row from the window supply, which is now a *recovered* row rather than a model
+one, so without the twin the recovering arm would have no negative test over the
+path this moved.
+
+**The bar has run out of road here, and that is worth stating plainly.** The
+citers that remain --- the elastic and knapsack availability lines,
+edge-finding's window rows, published not-first / not-last --- all sit behind
+`CumulativeRules` fields that are off by default, and the leak check's vehicle is
+an `.scp` model run through `glasgow_scp_solver`, which builds a plain
+`Cumulative` and has no flag for the rules. So no case that *could* stay in
+`prefix` and mark them outstanding can be written in this vehicle at all: the
+next rule to move over has no test that can express its own completion. Closing
+that needs either a way to select rules from the scp path, or the same
+strip-and-recheck applied to the proofs a C++ lane writes under
+`GCS_PRESERVE_PROOF_FILES` --- 34 of `cumulative_overload_test`'s 115 proofs
+already run the recovery, so the material is there. Until one exists, the
+remaining steps are tracked by #780 and not by this bar.
 
 ### What it costs in lines
 

--- a/dev_docs/cumulative-proof-logging.md
+++ b/dev_docs/cumulative-proof-logging.md
@@ -1855,8 +1855,9 @@ enumeration lane. It also checks that every new flag is UP-derivable
 from a full assignment, which the same rule demands.
 
 It cannot check *sufficiency* --- that the checkpoints imply the
-per-time rows --- because nothing derives from them. That gap is not
-theoretical, and the asymmetry is sharp. Four deliberate corruptions of
+per-time rows --- because nothing derives from them. (Under
+`BothRecovering`, where something does, see the whole-proof lane below.) That
+gap is not theoretical, and the asymmetry is sharp. Four deliberate corruptions of
 the encoding, run against `cumulative_constraint`,
 `cumulative_optional_constraint_enumerate`, `cumulative_overload` and
 `derived_cumulative`:
@@ -1901,9 +1902,9 @@ coverage of its own.
 The derivation below has been run against real OPBs, with **every `cap_t` row
 deleted from the model**, for `n = 3` to `6` and at every time point the
 encoding writes a row for. That deletion is the point: nothing in it can lean
-on a row the encoding is meant to lose. It is not yet in the solver ---
-`tmp/issue780-recovery/` outside the repo holds the generator that produced
-the proofs, and is the executable spec for the C++.
+on a row the encoding is meant to lose. `tmp/issue780-recovery/` outside the
+repo holds the generator that produced those first proofs, and was the
+executable spec for the C++ below.
 
 Fix a time point `t` and let the *candidates* be the tasks with flags at `t`
 (their possible-active windows differ, so this is not every task; a task with
@@ -1979,6 +1980,29 @@ OPB with every per-time capacity row stripped out --- the only thing that says
 the recovery is not quietly closing one of its rups against the very row it
 claims to be deriving. Both fail loudly if the recovery stops running at all,
 rather than passing vacuously.
+
+### Citing the recovered row: the time-table overflow contradiction
+
+`propagate_cumulative` has one accessor, `capacity_row(t)`, for the row saying
+the load at `t` is within the capacity. It returns the recovered row where the
+recovery is on and can speak about the constraint, and the model's own row
+otherwise --- a variable height or an optional task still falls back, which is
+why the two live side by side rather than one replacing the other.
+
+The time-table overflow contradiction is the first and so far only citer
+through it. On two tasks that must overlap and do not fit, the refutation
+cites the per-time capacity row **once** under `Both` and **not at all** under
+`BothRecovering` --- and the whole proof then verifies against an OPB with
+every `cap_t` row deleted. That is `cumulative_checkpoint_recovery_whole_proof`,
+and it is the first thing in this project to check *sufficiency* rather than
+soundness: what it says is that for that model the certificate stands on the
+start-checkpoint rows alone, which is the end state #780 is walking towards.
+
+The lane is deliberately narrow. It refuses any model whose proof still cites a
+per-time row, so it can only be pointed at models firing rules that have moved
+over --- today, that rule and no other. Each further citer moved across is
+another model that can be listed there, and when the last one is, that lane is
+what says the time-indexed block can go.
 
 **Transitivity is load-bearing**, which #780 predicted and this confirms:
 dropping the transitivity pols makes the `e`-lifting rups fail, and with them

--- a/dev_docs/cumulative-proof-logging.md
+++ b/dev_docs/cumulative-proof-logging.md
@@ -1781,6 +1781,127 @@ this keeps a flat array plus the incremental bitset (their Algorithm 3 shift-or)
 per time point. Same trade as #742 for edge-finding's scan, and the same answer
 --- what is missing is propagation performance, not proof content.
 
+## The start-checkpoint encoding, beside the time-indexed one (#780)
+
+The OPB above is `O(n x horizon)` and is paid unconditionally, before
+search, whether or not anything cites it. There is another encoding of
+the same constraint that is `O(n^2)` and free of the horizon: check the
+capacity only at the time points that are the *start of some task*.
+
+```
+before_{i,j} <-> s_i <= s_j
+after_{i,j}  <-> s_i + l_i >= s_j + 1
+active_{i,j} <-> before_{i,j} /\ after_{i,j}   [ /\ present_i ]
+
+C^start_j :  Sum_i h_i * active_{i,j}  <=  capacity
+```
+
+It says the same thing, because the load profile is a step function
+that only rises at the start of a task which could occupy the resource:
+a time point over capacity is dominated by the last such start at or
+before it, so checking every start checks every peak. Lengths, heights
+and the capacity are all non-negative already, so a checkpoint with
+nothing active is *satisfied* rather than merely vacuous.
+
+`CumulativeEncoding` selects which of the two is written.
+`TimeIndexed` is the per-time family alone and is the default;
+`Both` writes the checkpoints beside it. Nothing derives anything from
+the checkpoints yet, so `Both` changes no inference and no certificate
+--- deriving `C_t` from `C^start_*` and then dropping the per-time
+family is the rest of #780. A `StartCheckpoint` arm cannot exist before
+that recovery does, since an unconverted inference would have no
+per-time row left to cite.
+
+### Two details that are easy to get wrong
+
+**The diagonal.** `before_{j,j}` is a tautology and `after_{j,j}`
+reduces to `l_j >= 1`, so what is left of `active_{j,j}` is that
+conjunct and the presence. Both have to stay conjuncts: a bare `h_j` on
+the row charges a task for a resource it never takes when its length
+turns out to be zero or it turns out to be absent. Where *neither* says
+anything --- a constant length, which is at least 1 for a task that can
+raise the profile, and no presence --- the term genuinely is
+unconditional and goes on the row as itself, with no flag minted. That
+is what a nullopt from `pair_active_flag_key` means on a diagonal, and
+it is a different thing from what it means off one.
+
+**Which tasks get a checkpoint.** Sufficiency needs one at every task
+that can have positive height *and* positive duration, which is exactly
+`_active_tasks`. A checkpoint at an absent or zero-length task is
+harmless --- its start is still *some* time point, and the capacity
+holds at every time point --- it simply does not count towards
+sufficiency.
+
+### What running both arms checks, and what it cannot
+
+Every cumulative test lane is registered twice, the twin under
+`GCS_CUMULATIVE_ENCODING=both` in its own working directory (see
+`add_cumulative_test` in `gcs/CMakeLists.txt`). The twin's value is
+*soundness*: veripb's `solx` rule propagates the logged assignment and
+then requires every constraint in the database to be satisfied, so a
+checkpoint row that says too much is a solution veripb refuses, on any
+enumeration lane. It also checks that every new flag is UP-derivable
+from a full assignment, which the same rule demands.
+
+It cannot check *sufficiency* --- that the checkpoints imply the
+per-time rows --- because nothing derives from them. That gap is not
+theoretical, and the asymmetry is sharp. Four deliberate corruptions of
+the encoding, run against `cumulative_constraint`,
+`cumulative_optional_constraint_enumerate`, `cumulative_overload` and
+`derived_cumulative`:
+
+| corruption | direction | caught |
+|---|---|---|
+| diagonal as a bare constant | row too strong | 4 of 4 |
+| off-diagonal `active` without the presence conjunct | row too strong | 2 of 4 |
+| `after_{i,j}` off by one, task counted one tick long | row too strong | 4 of 4 |
+| `after_{i,j}` off by one, task counted one tick short | row too **weak** | **0 of 4** |
+
+Anything that makes a checkpoint row weaker is invisible until an
+inference tries to derive something from it. Sufficiency gets its first
+real test when the time-table overflow contradiction moves over.
+
+### What having both arms costs
+
+More model is more for unit propagation to reach, so a certificate step
+that was load-bearing against the per-time family alone need not be
+against the two together. Three mutation lanes ---
+`cumulative_published_nfnl_mutation_drop`,
+`cumulative_optional_mutation_wrong_task` and
+`cumulative_optional_mutation_emit_nothing` --- write corrupted proofs
+that veripb rejects under `TimeIndexed` and *accepts* under `Both`. In
+the published not-first / not-last case the checkpoints put back enough
+for the wrapping RUP to close without the dropped contiguity row; in
+the presence-falsification cases they relate the falsified task's start
+to every other task's directly, which is enough to close without the
+chain. Those three are registered bare rather than twinned. Every other
+mutation lane still discriminates under both arms.
+
+The general form of the hazard is worth stating plainly: while both
+encodings stand, an honest certificate developed under `Both` has been
+checked more weakly than one developed under `TimeIndexed`. The five
+`scp_chain_cumulative*` cases are a partial hedge, since they verify
+the solver's proof against *cake's* OPB, which has no checkpoint rows
+in it at all --- but that also means they give the new encoding no
+coverage of its own.
+
+### What it costs in lines
+
+The checkpoint block is `6n(n-1) + n` lines --- six per ordered pair
+(three flags at two reification halves each) and one row per task ---
+and is flat in the horizon. Measured through `fzn-glasgow --prove`:
+
+| | time-indexed | with checkpoints | delta |
+|---|---|---|---|
+| `n = 6`, `H = 50` | 2,086 lines | 2,272 | +186 |
+| `n = 6`, `H = 800` | 33,314 lines | 33,500 | +186 |
+| `n = 3`, `S = 9`, `D = 100` | 2,079 lines / 261 KB | 2,118 | +39 |
+| `n = 3`, `S = 9`, `D = 10000` | 190,179 lines / **25 MB** | 190,218 | +39 |
+
+The last row is the case for the whole exercise: 25 MB of per-time
+block, emitted unconditionally, next to 39 lines that say the same
+thing.
+
 ## Open follow-ups
 - **Cloutier & Quimper's Profile.** The doubly linked list over time points,
   which collapses the runs where the profile is constant and takes the sweep

--- a/dev_docs/cumulative-proof-logging.md
+++ b/dev_docs/cumulative-proof-logging.md
@@ -2114,9 +2114,28 @@ availability lines moved, and `cumulative_edge_finding`, `cumulative_ttef`,
 `cumulative_energetic{,_random}` and `cumulative_nfnl` came off together when
 edge-finding's window rows did. `cumulative_published_nfnl` and its random twin followed,
 and `derived_cumulative` with the presolver lanes that reach it went last.
-**The list is empty**: every rule is converted, and every lane that exercises one
-runs with the per-time block deleted from the model. That is the condition for
-deleting the block, which is the next step and not this one. That list
+**The list is empty** --- every rule is converted, and every lane that exercises
+one runs green with the per-time block deleted from the model.
+
+Read that precisely: every *rule*, not every *shape*. `capacity_row` still falls
+back to the model row for a Cumulative the recovery cannot speak about --- a
+variable length, a variable height, a variable capacity, an optional task ---
+and those keep the block and use it for everything. It is not a corner: **146 of
+the 424 proofs** the cumulative test binaries write under this arm still contain
+`cap_` rows, concentrated in `cumulative_overload_test` (83 of 115) and
+`cumulative_optional_test` (18 of 35). So the block cannot be deleted, only
+skipped where the recovery reaches.
+
+Two things follow for the default flip. The checkpoint block is **not**
+shape-gated on emission, so under this arm a non-qualifying constraint gets
+*both*: a variable-duration model measures 146 OPB lines against the
+time-indexed encoding's 105. Gating the checkpoint block on
+`cumulative_shape_supports_checkpoint_recovery` is a prerequisite for flipping
+the default, not an optimisation. And extending the recovery to those shapes is
+what would let the block go entirely --- a variable length moves the diagonal
+off the row and onto a flag, a variable height replaces a coefficient with a bit
+sum, a presence adds a conjunct to every activity flag, and a variable capacity
+is not written down anywhere yet. That list
 lives in `gcs/CMakeLists.txt` and is #780's progress bar: **when it is empty, the
 time-indexed block can go.**
 

--- a/dev_docs/cumulative-proof-logging.md
+++ b/dev_docs/cumulative-proof-logging.md
@@ -1805,12 +1805,13 @@ nothing active is *satisfied* rather than merely vacuous.
 
 `CumulativeEncoding` selects which of the two is written.
 `TimeIndexed` is the per-time family alone and is the default;
-`Both` writes the checkpoints beside it. Nothing derives anything from
-the checkpoints yet, so `Both` changes no inference and no certificate
---- deriving `C_t` from `C^start_*` and then dropping the per-time
-family is the rest of #780. A `StartCheckpoint` arm cannot exist before
-that recovery does, since an unconverted inference would have no
-per-time row left to cite.
+`Both` writes the checkpoints beside it, and changed no inference and no
+certificate when it was the only other arm. `BothRecovering` adds the
+eager differential. `StartCheckpoint` writes the checkpoints *instead*
+--- it arrived once the recovery did, since before that an unconverted
+inference would have had no per-time row left to cite, and it is now how
+a converted rule is held to having really been converted. See "Just
+turning the old encoding off", below.
 
 ### Two details that are easy to get wrong
 
@@ -2069,19 +2070,62 @@ row from the window supply, which is now a *recovered* row rather than a model
 one, so without the twin the recovering arm would have no negative test over the
 path this moved.
 
-**The bar has run out of road here, and that is worth stating plainly.** The
-citers that remain --- the elastic and knapsack availability lines,
-edge-finding's window rows, published not-first / not-last --- all sit behind
-`CumulativeRules` fields that are off by default, and the leak check's vehicle is
-an `.scp` model run through `glasgow_scp_solver`, which builds a plain
-`Cumulative` and has no flag for the rules. So no case that *could* stay in
-`prefix` and mark them outstanding can be written in this vehicle at all: the
-next rule to move over has no test that can express its own completion. Closing
-that needs either a way to select rules from the scp path, or the same
-strip-and-recheck applied to the proofs a C++ lane writes under
-`GCS_PRESERVE_PROOF_FILES` --- 34 of `cumulative_overload_test`'s 115 proofs
-already run the recovery, so the material is there. Until one exists, the
-remaining steps are tracked by #780 and not by this bar.
+### Just turning the old encoding off
+
+The `whole` mode above reconstructs the end state: solve with both blocks in the
+model, then delete the `cap_t` rows from the finished OPB and re-check. It ran
+out of road as soon as the default rule set was converted, because its vehicle is
+an `.scp` model through `glasgow_scp_solver`, which builds a plain `Cumulative`
+--- and every citer that remains is behind a `CumulativeRules` field that is off
+by default. No `.scp` model can fire those rules, so none could be registered to
+mark them outstanding.
+
+`CumulativeEncoding::StartCheckpoint` replaces it by doing the obvious thing
+instead: **never emit the per-time block at all**. A rule that still reads
+`capacity_lines` finds nothing there, its pol loses the supply it was counting
+on, and veripb rejects. Nobody has to enumerate where the old rows are read from
+--- the arm asks the question everywhere at once, which is the check a careful
+reader would do by hand over every access to the old constraint IDs, done
+mechanically and without the reader having to be exhaustive.
+
+It is better than the strip-and-recheck on every axis that matters. It is the end
+state itself rather than a reconstruction of it. It needs no post-processing and
+no `.scp` vehicle, so it is available to every C++ test lane --- and therefore to
+every rule, including the off-by-default ones. And it fails loudly.
+
+**The per-time block still appears where the recovery cannot reach**: a variable
+height, a variable length, an optional task, a variable capacity. There would
+otherwise be no capacity row at all for such a constraint, and every rule over it
+would be *uncertifiable* rather than merely unconverted. So the arm is
+"start-checkpoint wherever the recovery reaches", which is what the eventual
+default has to be too; `cumulative_shape_supports_checkpoint_recovery` is the one
+statement of where that is, shared with the recovery's own guard so the two
+cannot drift.
+
+That fallback is also the arm's one way to go quietly vacuous --- a lane all of
+whose fixtures fall back would pass while checking nothing new. So the four
+leak-check models are registered a second time in `no-block` mode, which asserts
+that the OPB contains *no* `cap_` row and does contain `scap_` ones. A model that
+falls back fails it by name.
+
+Run against the bare cumulative lanes, the arm reports the remaining work
+exactly: 57 of 70 pass, and the 11 genuine failures are `cumulative_kaoc`
+(the knapsack / elastic availability lines), `cumulative_edge_finding`,
+`cumulative_ttef`, `cumulative_energetic{,_random}` (edge-finding's window rows),
+`cumulative_nfnl`, `cumulative_published_nfnl{,_random}` (not-first / not-last),
+and `derived_cumulative` with the two presolver lanes that reach it. That list
+lives in `gcs/CMakeLists.txt` and is #780's progress bar: **when it is empty, the
+time-indexed block can go.**
+
+Two lanes are off the arm for a different reason and are not part of the bar:
+`cumulative_optional_mutation_wrong_task` and
+`cumulative_optional_mutation_emit_nothing` stop discriminating under it, as they
+already do under `Both` and for the same reason --- more model is more for unit
+propagation to reach. They are not unconverted; the arm just cannot hold them.
+
+The arm is not vacuous on the lanes that are on it: under it, 59 of
+`cumulative_test`'s 77 proofs and 37 of `cumulative_overload_test`'s 115 contain
+no `cap_` row at all.
 
 ### What it costs in lines
 

--- a/dev_docs/cumulative-proof-logging.md
+++ b/dev_docs/cumulative-proof-logging.md
@@ -1836,7 +1836,18 @@ sufficiency.
 
 Every cumulative test lane is registered twice, the twin under
 `GCS_CUMULATIVE_ENCODING=both` in its own working directory (see
-`add_cumulative_test` in `gcs/CMakeLists.txt`). The twin's value is
+`add_cumulative_test` in `gcs/CMakeLists.txt`), and most of them a third time
+under `both-recovering`.
+
+One trap, since it cost a round of vacuous lanes here: the encoding **cannot**
+be set with `set_tests_properties(... PROPERTIES ENVIRONMENT ...)` at
+registration. The runtime-cap block further down `gcs/CMakeLists.txt` sets
+`ENVIRONMENT` on every test in the directory, and that *replaces* the property
+rather than adding to it, so anything set earlier is dropped and the twin
+silently runs the arm it was meant to be twinning against. Record the lane and
+`set_property(TEST ... APPEND PROPERTY ENVIRONMENT ...)` after that block,
+which is what the linear and disjunctive lanes already do. Nothing caught this
+except a mutation lane that must fail starting to pass. The twin's value is
 *soundness*: veripb's `solx` rule propagates the logged assignment and
 then requires every constraint in the database to be satisfied, so a
 checkpoint row that says too much is a solution veripb refuses, on any
@@ -1929,6 +1940,22 @@ target row comes out from behind the fully reified `F_t` the cases were routed
 through --- the issue's guard-relativized rendering of a case split whose
 target is a row rather than a clause.
 
+**In the solver.** `recover_cumulative_capacity_row`
+(`gcs/constraints/cumulative/checkpoint_recovery.cc`) is this derivation,
+keyed on `t` alone and reason-free at `Top`, with the order facts cached
+across time points and the recovered rows cached across citers. Two things
+it does that the hand-written version did not have to:
+
+- **A lone task's case comes out unguarded.** With one candidate there is no
+  pairwise term to pin, so the case's `pol` produces the target row with no
+  `~W_j` on it, and the scan then has nothing to cancel against. The guard
+  goes on as a literal axiom, which costs nothing where the arithmetic already
+  produced it --- saturation flattens the coefficient either way.
+- **The clause has to be a `pol` and not a `rup`.** The guarded row and the
+  target's reverse half conflict by *arithmetic*, not by unit propagation:
+  `sum ~cact_i >= 2` and `sum cact_i >= 3` over four literals each have slack,
+  so nothing propagates and a `rup` stalls. Adding them is what finds it.
+
 **Measured**, lines per time point, at every non-trivial `t`:
 
 | `m` | 3 | 4 | 5 | 6 |
@@ -1942,6 +1969,16 @@ only the triples the scan actually resolves against would take a constant
 factor off it. Even unoptimised the cost argument holds with room to spare: at
 `n = 6` over the 60 points a complete refutation cites, this is under 30k lines
 against a 6.7M-line proof.
+
+**Two things hold the solver's version to what the hand-written one showed.**
+`cumulative_overload_mutation_recover_wrong` recovers a row from the
+neighbouring task's checkpoint and requires veripb to reject it, which only the
+implication check does. And `cumulative_checkpoint_recovery_leak_check` cuts
+the proof at the marker the recovery emits and rechecks the prefix against an
+OPB with every per-time capacity row stripped out --- the only thing that says
+the recovery is not quietly closing one of its rups against the very row it
+claims to be deriving. Both fail loudly if the recovery stops running at all,
+rather than passing vacuously.
 
 **Transitivity is load-bearing**, which #780 predicted and this confirms:
 dropping the transitivity pols makes the `e`-lifting rups fail, and with them

--- a/dev_docs/cumulative-proof-logging.md
+++ b/dev_docs/cumulative-proof-logging.md
@@ -2670,6 +2670,54 @@ recovery cost is paid per *cited* time point, and an easy instance cites almost
 none. The 2x proof ratios in the short-task family come from search-heavy
 instances, and neither figure generalises to the other regime.)
 
+### Step 10: the flags move into the proof
+
+`define_proof_model` names the per-`(i, t)` flags and stops; the install
+initialiser emits their two reification halves as `red` steps and registers the
+lines, and citers reach them through `reification_half`, which hides which kind
+of definition it got (`ProofLine` is already the variant of a line number and a
+label, so nothing at a call site changes type). What each flag *says* is stated
+once, in three functions both paths call --- a drifting second copy would make a
+flag mean one thing to the encoder and another to everything citing it.
+
+Same instances as the long-task table above:
+
+| `D` | time-indexed | start-checkpoint |
+|---|---|---|
+| 1,000 | 8,725 lines (832K) | **56 lines** (8.0K) |
+| 10,000 | 85,663 lines (8.3M) | **56 lines** (8.0K) |
+| 100,000 | 854,945 lines (86M) | **56 lines** (12K) |
+| 1,000,000 | 8,547,916 lines (**881 MB**) | **56 lines** (12K) |
+
+Fifty-six lines, flat in the duration. The OPB is horizon-free in fact now, and
+not only in its capacity rows.
+
+**What it does not yet do is remove the cost --- only move it.** The definitions
+go out eagerly, one per `(i, t)` over each task's window, so at `D = 100,000` the
+proof goes from 42 lines to 777,043 (86 MB): the same 86 MB, moved out of a file
+that has to be held and parsed whole and into one that is streamed and checked
+incrementally. Better, and not the point.
+
+The point is emitting a definition only for the `(i, t)` pairs something
+actually reasons about, which is bounded by search effort rather than by the
+horizon. Two things stand in the way, in this order:
+
+1. **The bridge-lemma loop**, in the same install initialiser. It emits
+   `end >= t+1 -> after` per `(i, t)` and cites every `after` flag, so it forces
+   every one of them into existence however lazy everything else becomes.
+2. **A variable height's contribution rows**, which are OPB rows *half-reified
+   on the activity flag*, so that flag has to be a model object for them to
+   exist at all. Hence the current gate: a constraint with any variable-height
+   task keeps its flags in the model. 82 of the 266 proofs the cumulative
+   binaries write are in that case, and they are exactly the `var_height` ones.
+   Those rows want the same treatment as the flags, and the same
+   label-or-line accessor on the row side that `reification_half` gives on the
+   flag side.
+
+Misses are loud rather than silent, which is worth knowing before doing (1): a
+flag whose definition never went out is a free variable, so a `pol` citing a
+half finds no such line and a `rup` over it stalls. Neither can pass quietly.
+
 ### What the flip actually needs
 
 **One thing above all others.** The per-`(i, t)` flags have to stop being model
@@ -2678,9 +2726,9 @@ until they move, `StartCheckpoint` collects about `1/(6n)` of a win that is
 otherwise nearly total. Every other question below is secondary to it, and two
 of the three are questions only about the short-task family.
 
-1. **The per-`(i, t)` flags minted lazily**, which removes the `6nH` term. This
-   is not a prerequisite for a marginal flip --- it is where the benefit is.
-   831 MB to a few kilobytes, projected on the long-task table above.
+1. **The per-`(i, t)` flags out of the model**, which removes the `6nH` term.
+   Done: 881 MB to 12 KB, measured, in "Step 10" above. What is left of it is
+   making the definitions *lazy* so the proof does not inherit the cost.
 2. A rule for *when* to use it, rather than a global default. On short tasks the
    encoding wins on the model only at `H >~ 6n^2` and loses on the proof; on
    long ones it wins outright. So "always" is not what today's measurement

--- a/dev_docs/cumulative-proof-logging.md
+++ b/dev_docs/cumulative-proof-logging.md
@@ -2705,18 +2705,60 @@ horizon. Two things stand in the way, in this order:
 1. **The bridge-lemma loop**, in the same install initialiser. It emits
    `end >= t+1 -> after` per `(i, t)` and cites every `after` flag, so it forces
    every one of them into existence however lazy everything else becomes.
-2. **A variable height's contribution rows**, which are OPB rows *half-reified
-   on the activity flag*, so that flag has to be a model object for them to
-   exist at all. Hence the current gate: a constraint with any variable-height
-   task keeps its flags in the model. 82 of the 266 proofs the cumulative
-   binaries write are in that case, and they are exactly the `var_height` ones.
-   Those rows want the same treatment as the flags, and the same
-   label-or-line accessor on the row side that `reification_half` gives on the
-   flag side.
+2. ~~A variable height's contribution rows~~ --- **done**, see below.
 
 Misses are loud rather than silent, which is worth knowing before doing (1): a
 flag whose definition never went out is a free variable, so a `pol` citing a
 half finds no such line and a `rup` over it stalls. Neither can pass quietly.
+
+#### A variable height, once the flags are out of the model
+
+The three rows per `(i, t)` and three per pair that linearise `contrib = h *
+active` are what forced the gate above: they are OPB rows *half-reified on the
+activity flag*, so that flag had to be a model object for them to exist. Out of
+the model they are not needed at all, because bit by bit the product **is** a
+conjunction:
+
+| | |
+|---|---|
+| `cc_{i,t,k}` | `<-> cact_{i,t} /\ bit_k(h_i)` --- in the proof |
+| `scc_{i,j,k}` | `<-> sact_{i,j} /\ bit_k(h_i)` --- in the model |
+
+If the task is active its contribution is its height, so bit for bit; if it is
+not, every bit is zero. Each is then a two-way reification of a fresh flag over
+literals that already exist --- the same primitive the activity flag uses --- at
+two rows per bit where the linearisation took three per pair.
+
+**That deletes the case split.** The swap the recovery does for a variable
+height needs `Sum cc <= Sum scc` with no `cact` guard on it, and under the
+three-row form that took a case split relativized on its own flag, because
+`cle`'s guard left a residue the scan could not resolve away. Over conjunctions
+it is one `rup` per bit,
+
+    ~w \/ ~cc_{i,t,k} \/ scc_{i,j,k}
+
+which closes by unit propagation alone: `cc` gives `cact` and the height bit,
+the pin turns `cact` into `sact` under `w`, and `sact` with that same bit is
+`scc`. Summed at `2^k` those come to `Sum scc - Sum cc + S.~w >= 0` --- guarded
+by `w` and nothing else, which is exactly where a constant height's pin leaves
+`~cact`. On a flagless diagonal there is no pair bit and `~cc_{j,t,k} \/
+bit_k(h_j)` does the same job, unguarded.
+
+`cge` is still what the energy rules and `donor_view` ask for, so it is derived
+from those definitions rather than asserted: `~cact \/ ~bit_b(h) \/ cc_b` per
+bit, summed at `2^b`, is that row with `S` as its guard coefficient.
+`NamesAndIDsTracker::constraint_row` is the row-side counterpart of
+`reification_half` --- "how do I cite this", label or derived line alike.
+
+**No proof in the cumulative binaries carries per-`(i, t)` flags in its OPB any
+more**: 0 of 266, where gating variable heights out left 82. The long-task table
+above holds with variable heights included.
+
+The one shape left out is a height whose *bits* cannot be cited --- a view,
+which has no bits of its own, or a declared lower bound below zero, which puts a
+sign bit in and shifts every weight. That keeps the three-row form and makes the
+recovery decline; `prepare()` decides it once for the whole constraint, a
+mixture not being available.
 
 ### What the flip actually needs
 

--- a/dev_docs/cumulative-proof-logging.md
+++ b/dev_docs/cumulative-proof-logging.md
@@ -2112,9 +2112,9 @@ Run against the bare cumulative lanes, the arm reports the remaining work
 exactly. It began at 11 genuine failures; `cumulative_kaoc` came off when the
 availability lines moved, and `cumulative_edge_finding`, `cumulative_ttef`,
 `cumulative_energetic{,_random}` and `cumulative_nfnl` came off together when
-edge-finding's window rows did. What is left is `cumulative_published_nfnl` and
-its random twin, and `derived_cumulative` with the two presolver lanes that reach
-it. That list
+edge-finding's window rows did. `cumulative_published_nfnl` and its random twin followed.
+What is left is `derived_cumulative` and the two presolver lanes that reach it
+--- and see the note below about those failing softly rather than loudly. That list
 lives in `gcs/CMakeLists.txt` and is #780's progress bar: **when it is empty, the
 time-indexed block can go.**
 
@@ -2216,6 +2216,44 @@ weakens the mutation lanes, because both effects come from having more in the
 database for unit propagation to reach. Neither arm dominates the other, which is
 why every lane is registered on the arms it still discriminates under, one at a
 time, on evidence.
+
+### Citing the recovered row: published not-first / not-last
+
+The last of the propagator's citers, and the only one that scales the row: its
+`capacity_at` helper adds the capacity line at `t` with a coefficient, and
+converts the contained set's and the pushed task's variable-height contributions
+back into activity so that contiguity has something to cancel against. Scaling
+a recovered row is the same as scaling the model's, so again the swap is one
+line. `cumulative_published_nfnl` and its random twin come off the bar, and all
+eight of its fixtures run checkpoint-only.
+
+Five of its six mutation lanes still discriminate on the arm and are registered
+there, `drop_pin` --- the one aimed at what #746 added --- among them.
+`cumulative_published_nfnl_mutation_drop` does not, which is not news: it was
+already off the `Both` arm for exactly this reason, since dropping a contiguity
+row is something the checkpoint rows put back.
+
+### The one place the arm does not fail loudly
+
+Worth knowing before relying on it, and it took a confusing failure to notice.
+
+`inferred_cumulative_presolver` under the start-checkpoint arm does not fail
+veripb --- its proof verifies. It fails its own assertion, with *"posted 0 cuts
+with a coefficient above one, not the one the fixture is about"*. The cause is
+`derived_cumulative.cc`, which looks its donors' per-time rows up by label; under
+this arm a donor wrote none, so the derivation **declines**. Declining is a
+supported outcome there and not rare --- "a cut spanning several donors reaches
+time points one of them wrote no row for" --- so the constraint is simply not
+installed, and propagation quietly weakens.
+
+So for step 9's citers the arm's blunt-and-total property does not hold: the leak
+is soft. What notices is a lane asserting what got posted, and a lane without
+such an assertion would pass while silently losing propagation strength. Two
+consequences. First, `derived_cumulative`, `inferred_cumulative_presolver` and
+`cumulative_strengthening_presolver` passing must not be read as evidence until
+step 9 moves that lookup onto the recovery like every other citer. Second, this
+is a good argument for those lanes keeping assertions about what they infer, and
+not only about whether the proof checks.
 
 ### What it costs in lines
 

--- a/dev_docs/cumulative-proof-logging.md
+++ b/dev_docs/cumulative-proof-logging.md
@@ -1987,8 +1987,10 @@ rather than passing vacuously.
 `propagate_cumulative` has one accessor, `capacity_row(t)`, for the row saying
 the load at `t` is within the capacity. It returns the recovered row where the
 recovery is on and can speak about the constraint, and the model's own row
-otherwise --- a variable height or an optional task still falls back, which is
-why the two live side by side rather than one replacing the other.
+otherwise. The fallback is unreachable now that the recovery speaks about every
+shape, but the two still live side by side: the model row is what the differential
+arm checks each recovery against, and it is what a `TimeIndexed` or `Both` run
+cites.
 
 The whole time-table family goes through it: the overflow contradiction and
 both bound pushes. On two tasks that must overlap and do not fit, the
@@ -2093,14 +2095,14 @@ state itself rather than a reconstruction of it. It needs no post-processing and
 no `.scp` vehicle, so it is available to every C++ test lane --- and therefore to
 every rule, including the off-by-default ones. And it fails loudly.
 
-**The per-time block still appears where the recovery cannot reach**: a variable
-height, a variable length, an optional task, a variable capacity. There would
-otherwise be no capacity row at all for such a constraint, and every rule over it
-would be *uncertifiable* rather than merely unconverted. So the arm is
-"start-checkpoint wherever the recovery reaches", which is what the eventual
-default has to be too; `cumulative_shape_supports_checkpoint_recovery` is the one
-statement of where that is, shared with the recovery's own guard so the two
-cannot drift.
+**The per-time block used to appear where the recovery could not reach**: a
+variable height, a variable length, an optional task, a variable capacity. There
+would otherwise be no capacity row at all for such a constraint, and every rule
+over it would be *uncertifiable* rather than merely unconverted. The recovery
+reaches all four now, so the fallback is unreachable for any Cumulative with an
+active task; `cumulative_shape_supports_checkpoint_recovery` is still the one
+statement of where the recovery can speak, shared with the recovery's own guard
+so the two cannot drift, and it now declines only the empty constraint.
 
 That fallback is also the arm's one way to go quietly vacuous --- a lane all of
 whose fixtures fall back would pass while checking nothing new. So the four
@@ -2117,27 +2119,26 @@ and `derived_cumulative` with the presolver lanes that reach it went last.
 **The list is empty** --- every rule is converted, and every lane that exercises
 one runs green with the per-time block deleted from the model.
 
-Read that precisely: every *rule*, not every *shape*. `capacity_row` still falls
-back to the model row for a Cumulative the recovery cannot speak about --- a
-variable length, a variable height, a variable capacity, an optional task ---
-and those keep the block and use it for everything. It is not a corner: **146 of
-the 424 proofs** the cumulative test binaries write under this arm still contain
-`cap_` rows, concentrated in `cumulative_overload_test` (83 of 115) and
-`cumulative_optional_test` (18 of 35). So the block cannot be deleted, only
-skipped where the recovery reaches.
+That was once only half the story --- every *rule*, not every *shape* --- and it
+is not any more. When the arm was built, `capacity_row` still fell back to the
+model row for a Cumulative the recovery could not speak about (a variable
+length, height or capacity, or an optional task), and **149 of the 440 proofs**
+the cumulative test binaries write under this arm carried `cap_` rows because of
+it, concentrated in `cumulative_overload_test` (83 of 115) and
+`cumulative_optional_test` (18 of 35).
 
-Two things follow for the default flip. The checkpoint block is **not**
-shape-gated on emission, so under this arm a non-qualifying constraint gets
-*both*: a variable-duration model measures 146 OPB lines against the
-time-indexed encoding's 105. Gating the checkpoint block on
-`cumulative_shape_supports_checkpoint_recovery` is a prerequisite for flipping
-the default, not an optimisation. And extending the recovery to those shapes is
-what would let the block go entirely --- a variable length moves the diagonal
-off the row and onto a flag, a variable height replaces a coefficient with a bit
-sum, a presence adds a conjunct to every activity flag, and a variable capacity
-is not written down anywhere yet. That list
-lives in `gcs/CMakeLists.txt` and is #780's progress bar: **when it is empty, the
-time-indexed block can go.**
+Every one of those shapes has since been brought in, and the count went
+**149 -> 121 -> 95 -> 10 -> 0**. See "Every shape, and what each one took" below.
+`capacity_row`'s fallback is now unreachable for any Cumulative with an active
+task, and the block is not merely skipped where it is safe to skip --- it is
+replaceable outright.
+
+The other prerequisite for the default flip was that the checkpoint block was
+**not** shape-gated on emission, so a non-qualifying constraint got *both*
+blocks; it is gated now. What still blocks the flip is neither of these: it is
+the per-`(i, t)` flag family, which is where the `O(n x horizon)` lines actually
+live and which no part of this touches. See "What `StartCheckpoint` saves today"
+below for the measurement.
 
 Those lanes fail by *aborting*, not by a quiet mismatch: they verify inline, so
 the harness throws `UnexpectedException{"veripb verification failed"}` the moment
@@ -2334,12 +2335,16 @@ for every time point in its window up front, so that it can decline cleanly
 rather than install a propagator whose inferences it cannot justify. Each
 recovery is `~2m^3` lines against the per-time block's `O(n)` rows per point, so
 on a wide horizon the derivations can cost more lines than the block they
-replace. Three things bound it: the donor's cache is shared with its own
-propagation, so points it cites anyway are paid once; the window is the derived
-constraint's, not the donor's horizon; and a donor with a variable height or an
-optional task does not qualify for the recovery at all, keeps its block, and is
-found by label as before. Making the resolution lazy would avoid paying for
-points never cited, but would cost the clean decline, which is deliberate.
+replace. Two things bound it: the donor's cache is shared with its own
+propagation, so points it cites anyway are paid once, and the window is the
+derived constraint's rather than the donor's horizon. A third used to: a donor
+with a variable height or an optional task did not qualify for the recovery,
+kept its block and was found by label as before. That escape is gone now the
+recovery speaks about every shape, so a derived Cumulative pays the derivation
+wherever its donors do. (Derived Cumulatives take constant heights only in any
+case, so what changed for them in practice is optional and variable-length
+donors.) Making the resolution lazy would avoid paying for points never cited,
+but would cost the clean decline, which is deliberate.
 
 ### What it costs in lines
 
@@ -2357,6 +2362,106 @@ and is flat in the horizon. Measured through `fzn-glasgow --prove`:
 The last row is the case for the whole exercise: 25 MB of per-time
 block, emitted unconditionally, next to 39 lines that say the same
 thing.
+
+### Every shape, and what each one took
+
+The recovery was written for constant lengths, heights and capacity and no
+optional tasks, and the other four shapes were listed as "known extensions,
+none of them done". Doing them moved the fallback fraction from 149 of 440
+proofs to none. What they actually cost is worth recording, because the
+ordering of easy and hard was not the one the list implied.
+
+**Optional tasks, and variable lengths: the same one change, on the diagonal.**
+The scheduling argument never needed a task to be mandatory or its length
+fixed. `cact_{i,t}` carries the presence conjunct and so does `sact_{i,j}`, so
+"every candidate active at `t` has `sb` and `sa`, hence `sact`" holds as
+written, and the pins that say so stay RUP because the presence is the same atom
+on both sides. `sa_{i,j}` already reified on `s_i + l_i` directly when the
+length varied.
+
+What differs is the **diagonal**. With a constant length and no presence the
+encoder mints no `sact_{j,j}` --- before is a tautology, after reduces to
+`length >= 1` --- and folds `j`'s height into the checkpoint row's right hand
+side, which is why the recovery puts it back with a literal axiom rather than
+cancelling it. Give `j` a presence or a variable length and the flag exists,
+the height is on the row like everyone else's, and it has to be cancelled like
+everyone else's. So: pin the diagonal where the flag is there, axiomatise it
+where it is not. That one change is both shapes.
+
+*A pol that looked necessary is not.* The obvious next move is a diagonal
+counterpart to the `ca /\ cb -> sa` pol, with `sact_{j,j}` standing in for the
+`sa_{j,j}` the encoder never mints, on the grounds that getting `l_j >= 1` out
+of `s_j <= t` and `s_j + l_j >= t+1` is arithmetic and a rup asked to do
+arithmetic stalls. Written and measured, it changes nothing: the pin closes on
+its own, because unlike the off-diagonal fact this one is about a *single*
+task's variables, so `l_j <= 0` pushes `s_j` past `t` and propagation has its
+contradiction. The off-diagonal pol really is load-bearing --- deleting it fails
+five lanes --- which is what makes the difference between them a fact rather
+than a guess.
+
+**A variable height: the one that needed an argument.** A constant height is a
+coefficient on an activity flag, and the pin cancels it off the checkpoint row
+and leaves the same coefficient on `~cact` --- which *is* the load term the
+target's reverse half then cancels against, so the conversion and the arithmetic
+are one act. A variable height is a coefficient on neither flag: the checkpoint
+row carries the pair's bit-linearised contribution `scc_{i,j,k}` and the target
+carries the per-time one `cc_{i,t,k}`. The conversion is between two bit sums,
+`~cact` stops being the load, and it becomes a guard residue --- and a residue
+left on a case clause is a literal the scan cannot resolve away, which comes out
+as a recovered row weaker than the one asked for. That is how the first attempt
+failed, and the differential arm said so precisely.
+
+So the swap needs
+
+    Sum_k 2^k cc_{i,t,k}  <=  Sum_k 2^k scc_{i,j,k}
+
+with **no** `cact` guard, and that holds either side of `cact` for two different
+reasons: active at `t`, and both sides are `h_i`; not active, and the left is
+zero while the right is a sum of non-negative terms. Two reasons is a case
+split, and a case split whose target is a row rather than a clause gets
+relativized on a flag of its own --- the same technique, and the same reason for
+it, as the target row itself. The active case is the per-time `cle` row and the
+pair's `scge` row with `h_i` cancelling between them, the pair row's guard
+discharged by the pin; the inactive case is the `czero` row plus literal axioms
+for the right hand side; resolving the two leaves the goal holding under `w`
+alone, and it comes out from behind its flag exactly as the target does. The
+flagless diagonal is the same shape with `h_j` itself on the right and the
+height's non-negativity for the inactive case.
+
+**A variable capacity: nearly free, and this document said otherwise.** An
+earlier note here held that `degree = total - capacity` was "the degree the
+derivation saturates at" and that the guard coefficients were computed against
+it, so a capacity carried as a bit sum would have no single constant degree.
+Neither half is true. `degree` was only ever the test for the trivial case, and
+the capacity needs no handling of its own, because it **cancels between the
+checkpoint row and the target's own reverse half** exactly as the load does ---
+one carrying `+capacity`, the other `-capacity`. All it took was carrying the
+row in the encoder's own two forms, and giving up the trivial-case shortcut,
+which asks "does the most the candidates can take fit in what the resource
+supplies" and has no single number to ask that of. Skipping the shortcut costs a
+longer derivation on a row that happens to be slack, and nothing else.
+
+The wrong note is worth keeping in mind rather than just deleting: the argument
+was about *scheduling* and never mentioned the capacity's constancy, and
+guessing that PB arithmetic would be the obstacle --- without following the
+constant through the code to see what it actually reached --- produced a
+confident note pointing at the wrong thing.
+
+**How each was checked.** Not by the suite going green, which it did after every
+one of them, but by breaking the new step and counting what noticed:
+
+| change | sabotage | lanes that failed |
+|---|---|---|
+| optional tasks | diagonal falls back to the axiom always | 3, all `_recovering` |
+| variable lengths | the same, with lengths now in | 14, `_recovering` and `_startcheckpoint` |
+| variable heights | cite the pair `zero` row, not the per-time one | 7 |
+| variable capacity | off-by-one in the variable form of the row | 5 |
+
+The `_recovering` arm is what catches these. A recovery that is *invalid* fails
+where it is emitted; one that is valid but derives the *wrong row* emits a
+perfectly good line, and only the implication check against the row the model
+still carries beside it notices. The optional-task sabotage is the sharpest
+illustration: the `_startcheckpoint` lanes stayed green right through it.
 
 ### What `StartCheckpoint` saves today, and why the default cannot flip yet
 

--- a/examples/cumulative/CMakeLists.txt
+++ b/examples/cumulative/CMakeLists.txt
@@ -5,3 +5,27 @@ target_link_libraries(cumulative PRIVATE glasgow_constraint_solver)
 target_link_libraries(cumulative PRIVATE cxxopts)
 
 add_test(NAME cumulative COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:cumulative>)
+
+# The encoding switch (#780). Distinct basenames so a parallel ctest does not
+# race these over one set of proof files (#562), and names that avoid the
+# `_startcheckpoint` suffix: that one belongs to the encoding *arms* registered
+# in gcs/CMakeLists.txt, and `ctest -N -R startcheckpoint` counting exactly
+# those is a sanity check worth keeping meaningful.
+#
+# The built-in five-task instance has constant lengths, heights and capacity
+# and no optional task, so it is a shape the recovery reaches: this entry gets
+# the strict encoding, with no per-time capacity row to fall back on, through a
+# real example binary rather than a test fixture.
+add_test(NAME cumulative_encoding_start_checkpoint COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash
+    --basename cumulative_encoding_start_checkpoint $<TARGET_FILE:cumulative> --variant start-checkpoint)
+
+# Both families in the model, and every recovered per-time row checked against
+# the one the model still carries beside it.
+add_test(NAME cumulative_encoding_both_recovering COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash
+    --basename cumulative_encoding_both_recovering $<TARGET_FILE:cumulative> --variant both-recovering)
+
+# The generated instance and the horizon override, which are how the two
+# encodings get compared at a chosen n and H. Nothing else posts them, so
+# without this entry they could rot unnoticed between measurements.
+add_test(NAME cumulative_generated_instance COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash
+    --basename cumulative_generated_instance $<TARGET_FILE:cumulative> --tasks 8 --seed 1 --horizon 20)

--- a/examples/cumulative/CMakeLists.txt
+++ b/examples/cumulative/CMakeLists.txt
@@ -29,3 +29,14 @@ add_test(NAME cumulative_encoding_both_recovering COMMAND ${GCS_BASH} ${CMAKE_SO
 # without this entry they could rot unnoticed between measurements.
 add_test(NAME cumulative_generated_instance COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash
     --basename cumulative_generated_instance $<TARGET_FILE:cumulative> --tasks 8 --seed 1 --horizon 20)
+
+# The regime the start-checkpoint encoding exists for, which none of the
+# entries above reach: a few tasks of long duration, so that each task's
+# possible-active window --- and with it the time-indexed block --- is long
+# while the instance stays trivial to solve. --max-start is what separates
+# those two, and without an entry here nothing would notice if it stopped
+# doing so. 3 tasks at duration up to 500 is 3,182 OPB lines against the
+# built-in instance's 522, and still verifies in well under a second.
+add_test(NAME cumulative_long_duration COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash
+    --basename cumulative_long_duration $<TARGET_FILE:cumulative>
+    --variant start-checkpoint --tasks 3 --seed 2 --max-length 500 --max-start 5 --horizon 508)

--- a/examples/cumulative/cumulative.cc
+++ b/examples/cumulative/cumulative.cc
@@ -7,7 +7,10 @@
 #include <cstdlib>
 #include <iostream>
 #include <optional>
+#include <random>
 #include <ranges>
+#include <string>
+#include <utility>
 #include <vector>
 
 #include <cxxopts.hpp>
@@ -27,8 +30,12 @@ using namespace gcs;
 using std::cerr;
 using std::cref;
 using std::make_optional;
+using std::move;
+using std::mt19937;
 using std::nullopt;
+using std::optional;
 using std::string;
+using std::uniform_int_distribution;
 using std::vector;
 
 #if defined(__cpp_lib_print) && defined(__cpp_lib_format)
@@ -38,6 +45,30 @@ using std::println;
 using fmt::print;
 using fmt::println;
 #endif
+
+namespace
+{
+    // --variant selects the OPB encoding of the Cumulative, spelled exactly as
+    // the GCS_CUMULATIVE_ENCODING environment variable spells it so that a
+    // measurement taken here transfers to a test lane without translation.
+    auto encoding_from_string(const string & spec) -> optional<CumulativeEncoding>
+    {
+        if (spec == "time-indexed")
+            return CumulativeEncoding::TimeIndexed;
+        if (spec == "both")
+            return CumulativeEncoding::Both;
+        if (spec == "both-recovering")
+            return CumulativeEncoding::BothRecovering;
+        if (spec == "start-checkpoint")
+            return CumulativeEncoding::StartCheckpoint;
+        return nullopt;
+    }
+
+    auto encoding_names() -> string
+    {
+        return "time-indexed, both, both-recovering, start-checkpoint";
+    }
+}
 
 auto main(int argc, char * argv[]) -> int
 {
@@ -53,6 +84,32 @@ auto main(int argc, char * argv[]) -> int
             ("stats", "Print solve statistics")                              //
             ;
 
+        options.add_options("Model")                                                              //
+            ("variant",                                                                           //
+                "Which OPB encoding to give the Cumulative. Supported: " + encoding_names() +     //
+                    ". Left alone by default, so the solver's own default applies. The encoding " //
+                    "changes the proof and nothing else: the same solutions are found, by the "   //
+                    "same search, whichever is chosen",                                           //
+                cxxopts::value<string>())                                                         //
+            ;
+
+        options.add_options("Instance")                                                                            //
+            ("tasks",                                                                                              //
+                "Generate this many random tasks instead of the built-in five. The lengths and "                   //
+                "heights come from --seed; the capacity from --capacity",                                          //
+                cxxopts::value<long long>())                                                                       //
+            ("capacity", "Resource capacity for a generated instance",                                             //
+                cxxopts::value<long long>()->default_value("3"))                                                   //
+            ("horizon",                                                                                            //
+                "Override the planning horizon. The optimum does not depend on it once it is large "               //
+                "enough to hold one, but the time-indexed encoding is linear in it and the "                       //
+                "start-checkpoint one does not mention it, so sweeping it against --tasks is how the "             //
+                "two are compared. Zero, the default, uses ten for the built-in instance and the sum "             //
+                "of the lengths for a generated one",                                                              //
+                cxxopts::value<long long>()->default_value("0"))                                                   //
+            ("seed", "Seed for the generated lengths and heights", cxxopts::value<unsigned>()->default_value("0")) //
+            ;
+
         options_vars = options.parse(argc, argv);
     }
     catch (const cxxopts::exceptions::exception & e) {
@@ -64,25 +121,81 @@ auto main(int argc, char * argv[]) -> int
     if (options_vars.contains("help")) {
         println("Usage: {} [options]", argv[0]);
         println("");
-        println("Five tasks share a single resource of capacity 3.");
+        println("Tasks share a single cumulative resource.");
         println("Minimise the makespan: the time at which the last task finishes.");
         println("");
         print("{}", options.help());
         return EXIT_SUCCESS;
     }
 
-    // Five tasks on a resource of capacity 3. Lengths and heights are fixed;
-    // each task's start time is the decision variable. The schedule must keep
-    // the cumulated demand at every time point at or below the capacity.
+    optional<CumulativeEncoding> encoding;
+    if (options_vars.contains("variant")) {
+        auto variant_name = options_vars["variant"].as<string>();
+        encoding = encoding_from_string(variant_name);
+        if (! encoding) {
+            println(cerr, "Error: unknown --variant value '{}'. Supported: {}.", variant_name, encoding_names());
+            return EXIT_FAILURE;
+        }
+    }
+
+    // Tasks on a resource of capacity 3. Lengths and heights are fixed; each
+    // task's start time is the decision variable. The schedule must keep the
+    // cumulated demand at every time point at or below the capacity.
+    //
+    // The built-in five, unless --tasks asks for a generated instance: the
+    // encoding comparison wants n and the horizon moved independently, which
+    // one fixed instance cannot do.
     vector<Integer> lengths = {3_i, 2_i, 2_i, 1_i, 4_i};
     vector<Integer> heights = {2_i, 1_i, 2_i, 3_i, 1_i};
     Integer capacity = 3_i;
     Integer horizon = 10_i;
 
+    if (options_vars.contains("tasks")) {
+        auto n = options_vars["tasks"].as<long long>();
+        if (n < 1) {
+            println(cerr, "Error: --tasks must be at least 1, not {}.", n);
+            return EXIT_FAILURE;
+        }
+        capacity = Integer{options_vars["capacity"].as<long long>()};
+        if (capacity < 1_i) {
+            println(cerr, "Error: --capacity must be at least 1, not {}.", capacity);
+            return EXIT_FAILURE;
+        }
+
+        mt19937 rand(options_vars["seed"].as<unsigned>());
+        lengths.clear();
+        heights.clear();
+        // Heights up to the capacity, so a task can be forced to run alone,
+        // and lengths from one to four: enough of a mix that the profile has
+        // peaks to check, without the instance's difficulty running away with
+        // n.
+        for (long long i = 0; i < n; ++i) {
+            lengths.push_back(Integer{uniform_int_distribution<long long>{1, 4}(rand)});
+            heights.push_back(Integer{uniform_int_distribution<long long>{1, capacity.raw_value}(rand)});
+        }
+
+        // Every task end to end always fits, so a generated instance is always
+        // feasible and --horizon only ever has to be raised from here.
+        horizon = 0_i;
+        for (const auto & l : lengths)
+            horizon += l;
+    }
+
+    if (auto horizon_override = options_vars["horizon"].as<long long>(); horizon_override != 0) {
+        if (horizon_override < 1) {
+            println(cerr, "Error: --horizon must be positive, not {}.", horizon_override);
+            return EXIT_FAILURE;
+        }
+        horizon = Integer{horizon_override};
+    }
+
     Problem p;
     auto starts = p.create_integer_variable_vector(lengths.size(), 0_i, horizon, "s");
 
-    p.post(Cumulative{starts, lengths, heights, capacity});
+    auto cumulative = Cumulative{starts, lengths, heights, capacity};
+    if (encoding)
+        cumulative.with_encoding(*encoding);
+    p.post(move(cumulative));
 
     auto makespan = p.create_integer_variable(0_i, horizon + Integer{static_cast<long long>(lengths.size())}, "makespan");
     for (auto i = 0u; i < lengths.size(); ++i)

--- a/examples/cumulative/cumulative.cc
+++ b/examples/cumulative/cumulative.cc
@@ -100,6 +100,19 @@ auto main(int argc, char * argv[]) -> int
                 cxxopts::value<long long>())                                                                       //
             ("capacity", "Resource capacity for a generated instance",                                             //
                 cxxopts::value<long long>()->default_value("3"))                                                   //
+            ("max-length",                                                                                         //
+                "Generated lengths are drawn from 1 .. this. The default of four keeps a generated "               //
+                "instance small enough to solve; the case the start-checkpoint encoding exists for is "            //
+                "the opposite one, a few tasks of very long duration, where the time-indexed block is "            //
+                "linear in the duration and the start-checkpoint one does not mention it",                         //
+                cxxopts::value<long long>()->default_value("4"))                                                   //
+            ("max-start",                                                                                          //
+                "Start times are drawn from 0 .. this. Zero, the default, uses the whole horizon, which "          //
+                "is what makes a long duration expensive to *solve* as well as to encode. Setting it "             //
+                "small separates the two: a task of duration 10000 whose start has nine possible values "          //
+                "still has a 10000-long window, and so a per-time block linear in the duration, but an "           //
+                "instance anyone can solve",                                                                       //
+                cxxopts::value<long long>()->default_value("0"))                                                   //
             ("horizon",                                                                                            //
                 "Override the planning horizon. The optimum does not depend on it once it is large "               //
                 "enough to hold one, but the time-indexed encoding is linear in it and the "                       //
@@ -162,15 +175,20 @@ auto main(int argc, char * argv[]) -> int
             return EXIT_FAILURE;
         }
 
+        auto max_length = options_vars["max-length"].as<long long>();
+        if (max_length < 1) {
+            println(cerr, "Error: --max-length must be at least 1, not {}.", max_length);
+            return EXIT_FAILURE;
+        }
+
         mt19937 rand(options_vars["seed"].as<unsigned>());
         lengths.clear();
         heights.clear();
         // Heights up to the capacity, so a task can be forced to run alone,
-        // and lengths from one to four: enough of a mix that the profile has
-        // peaks to check, without the instance's difficulty running away with
-        // n.
+        // and lengths from one to --max-length: enough of a mix that the
+        // profile has peaks to check.
         for (long long i = 0; i < n; ++i) {
-            lengths.push_back(Integer{uniform_int_distribution<long long>{1, 4}(rand)});
+            lengths.push_back(Integer{uniform_int_distribution<long long>{1, max_length}(rand)});
             heights.push_back(Integer{uniform_int_distribution<long long>{1, capacity.raw_value}(rand)});
         }
 
@@ -189,8 +207,24 @@ auto main(int argc, char * argv[]) -> int
         horizon = Integer{horizon_override};
     }
 
+    // The start domain, which --max-start separates from the horizon. They are
+    // the same thing by default, and a long duration then makes the instance
+    // expensive to solve as well as to encode --- which is the confound to
+    // avoid when the question is about the *encoding*: what makes the per-time
+    // block big is the task's possible-active window, which runs from the
+    // earliest start to the latest start plus the length, so a long task has a
+    // long window however few starts it can take.
+    auto max_start = horizon;
+    if (auto max_start_override = options_vars["max-start"].as<long long>(); max_start_override != 0) {
+        if (max_start_override < 0) {
+            println(cerr, "Error: --max-start must not be negative, not {}.", max_start_override);
+            return EXIT_FAILURE;
+        }
+        max_start = Integer{max_start_override};
+    }
+
     Problem p;
-    auto starts = p.create_integer_variable_vector(lengths.size(), 0_i, horizon, "s");
+    auto starts = p.create_integer_variable_vector(lengths.size(), 0_i, max_start, "s");
 
     auto cumulative = Cumulative{starts, lengths, heights, capacity};
     if (encoding)

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -247,8 +247,22 @@ if(GCS_BUILD_TESTS)
     # `scp_chain_cumulative*` case must not have one either, for a better
     # reason: the chain checks our proof against *cake's* OPB, which has no
     # start-checkpoint rows in it at all, so a recovery has nothing to cite.
+    #
+    # A fourth arm, `<name>_startcheckpoint`, drops the per-time capacity rows
+    # from the model altogether (CumulativeEncoding::StartCheckpoint). This is
+    # the leak check, and it replaces the OPB-stripping one the script beside it
+    # does: a rule that still reads `capacity_lines` finds nothing there, its pol
+    # loses the supply it was counting on, and veripb rejects. Nobody has to
+    # enumerate where the old rows are read from --- the arm asks the question
+    # everywhere at once, and it reaches the rules CumulativeRules leaves off by
+    # default, which an .scp-driven check cannot.
+    #
+    # It goes only on lanes whose every firing rule has moved over. The list of
+    # lanes that are *not* on it, further down, is #780's progress bar: when it
+    # is empty, the time-indexed block can go.
     file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/cumulative_checkpoint)
     file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/cumulative_recovering)
+    file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/cumulative_startcheckpoint)
     #
     # Which arm a lane belongs to is *recorded* here and applied further down,
     # after the runtime-cap block: that block sets ENVIRONMENT on every test in
@@ -272,6 +286,15 @@ if(GCS_BUILD_TESTS)
         add_test(NAME ${name} COMMAND ${ARGN})
         add_cumulative_arm(${name} checkpoint ${CMAKE_CURRENT_BINARY_DIR}/cumulative_checkpoint ${ARGN})
         add_cumulative_arm(${name} recovering ${CMAKE_CURRENT_BINARY_DIR}/cumulative_recovering ${ARGN})
+    endfunction()
+    # For a lane every rule of which has moved over to the recovered rows: as
+    # add_cumulative_test_with_recovery, plus the arm that deletes the per-time
+    # block from the model entirely. See the note above about what that checks.
+    function(add_cumulative_test_converted name)
+        add_test(NAME ${name} COMMAND ${ARGN})
+        add_cumulative_arm(${name} checkpoint ${CMAKE_CURRENT_BINARY_DIR}/cumulative_checkpoint ${ARGN})
+        add_cumulative_arm(${name} recovering ${CMAKE_CURRENT_BINARY_DIR}/cumulative_recovering ${ARGN})
+        add_cumulative_arm(${name} startcheckpoint ${CMAKE_CURRENT_BINARY_DIR}/cumulative_startcheckpoint ${ARGN})
     endfunction()
 
     add_executable(inferred_cumulative_presolver_test presolvers/inferred_cumulative/inferred_cumulative_test.cc)
@@ -426,8 +449,8 @@ if(GCS_BUILD_TESTS)
     add_test(NAME count_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:count_test>)
     add_test(NAME bounds_global_cardinality_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:bounds_global_cardinality_test>)
     add_test(NAME gac_global_cardinality_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:gac_global_cardinality_test>)
-    add_cumulative_test_with_recovery(cumulative_constraint ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_test>)
-    add_cumulative_test_with_recovery(cumulative_overload ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_overload_test>)
+    add_cumulative_test_converted(cumulative_constraint ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_test>)
+    add_cumulative_test_converted(cumulative_overload ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_overload_test>)
     add_cumulative_test_with_recovery(cumulative_edge_finding ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_edge_finding_test>)
     foreach(mutation drop toofar capacity mirror_drop mirror_toofar)
         add_cumulative_test(cumulative_edge_finding_mutation_${mutation}
@@ -503,7 +526,7 @@ if(GCS_BUILD_TESTS)
     # corrupts a *derived* row rather than a model one, and without the twin the
     # recovering arm would have no negative test over that path at all.
     foreach(mutation energy capacity window)
-        add_cumulative_test_with_recovery(cumulative_overload_mutation_${mutation}
+        add_cumulative_test_converted(cumulative_overload_mutation_${mutation}
             ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_expect_verify_failure.bash
                 --basename cumulative_overload_mutation_${mutation} $<TARGET_FILE:cumulative_overload_test> --mutate=${mutation})
     endforeach()
@@ -527,24 +550,20 @@ if(GCS_BUILD_TESTS)
     # it whole (`whole`), and recheck against an OPB with the per-time capacity
     # rows stripped out.
     #
-    # `whole` is the stronger claim and the one that measures progress: it
-    # refuses any model whose proof still cites a per-time row, so a model can
-    # only go in that mode once every rule it fires has been moved over to the
-    # recovered rows.
+    # `whole` is the stronger claim: it refuses any model whose proof still cites
+    # a per-time row, so a model can only go in that mode once every rule it
+    # fires has been moved over to the recovered rows. Every case here is `whole`
+    # now, which says the *default* rule set --- time-tabling, the overload check
+    # and its (TTOC) strengthening --- is converted.
     #
-    # Every case here is now `whole`, which says something narrower than it
-    # looks: it says the *default* rule set --- time-tabling, the overload check
-    # and its (TTOC) strengthening --- is fully converted. It does not say the
-    # time-indexed block can go. The citers that are left (the elastic and
-    # knapsack availability lines, edge-finding's window rows, published
-    # not-first / not-last) all sit behind CumulativeRules fields that are off by
-    # default, and an .scp model has no way to turn them on --- the reader builds
-    # a plain Cumulative and glasgow_scp_solver has no flag for the rules. So no
-    # case that could stay in `prefix` and mark them outstanding can be written
-    # in this vehicle at all. Reaching them needs a way to select rules from the
-    # scp path, or the same strip-and-recheck applied to the proofs a C++ lane
-    # writes under GCS_PRESERVE_PROOF_FILES; until one of those exists, the
-    # remaining steps of #780 are tracked by the issue and not by this bar.
+    # These stay as a direct check on the recovery's own derivation --- `prefix`
+    # mode cuts the proof at the recovery's marker, which nothing else does ---
+    # but they are no longer #780's progress bar. The `startcheckpoint` arm is,
+    # and it is a better one in every way: it deletes the per-time rows at the
+    # source rather than post-processing a finished OPB, it needs no .scp
+    # vehicle, and it therefore reaches the rules CumulativeRules leaves off by
+    # default, which these four models cannot fire at all. See the list of lanes
+    # not yet on that arm, below.
     function(add_checkpoint_recovery_leak_check case mode)
         add_test(NAME cumulative_checkpoint_recovery_${case}_${mode}
             COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_checkpoint_recovery_leak_check.bash
@@ -571,11 +590,53 @@ if(GCS_BUILD_TESTS)
     # has mandatory part [3,4) at height 2, and that is what tips it to 14 > 12.
     # So the case cannot pass by accident on the plain overload check.
     add_checkpoint_recovery_leak_check(ttoc whole)
+    # And each again in `no-block` mode, which never emits the per-time rows at
+    # all rather than deleting them afterwards. These are what stop the
+    # `startcheckpoint` ctest arm going vacuous: they fail if the encoding falls
+    # back for these models instead of dropping the block. See the script.
+    add_checkpoint_recovery_leak_check(overflow_only no-block)
+    add_checkpoint_recovery_leak_check(leak_check no-block)
+    add_checkpoint_recovery_leak_check(overload no-block)
+    add_checkpoint_recovery_leak_check(ttoc no-block)
+
+    # #780's progress bar: the cumulative lanes that are *not* on the
+    # `startcheckpoint` arm, and what has to happen before they can be. Each is
+    # a lane whose proof still reads capacity_lines somewhere, so deleting the
+    # per-time rows leaves one of its pols short of supply and veripb rejects.
+    # Confirmed by running each under GCS_CUMULATIVE_ENCODING=start-checkpoint;
+    # they fail, and they fail loudly.
+    #
+    #   cumulative_kaoc                    the knapsack / elastic per-time
+    #                                      availability lines
+    #   cumulative_edge_finding            edge-finding's window rows
+    #   cumulative_ttef                    (same, via the profile term)
+    #   cumulative_energetic               (same, energetic form)
+    #   cumulative_energetic_random
+    #   cumulative_nfnl                    not-first / not-last
+    #   cumulative_published_nfnl          published not-first / not-last
+    #   cumulative_published_nfnl_random
+    #   derived_cumulative                 derived_cumulative.cc: donor rows and
+    #                                      the makespan bound
+    #   inferred_cumulative_presolver      (reach derived_cumulative)
+    #   cumulative_strengthening_presolver
+    #
+    # Move a lane onto the arm by changing its add_cumulative_test_with_recovery
+    # to add_cumulative_test_converted, and delete its line here. **When this
+    # list is empty, the time-indexed block can go.**
+    #
+    # Two lanes are absent from the arm for a different reason and are not part
+    # of the bar: cumulative_optional_mutation_wrong_task and
+    # cumulative_optional_mutation_emit_nothing stop discriminating under it, as
+    # they already do under `both` and for the same reason --- more model is
+    # more for unit propagation to reach. They are not unconverted; the arm just
+    # cannot hold them. The scp_chain_cumulative* cases are out for the reason
+    # they are out of the recovering arm: they check our proof against cake's
+    # OPB, which has no start-checkpoint rows at all.
 
     # One ctest entry per mode, each writing proofs under its own basename, so a
     # parallel run does not have two entries racing over one set of files.
     foreach(mode enumerate falsify bijection objective)
-        add_cumulative_test_with_recovery(cumulative_optional_constraint_${mode}
+        add_cumulative_test_converted(cumulative_optional_constraint_${mode}
             ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_optional_test> ${mode})
     endforeach()
     # Presence-falsification mutation lanes, the same shape as the overload
@@ -803,6 +864,8 @@ if(GCS_BUILD_TESTS)
     add_cumulative_arm(cumulative_constraint_view_mixed checkpoint ${CMAKE_CURRENT_BINARY_DIR}/cumulative_checkpoint
         ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_test> --view-position=mixed)
     add_cumulative_arm(cumulative_constraint_view_mixed recovering ${CMAKE_CURRENT_BINARY_DIR}/cumulative_recovering
+        ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_test> --view-position=mixed)
+    add_cumulative_arm(cumulative_constraint_view_mixed startcheckpoint ${CMAKE_CURRENT_BINARY_DIR}/cumulative_startcheckpoint
         ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_test> --view-position=mixed)
     add_view_tests(regular_constraint regular_test 4)
     add_test(NAME in_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:in_test>)
@@ -1075,6 +1138,10 @@ if(GCS_BUILD_TESTS)
     get_property(gcs_cumulative_recovering_tests GLOBAL PROPERTY gcs_cumulative_recovering_tests)
     foreach(cumulative_arm_test IN LISTS gcs_cumulative_recovering_tests)
         set_property(TEST ${cumulative_arm_test} APPEND PROPERTY ENVIRONMENT "GCS_CUMULATIVE_ENCODING=both-recovering")
+    endforeach()
+    get_property(gcs_cumulative_startcheckpoint_tests GLOBAL PROPERTY gcs_cumulative_startcheckpoint_tests)
+    foreach(cumulative_arm_test IN LISTS gcs_cumulative_startcheckpoint_tests)
+        set_property(TEST ${cumulative_arm_test} APPEND PROPERTY ENVIRONMENT "GCS_CUMULATIVE_ENCODING=start-checkpoint")
     endforeach()
     get_property(gcs_cumulative_checkpoint_recovering_tests GLOBAL PROPERTY gcs_cumulative_checkpoint_recovering_tests)
     foreach(cumulative_arm_test IN LISTS gcs_cumulative_checkpoint_recovering_tests)

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -33,6 +33,7 @@ add_library(glasgow_constraint_solver
         constraints/comparison/comparison.cc
         constraints/count/count.cc
         constraints/cumulative/cumulative.cc
+        constraints/cumulative/checkpoint_recovery.cc
         constraints/cumulative/derived_cumulative.cc
         constraints/cumulative/derived_cumulative_stats.cc
         constraints/cumulative/donor_view.cc
@@ -235,29 +236,58 @@ if(GCS_BUILD_TESTS)
     # twin of one of those would assert something false. When a lane comes off
     # that list it should be because its certificate stopped leaning on rows
     # the encoding is about to lose, not because the list got tidied.
+    #
+    # A third arm, `<name>_recovering`, derives every capacity row back out of
+    # the start-checkpoint rows and checks it against the one the model still
+    # carries (CumulativeEncoding::BothRecovering). It goes only on the lanes
+    # registered through add_cumulative_test_with_recovery, which is every
+    # cumulative lane except two kinds. A mutation lane must not have one: the
+    # recovery puts yet more in the database for unit propagation to reach, and
+    # four more of them stop discriminating under it than under `both` alone. A
+    # `scp_chain_cumulative*` case must not have one either, for a better
+    # reason: the chain checks our proof against *cake's* OPB, which has no
+    # start-checkpoint rows in it at all, so a recovery has nothing to cite.
     file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/cumulative_checkpoint)
+    file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/cumulative_recovering)
+    #
+    # Which arm a lane belongs to is *recorded* here and applied further down,
+    # after the runtime-cap block: that block sets ENVIRONMENT on every test in
+    # the directory with set_tests_properties, which replaces the property
+    # rather than adding to it, so an encoding set here would be silently
+    # dropped and the twin would run the arm it was meant to be twinning. That
+    # is not hypothetical --- it is how these lanes were first written, and
+    # every one of them was quietly vacuous until a mutation lane that must
+    # fail started passing. Follow the APPEND idiom the linear and disjunctive
+    # lanes below already use.
+    function(add_cumulative_arm name arm directory)
+        add_test(NAME ${name}_${arm} COMMAND ${ARGN})
+        set_tests_properties(${name}_${arm} PROPERTIES WORKING_DIRECTORY ${directory})
+        set_property(GLOBAL APPEND PROPERTY gcs_cumulative_${arm}_tests ${name}_${arm})
+    endfunction()
     function(add_cumulative_test name)
         add_test(NAME ${name} COMMAND ${ARGN})
-        add_test(NAME ${name}_checkpoint COMMAND ${ARGN})
-        set_tests_properties(${name}_checkpoint PROPERTIES
-            ENVIRONMENT "GCS_CUMULATIVE_ENCODING=both"
-            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/cumulative_checkpoint)
+        add_cumulative_arm(${name} checkpoint ${CMAKE_CURRENT_BINARY_DIR}/cumulative_checkpoint ${ARGN})
+    endfunction()
+    function(add_cumulative_test_with_recovery name)
+        add_test(NAME ${name} COMMAND ${ARGN})
+        add_cumulative_arm(${name} checkpoint ${CMAKE_CURRENT_BINARY_DIR}/cumulative_checkpoint ${ARGN})
+        add_cumulative_arm(${name} recovering ${CMAKE_CURRENT_BINARY_DIR}/cumulative_recovering ${ARGN})
     endfunction()
 
     add_executable(inferred_cumulative_presolver_test presolvers/inferred_cumulative/inferred_cumulative_test.cc)
     target_link_libraries(inferred_cumulative_presolver_test PRIVATE glasgow_constraint_solver)
-    add_cumulative_test(inferred_cumulative_presolver
+    add_cumulative_test_with_recovery(inferred_cumulative_presolver
         ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:inferred_cumulative_presolver_test>)
 
     add_executable(inferred_disjunctive_presolver_test presolvers/inferred_disjunctive/inferred_disjunctive_test.cc)
     target_link_libraries(inferred_disjunctive_presolver_test PRIVATE glasgow_constraint_solver)
     # Twinned too: it cites a *Cumulative* donor's per-(task, time) flags.
-    add_cumulative_test(inferred_disjunctive_presolver
+    add_cumulative_test_with_recovery(inferred_disjunctive_presolver
         ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:inferred_disjunctive_presolver_test>)
 
     add_executable(cumulative_strengthening_presolver_test presolvers/cumulative_strengthening/cumulative_strengthening_test.cc)
     target_link_libraries(cumulative_strengthening_presolver_test PRIVATE glasgow_constraint_solver)
-    add_cumulative_test(cumulative_strengthening_presolver
+    add_cumulative_test_with_recovery(cumulative_strengthening_presolver
         ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_strengthening_presolver_test>)
 
     add_executable(constraint_enumeration_test constraint_enumeration_test.cc)
@@ -396,17 +426,17 @@ if(GCS_BUILD_TESTS)
     add_test(NAME count_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:count_test>)
     add_test(NAME bounds_global_cardinality_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:bounds_global_cardinality_test>)
     add_test(NAME gac_global_cardinality_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:gac_global_cardinality_test>)
-    add_cumulative_test(cumulative_constraint ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_test>)
-    add_cumulative_test(cumulative_overload ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_overload_test>)
-    add_cumulative_test(cumulative_edge_finding ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_edge_finding_test>)
+    add_cumulative_test_with_recovery(cumulative_constraint ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_test>)
+    add_cumulative_test_with_recovery(cumulative_overload ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_overload_test>)
+    add_cumulative_test_with_recovery(cumulative_edge_finding ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_edge_finding_test>)
     foreach(mutation drop toofar capacity mirror_drop mirror_toofar)
         add_cumulative_test(cumulative_edge_finding_mutation_${mutation}
             ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_expect_verify_failure.bash
                 --basename cumulative_edge_finding_mutation_${mutation} $<TARGET_FILE:cumulative_edge_finding_test> --mutate=${mutation})
     endforeach()
-    add_cumulative_test(cumulative_ttef ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_ttef_test>)
-    add_cumulative_test(cumulative_nfnl ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_nfnl_test>)
-    add_cumulative_test(cumulative_kaoc ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_kaoc_test>)
+    add_cumulative_test_with_recovery(cumulative_ttef ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_ttef_test>)
+    add_cumulative_test_with_recovery(cumulative_nfnl ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_nfnl_test>)
+    add_cumulative_test_with_recovery(cumulative_kaoc ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_kaoc_test>)
     foreach(fixture cloutier_ex2 dp_path compulsory)
         foreach(mutation claim_one_better strengthen_one_fewer capacity)
             add_cumulative_test(cumulative_kaoc_mutation_${fixture}_${mutation}
@@ -424,9 +454,9 @@ if(GCS_BUILD_TESTS)
     # the window-energy lemma. `emit_nothing` is the control and `drop_pin` the
     # lane aimed at what is new; dropping the contiguity rows themselves cannot
     # be caught, and cumulative_mutations.hh records why.
-    add_cumulative_test(cumulative_published_nfnl
+    add_cumulative_test_with_recovery(cumulative_published_nfnl
         ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_published_nfnl_test>)
-    add_cumulative_test(cumulative_published_nfnl_random
+    add_cumulative_test_with_recovery(cumulative_published_nfnl_random
         ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_published_nfnl_test> --random 7)
     foreach(mutation emit_nothing drop_pin toofar roomy_toofar roomy_drop_pin)
         add_cumulative_test(cumulative_published_nfnl_mutation_${mutation}
@@ -450,16 +480,16 @@ if(GCS_BUILD_TESTS)
     # mandatory part. `drop_energetic` is the lane that matters: it removes the
     # row of a task the window does not contain, which is the only energy plain
     # edge-finding would not have cited.
-    add_cumulative_test(cumulative_energetic
+    add_cumulative_test_with_recovery(cumulative_energetic
         ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_energetic_test>)
-    add_cumulative_test(cumulative_energetic_random
+    add_cumulative_test_with_recovery(cumulative_energetic_random
         ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_energetic_test> --random 17)
     foreach(mutation drop_energetic drop toofar capacity mirror_drop_energetic mirror_toofar)
         add_cumulative_test(cumulative_energetic_mutation_${mutation}
             ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_expect_verify_failure.bash
                 --basename cumulative_energetic_mutation_${mutation} $<TARGET_FILE:cumulative_energetic_test> --mutate=${mutation})
     endforeach()
-    add_cumulative_test(derived_cumulative ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:derived_cumulative_test>)
+    add_cumulative_test_with_recovery(derived_cumulative ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:derived_cumulative_test>)
     # Mutation lanes: each writes a deliberately corrupted proof of the
     # sharp-margin fixture, and passes only if veripb rejects it. Distinct
     # basenames so the lanes do not race over one set of proof files.
@@ -468,10 +498,36 @@ if(GCS_BUILD_TESTS)
             ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_expect_verify_failure.bash
                 --basename cumulative_overload_mutation_${mutation} $<TARGET_FILE:cumulative_overload_test> --mutate=${mutation})
     endforeach()
+    # #780: the corruption no `pol` failure catches. Recovering a capacity row
+    # from the neighbouring task's checkpoint leaves every step of the
+    # derivation valid and produces a perfectly good line --- it is simply not
+    # the row the model states, and only the implication check against that row
+    # rejects it. Needs the recovering encoding, since under any other the
+    # recovery does not run and the proof comes out honest.
+    add_cumulative_arm(cumulative_overload_mutation_recover_wrong checkpoint_recovering
+        ${CMAKE_CURRENT_BINARY_DIR}/cumulative_recovering
+        ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_expect_verify_failure.bash
+            --basename cumulative_overload_mutation_recover_wrong $<TARGET_FILE:cumulative_overload_test>
+            --mutate=recover_wrong_checkpoint)
+
+    # And the other half of what the recovering arm has to be held to: that the
+    # recovery stands on the start-checkpoint rows *alone*. Every lane above
+    # runs with both blocks in the model, where a rup inside the recovery could
+    # be closing against the very row it claims to derive and nothing would
+    # say so. This one cuts the proof at the recovery's own marker and rechecks
+    # the prefix against an OPB with the per-time rows stripped out. The model
+    # is four tasks with four different durations, so the candidate set differs
+    # from one time point to the next and the weakening path is exercised.
+    add_test(NAME cumulative_checkpoint_recovery_leak_check
+        COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_checkpoint_recovery_leak_check.bash
+            $<TARGET_FILE:glasgow_scp_solver> ${CMAKE_CURRENT_SOURCE_DIR}/constraints/cumulative/checkpoint_recovery_leak_check.scp)
+    set_tests_properties(cumulative_checkpoint_recovery_leak_check PROPERTIES SKIP_RETURN_CODE 77
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/cumulative_recovering)
+
     # One ctest entry per mode, each writing proofs under its own basename, so a
     # parallel run does not have two entries racing over one set of files.
     foreach(mode enumerate falsify bijection objective)
-        add_cumulative_test(cumulative_optional_constraint_${mode}
+        add_cumulative_test_with_recovery(cumulative_optional_constraint_${mode}
             ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_optional_test> ${mode})
     endforeach()
     # Presence-falsification mutation lanes, the same shape as the overload
@@ -696,11 +752,10 @@ if(GCS_BUILD_TESTS)
     # And its always-on mixed-view lane under the other encoding (#780): two
     # different views in one constraint is the shape the checkpoint rows meet
     # that the per-time ones never do, since a checkpoint row names two starts.
-    add_test(NAME cumulative_constraint_view_mixed_checkpoint
-        COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_test> --view-position=mixed)
-    set_tests_properties(cumulative_constraint_view_mixed_checkpoint PROPERTIES
-        ENVIRONMENT "GCS_CUMULATIVE_ENCODING=both"
-        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/cumulative_checkpoint)
+    add_cumulative_arm(cumulative_constraint_view_mixed checkpoint ${CMAKE_CURRENT_BINARY_DIR}/cumulative_checkpoint
+        ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_test> --view-position=mixed)
+    add_cumulative_arm(cumulative_constraint_view_mixed recovering ${CMAKE_CURRENT_BINARY_DIR}/cumulative_recovering
+        ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_test> --view-position=mixed)
     add_view_tests(regular_constraint regular_test 4)
     add_test(NAME in_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:in_test>)
     add_test(NAME increasing_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:increasing_test>)
@@ -961,6 +1016,22 @@ if(GCS_BUILD_TESTS)
         set_tests_properties(${gcs_registered_tests} PROPERTIES ENVIRONMENT
             "GCS_TEST_MAX_SOLUTIONS=${GCS_TEST_MAX_SOLUTIONS};GCS_TEST_MAX_RECURSIONS=${GCS_TEST_MAX_RECURSIONS}")
     endif()
+
+    # #780's encoding arms, APPENDed after the runtime caps above rather than
+    # set at registration, since set_tests_properties there replaces the whole
+    # ENVIRONMENT property. See add_cumulative_arm.
+    get_property(gcs_cumulative_checkpoint_tests GLOBAL PROPERTY gcs_cumulative_checkpoint_tests)
+    foreach(cumulative_arm_test IN LISTS gcs_cumulative_checkpoint_tests)
+        set_property(TEST ${cumulative_arm_test} APPEND PROPERTY ENVIRONMENT "GCS_CUMULATIVE_ENCODING=both")
+    endforeach()
+    get_property(gcs_cumulative_recovering_tests GLOBAL PROPERTY gcs_cumulative_recovering_tests)
+    foreach(cumulative_arm_test IN LISTS gcs_cumulative_recovering_tests)
+        set_property(TEST ${cumulative_arm_test} APPEND PROPERTY ENVIRONMENT "GCS_CUMULATIVE_ENCODING=both-recovering")
+    endforeach()
+    get_property(gcs_cumulative_checkpoint_recovering_tests GLOBAL PROPERTY gcs_cumulative_checkpoint_recovering_tests)
+    foreach(cumulative_arm_test IN LISTS gcs_cumulative_checkpoint_recovering_tests)
+        set_property(TEST ${cumulative_arm_test} APPEND PROPERTY ENVIRONMENT "GCS_CUMULATIVE_ENCODING=both-recovering")
+    endforeach()
 
     # Clear the runtime caps for the two lanes whose whole content is comparing
     # one model's solution *set* against another's. A cap that fires truncates

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -646,24 +646,19 @@ if(GCS_BUILD_TESTS)
     # Read that precisely: every *rule* is converted, and not yet every *shape*.
     # Nothing reads capacity_lines directly any more --- it all goes through
     # capacity_row --- but capacity_row still falls back to the model row for a
-    # Cumulative the recovery cannot speak about: a variable height or a
-    # variable capacity. Those keep the per-time block and use it for
-    # everything, and they are not rare: 95 of the 440 proofs the
-    # cumulative test binaries write under this arm still contain cap_ rows. So
+    # Cumulative the recovery cannot speak about, which is now only a variable
+    # capacity. Those keep the per-time block and use it for everything, and
+    # there are 10 such proofs out of the 440 the cumulative test binaries
+    # write under this arm --- every one of them named for a variable
+    # capacity. So
     # the block cannot be *deleted* yet; it can only stop being emitted for
     # constraints that qualify, which is what this arm already does. Extending
     # the recovery to the rest is the remaining work, and
     # checkpoint_recovery.hh says what each would take.
     #
-    # **Optional tasks and variable lengths are no longer on that list.** Both
-    # came out of the same one change, the diagonal: give a task a presence or a
-    # variable length and the encoding mints sact_{j,j} and puts j's own height
-    # on the checkpoint row, where a constant-length task with no presence has
-    # it folded into the right hand side and needs a literal axiom instead. So
-    # the recovery pins the diagonal where the flag is there and axiomatises it
-    # where it is not. Every one of cumulative_optional_test's 35 proofs is now
-    # free of cap_ rows, where 18 were not, and the fallback fraction went
-    # 149 -> 121 -> 95 over the two.
+    # **Optional tasks, variable lengths and variable heights have all come off
+    # that list**, and the fallback fraction with them: 149 -> 121 -> 95 -> 10
+    # out of 440. See dev_docs for what each took.
     #
     # Lanes that are off the arm but are *not* part of the bar, all of them
     # mutation lanes that stop discriminating once the per-time block is gone

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -645,20 +645,14 @@ if(GCS_BUILD_TESTS)
     #
     # Read that precisely: every *rule* is converted, and not yet every *shape*.
     # Nothing reads capacity_lines directly any more --- it all goes through
-    # capacity_row --- but capacity_row still falls back to the model row for a
-    # Cumulative the recovery cannot speak about, which is now only a variable
-    # capacity. Those keep the per-time block and use it for everything, and
-    # there are 10 such proofs out of the 440 the cumulative test binaries
-    # write under this arm --- every one of them named for a variable
-    # capacity. So
-    # the block cannot be *deleted* yet; it can only stop being emitted for
-    # constraints that qualify, which is what this arm already does. Extending
-    # the recovery to the rest is the remaining work, and
-    # checkpoint_recovery.hh says what each would take.
-    #
-    # **Optional tasks, variable lengths and variable heights have all come off
-    # that list**, and the fallback fraction with them: 149 -> 121 -> 95 -> 10
-    # out of 440. See dev_docs for what each took.
+    # capacity_row --- and **every shape is converted now too**. The recovery
+    # speaks about optional tasks, variable lengths, variable heights and a
+    # variable capacity, so capacity_row's fallback to the model row is
+    # unreachable for any Cumulative that has an active task at all: of the 440
+    # proofs the cumulative test binaries write under this arm, **none**
+    # contains a cap_ row, where 149 did when the arm was built. The per-time
+    # block is not merely skipped where it happens to be safe any more --- it
+    # is replaceable outright. See dev_docs for what each shape took.
     #
     # Lanes that are off the arm but are *not* part of the bar, all of them
     # mutation lanes that stop discriminating once the per-time block is gone

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -458,14 +458,17 @@ if(GCS_BUILD_TESTS)
     add_test(NAME gac_global_cardinality_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:gac_global_cardinality_test>)
     add_cumulative_test_converted(cumulative_constraint ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_test>)
     add_cumulative_test_converted(cumulative_overload ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_overload_test>)
-    add_cumulative_test_with_recovery(cumulative_edge_finding ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_edge_finding_test>)
+    add_cumulative_test_converted(cumulative_edge_finding ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_edge_finding_test>)
+    # All five still discriminate on the startcheckpoint arm, checked one at a
+    # time. `capacity` is the direct negative test for #780's step 7: it omits a
+    # row from the window supply, which on that arm is a recovered row.
     foreach(mutation drop toofar capacity mirror_drop mirror_toofar)
-        add_cumulative_test(cumulative_edge_finding_mutation_${mutation}
+        add_cumulative_test_converted_no_recovery(cumulative_edge_finding_mutation_${mutation}
             ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_expect_verify_failure.bash
                 --basename cumulative_edge_finding_mutation_${mutation} $<TARGET_FILE:cumulative_edge_finding_test> --mutate=${mutation})
     endforeach()
-    add_cumulative_test_with_recovery(cumulative_ttef ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_ttef_test>)
-    add_cumulative_test_with_recovery(cumulative_nfnl ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_nfnl_test>)
+    add_cumulative_test_converted(cumulative_ttef ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_ttef_test>)
+    add_cumulative_test_converted(cumulative_nfnl ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_nfnl_test>)
     add_cumulative_test_converted(cumulative_kaoc ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_kaoc_test>)
     # On the startcheckpoint arm as well, each checked to still discriminate
     # there. `capacity` is the one that earns it: it omits a row from the
@@ -479,11 +482,16 @@ if(GCS_BUILD_TESTS)
                     --mutate=${mutation} --fixture=${fixture})
         endforeach()
     endforeach()
-    foreach(mutation toofar drop roomy_toofar roomy_drop)
-        add_cumulative_test(cumulative_nfnl_mutation_${mutation}
+    foreach(mutation toofar drop roomy_toofar)
+        add_cumulative_test_converted_no_recovery(cumulative_nfnl_mutation_${mutation}
             ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_expect_verify_failure.bash
                 --basename cumulative_nfnl_mutation_${mutation} $<TARGET_FILE:cumulative_nfnl_test> --mutate=${mutation})
     endforeach()
+    # Not on the startcheckpoint arm, for the same reason the ttef pin lanes are
+    # not: veripb accepts the corruption once the per-time block is gone.
+    add_cumulative_test(cumulative_nfnl_mutation_roomy_drop
+        ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_expect_verify_failure.bash
+            --basename cumulative_nfnl_mutation_roomy_drop $<TARGET_FILE:cumulative_nfnl_test> --mutate=roomy_drop)
     # The detection as published (#746), certified by contiguity rather than by
     # the window-energy lemma. `emit_nothing` is the control and `drop_pin` the
     # lane aimed at what is new; dropping the contiguity rows themselves cannot
@@ -504,7 +512,17 @@ if(GCS_BUILD_TESTS)
     add_test(NAME cumulative_published_nfnl_mutation_drop
         COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_expect_verify_failure.bash
             --basename cumulative_published_nfnl_mutation_drop $<TARGET_FILE:cumulative_published_nfnl_test> --mutate=drop)
-    foreach(mutation pins pin drop toofar mirror_pins mirror_pin mirror_toofar)
+    foreach(mutation pins drop toofar mirror_pins mirror_toofar)
+        add_cumulative_test_converted_no_recovery(cumulative_ttef_mutation_${mutation}
+            ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_expect_verify_failure.bash
+                --basename cumulative_ttef_mutation_${mutation} $<TARGET_FILE:cumulative_ttef_test> --mutate=${mutation})
+    endforeach()
+    # Not on the startcheckpoint arm: `pin` drops a single (task, time) pin, and
+    # with the per-time block gone the checkpoint rows relate the starts
+    # directly, which is enough for the wrapping RUP to close without it. veripb
+    # accepts the corrupted proof, so the lane would stop discriminating. It
+    # still says what it always said about the other encodings.
+    foreach(mutation pin mirror_pin)
         add_cumulative_test(cumulative_ttef_mutation_${mutation}
             ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_expect_verify_failure.bash
                 --basename cumulative_ttef_mutation_${mutation} $<TARGET_FILE:cumulative_ttef_test> --mutate=${mutation})
@@ -514,15 +532,23 @@ if(GCS_BUILD_TESTS)
     # mandatory part. `drop_energetic` is the lane that matters: it removes the
     # row of a task the window does not contain, which is the only energy plain
     # edge-finding would not have cited.
-    add_cumulative_test_with_recovery(cumulative_energetic
+    add_cumulative_test_converted(cumulative_energetic
         ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_energetic_test>)
-    add_cumulative_test_with_recovery(cumulative_energetic_random
+    add_cumulative_test_converted(cumulative_energetic_random
         ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_energetic_test> --random 17)
-    foreach(mutation drop_energetic drop toofar capacity mirror_drop_energetic mirror_toofar)
-        add_cumulative_test(cumulative_energetic_mutation_${mutation}
+    foreach(mutation drop_energetic drop toofar capacity mirror_toofar)
+        add_cumulative_test_converted_no_recovery(cumulative_energetic_mutation_${mutation}
             ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_expect_verify_failure.bash
                 --basename cumulative_energetic_mutation_${mutation} $<TARGET_FILE:cumulative_energetic_test> --mutate=${mutation})
     endforeach()
+    # Not on the startcheckpoint arm: same shape again --- veripb accepts the
+    # dropped row once the per-time block is gone. The forward `drop_energetic`
+    # lane, which is the one that matters for #755, does still discriminate and
+    # is on the arm above.
+    add_cumulative_test(cumulative_energetic_mutation_mirror_drop_energetic
+        ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_expect_verify_failure.bash
+            --basename cumulative_energetic_mutation_mirror_drop_energetic $<TARGET_FILE:cumulative_energetic_test>
+            --mutate=mirror_drop_energetic)
     add_cumulative_test_with_recovery(derived_cumulative ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:derived_cumulative_test>)
     # Mutation lanes: each writes a deliberately corrupted proof of the
     # sharp-margin fixture, and passes only if veripb rejects it. Distinct
@@ -617,11 +643,6 @@ if(GCS_BUILD_TESTS)
     # Confirmed by running each under GCS_CUMULATIVE_ENCODING=start-checkpoint;
     # they fail, and they fail loudly.
     #
-    #   cumulative_edge_finding            edge-finding's window rows
-    #   cumulative_ttef                    (same, via the profile term)
-    #   cumulative_energetic               (same, energetic form)
-    #   cumulative_energetic_random
-    #   cumulative_nfnl                    not-first / not-last
     #   cumulative_published_nfnl          published not-first / not-last
     #   cumulative_published_nfnl_random
     #   derived_cumulative                 derived_cumulative.cc: donor rows and

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -306,18 +306,18 @@ if(GCS_BUILD_TESTS)
 
     add_executable(inferred_cumulative_presolver_test presolvers/inferred_cumulative/inferred_cumulative_test.cc)
     target_link_libraries(inferred_cumulative_presolver_test PRIVATE glasgow_constraint_solver)
-    add_cumulative_test_with_recovery(inferred_cumulative_presolver
+    add_cumulative_test_converted(inferred_cumulative_presolver
         ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:inferred_cumulative_presolver_test>)
 
     add_executable(inferred_disjunctive_presolver_test presolvers/inferred_disjunctive/inferred_disjunctive_test.cc)
     target_link_libraries(inferred_disjunctive_presolver_test PRIVATE glasgow_constraint_solver)
     # Twinned too: it cites a *Cumulative* donor's per-(task, time) flags.
-    add_cumulative_test_with_recovery(inferred_disjunctive_presolver
+    add_cumulative_test_converted(inferred_disjunctive_presolver
         ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:inferred_disjunctive_presolver_test>)
 
     add_executable(cumulative_strengthening_presolver_test presolvers/cumulative_strengthening/cumulative_strengthening_test.cc)
     target_link_libraries(cumulative_strengthening_presolver_test PRIVATE glasgow_constraint_solver)
-    add_cumulative_test_with_recovery(cumulative_strengthening_presolver
+    add_cumulative_test_converted(cumulative_strengthening_presolver
         ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_strengthening_presolver_test>)
 
     add_executable(constraint_enumeration_test constraint_enumeration_test.cc)
@@ -552,7 +552,7 @@ if(GCS_BUILD_TESTS)
         ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_expect_verify_failure.bash
             --basename cumulative_energetic_mutation_mirror_drop_energetic $<TARGET_FILE:cumulative_energetic_test>
             --mutate=mirror_drop_energetic)
-    add_cumulative_test_with_recovery(derived_cumulative ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:derived_cumulative_test>)
+    add_cumulative_test_converted(derived_cumulative ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:derived_cumulative_test>)
     # Mutation lanes: each writes a deliberately corrupted proof of the
     # sharp-margin fixture, and passes only if veripb rejects it. Distinct
     # basenames so the lanes do not race over one set of proof files.
@@ -640,39 +640,37 @@ if(GCS_BUILD_TESTS)
     add_checkpoint_recovery_leak_check(ttoc no-block)
 
     # #780's progress bar: the cumulative lanes that are *not* on the
-    # `startcheckpoint` arm, and what has to happen before they can be. Each is
-    # a lane whose proof still reads capacity_lines somewhere, so deleting the
-    # per-time rows leaves one of its pols short of supply and veripb rejects.
-    # Confirmed by running each under GCS_CUMULATIVE_ENCODING=start-checkpoint;
-    # they fail, and they fail loudly.
+    # `startcheckpoint` arm because a rule they fire still reads the per-time
+    # block. **It is empty.** Every rule is converted, and every lane that
+    # exercises one runs with the block deleted from the model.
     #
-    #   derived_cumulative                 derived_cumulative.cc: donor rows and
-    #                                      the makespan bound
-    #   inferred_cumulative_presolver      (reach derived_cumulative)
-    #   cumulative_strengthening_presolver
+    # That is the condition for the time-indexed block to go, which is the next
+    # step of #780 and is deliberately not this one: deleting it means flipping
+    # the default, retiring the other arms, and pinning the scp_chain_cumulative*
+    # cases to the time-indexed encoding, none of which is a test registration.
     #
-    # Those last three are the one place the arm does *not* fail loudly, and it
-    # is worth knowing before relying on it. derived_cumulative.cc reads its
-    # donors' per-time rows by label, and a donor that wrote none makes the
-    # derivation decline --- which is a supported outcome, not an error, so the
-    # constraint is simply not installed and propagation quietly weakens. What
-    # notices is the lanes' own assertions about what got posted ("posted 0 cuts
-    # with a coefficient above one"), not veripb. Step 9 has to move that
-    # lookup onto the recovery like every other citer; until it does, do not
-    # read those three passing as evidence of anything.
+    # Lanes that are off the arm but are *not* part of the bar, all of them
+    # mutation lanes that stop discriminating once the per-time block is gone
+    # --- each drops a row or a pin that the checkpoint rows then put back by
+    # relating the starts directly, so veripb accepts the corruption:
     #
-    # Move a lane onto the arm by changing its add_cumulative_test_with_recovery
-    # to add_cumulative_test_converted, and delete its line here. **When this
-    # list is empty, the time-indexed block can go.**
+    #   cumulative_optional_mutation_{wrong_task,emit_nothing}
+    #   cumulative_ttef_mutation_{pin,mirror_pin}
+    #   cumulative_nfnl_mutation_roomy_drop
+    #   cumulative_energetic_mutation_mirror_drop_energetic
+    #   cumulative_published_nfnl_mutation_drop
     #
-    # Two lanes are absent from the arm for a different reason and are not part
-    # of the bar: cumulative_optional_mutation_wrong_task and
-    # cumulative_optional_mutation_emit_nothing stop discriminating under it, as
-    # they already do under `both` and for the same reason --- more model is
-    # more for unit propagation to reach. They are not unconverted; the arm just
-    # cannot hold them. The scp_chain_cumulative* cases are out for the reason
-    # they are out of the recovering arm: they check our proof against cake's
-    # OPB, which has no start-checkpoint rows at all.
+    # They still say what they always said about the other encodings. The
+    # scp_chain_cumulative* cases are off for the older reason: they check our
+    # proof against cake's OPB, which has no start-checkpoint rows at all.
+    #
+    # One thing to keep in mind if this bar is ever rebuilt for another rule:
+    # the derived-cumulative lanes are the one place the arm does *not* fail
+    # loudly. derived_cumulative.cc reads its donors' rows and a donor with none
+    # makes the derivation *decline*, which is a supported outcome rather than
+    # an error --- so before step 9 those lanes failed on their own assertions
+    # about what got posted, not on veripb. A lane without such an assertion
+    # would have passed while silently losing propagation.
 
     # One ctest entry per mode, each writing proofs under its own basename, so a
     # parallel run does not have two entries racing over one set of files.

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -513,29 +513,36 @@ if(GCS_BUILD_TESTS)
     # And the other half of what the recovering arm has to be held to: that the
     # recovery stands on the start-checkpoint rows *alone*. Every lane above
     # runs with both blocks in the model, where a rup inside the recovery could
-    # be closing against the very row it claims to derive and nothing would
-    # say so. This one cuts the proof at the recovery's own marker and rechecks
-    # the prefix against an OPB with the per-time rows stripped out. The model
-    # is four tasks with four different durations, so the candidate set differs
-    # from one time point to the next and the weakening path is exercised.
-    add_test(NAME cumulative_checkpoint_recovery_leak_check
-        COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_checkpoint_recovery_leak_check.bash
-            $<TARGET_FILE:glasgow_scp_solver> ${CMAKE_CURRENT_SOURCE_DIR}/constraints/cumulative/checkpoint_recovery_leak_check.scp)
-    set_tests_properties(cumulative_checkpoint_recovery_leak_check PROPERTIES SKIP_RETURN_CODE 77
-        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/cumulative_recovering)
-
-    # And the end state, on a model small enough to have reached it: every rule
-    # that fires here has moved over to the recovered rows, so the *whole*
-    # certificate is checked against an OPB with no per-time capacity block at
-    # all. Today that means a model whose only firing rule is the time-table
-    # overflow contradiction --- two tasks that must overlap and do not fit.
-    # Each further rule moved over is another model that can be listed here,
-    # and when the last one is, this is what says the block can go.
-    add_test(NAME cumulative_checkpoint_recovery_whole_proof
-        COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_checkpoint_recovery_leak_check.bash
-            $<TARGET_FILE:glasgow_scp_solver> ${CMAKE_CURRENT_SOURCE_DIR}/constraints/cumulative/checkpoint_recovery_overflow_only.scp whole)
-    set_tests_properties(cumulative_checkpoint_recovery_whole_proof PROPERTIES SKIP_RETURN_CODE 77
-        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/cumulative_recovering)
+    # be closing against the very row it claims to derive and nothing would say
+    # so. These cut the proof at the recovery's own marker (`prefix`) or leave
+    # it whole (`whole`), and recheck against an OPB with the per-time capacity
+    # rows stripped out.
+    #
+    # `whole` is the stronger claim and the one that measures progress: it
+    # refuses any model whose proof still cites a per-time row, so a model can
+    # only go in that mode once every rule it fires has been moved over to the
+    # recovered rows. The time-table family has; the overload check and the
+    # rules above it have not, which is what keeps the third case in `prefix`.
+    # When the last citer moves, every case here is `whole` and the block can go.
+    function(add_checkpoint_recovery_leak_check case mode)
+        add_test(NAME cumulative_checkpoint_recovery_${case}_${mode}
+            COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_checkpoint_recovery_leak_check.bash
+                $<TARGET_FILE:glasgow_scp_solver>
+                ${CMAKE_CURRENT_SOURCE_DIR}/constraints/cumulative/checkpoint_recovery_${case}.scp ${mode})
+        set_tests_properties(cumulative_checkpoint_recovery_${case}_${mode} PROPERTIES SKIP_RETURN_CODE 77
+            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/cumulative_recovering)
+    endfunction()
+    # Two tasks that must overlap and do not fit: the overflow contradiction and
+    # nothing else, which is the minimal end-state regression.
+    add_checkpoint_recovery_leak_check(overflow_only whole)
+    # Four tasks with four different durations, so the candidate set differs
+    # from one time point to the next and the weakening path is exercised. Fires
+    # both bound pushes as well as the overflow check.
+    add_checkpoint_recovery_leak_check(leak_check whole)
+    # Three tasks whose mandatory parts are all empty, so time-tabling sees
+    # nothing and the overload check is what refutes it. Moves to `whole` when
+    # the overload check's certificate moves over.
+    add_checkpoint_recovery_leak_check(overload prefix)
 
     # One ctest entry per mode, each writing proofs under its own basename, so a
     # parallel run does not have two entries racing over one set of files.

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -643,17 +643,25 @@ if(GCS_BUILD_TESTS)
     # `startcheckpoint` arm because a rule they fire still reads the per-time
     # block. **It is empty.**
     #
-    # Read that precisely: every *rule* is converted, not every *shape*. Nothing
-    # reads capacity_lines directly any more --- it all goes through
+    # Read that precisely: every *rule* is converted, and not yet every *shape*.
+    # Nothing reads capacity_lines directly any more --- it all goes through
     # capacity_row --- but capacity_row still falls back to the model row for a
     # Cumulative the recovery cannot speak about: a variable length, a variable
-    # height, a variable capacity, or an optional task. Those keep the per-time
-    # block and use it for everything, and they are not rare: 146 of the 424
-    # proofs the cumulative test binaries write under this arm still contain
-    # cap_ rows. So the block cannot be *deleted*; it can only stop being
-    # emitted for constraints that qualify, which is what this arm already does.
-    # Extending the recovery to those shapes is separate work, and
+    # height or a variable capacity. Those keep the per-time block and use it
+    # for everything, and they are not rare: 121 of the 440 proofs the
+    # cumulative test binaries write under this arm still contain cap_ rows. So
+    # the block cannot be *deleted* yet; it can only stop being emitted for
+    # constraints that qualify, which is what this arm already does. Extending
+    # the recovery to the rest is the remaining work, and
     # checkpoint_recovery.hh says what each would take.
+    #
+    # **Optional tasks are no longer on that list.** The recovery speaks about
+    # a presence now, so every one of cumulative_optional_test's 35 proofs is
+    # free of cap_ rows where 18 of them were not. The whole extension was the
+    # diagonal: with a presence the encoding mints sact_{j,j} and puts j's own
+    # height on the checkpoint row, where a constant-length task with no
+    # presence has it folded into the right hand side and needs a literal axiom
+    # instead.
     #
     # Lanes that are off the arm but are *not* part of the bar, all of them
     # mutation lanes that stop discriminating once the per-time block is gone
@@ -661,6 +669,8 @@ if(GCS_BUILD_TESTS)
     # relating the starts directly, so veripb accepts the corruption:
     #
     #   cumulative_optional_mutation_{wrong_task,emit_nothing}
+    #     (one_too_far was in this list and is not any more --- it rejects
+    #     under all four encodings, rechecked when optional tasks joined)
     #   cumulative_ttef_mutation_{pin,mirror_pin}
     #   cumulative_nfnl_mutation_roomy_drop
     #   cumulative_energetic_mutation_mirror_drop_energetic
@@ -686,9 +696,11 @@ if(GCS_BUILD_TESTS)
     endforeach()
     # Presence-falsification mutation lanes, the same shape as the overload
     # ones above: each writes a deliberately corrupted proof and passes only if
-    # veripb rejects it.
+    # veripb rejects it. one_too_far is on all four arms: checked one encoding
+    # at a time once the recovery learned to speak about optional tasks, and it
+    # still rejects under every one of them.
     foreach(mutation one_too_far)
-        add_cumulative_test(cumulative_optional_mutation_${mutation}
+        add_cumulative_test_converted(cumulative_optional_mutation_${mutation}
             ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_expect_verify_failure.bash
                 --basename cumulative_optional_mutation_${mutation} $<TARGET_FILE:cumulative_optional_test> --mutate=${mutation})
     endforeach()

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -287,6 +287,13 @@ if(GCS_BUILD_TESTS)
         add_cumulative_arm(${name} checkpoint ${CMAKE_CURRENT_BINARY_DIR}/cumulative_checkpoint ${ARGN})
         add_cumulative_arm(${name} recovering ${CMAKE_CURRENT_BINARY_DIR}/cumulative_recovering ${ARGN})
     endfunction()
+    # As add_cumulative_test (no recovering arm, for a mutation lane that stops
+    # discriminating under it), plus the arm that deletes the per-time block.
+    function(add_cumulative_test_converted_no_recovery name)
+        add_test(NAME ${name} COMMAND ${ARGN})
+        add_cumulative_arm(${name} checkpoint ${CMAKE_CURRENT_BINARY_DIR}/cumulative_checkpoint ${ARGN})
+        add_cumulative_arm(${name} startcheckpoint ${CMAKE_CURRENT_BINARY_DIR}/cumulative_startcheckpoint ${ARGN})
+    endfunction()
     # For a lane every rule of which has moved over to the recovered rows: as
     # add_cumulative_test_with_recovery, plus the arm that deletes the per-time
     # block from the model entirely. See the note above about what that checks.
@@ -459,10 +466,14 @@ if(GCS_BUILD_TESTS)
     endforeach()
     add_cumulative_test_with_recovery(cumulative_ttef ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_ttef_test>)
     add_cumulative_test_with_recovery(cumulative_nfnl ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_nfnl_test>)
-    add_cumulative_test_with_recovery(cumulative_kaoc ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_kaoc_test>)
+    add_cumulative_test_converted(cumulative_kaoc ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_kaoc_test>)
+    # On the startcheckpoint arm as well, each checked to still discriminate
+    # there. `capacity` is the one that earns it: it omits a row from the
+    # per-time availability line, which under that arm is a *recovered* row, so
+    # this is the negative test over the path #780's step 6 moved.
     foreach(fixture cloutier_ex2 dp_path compulsory)
         foreach(mutation claim_one_better strengthen_one_fewer capacity)
-            add_cumulative_test(cumulative_kaoc_mutation_${fixture}_${mutation}
+            add_cumulative_test_converted_no_recovery(cumulative_kaoc_mutation_${fixture}_${mutation}
                 ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_expect_verify_failure.bash
                     --basename cumulative_kaoc_mutation_${fixture}_${mutation} $<TARGET_FILE:cumulative_kaoc_test>
                     --mutate=${mutation} --fixture=${fixture})
@@ -606,8 +617,6 @@ if(GCS_BUILD_TESTS)
     # Confirmed by running each under GCS_CUMULATIVE_ENCODING=start-checkpoint;
     # they fail, and they fail loudly.
     #
-    #   cumulative_kaoc                    the knapsack / elastic per-time
-    #                                      availability lines
     #   cumulative_edge_finding            edge-finding's window rows
     #   cumulative_ttef                    (same, via the profile term)
     #   cumulative_energetic               (same, energetic form)

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -646,22 +646,24 @@ if(GCS_BUILD_TESTS)
     # Read that precisely: every *rule* is converted, and not yet every *shape*.
     # Nothing reads capacity_lines directly any more --- it all goes through
     # capacity_row --- but capacity_row still falls back to the model row for a
-    # Cumulative the recovery cannot speak about: a variable length, a variable
-    # height or a variable capacity. Those keep the per-time block and use it
-    # for everything, and they are not rare: 121 of the 440 proofs the
+    # Cumulative the recovery cannot speak about: a variable height or a
+    # variable capacity. Those keep the per-time block and use it for
+    # everything, and they are not rare: 95 of the 440 proofs the
     # cumulative test binaries write under this arm still contain cap_ rows. So
     # the block cannot be *deleted* yet; it can only stop being emitted for
     # constraints that qualify, which is what this arm already does. Extending
     # the recovery to the rest is the remaining work, and
     # checkpoint_recovery.hh says what each would take.
     #
-    # **Optional tasks are no longer on that list.** The recovery speaks about
-    # a presence now, so every one of cumulative_optional_test's 35 proofs is
-    # free of cap_ rows where 18 of them were not. The whole extension was the
-    # diagonal: with a presence the encoding mints sact_{j,j} and puts j's own
-    # height on the checkpoint row, where a constant-length task with no
-    # presence has it folded into the right hand side and needs a literal axiom
-    # instead.
+    # **Optional tasks and variable lengths are no longer on that list.** Both
+    # came out of the same one change, the diagonal: give a task a presence or a
+    # variable length and the encoding mints sact_{j,j} and puts j's own height
+    # on the checkpoint row, where a constant-length task with no presence has
+    # it folded into the right hand side and needs a literal axiom instead. So
+    # the recovery pins the diagonal where the flag is there and axiomatises it
+    # where it is not. Every one of cumulative_optional_test's 35 proofs is now
+    # free of cap_ rows, where 18 were not, and the fallback fraction went
+    # 149 -> 121 -> 95 over the two.
     #
     # Lanes that are off the arm but are *not* part of the bar, all of them
     # mutation lanes that stop discriminating once the per-time block is gone

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -641,13 +641,19 @@ if(GCS_BUILD_TESTS)
 
     # #780's progress bar: the cumulative lanes that are *not* on the
     # `startcheckpoint` arm because a rule they fire still reads the per-time
-    # block. **It is empty.** Every rule is converted, and every lane that
-    # exercises one runs with the block deleted from the model.
+    # block. **It is empty.**
     #
-    # That is the condition for the time-indexed block to go, which is the next
-    # step of #780 and is deliberately not this one: deleting it means flipping
-    # the default, retiring the other arms, and pinning the scp_chain_cumulative*
-    # cases to the time-indexed encoding, none of which is a test registration.
+    # Read that precisely: every *rule* is converted, not every *shape*. Nothing
+    # reads capacity_lines directly any more --- it all goes through
+    # capacity_row --- but capacity_row still falls back to the model row for a
+    # Cumulative the recovery cannot speak about: a variable length, a variable
+    # height, a variable capacity, or an optional task. Those keep the per-time
+    # block and use it for everything, and they are not rare: 146 of the 424
+    # proofs the cumulative test binaries write under this arm still contain
+    # cap_ rows. So the block cannot be *deleted*; it can only stop being
+    # emitted for constraints that qualify, which is what this arm already does.
+    # Extending the recovery to those shapes is separate work, and
+    # checkpoint_recovery.hh says what each would take.
     #
     # Lanes that are off the arm but are *not* part of the bar, all of them
     # mutation lanes that stop discriminating once the per-time block is gone

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -496,19 +496,22 @@ if(GCS_BUILD_TESTS)
     # the window-energy lemma. `emit_nothing` is the control and `drop_pin` the
     # lane aimed at what is new; dropping the contiguity rows themselves cannot
     # be caught, and cumulative_mutations.hh records why.
-    add_cumulative_test_with_recovery(cumulative_published_nfnl
+    add_cumulative_test_converted(cumulative_published_nfnl
         ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_published_nfnl_test>)
-    add_cumulative_test_with_recovery(cumulative_published_nfnl_random
+    add_cumulative_test_converted(cumulative_published_nfnl_random
         ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_published_nfnl_test> --random 7)
+    # All five still discriminate on the startcheckpoint arm, checked one at a
+    # time. `drop_pin` is the one aimed at what #746 added, and it survives.
     foreach(mutation emit_nothing drop_pin toofar roomy_toofar roomy_drop_pin)
-        add_cumulative_test(cumulative_published_nfnl_mutation_${mutation}
+        add_cumulative_test_converted_no_recovery(cumulative_published_nfnl_mutation_${mutation}
             ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_expect_verify_failure.bash
                 --basename cumulative_published_nfnl_mutation_${mutation} $<TARGET_FILE:cumulative_published_nfnl_test> --mutate=${mutation})
     endforeach()
     # Not twinned (#780): `drop` removes a contiguity row, and the start-
     # checkpoint rows put back enough for the wrapping RUP to close without it,
-    # so veripb accepts the corrupted proof under `both`. The lane still says
-    # what it always said about the time-indexed encoding.
+    # so veripb accepts the corrupted proof under `both` --- and, for the same
+    # reason, under the startcheckpoint arm. The lane still says what it always
+    # said about the time-indexed encoding.
     add_test(NAME cumulative_published_nfnl_mutation_drop
         COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_expect_verify_failure.bash
             --basename cumulative_published_nfnl_mutation_drop $<TARGET_FILE:cumulative_published_nfnl_test> --mutate=drop)
@@ -643,12 +646,20 @@ if(GCS_BUILD_TESTS)
     # Confirmed by running each under GCS_CUMULATIVE_ENCODING=start-checkpoint;
     # they fail, and they fail loudly.
     #
-    #   cumulative_published_nfnl          published not-first / not-last
-    #   cumulative_published_nfnl_random
     #   derived_cumulative                 derived_cumulative.cc: donor rows and
     #                                      the makespan bound
     #   inferred_cumulative_presolver      (reach derived_cumulative)
     #   cumulative_strengthening_presolver
+    #
+    # Those last three are the one place the arm does *not* fail loudly, and it
+    # is worth knowing before relying on it. derived_cumulative.cc reads its
+    # donors' per-time rows by label, and a donor that wrote none makes the
+    # derivation decline --- which is a supported outcome, not an error, so the
+    # constraint is simply not installed and propagation quietly weakens. What
+    # notices is the lanes' own assertions about what got posted ("posted 0 cuts
+    # with a coefficient above one"), not veripb. Step 9 has to move that
+    # lookup onto the recovery like every other citer; until it does, do not
+    # read those three passing as evidence of anything.
     #
     # Move a lane onto the arm by changing its add_cumulative_test_with_recovery
     # to add_cumulative_test_converted, and delete its line here. **When this

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -210,20 +210,55 @@ if(GCS_BUILD_TESTS)
     add_test(NAME difference_logic_presolver_proofs
         COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:difference_logic_presolver_test> proofs)
 
+    # ---- issue #780: the start-checkpoint encoding, run beside the time-indexed one
+    #
+    # Every cumulative lane registered through add_cumulative_test runs twice:
+    # once as it always did, over the time-indexed OPB block alone, and once as
+    # `<name>_checkpoint` with the start-checkpoint block (CumulativeEncoding)
+    # emitted beside it. Nothing derives anything from the second block yet, so
+    # what the twin buys is the check that its rows are *sound*: a checkpoint
+    # row that says too much is a solution veripb refuses on the `solx` line of
+    # any enumeration lane. What no lane can check yet is sufficiency, since
+    # nothing cites them.
+    #
+    # The encoding comes from the environment rather than an argv flag because
+    # the fixtures build Cumulatives in sixty places, and threading a parameter
+    # through all of them would say nothing that GCS_CUMULATIVE_ENCODING does
+    # not. The twin gets its own working directory because the two copies write
+    # proof files under the same names (issue #562's problem, one directory up).
+    #
+    # Mutation lanes are the exception, and are twinned one at a time rather
+    # than by default. More model is more for unit propagation to reach, so a
+    # corrupted proof that veripb rejects against the time-indexed block alone
+    # need not be rejected with the checkpoint rows beside it --- and three are
+    # not, which is why they are registered bare below with a note apiece. A
+    # twin of one of those would assert something false. When a lane comes off
+    # that list it should be because its certificate stopped leaning on rows
+    # the encoding is about to lose, not because the list got tidied.
+    file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/cumulative_checkpoint)
+    function(add_cumulative_test name)
+        add_test(NAME ${name} COMMAND ${ARGN})
+        add_test(NAME ${name}_checkpoint COMMAND ${ARGN})
+        set_tests_properties(${name}_checkpoint PROPERTIES
+            ENVIRONMENT "GCS_CUMULATIVE_ENCODING=both"
+            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/cumulative_checkpoint)
+    endfunction()
+
     add_executable(inferred_cumulative_presolver_test presolvers/inferred_cumulative/inferred_cumulative_test.cc)
     target_link_libraries(inferred_cumulative_presolver_test PRIVATE glasgow_constraint_solver)
-    add_test(NAME inferred_cumulative_presolver
-        COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:inferred_cumulative_presolver_test>)
+    add_cumulative_test(inferred_cumulative_presolver
+        ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:inferred_cumulative_presolver_test>)
 
     add_executable(inferred_disjunctive_presolver_test presolvers/inferred_disjunctive/inferred_disjunctive_test.cc)
     target_link_libraries(inferred_disjunctive_presolver_test PRIVATE glasgow_constraint_solver)
-    add_test(NAME inferred_disjunctive_presolver
-        COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:inferred_disjunctive_presolver_test>)
+    # Twinned too: it cites a *Cumulative* donor's per-(task, time) flags.
+    add_cumulative_test(inferred_disjunctive_presolver
+        ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:inferred_disjunctive_presolver_test>)
 
     add_executable(cumulative_strengthening_presolver_test presolvers/cumulative_strengthening/cumulative_strengthening_test.cc)
     target_link_libraries(cumulative_strengthening_presolver_test PRIVATE glasgow_constraint_solver)
-    add_test(NAME cumulative_strengthening_presolver
-        COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_strengthening_presolver_test>)
+    add_cumulative_test(cumulative_strengthening_presolver
+        ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_strengthening_presolver_test>)
 
     add_executable(constraint_enumeration_test constraint_enumeration_test.cc)
     target_link_libraries(constraint_enumeration_test PRIVATE glasgow_constraint_solver Catch2::Catch2WithMain)
@@ -361,46 +396,53 @@ if(GCS_BUILD_TESTS)
     add_test(NAME count_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:count_test>)
     add_test(NAME bounds_global_cardinality_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:bounds_global_cardinality_test>)
     add_test(NAME gac_global_cardinality_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:gac_global_cardinality_test>)
-    add_test(NAME cumulative_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_test>)
-    add_test(NAME cumulative_overload COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_overload_test>)
-    add_test(NAME cumulative_edge_finding COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_edge_finding_test>)
+    add_cumulative_test(cumulative_constraint ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_test>)
+    add_cumulative_test(cumulative_overload ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_overload_test>)
+    add_cumulative_test(cumulative_edge_finding ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_edge_finding_test>)
     foreach(mutation drop toofar capacity mirror_drop mirror_toofar)
-        add_test(NAME cumulative_edge_finding_mutation_${mutation}
-            COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_expect_verify_failure.bash
+        add_cumulative_test(cumulative_edge_finding_mutation_${mutation}
+            ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_expect_verify_failure.bash
                 --basename cumulative_edge_finding_mutation_${mutation} $<TARGET_FILE:cumulative_edge_finding_test> --mutate=${mutation})
     endforeach()
-    add_test(NAME cumulative_ttef COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_ttef_test>)
-    add_test(NAME cumulative_nfnl COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_nfnl_test>)
-    add_test(NAME cumulative_kaoc COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_kaoc_test>)
+    add_cumulative_test(cumulative_ttef ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_ttef_test>)
+    add_cumulative_test(cumulative_nfnl ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_nfnl_test>)
+    add_cumulative_test(cumulative_kaoc ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_kaoc_test>)
     foreach(fixture cloutier_ex2 dp_path compulsory)
         foreach(mutation claim_one_better strengthen_one_fewer capacity)
-            add_test(NAME cumulative_kaoc_mutation_${fixture}_${mutation}
-                COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_expect_verify_failure.bash
+            add_cumulative_test(cumulative_kaoc_mutation_${fixture}_${mutation}
+                ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_expect_verify_failure.bash
                     --basename cumulative_kaoc_mutation_${fixture}_${mutation} $<TARGET_FILE:cumulative_kaoc_test>
                     --mutate=${mutation} --fixture=${fixture})
         endforeach()
     endforeach()
     foreach(mutation toofar drop roomy_toofar roomy_drop)
-        add_test(NAME cumulative_nfnl_mutation_${mutation}
-            COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_expect_verify_failure.bash
+        add_cumulative_test(cumulative_nfnl_mutation_${mutation}
+            ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_expect_verify_failure.bash
                 --basename cumulative_nfnl_mutation_${mutation} $<TARGET_FILE:cumulative_nfnl_test> --mutate=${mutation})
     endforeach()
     # The detection as published (#746), certified by contiguity rather than by
     # the window-energy lemma. `emit_nothing` is the control and `drop_pin` the
     # lane aimed at what is new; dropping the contiguity rows themselves cannot
     # be caught, and cumulative_mutations.hh records why.
-    add_test(NAME cumulative_published_nfnl
-        COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_published_nfnl_test>)
-    add_test(NAME cumulative_published_nfnl_random
-        COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_published_nfnl_test> --random 7)
-    foreach(mutation emit_nothing drop_pin drop toofar roomy_toofar roomy_drop_pin)
-        add_test(NAME cumulative_published_nfnl_mutation_${mutation}
-            COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_expect_verify_failure.bash
+    add_cumulative_test(cumulative_published_nfnl
+        ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_published_nfnl_test>)
+    add_cumulative_test(cumulative_published_nfnl_random
+        ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_published_nfnl_test> --random 7)
+    foreach(mutation emit_nothing drop_pin toofar roomy_toofar roomy_drop_pin)
+        add_cumulative_test(cumulative_published_nfnl_mutation_${mutation}
+            ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_expect_verify_failure.bash
                 --basename cumulative_published_nfnl_mutation_${mutation} $<TARGET_FILE:cumulative_published_nfnl_test> --mutate=${mutation})
     endforeach()
+    # Not twinned (#780): `drop` removes a contiguity row, and the start-
+    # checkpoint rows put back enough for the wrapping RUP to close without it,
+    # so veripb accepts the corrupted proof under `both`. The lane still says
+    # what it always said about the time-indexed encoding.
+    add_test(NAME cumulative_published_nfnl_mutation_drop
+        COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_expect_verify_failure.bash
+            --basename cumulative_published_nfnl_mutation_drop $<TARGET_FILE:cumulative_published_nfnl_test> --mutate=drop)
     foreach(mutation pins pin drop toofar mirror_pins mirror_pin mirror_toofar)
-        add_test(NAME cumulative_ttef_mutation_${mutation}
-            COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_expect_verify_failure.bash
+        add_cumulative_test(cumulative_ttef_mutation_${mutation}
+            ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_expect_verify_failure.bash
                 --basename cumulative_ttef_mutation_${mutation} $<TARGET_FILE:cumulative_ttef_test> --mutate=${mutation})
     endforeach()
     # The energetic form (#755), which charges every task its guaranteed energy
@@ -408,34 +450,44 @@ if(GCS_BUILD_TESTS)
     # mandatory part. `drop_energetic` is the lane that matters: it removes the
     # row of a task the window does not contain, which is the only energy plain
     # edge-finding would not have cited.
-    add_test(NAME cumulative_energetic
-        COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_energetic_test>)
-    add_test(NAME cumulative_energetic_random
-        COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_energetic_test> --random 17)
+    add_cumulative_test(cumulative_energetic
+        ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_energetic_test>)
+    add_cumulative_test(cumulative_energetic_random
+        ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_energetic_test> --random 17)
     foreach(mutation drop_energetic drop toofar capacity mirror_drop_energetic mirror_toofar)
-        add_test(NAME cumulative_energetic_mutation_${mutation}
-            COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_expect_verify_failure.bash
+        add_cumulative_test(cumulative_energetic_mutation_${mutation}
+            ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_expect_verify_failure.bash
                 --basename cumulative_energetic_mutation_${mutation} $<TARGET_FILE:cumulative_energetic_test> --mutate=${mutation})
     endforeach()
-    add_test(NAME derived_cumulative COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:derived_cumulative_test>)
+    add_cumulative_test(derived_cumulative ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:derived_cumulative_test>)
     # Mutation lanes: each writes a deliberately corrupted proof of the
     # sharp-margin fixture, and passes only if veripb rejects it. Distinct
     # basenames so the lanes do not race over one set of proof files.
     foreach(mutation energy capacity window)
-        add_test(NAME cumulative_overload_mutation_${mutation}
-            COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_expect_verify_failure.bash
+        add_cumulative_test(cumulative_overload_mutation_${mutation}
+            ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_expect_verify_failure.bash
                 --basename cumulative_overload_mutation_${mutation} $<TARGET_FILE:cumulative_overload_test> --mutate=${mutation})
     endforeach()
     # One ctest entry per mode, each writing proofs under its own basename, so a
     # parallel run does not have two entries racing over one set of files.
     foreach(mode enumerate falsify bijection objective)
-        add_test(NAME cumulative_optional_constraint_${mode}
-            COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_optional_test> ${mode})
+        add_cumulative_test(cumulative_optional_constraint_${mode}
+            ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_optional_test> ${mode})
     endforeach()
     # Presence-falsification mutation lanes, the same shape as the overload
     # ones above: each writes a deliberately corrupted proof and passes only if
     # veripb rejects it.
-    foreach(mutation wrong_task emit_nothing one_too_far)
+    foreach(mutation one_too_far)
+        add_cumulative_test(cumulative_optional_mutation_${mutation}
+            ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_expect_verify_failure.bash
+                --basename cumulative_optional_mutation_${mutation} $<TARGET_FILE:cumulative_optional_test> --mutate=${mutation})
+    endforeach()
+    # Not twinned (#780): both of these corrupt the presence-falsification
+    # chain, and the start-checkpoint rows relate the falsified task's start to
+    # every other task's directly, which is enough for the wrapping RUP to
+    # close without the chain. veripb accepts them under `both`. They still say
+    # what they always said about the time-indexed encoding.
+    foreach(mutation wrong_task emit_nothing)
         add_test(NAME cumulative_optional_mutation_${mutation}
             COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_expect_verify_failure.bash
                 --basename cumulative_optional_mutation_${mutation} $<TARGET_FILE:cumulative_optional_test> --mutate=${mutation})
@@ -641,6 +693,14 @@ if(GCS_BUILD_TESTS)
         add_view_tests(disjunctive_constraint_${mode} disjunctive_test 4 ${mode})
     endforeach()
     add_view_tests(cumulative_constraint cumulative_test 4)
+    # And its always-on mixed-view lane under the other encoding (#780): two
+    # different views in one constraint is the shape the checkpoint rows meet
+    # that the per-time ones never do, since a checkpoint row names two starts.
+    add_test(NAME cumulative_constraint_view_mixed_checkpoint
+        COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_test> --view-position=mixed)
+    set_tests_properties(cumulative_constraint_view_mixed_checkpoint PROPERTIES
+        ENVIRONMENT "GCS_CUMULATIVE_ENCODING=both"
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/cumulative_checkpoint)
     add_view_tests(regular_constraint regular_test 4)
     add_test(NAME in_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:in_test>)
     add_test(NAME increasing_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:increasing_test>)

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -524,6 +524,19 @@ if(GCS_BUILD_TESTS)
     set_tests_properties(cumulative_checkpoint_recovery_leak_check PROPERTIES SKIP_RETURN_CODE 77
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/cumulative_recovering)
 
+    # And the end state, on a model small enough to have reached it: every rule
+    # that fires here has moved over to the recovered rows, so the *whole*
+    # certificate is checked against an OPB with no per-time capacity block at
+    # all. Today that means a model whose only firing rule is the time-table
+    # overflow contradiction --- two tasks that must overlap and do not fit.
+    # Each further rule moved over is another model that can be listed here,
+    # and when the last one is, this is what says the block can go.
+    add_test(NAME cumulative_checkpoint_recovery_whole_proof
+        COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_checkpoint_recovery_leak_check.bash
+            $<TARGET_FILE:glasgow_scp_solver> ${CMAKE_CURRENT_SOURCE_DIR}/constraints/cumulative/checkpoint_recovery_overflow_only.scp whole)
+    set_tests_properties(cumulative_checkpoint_recovery_whole_proof PROPERTIES SKIP_RETURN_CODE 77
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/cumulative_recovering)
+
     # One ctest entry per mode, each writing proofs under its own basename, so a
     # parallel run does not have two entries racing over one set of files.
     foreach(mode enumerate falsify bijection objective)

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -493,8 +493,17 @@ if(GCS_BUILD_TESTS)
     # Mutation lanes: each writes a deliberately corrupted proof of the
     # sharp-margin fixture, and passes only if veripb rejects it. Distinct
     # basenames so the lanes do not race over one set of proof files.
+    #
+    # These three are twinned onto the recovering arm as well, which most
+    # mutation lanes are not: adding model rows gives unit propagation more to
+    # reach, so a lane that discriminates under one encoding need not under
+    # another, and each twin goes on only once it has been shown to still fail.
+    # These have been, and it matters here specifically --- since the overload
+    # check's window supply moved onto the recovered rows (#780), `capacity`
+    # corrupts a *derived* row rather than a model one, and without the twin the
+    # recovering arm would have no negative test over that path at all.
     foreach(mutation energy capacity window)
-        add_cumulative_test(cumulative_overload_mutation_${mutation}
+        add_cumulative_test_with_recovery(cumulative_overload_mutation_${mutation}
             ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_expect_verify_failure.bash
                 --basename cumulative_overload_mutation_${mutation} $<TARGET_FILE:cumulative_overload_test> --mutate=${mutation})
     endforeach()
@@ -521,9 +530,21 @@ if(GCS_BUILD_TESTS)
     # `whole` is the stronger claim and the one that measures progress: it
     # refuses any model whose proof still cites a per-time row, so a model can
     # only go in that mode once every rule it fires has been moved over to the
-    # recovered rows. The time-table family has; the overload check and the
-    # rules above it have not, which is what keeps the third case in `prefix`.
-    # When the last citer moves, every case here is `whole` and the block can go.
+    # recovered rows.
+    #
+    # Every case here is now `whole`, which says something narrower than it
+    # looks: it says the *default* rule set --- time-tabling, the overload check
+    # and its (TTOC) strengthening --- is fully converted. It does not say the
+    # time-indexed block can go. The citers that are left (the elastic and
+    # knapsack availability lines, edge-finding's window rows, published
+    # not-first / not-last) all sit behind CumulativeRules fields that are off by
+    # default, and an .scp model has no way to turn them on --- the reader builds
+    # a plain Cumulative and glasgow_scp_solver has no flag for the rules. So no
+    # case that could stay in `prefix` and mark them outstanding can be written
+    # in this vehicle at all. Reaching them needs a way to select rules from the
+    # scp path, or the same strip-and-recheck applied to the proofs a C++ lane
+    # writes under GCS_PRESERVE_PROOF_FILES; until one of those exists, the
+    # remaining steps of #780 are tracked by the issue and not by this bar.
     function(add_checkpoint_recovery_leak_check case mode)
         add_test(NAME cumulative_checkpoint_recovery_${case}_${mode}
             COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_checkpoint_recovery_leak_check.bash
@@ -540,9 +561,16 @@ if(GCS_BUILD_TESTS)
     # both bound pushes as well as the overflow check.
     add_checkpoint_recovery_leak_check(leak_check whole)
     # Three tasks whose mandatory parts are all empty, so time-tabling sees
-    # nothing and the overload check is what refutes it. Moves to `whole` when
-    # the overload check's certificate moves over.
-    add_checkpoint_recovery_leak_check(overload prefix)
+    # nothing and the overload check is what refutes it. This is the (OC) arm:
+    # the contained tasks' own energy is what overflows the window.
+    add_checkpoint_recovery_leak_check(overload whole)
+    # And the (TTOC) arm, which supplies the same window and then adds the
+    # mandatory load of a task the window does *not* contain. Capacity 3 over
+    # [0,4): S1 (fixed at 0) and S2 are contained and carry 6 + 6 = 12 against a
+    # supply of 12, so (OC) alone finds nothing --- S0, which is not contained,
+    # has mandatory part [3,4) at height 2, and that is what tips it to 14 > 12.
+    # So the case cannot pass by accident on the plain overload check.
+    add_checkpoint_recovery_leak_check(ttoc whole)
 
     # One ctest entry per mode, each writing proofs under its own basename, so a
     # parallel run does not have two entries racing over one set of files.

--- a/gcs/constraints/cumulative/checkpoint_recovery.cc
+++ b/gcs/constraints/cumulative/checkpoint_recovery.cc
@@ -54,12 +54,15 @@ namespace
     // make the check compare the recovery against something the model does not
     // say, which is the one failure the check exists to catch and the one it
     // could not report.
-    auto per_time_load(const CumulativeInputs & inputs, Integer t) -> WPBSum
+    auto per_time_load(ProofLogger & logger, const CumulativeInputs & inputs, Integer t) -> WPBSum
     {
         WPBSum load;
         for (auto i : inputs.active_tasks) {
             if (t < inputs.per_task_t_lo[i] || t > inputs.per_task_t_hi[i])
                 continue;
+            // As flag_at: the row is stated over flags that may only be defined
+            // on demand, and stating it is an ask for them.
+            logger.names_and_ids_tracker().ensure_flag_defined(inputs.owner, Data::active_flag_key(i, t), logger);
             auto idx = (t - inputs.per_task_t_lo[i]).raw_value;
             if (is_constant_variable(inputs.heights[i]))
                 load += constant_value_of(inputs.heights[i]) * inputs.active_flags[i][idx];
@@ -76,9 +79,9 @@ namespace
     // constancy picks: a number on the right where it is constant, and a
     // (-1)*capacity term on the left where it is not, exactly as the encoder
     // writes it. Shared for the same reason per_time_load is.
-    auto per_time_capacity_row(const CumulativeInputs & inputs, Integer t) -> WPBSumLE
+    auto per_time_capacity_row(ProofLogger & logger, const CumulativeInputs & inputs, Integer t) -> WPBSumLE
     {
-        auto load = per_time_load(inputs, t);
+        auto load = per_time_load(logger, inputs, t);
         if (is_constant_variable(inputs.capacity))
             return move(load) <= constant_value_of(inputs.capacity);
         load += -1_i * inputs.capacity;
@@ -149,7 +152,12 @@ auto gcs::innards::recover_cumulative_capacity_row(ProofLogger & logger, const C
         return nullopt;
 
     auto height = [&](size_t i) { return constant_value_of(inputs.heights[i]); };
+    // #780 step 10: the per-(task, time) flags may only be *defined* on demand,
+    // so asking for one at `t` asks for its definition first. Nothing happens
+    // where the constraint published no definer, which is every encoding whose
+    // flags are OPB rows. Every one of this file's uses goes through here.
     auto flag_at = [&](const vector<vector<ProofFlag>> & flags, size_t i) -> const ProofFlag & {
+        tracker.ensure_flag_defined(inputs.owner, Data::active_flag_key(i, t), logger);
         return flags[i][(t - inputs.per_task_t_lo[i]).raw_value];
     };
     auto cb = [&](size_t i) -> const ProofFlag & { return flag_at(inputs.before_flags, i); };
@@ -171,7 +179,10 @@ auto gcs::innards::recover_cumulative_capacity_row(ProofLogger & logger, const C
     // every capacity row is the bit-linearised contribution, `cc` per (task,
     // time) and `scc` per (task, task). See the encoding.
     auto var_height = [&](size_t i) { return ! is_constant_variable(inputs.heights[i]); };
-    auto cc_bits = [&](size_t i) -> const vector<ProofFlag> & { return inputs.contrib_flags[i][(t - inputs.per_task_t_lo[i]).raw_value]; };
+    auto cc_bits = [&](size_t i) -> const vector<ProofFlag> & {
+        tracker.ensure_flag_defined(inputs.owner, Data::active_flag_key(i, t), logger);
+        return inputs.contrib_flags[i][(t - inputs.per_task_t_lo[i]).raw_value];
+    };
     auto scc_bits = [&](size_t i, size_t j) {
         vector<ProofFlag> bits;
         for (Integer k = 0_i;; ++k) {
@@ -217,7 +228,7 @@ auto gcs::innards::recover_cumulative_capacity_row(ProofLogger & logger, const C
     // variable capacity simply takes the long way round, the derivation not
     // caring whether the row it proves happens to be slack.
     if (is_constant_variable(inputs.capacity) && total - constant_value_of(inputs.capacity) <= 0_i) {
-        auto trivial = logger.emit_rup_proof_line(per_time_capacity_row(inputs, t), ProofLevel::Top);
+        auto trivial = logger.emit_rup_proof_line(per_time_capacity_row(logger, inputs, t), ProofLevel::Top);
         cache.recovered.emplace(t, trivial);
         return trivial;
     }
@@ -358,7 +369,7 @@ auto gcs::innards::recover_cumulative_capacity_row(ProofLogger & logger, const C
     auto last = candidates.size() - 1;
 
     // --- literalise the target, so an n-way split over a row stays resolution -
-    auto target = per_time_capacity_row(inputs, t);
+    auto target = per_time_capacity_row(logger, inputs, t);
     auto [target_flag, target_forward, target_reverse] = logger.create_proof_flag_reifying(target, "ckpf", ProofLevel::Top);
 
     // --- each case implies the target ---------------------------------------
@@ -547,7 +558,7 @@ auto gcs::innards::check_recovered_cumulative_capacity_rows(ProofLogger & logger
         if (! recovered)
             continue;
 
-        logger.emit(ImpliesProofRule{*recovered}, per_time_capacity_row(inputs, t), ProofLevel::Top);
+        logger.emit(ImpliesProofRule{*recovered}, per_time_capacity_row(logger, inputs, t), ProofLevel::Top);
     }
     logger.emit_proof_comment("#780 checkpoint recovery ends");
 }

--- a/gcs/constraints/cumulative/checkpoint_recovery.cc
+++ b/gcs/constraints/cumulative/checkpoint_recovery.cc
@@ -114,6 +114,15 @@ auto gcs::innards::cumulative_checkpoint_recovery_applies(const CumulativeInputs
         // or for none.
         if (! logger.names_and_ids_tracker().constraint_row_label(inputs.owner, Data::checkpoint_row_role(i)))
             return false;
+        // A variable height's swap is stated over the reification halves of the
+        // pair contribution bits, so it needs those bits to *be* reifications:
+        // conjunctions with the height's own bits. Where a height has no bits
+        // to conjoin with --- a view, or a declared lower bound below zero ---
+        // the encoding falls back to linearising the product with three rows
+        // per pair, and this declines rather than recovering a row it cannot
+        // state.
+        if (! is_constant_variable(inputs.heights[i]) && ! inputs.pair_contribution_bits_are_conjunctions)
+            return false;
     }
     return true;
 }
@@ -421,62 +430,46 @@ auto gcs::innards::recover_cumulative_capacity_row(ProofLogger & logger, const C
         // rather than a clause is relativized on a flag for it --- the same
         // technique, and the same reason for it, as the target row itself a
         // few lines down.
+        // A variable height's checkpoint term is a bit sum and so is its
+        // per-time one, and swapping them is one `rup` per bit.
+        //
+        // That is what defining both families as *conjunctions* buys. Bit for
+        // bit, cc_{i,t,k} is `cact_{i,t} /\\ bit_k(h_i)` and scc_{i,j,k} is
+        // `sact_{i,j} /\\ bit_k(h_i)`, over the same height bit, so
+        //
+        //     ~w  \\/  ~cc_{i,t,k}  \\/  scc_{i,j,k}
+        //
+        // closes by unit propagation alone: cc_{i,t,k} gives cact and the
+        // height bit, the pin turns cact into sact under w, and sact with that
+        // same height bit is scc_{i,j,k}. Summed at 2^k the clauses come to
+        //
+        //     Sum scc - Sum cc + S.~w >= 0,
+        //
+        // which cancels the checkpoint row's bits and leaves the per-time ones
+        // exactly where a constant height's pin leaves ~cact. Guarded by w
+        // alone --- no residue on cact, and so none of the case split this
+        // replaced, which existed only because the three-row linearisation put
+        // a cact guard on the fact that the two agree.
+        //
+        // On a flagless diagonal there is no pair bit: the encoding put the
+        // height itself on the checkpoint row, and `~cc_{j,t,k} \\/ bit_k(h_j)`
+        // --- true with no guard at all, cc being a conjunction that includes
+        // that bit --- does the same job.
         auto swap_var_height = [&](size_t i, optional<ProofLine> pin) {
-            // (*), or its diagonal form. Where the encoding minted no activity
-            // flag for j on the diagonal it put the *height itself* on the
-            // checkpoint row rather than a bit sum, so the right hand side is
-            // h_j and there are no pair bits.
+            auto height_var = std::get<SimpleIntegerVariableID>(inputs.heights[i]);
+            const auto & cc = cc_bits(i);
             auto pair = pin ? make_optional(scc_bits(i, j)) : optional<vector<ProofFlag>>{};
-            auto goal_sum = bit_sum(cc_bits(i));
-            if (pair)
-                for (Integer k = 0_i; k.raw_value < static_cast<long long>(pair->size()); ++k)
-                    goal_sum += -power2(k) * (*pair)[k.raw_value];
-            else
-                goal_sum += -1_i * inputs.heights[i];
-            auto goal = move(goal_sum) <= 0_i;
-            auto [g, g_forward, g_reverse] = logger.create_proof_flag_reifying(goal, "ckpg", ProofLevel::Top);
-
-            // Active at t: the per-time `le` row caps the left at h_i and, off
-            // the diagonal, the pair's `ge` row floors the right at the same
-            // h_i, so h_i cancels between them. The pair row's own guard is
-            // discharged by the pin, at the coefficient it was emitted with ---
-            // asked for, not assumed, for the same reason guard_coefficient
-            // exists.
-            PolBuilder active;
-            active.add(row(Data::contribution_le_row_role(i, t)));
-            if (pair) {
-                active.add(row(Data::pair_contribution_ge_row_role(i, j)));
-                active.add(*pin, guard_coefficient(tracker, bit_sum(*pair) + -1_i * inputs.heights[i] >= 0_i, sact(i, j)));
+            for (Integer k = 0_i; k.raw_value < static_cast<long long>(cc.size()); ++k) {
+                WPBSum clause;
+                if (pin)
+                    clause += 1_i * ! w;
+                clause += 1_i * ! cc[k.raw_value];
+                if (pair)
+                    clause += 1_i * (*pair)[k.raw_value];
+                else
+                    clause += 1_i * ProofBitVariable{height_var, k, true};
+                pol.add(logger.emit_rup_proof_line(move(clause) >= 1_i, ProofLevel::Top), power2(k));
             }
-            active.add(g_reverse);
-            active.saturate().emit(logger, ProofLevel::Top);
-
-            // Not active at t: the `zero` row says the left is zero, and the
-            // right is a sum of non-negative terms --- bits, or a height the
-            // constructor has already required to be non-negative --- which go
-            // on as literal axioms.
-            PolBuilder inactive;
-            inactive.add(row(Data::contribution_zero_row_role(i, t)));
-            if (pair)
-                for (Integer k = 0_i; k.raw_value < static_cast<long long>(pair->size()); ++k)
-                    inactive.add((*pair)[k.raw_value], power2(k), tracker);
-            else
-                inactive.add_for_literal(tracker, inputs.heights[i] >= 0_i);
-            inactive.add(g_reverse);
-            inactive.saturate().emit(logger, ProofLevel::Top);
-
-            // The two clauses differ only in the polarity of cact, so resolving
-            // them leaves the goal holding whatever it is --- guarded by w
-            // where the pin brought w in, and by nothing at all on a flagless
-            // diagonal.
-            auto everywhere = pin ? logger.emit_rup_proof_line(WPBSum{} + 1_i * g + 1_i * ! w >= 1_i, ProofLevel::Top)
-                                  : logger.emit_rup_proof_line(WPBSum{} + 1_i * g >= 1_i, ProofLevel::Top);
-
-            // And out from behind the flag, exactly as the target row is.
-            PolBuilder unwrap;
-            unwrap.add(g_forward);
-            unwrap.add(everywhere, guard_coefficient(tracker, goal, g));
-            pol.add(unwrap.emit(logger, ProofLevel::Top));
         };
 
         auto swap_term = [&](size_t i, optional<ProofLine> pin) {

--- a/gcs/constraints/cumulative/checkpoint_recovery.cc
+++ b/gcs/constraints/cumulative/checkpoint_recovery.cc
@@ -52,7 +52,7 @@ auto gcs::innards::cumulative_shape_supports_checkpoint_recovery(const vector<si
     if (! is_constant_variable(capacity))
         return false;
     for (auto i : active_tasks)
-        if (! is_constant_variable(lengths[i]) || ! is_constant_variable(heights[i]))
+        if (! is_constant_variable(heights[i]))
             return false;
     return true;
 }
@@ -185,6 +185,23 @@ auto gcs::innards::recover_cumulative_capacity_row(ProofLogger & logger, const C
             pol.add(half_of(tracker, sa(i, j), "[f]"));
             pol.saturate().emit(logger, ProofLevel::Top);
         }
+
+    // **No diagonal counterpart, deliberately.** A variable-length task needs
+    // `cact_{j,t} -> sact_{j,j}`, which is `s_j <= t` and `s_j + l_j >= t+1`
+    // giving `l_j >= 1`, and it is tempting to write the pol above for it with
+    // sact_{j,j} standing in for the sa_{j,j} the encoding never mints. It is
+    // not needed: the pin below closes on its own, because that fact is about
+    // *one* task's variables --- with `l_j <= 0` the sum row pushes `s_j` past
+    // `t` and unit propagation has its contradiction. The pol above is needed
+    // precisely because its fact is not: it relates `s_i + l_i` to `s_j`, two
+    // tasks' starts, and no propagation reaches across them.
+    //
+    // That is measured, not assumed, and both halves of it: deleting the pol
+    // above fails five lanes (derived_cumulative_startcheckpoint, both
+    // leak-check lanes, both example encoding lanes), and a diagonal one added
+    // beside it changes nothing anywhere. Should a rup ever stall here, it
+    // fails loudly at the pin rather than quietly, and this comment says what
+    // to write.
 
     // --- e_{i,j}: i does not stand between j and being the latest starter -----
     std::map<pair<size_t, size_t>, ProofFlag> e;

--- a/gcs/constraints/cumulative/checkpoint_recovery.cc
+++ b/gcs/constraints/cumulative/checkpoint_recovery.cc
@@ -1,5 +1,6 @@
 #include <gcs/constraints/cumulative/checkpoint_recovery.hh>
 #include <gcs/innards/power.hh>
+#include <gcs/innards/proofs/flag_bridge.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
 #include <gcs/innards/proofs/pol_builder.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
@@ -25,13 +26,13 @@ namespace
 {
     using Data = ConstraintProofModelData<Cumulative>;
 
-    // The label of one half of a flag's reification. These flags all come from
-    // create_proof_flag_values_fully_reifying, whose halves are labelled off
-    // name_of --- not off pb_file_string_for, which is what the flags with no
-    // ConstraintID to key them use.
-    auto half_of(const NamesAndIDsTracker & tracker, const ProofFlag & flag, const string & which) -> ProofLineLabel
+    // One half of a flag's reification, as whatever it takes to cite it: a
+    // label where the halves are OPB rows, a line number where they were
+    // emitted inside the proof. reification_half is what knows the difference,
+    // and #780 step 10 is what makes there be one.
+    auto half_of(const NamesAndIDsTracker & tracker, const ProofFlag & flag, ReificationHalf which) -> ProofLine
     {
-        return ProofLineLabel{tracker.name_of(flag) + which};
+        return reification_half(tracker, flag, which);
     }
 
     // The reification coefficient a forward half was emitted with, which is
@@ -225,8 +226,8 @@ auto gcs::innards::recover_cumulative_capacity_row(ProofLogger & logger, const C
             if (cache.totality.contains(make_pair(i, j)))
                 continue;
             PolBuilder pol;
-            pol.add(half_of(tracker, sb(i, j), "[f]"));
-            pol.add(half_of(tracker, sb(j, i), "[f]"));
+            pol.add(half_of(tracker, sb(i, j), ReificationHalf::ImpliedBy));
+            pol.add(half_of(tracker, sb(j, i), ReificationHalf::ImpliedBy));
             cache.totality.emplace(make_pair(i, j), pol.divide_by(2_i).saturate().emit(logger, ProofLevel::Top));
         }
 
@@ -242,9 +243,9 @@ auto gcs::innards::recover_cumulative_capacity_row(ProofLogger & logger, const C
                 if (cache.transitivity.contains(make_tuple(a, b, c)))
                     continue;
                 PolBuilder pol;
-                pol.add(half_of(tracker, sb(a, b), "[r]"));
-                pol.add(half_of(tracker, sb(b, c), "[r]"));
-                pol.add(half_of(tracker, sb(a, c), "[f]"));
+                pol.add(half_of(tracker, sb(a, b), ReificationHalf::Implies));
+                pol.add(half_of(tracker, sb(b, c), ReificationHalf::Implies));
+                pol.add(half_of(tracker, sb(a, c), ReificationHalf::ImpliedBy));
                 cache.transitivity.emplace(make_tuple(a, b, c), pol.saturate().emit(logger, ProofLevel::Top));
             }
 
@@ -261,9 +262,9 @@ auto gcs::innards::recover_cumulative_capacity_row(ProofLogger & logger, const C
             if (i == j)
                 continue;
             PolBuilder pol;
-            pol.add(half_of(tracker, ca(i), "[r]"));
-            pol.add(half_of(tracker, cb(j), "[r]"));
-            pol.add(half_of(tracker, sa(i, j), "[f]"));
+            pol.add(half_of(tracker, ca(i), ReificationHalf::Implies));
+            pol.add(half_of(tracker, cb(j), ReificationHalf::Implies));
+            pol.add(half_of(tracker, sa(i, j), ReificationHalf::ImpliedBy));
             pol.saturate().emit(logger, ProofLevel::Top);
         }
 

--- a/gcs/constraints/cumulative/checkpoint_recovery.cc
+++ b/gcs/constraints/cumulative/checkpoint_recovery.cc
@@ -52,7 +52,7 @@ auto gcs::innards::cumulative_shape_supports_checkpoint_recovery(const vector<si
     if (! is_constant_variable(capacity))
         return false;
     for (auto i : active_tasks)
-        if (presence[i] || ! is_constant_variable(lengths[i]) || ! is_constant_variable(heights[i]))
+        if (! is_constant_variable(lengths[i]) || ! is_constant_variable(heights[i]))
             return false;
     return true;
 }
@@ -104,6 +104,13 @@ auto gcs::innards::recover_cumulative_capacity_row(ProofLogger & logger, const C
     auto sb = [&](size_t i, size_t j) { return pair_flag(Data::pair_before_flag_key(i, j)); };
     auto sa = [&](size_t i, size_t j) { return pair_flag(Data::pair_after_flag_key(i, j)); };
     auto sact = [&](size_t i, size_t j) { return pair_flag(Data::pair_active_flag_key(i, j)); };
+    // The diagonal is the one pair whose activity flag may not exist: `j` is on
+    // its own checkpoint row unconditionally when it has a constant length and
+    // no presence, and then the encoding folds its height into the right hand
+    // side rather than minting a flag to carry it. Where the flag *is* there,
+    // `j`'s term is on the row like anyone else's and has to be cancelled like
+    // anyone else's. See Data::pair_active_flag_key.
+    auto sact_diagonal = [&](size_t j) { return tracker.find_proof_flag_values(inputs.owner, Data::pair_active_flag_key(j, j)); };
 
     // The row being recovered, as the model states it: the load at t is within
     // the capacity. In the form the derivation ends on, which is the negated
@@ -256,6 +263,19 @@ auto gcs::innards::recover_cumulative_capacity_row(ProofLogger & logger, const C
             if (i != j)
                 pinned.push_back(logger.emit_rup_proof_line(WPBSum{} + 1_i * ! w + 1_i * ! cact(i) + 1_i * sact(i, j) >= 1_i, ProofLevel::Top));
 
+        // The diagonal, where the encoding minted a flag for it: `j` active at
+        // `t` means `j` is running when `j` starts, which is what sact_{j,j}
+        // says. The conjuncts it is defined over are a sub-list of cact_{j,t}'s
+        // --- a presence is literally the same atom, and a length is what
+        // cb_{j,t} and ca_{j,t} pin between them --- so unit propagation closes
+        // it, and no `w` is needed: this one holds whether or not `j` is the
+        // latest starter. It is written with the guard anyway, so that the
+        // arithmetic below can treat every candidate the same way.
+        auto diagonal = sact_diagonal(j);
+        optional<ProofLine> diagonal_pin;
+        if (diagonal)
+            diagonal_pin = logger.emit_rup_proof_line(WPBSum{} + 1_i * ! w + 1_i * ! cact(j) + 1_i * *diagonal >= 1_i, ProofLevel::Top);
+
         // Tests only: cite the next candidate's checkpoint instead of this
         // one's. Everything still checks --- see RecoverFromWrongCheckpoint.
         auto cite = j;
@@ -276,13 +296,19 @@ auto gcs::innards::recover_cumulative_capacity_row(ProofLogger & logger, const C
         for (auto i : candidates)
             if (i != j)
                 pol.add(pinned[p++], height(i));
-        // j's own term is the one the checkpoint row folded into its right hand
-        // side, so nothing pins it and nothing cancels against it. It belongs on
-        // the row all the same --- j is one of the tasks whose load is being
-        // bounded --- so it goes on as a literal axiom, which adds the term
-        // without moving the degree. What stands now is the target row, guarded
-        // by j being the latest starter.
-        pol.add(! cact(j), height(j), tracker);
+        // And j's own term, by whichever of the two routes the encoding left
+        // open. With a flag on the diagonal it cancels exactly as everyone
+        // else's does, off the pin above. Without one, the checkpoint row
+        // folded j's height into its right hand side, so nothing pins it and
+        // nothing cancels against it --- it belongs on the row all the same,
+        // j being one of the tasks whose load is being bounded, so it goes on
+        // as a literal axiom, which adds the term without moving the degree.
+        // Either way what stands now is the target row, guarded by j being the
+        // latest starter.
+        if (diagonal_pin)
+            pol.add(*diagonal_pin, height(j));
+        else
+            pol.add(! cact(j), height(j), tracker);
 
         // Turn that into the clause the scan can resolve against, by cancelling
         // the whole load away against the target's own reverse half. The degree

--- a/gcs/constraints/cumulative/checkpoint_recovery.cc
+++ b/gcs/constraints/cumulative/checkpoint_recovery.cc
@@ -70,20 +70,37 @@ namespace
         }
         return load;
     }
+
+    // And the whole row, in whichever of the two forms the capacity's
+    // constancy picks: a number on the right where it is constant, and a
+    // (-1)*capacity term on the left where it is not, exactly as the encoder
+    // writes it. Shared for the same reason per_time_load is.
+    auto per_time_capacity_row(const CumulativeInputs & inputs, Integer t) -> WPBSumLE
+    {
+        auto load = per_time_load(inputs, t);
+        if (is_constant_variable(inputs.capacity))
+            return move(load) <= constant_value_of(inputs.capacity);
+        load += -1_i * inputs.capacity;
+        return move(load) <= 0_i;
+    }
 }
 
-auto gcs::innards::cumulative_shape_supports_checkpoint_recovery(const vector<size_t> & active_tasks,
-    const vector<optional<IntegerVariableID>> & presence, const vector<IntegerVariableID> & lengths, const vector<IntegerVariableID> & heights,
-    IntegerVariableID capacity) -> bool
+auto gcs::innards::cumulative_shape_supports_checkpoint_recovery(const vector<size_t> & active_tasks, const vector<optional<IntegerVariableID>> &,
+    const vector<IntegerVariableID> &, const vector<IntegerVariableID> &, IntegerVariableID) -> bool
 {
-    if (active_tasks.empty())
-        return false;
-    if (! is_constant_variable(capacity))
-        return false;
-    (void)heights;
-    (void)lengths;
-    (void)presence;
-    return true;
+    // Every shape the encoder can write is now one the recovery can speak
+    // about: an optional task and a variable length through the diagonal, a
+    // variable height through the contribution swap, a variable capacity by
+    // carrying the capacity as a term the way the encoder does. What is left
+    // is the one thing that is not a shape --- a Cumulative with no active
+    // task has no checkpoint row to recover from, because the encoding writes
+    // them over the active tasks.
+    //
+    // The presence, length, height and capacity parameters stay in the
+    // signature: this is the question "could the recovery speak about a
+    // Cumulative of this shape", the answer happens to have stopped depending
+    // on them, and a caller should not have to know that.
+    return ! active_tasks.empty();
 }
 
 auto gcs::innards::cumulative_checkpoint_recovery_applies(const CumulativeInputs & inputs, const ProofLogger & logger) -> bool
@@ -122,7 +139,6 @@ auto gcs::innards::recover_cumulative_capacity_row(ProofLogger & logger, const C
         return nullopt;
 
     auto height = [&](size_t i) { return constant_value_of(inputs.heights[i]); };
-    auto capacity = constant_value_of(inputs.capacity);
     auto flag_at = [&](const vector<vector<ProofFlag>> & flags, size_t i) -> const ProofFlag & {
         return flags[i][(t - inputs.per_task_t_lo[i]).raw_value];
     };
@@ -164,10 +180,8 @@ auto gcs::innards::recover_cumulative_capacity_row(ProofLogger & logger, const C
     };
     auto row = [&](const string & role) { return ProofLine{*tracker.constraint_row_label(inputs.owner, role)}; };
 
-    // The row being recovered, as the model states it: the load at t is within
-    // the capacity. In the form the derivation ends on, which is the negated
-    // one, this has degree `total - capacity`.
-    auto load = per_time_load(inputs, t);
+    // The most the candidates could take between them, which is all the
+    // trivial-case test below needs.
     Integer total = 0_i;
     for (auto i : candidates) {
         if (var_height(i)) {
@@ -181,12 +195,19 @@ auto gcs::innards::recover_cumulative_capacity_row(ProofLogger & logger, const C
         else
             total += height(i);
     }
-    auto degree = total - capacity;
 
     // Nothing to argue about: even every candidate at once fits. The row is a
     // tautology over the flags' own bounds, so it needs no checkpoint at all.
-    if (degree <= 0_i) {
-        auto trivial = logger.emit_rup_proof_line(move(load) <= capacity, ProofLevel::Top);
+    //
+    // Only available against a constant capacity: the test is "does the most
+    // the candidates can take fit in what the resource supplies", and a
+    // variable capacity has no single number to be compared against. It could
+    // be asked of the capacity's lower bound, but that bound is not among the
+    // recovery's inputs and this is a shortcut rather than a step --- a
+    // variable capacity simply takes the long way round, the derivation not
+    // caring whether the row it proves happens to be slack.
+    if (is_constant_variable(inputs.capacity) && total - constant_value_of(inputs.capacity) <= 0_i) {
+        auto trivial = logger.emit_rup_proof_line(per_time_capacity_row(inputs, t), ProofLevel::Top);
         cache.recovered.emplace(t, trivial);
         return trivial;
     }
@@ -327,7 +348,7 @@ auto gcs::innards::recover_cumulative_capacity_row(ProofLogger & logger, const C
     auto last = candidates.size() - 1;
 
     // --- literalise the target, so an n-way split over a row stays resolution -
-    auto target = move(load) <= capacity;
+    auto target = per_time_capacity_row(inputs, t);
     auto [target_flag, target_forward, target_reverse] = logger.create_proof_flag_reifying(target, "ckpf", ProofLevel::Top);
 
     // --- each case implies the target ---------------------------------------
@@ -532,7 +553,7 @@ auto gcs::innards::check_recovered_cumulative_capacity_rows(ProofLogger & logger
         if (! recovered)
             continue;
 
-        logger.emit(ImpliesProofRule{*recovered}, per_time_load(inputs, t) <= constant_value_of(inputs.capacity), ProofLevel::Top);
+        logger.emit(ImpliesProofRule{*recovered}, per_time_capacity_row(inputs, t), ProofLevel::Top);
     }
     logger.emit_proof_comment("#780 checkpoint recovery ends");
 }

--- a/gcs/constraints/cumulative/checkpoint_recovery.cc
+++ b/gcs/constraints/cumulative/checkpoint_recovery.cc
@@ -308,7 +308,8 @@ auto gcs::innards::recover_cumulative_capacity_row(ProofLogger & logger, const C
     return recovered;
 }
 
-auto gcs::innards::check_recovered_cumulative_capacity_rows(ProofLogger & logger, const CumulativeInputs & inputs) -> void
+auto gcs::innards::check_recovered_cumulative_capacity_rows(ProofLogger & logger, const CumulativeInputs & inputs, CheckpointRecoveryCache & cache)
+    -> void
 {
     if (! cumulative_checkpoint_recovery_applies(inputs, logger))
         return;
@@ -319,7 +320,6 @@ auto gcs::innards::check_recovered_cumulative_capacity_rows(ProofLogger & logger
     // quietly leaning, through one of its rups, on a row the encoding is about
     // to lose.
     logger.emit_proof_comment("#780 checkpoint recovery begins");
-    CheckpointRecoveryCache cache;
     for (const auto & [t, model_row] : inputs.capacity_lines) {
         auto recovered = recover_cumulative_capacity_row(logger, inputs, cache, t);
         if (! recovered)

--- a/gcs/constraints/cumulative/checkpoint_recovery.cc
+++ b/gcs/constraints/cumulative/checkpoint_recovery.cc
@@ -1,4 +1,5 @@
 #include <gcs/constraints/cumulative/checkpoint_recovery.hh>
+#include <gcs/innards/power.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
 #include <gcs/innards/proofs/pol_builder.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
@@ -41,6 +42,34 @@ namespace
     {
         return -tracker.reification_shape(ineq, HalfReifyOnConjunctionOf{{flag}}).reif_coefficient;
     }
+
+    // The load at `t` as the per-time capacity row states it: a coefficient on
+    // the activity flag for a constant height, and the bit-linearised
+    // contribution for a variable one.
+    //
+    // One function because it has two callers who must agree exactly --- the
+    // recovery, which derives this row, and the differential check, which
+    // asserts the derived row implies the model's. A copy that drifted would
+    // make the check compare the recovery against something the model does not
+    // say, which is the one failure the check exists to catch and the one it
+    // could not report.
+    auto per_time_load(const CumulativeInputs & inputs, Integer t) -> WPBSum
+    {
+        WPBSum load;
+        for (auto i : inputs.active_tasks) {
+            if (t < inputs.per_task_t_lo[i] || t > inputs.per_task_t_hi[i])
+                continue;
+            auto idx = (t - inputs.per_task_t_lo[i]).raw_value;
+            if (is_constant_variable(inputs.heights[i]))
+                load += constant_value_of(inputs.heights[i]) * inputs.active_flags[i][idx];
+            else {
+                const auto & bits = inputs.contrib_flags[i][idx];
+                for (Integer k = 0_i; k.raw_value < static_cast<long long>(bits.size()); ++k)
+                    load += power2(k) * bits[k.raw_value];
+            }
+        }
+        return load;
+    }
 }
 
 auto gcs::innards::cumulative_shape_supports_checkpoint_recovery(const vector<size_t> & active_tasks,
@@ -51,9 +80,9 @@ auto gcs::innards::cumulative_shape_supports_checkpoint_recovery(const vector<si
         return false;
     if (! is_constant_variable(capacity))
         return false;
-    for (auto i : active_tasks)
-        if (! is_constant_variable(heights[i]))
-            return false;
+    (void)heights;
+    (void)lengths;
+    (void)presence;
     return true;
 }
 
@@ -112,14 +141,45 @@ auto gcs::innards::recover_cumulative_capacity_row(ProofLogger & logger, const C
     // anyone else's. See Data::pair_active_flag_key.
     auto sact_diagonal = [&](size_t j) { return tracker.find_proof_flag_values(inputs.owner, Data::pair_active_flag_key(j, j)); };
 
+    // A variable height is not a coefficient on an activity flag: what is on
+    // every capacity row is the bit-linearised contribution, `cc` per (task,
+    // time) and `scc` per (task, task). See the encoding.
+    auto var_height = [&](size_t i) { return ! is_constant_variable(inputs.heights[i]); };
+    auto cc_bits = [&](size_t i) -> const vector<ProofFlag> & { return inputs.contrib_flags[i][(t - inputs.per_task_t_lo[i]).raw_value]; };
+    auto scc_bits = [&](size_t i, size_t j) {
+        vector<ProofFlag> bits;
+        for (Integer k = 0_i;; ++k) {
+            auto flag = tracker.find_proof_flag_values(inputs.owner, Data::pair_contribution_flag_key(i, j, k));
+            if (! flag)
+                break;
+            bits.push_back(*flag);
+        }
+        return bits;
+    };
+    auto bit_sum = [&](const vector<ProofFlag> & bits) {
+        WPBSum sum;
+        for (Integer k = 0_i; k.raw_value < static_cast<long long>(bits.size()); ++k)
+            sum += power2(k) * bits[k.raw_value];
+        return sum;
+    };
+    auto row = [&](const string & role) { return ProofLine{*tracker.constraint_row_label(inputs.owner, role)}; };
+
     // The row being recovered, as the model states it: the load at t is within
     // the capacity. In the form the derivation ends on, which is the negated
     // one, this has degree `total - capacity`.
-    WPBSum load;
+    auto load = per_time_load(inputs, t);
     Integer total = 0_i;
     for (auto i : candidates) {
-        load += height(i) * cact(i);
-        total += height(i);
+        if (var_height(i)) {
+            // The most the bits can say, which is all the trivial-case test
+            // below needs. Looser than ub(h_i) when the height's range does not
+            // fill its bits, which only ever costs a shortcut, never a wrong
+            // answer.
+            for (Integer k = 0_i; k.raw_value < static_cast<long long>(cc_bits(i).size()); ++k)
+                total += power2(k);
+        }
+        else
+            total += height(i);
     }
     auto degree = total - capacity;
 
@@ -307,12 +367,109 @@ auto gcs::innards::recover_cumulative_capacity_row(ProofLogger & logger, const C
         // checkpoint term is dropped rather than pinned. Weakening, while the
         // checkpoint row is still the whole of the running total.
         for (auto i : inputs.active_tasks)
-            if (i != j && (t < inputs.per_task_t_lo[i] || t > inputs.per_task_t_hi[i]))
-                pol.weaken(sact(i, j), tracker);
+            if (i != j && (t < inputs.per_task_t_lo[i] || t > inputs.per_task_t_hi[i])) {
+                if (var_height(i))
+                    for (const auto & bit : scc_bits(i, j))
+                        pol.weaken(bit, tracker);
+                else
+                    pol.weaken(sact(i, j), tracker);
+            }
+        // Swapping each candidate's checkpoint term for its per-time one.
+        //
+        // A constant height is a coefficient on sact_{i,j}, and the pin cancels
+        // it and leaves the same coefficient on ~cact_{i,t}, which is the whole
+        // of the conversion: the load term the target's reverse half then
+        // cancels against *is* that ~cact term.
+        //
+        // A variable height is a coefficient on neither. What is on the
+        // checkpoint row is the pair's bit-linearised contribution and what is
+        // on the target is the per-time one, so the conversion is between two
+        // bit sums and the ~cact term is no longer the load --- it is a guard
+        // residue, and a residue left on the case clause is a literal the scan
+        // cannot resolve away, which comes out as a recovered row weaker than
+        // the one asked for. So it has to go, and getting rid of it needs the
+        // fact
+        //
+        //     Sum_k 2^k cc_{i,t,k}  <=  Sum_k 2^k scc_{i,j,k}          (*)
+        //
+        // *unguarded by cact*, which is true for two different reasons either
+        // side of that flag: active at t, and both sides are h_i; not active,
+        // and the left is zero while the right is a sum of non-negative terms.
+        // Two reasons is a case split, and a case split whose target is a row
+        // rather than a clause is relativized on a flag for it --- the same
+        // technique, and the same reason for it, as the target row itself a
+        // few lines down.
+        auto swap_var_height = [&](size_t i, optional<ProofLine> pin) {
+            // (*), or its diagonal form. Where the encoding minted no activity
+            // flag for j on the diagonal it put the *height itself* on the
+            // checkpoint row rather than a bit sum, so the right hand side is
+            // h_j and there are no pair bits.
+            auto pair = pin ? make_optional(scc_bits(i, j)) : optional<vector<ProofFlag>>{};
+            auto goal_sum = bit_sum(cc_bits(i));
+            if (pair)
+                for (Integer k = 0_i; k.raw_value < static_cast<long long>(pair->size()); ++k)
+                    goal_sum += -power2(k) * (*pair)[k.raw_value];
+            else
+                goal_sum += -1_i * inputs.heights[i];
+            auto goal = move(goal_sum) <= 0_i;
+            auto [g, g_forward, g_reverse] = logger.create_proof_flag_reifying(goal, "ckpg", ProofLevel::Top);
+
+            // Active at t: the per-time `le` row caps the left at h_i and, off
+            // the diagonal, the pair's `ge` row floors the right at the same
+            // h_i, so h_i cancels between them. The pair row's own guard is
+            // discharged by the pin, at the coefficient it was emitted with ---
+            // asked for, not assumed, for the same reason guard_coefficient
+            // exists.
+            PolBuilder active;
+            active.add(row(Data::contribution_le_row_role(i, t)));
+            if (pair) {
+                active.add(row(Data::pair_contribution_ge_row_role(i, j)));
+                active.add(*pin, guard_coefficient(tracker, bit_sum(*pair) + -1_i * inputs.heights[i] >= 0_i, sact(i, j)));
+            }
+            active.add(g_reverse);
+            active.saturate().emit(logger, ProofLevel::Top);
+
+            // Not active at t: the `zero` row says the left is zero, and the
+            // right is a sum of non-negative terms --- bits, or a height the
+            // constructor has already required to be non-negative --- which go
+            // on as literal axioms.
+            PolBuilder inactive;
+            inactive.add(row(Data::contribution_zero_row_role(i, t)));
+            if (pair)
+                for (Integer k = 0_i; k.raw_value < static_cast<long long>(pair->size()); ++k)
+                    inactive.add((*pair)[k.raw_value], power2(k), tracker);
+            else
+                inactive.add_for_literal(tracker, inputs.heights[i] >= 0_i);
+            inactive.add(g_reverse);
+            inactive.saturate().emit(logger, ProofLevel::Top);
+
+            // The two clauses differ only in the polarity of cact, so resolving
+            // them leaves the goal holding whatever it is --- guarded by w
+            // where the pin brought w in, and by nothing at all on a flagless
+            // diagonal.
+            auto everywhere = pin ? logger.emit_rup_proof_line(WPBSum{} + 1_i * g + 1_i * ! w >= 1_i, ProofLevel::Top)
+                                  : logger.emit_rup_proof_line(WPBSum{} + 1_i * g >= 1_i, ProofLevel::Top);
+
+            // And out from behind the flag, exactly as the target row is.
+            PolBuilder unwrap;
+            unwrap.add(g_forward);
+            unwrap.add(everywhere, guard_coefficient(tracker, goal, g));
+            pol.add(unwrap.emit(logger, ProofLevel::Top));
+        };
+
+        auto swap_term = [&](size_t i, optional<ProofLine> pin) {
+            if (var_height(i))
+                swap_var_height(i, pin);
+            else if (pin)
+                pol.add(*pin, height(i));
+            else
+                pol.add(! cact(i), height(i), tracker);
+        };
+
         size_t p = 0;
         for (auto i : candidates)
             if (i != j)
-                pol.add(pinned[p++], height(i));
+                swap_term(i, pinned[p++]);
         // And j's own term, by whichever of the two routes the encoding left
         // open. With a flag on the diagonal it cancels exactly as everyone
         // else's does, off the pin above. Without one, the checkpoint row
@@ -322,10 +479,7 @@ auto gcs::innards::recover_cumulative_capacity_row(ProofLogger & logger, const C
         // as a literal axiom, which adds the term without moving the degree.
         // Either way what stands now is the target row, guarded by j being the
         // latest starter.
-        if (diagonal_pin)
-            pol.add(*diagonal_pin, height(j));
-        else
-            pol.add(! cact(j), height(j), tracker);
+        swap_term(j, diagonal_pin);
 
         // Turn that into the clause the scan can resolve against, by cancelling
         // the whole load away against the target's own reverse half. The degree
@@ -378,11 +532,7 @@ auto gcs::innards::check_recovered_cumulative_capacity_rows(ProofLogger & logger
         if (! recovered)
             continue;
 
-        WPBSum load;
-        for (auto i : inputs.active_tasks)
-            if (t >= inputs.per_task_t_lo[i] && t <= inputs.per_task_t_hi[i])
-                load += constant_value_of(inputs.heights[i]) * inputs.active_flags[i][(t - inputs.per_task_t_lo[i]).raw_value];
-        logger.emit(ImpliesProofRule{*recovered}, move(load) <= constant_value_of(inputs.capacity), ProofLevel::Top);
+        logger.emit(ImpliesProofRule{*recovered}, per_time_load(inputs, t) <= constant_value_of(inputs.capacity), ProofLevel::Top);
     }
     logger.emit_proof_comment("#780 checkpoint recovery ends");
 }

--- a/gcs/constraints/cumulative/checkpoint_recovery.cc
+++ b/gcs/constraints/cumulative/checkpoint_recovery.cc
@@ -1,0 +1,335 @@
+#include <gcs/constraints/cumulative/checkpoint_recovery.hh>
+#include <gcs/innards/proofs/names_and_ids_tracker.hh>
+#include <gcs/innards/proofs/pol_builder.hh>
+#include <gcs/innards/proofs/proof_logger.hh>
+
+#include <string>
+#include <variant>
+#include <vector>
+
+using namespace gcs;
+using namespace gcs::innards;
+
+using std::make_pair;
+using std::make_tuple;
+using std::nullopt;
+using std::optional;
+using std::pair;
+using std::size_t;
+using std::string;
+using std::to_string;
+using std::vector;
+
+namespace
+{
+    using Data = ConstraintProofModelData<Cumulative>;
+
+    // The label of one half of a flag's reification. These flags all come from
+    // create_proof_flag_values_fully_reifying, whose halves are labelled off
+    // name_of --- not off pb_file_string_for, which is what the flags with no
+    // ConstraintID to key them use.
+    auto half_of(const NamesAndIDsTracker & tracker, const ProofFlag & flag, const string & which) -> ProofLineLabel
+    {
+        return ProofLineLabel{tracker.name_of(flag) + which};
+    }
+
+    // The reification coefficient a forward half was emitted with, which is
+    // what a pol has to multiply the flag by for the guard terms to cancel
+    // rather than leave a residue. Asked rather than assumed, exactly as
+    // Disjunctive's sorting-network certificate asks it.
+    auto guard_coefficient(NamesAndIDsTracker & tracker, const WPBSumLE & ineq, const ProofFlag & flag) -> Integer
+    {
+        return -tracker.reification_shape(ineq, HalfReifyOnConjunctionOf{{flag}}).reif_coefficient;
+    }
+}
+
+auto gcs::innards::cumulative_checkpoint_recovery_applies(const CumulativeInputs & inputs, const ProofLogger & logger) -> bool
+{
+    if (inputs.active_tasks.empty())
+        return false;
+    if (! is_constant_variable(inputs.capacity))
+        return false;
+    for (auto i : inputs.active_tasks) {
+        if (inputs.presence[i] || ! is_constant_variable(inputs.lengths[i]) || ! is_constant_variable(inputs.heights[i]))
+            return false;
+        // The block has to be in the model to be recovered from. Asking for one
+        // task's row is enough: the encoding writes them for every active task
+        // or for none.
+        if (! logger.names_and_ids_tracker().constraint_row_label(inputs.owner, Data::checkpoint_row_role(i)))
+            return false;
+    }
+    return true;
+}
+
+auto gcs::innards::recover_cumulative_capacity_row(ProofLogger & logger, const CumulativeInputs & inputs, CheckpointRecoveryCache & cache, Integer t)
+    -> optional<ProofLine>
+{
+    if (auto already = cache.recovered.find(t); already != cache.recovered.end())
+        return already->second;
+    if (! cumulative_checkpoint_recovery_applies(inputs, logger))
+        return nullopt;
+
+    auto & tracker = logger.names_and_ids_tracker();
+
+    // The candidates: the tasks the encoding gave a flag at t. Windows differ
+    // from task to task, so this is not every active task --- and a task
+    // without a flag at t is not in the row being recovered, takes no part in
+    // the case split, and has its checkpoint term weakened away below.
+    vector<size_t> candidates;
+    for (auto i : inputs.active_tasks)
+        if (t >= inputs.per_task_t_lo[i] && t <= inputs.per_task_t_hi[i])
+            candidates.push_back(i);
+    if (candidates.empty())
+        return nullopt;
+
+    auto height = [&](size_t i) { return constant_value_of(inputs.heights[i]); };
+    auto capacity = constant_value_of(inputs.capacity);
+    auto flag_at = [&](const vector<vector<ProofFlag>> & flags, size_t i) -> const ProofFlag & {
+        return flags[i][(t - inputs.per_task_t_lo[i]).raw_value];
+    };
+    auto cb = [&](size_t i) -> const ProofFlag & { return flag_at(inputs.before_flags, i); };
+    auto ca = [&](size_t i) -> const ProofFlag & { return flag_at(inputs.after_flags, i); };
+    auto cact = [&](size_t i) -> const ProofFlag & { return flag_at(inputs.active_flags, i); };
+    auto pair_flag = [&](const ProofFlagKey & key) { return *tracker.find_proof_flag_values(inputs.owner, key); };
+    auto sb = [&](size_t i, size_t j) { return pair_flag(Data::pair_before_flag_key(i, j)); };
+    auto sa = [&](size_t i, size_t j) { return pair_flag(Data::pair_after_flag_key(i, j)); };
+    auto sact = [&](size_t i, size_t j) { return pair_flag(Data::pair_active_flag_key(i, j)); };
+
+    // The row being recovered, as the model states it: the load at t is within
+    // the capacity. In the form the derivation ends on, which is the negated
+    // one, this has degree `total - capacity`.
+    WPBSum load;
+    Integer total = 0_i;
+    for (auto i : candidates) {
+        load += height(i) * cact(i);
+        total += height(i);
+    }
+    auto degree = total - capacity;
+
+    // Nothing to argue about: even every candidate at once fits. The row is a
+    // tautology over the flags' own bounds, so it needs no checkpoint at all.
+    if (degree <= 0_i) {
+        auto trivial = logger.emit_rup_proof_line(move(load) <= capacity, ProofLevel::Top);
+        cache.recovered.emplace(t, trivial);
+        return trivial;
+    }
+
+    // --- the order facts, which say nothing about t and are derived once -----
+    //
+    // Totality is a theorem here rather than an axiom, which is the one place
+    // the start-checkpoint encoding is better off than Disjunctive's: its
+    // before flag carries a duration, so its separation clause has to be
+    // asserted. sb_{i,j} is starts-only, so the two [f] halves have starts that
+    // cancel exactly between them, and what is left divides by two.
+    for (size_t a = 0; a < candidates.size(); ++a)
+        for (size_t b = a + 1; b < candidates.size(); ++b) {
+            auto i = candidates[a], j = candidates[b];
+            if (cache.totality.contains(make_pair(i, j)))
+                continue;
+            PolBuilder pol;
+            pol.add(half_of(tracker, sb(i, j), "[f]"));
+            pol.add(half_of(tracker, sb(j, i), "[f]"));
+            cache.totality.emplace(make_pair(i, j), pol.divide_by(2_i).saturate().emit(logger, ProofLevel::Top));
+        }
+
+    // Transitivity, one pol per ordered triple, all three starts cancelling.
+    // Materialised only for the triples a recovery actually asks for: the pool
+    // is cubic, and standing rows are the one cost of this that grows with the
+    // task count rather than with what the search touches.
+    for (auto a : candidates)
+        for (auto b : candidates)
+            for (auto c : candidates) {
+                if (a == b || b == c || a == c)
+                    continue;
+                if (cache.transitivity.contains(make_tuple(a, b, c)))
+                    continue;
+                PolBuilder pol;
+                pol.add(half_of(tracker, sb(a, b), "[r]"));
+                pol.add(half_of(tracker, sb(b, c), "[r]"));
+                pol.add(half_of(tracker, sb(a, c), "[f]"));
+                cache.transitivity.emplace(make_tuple(a, b, c), pol.saturate().emit(logger, ProofLevel::Top));
+            }
+
+    // --- ca_{i,t} /\ cb_{j,t} -> sa_{i,j} ------------------------------------
+    //
+    // If i is still running at t and j has started by t, then i is still
+    // running when j starts: s_i + l_i >= t + 1 >= s_j + 1. One pol, with the
+    // starts (and, when it is there, the length) cancelling across the three
+    // rows and the constants leaving degree one, so saturating gives a clause
+    // rather than something at its own degree. This is Disjunctive's
+    // emit_before_pol with the flag polarity flipped.
+    for (auto i : candidates)
+        for (auto j : candidates) {
+            if (i == j)
+                continue;
+            PolBuilder pol;
+            pol.add(half_of(tracker, ca(i), "[r]"));
+            pol.add(half_of(tracker, cb(j), "[r]"));
+            pol.add(half_of(tracker, sa(i, j), "[f]"));
+            pol.saturate().emit(logger, ProofLevel::Top);
+        }
+
+    // --- e_{i,j}: i does not stand between j and being the latest starter -----
+    std::map<pair<size_t, size_t>, ProofFlag> e;
+    for (auto i : candidates)
+        for (auto j : candidates) {
+            if (i == j)
+                continue;
+            e.emplace(make_pair(i, j),
+                std::get<0>(logger.create_proof_flag_reifying(WPBSum{} + 1_i * ! cb(i) + 1_i * sb(i, j) >= 1_i, "ckpe", ProofLevel::Top)));
+        }
+
+    // Lifting e along the order, which is where transitivity earns its place:
+    // without these the scan below cannot move its champion.
+    for (auto i : candidates)
+        for (auto j : candidates)
+            for (auto k : candidates) {
+                if (i == j || j == k || i == k)
+                    continue;
+                logger.emit_rup_proof_line(
+                    WPBSum{} + 1_i * ! e.at(make_pair(i, j)) + 1_i * ! sb(j, k) + 1_i * e.at(make_pair(i, k)) >= 1_i, ProofLevel::Top);
+            }
+
+    // --- the scan ------------------------------------------------------------
+    //
+    // N_k: none of the first k+1 candidates has started by t.
+    // W_{j,k}: j has, and is the latest of the first k+1 to have done so.
+    // A_k: one of those two things holds. Carried up one candidate at a time.
+    vector<ProofFlag> nothing_yet;
+    std::map<pair<size_t, size_t>, ProofFlag> champion;
+    for (size_t k = 0; k < candidates.size(); ++k) {
+        WPBSum none;
+        for (size_t p = 0; p <= k; ++p)
+            none += 1_i * ! cb(candidates[p]);
+        nothing_yet.push_back(
+            std::get<0>(logger.create_proof_flag_reifying(move(none) >= Integer(static_cast<long long>(k) + 1), "ckpn", ProofLevel::Top)));
+
+        for (size_t p = 0; p <= k; ++p) {
+            auto j = candidates[p];
+            WPBSum latest = WPBSum{} + 1_i * cb(j);
+            for (size_t q = 0; q <= k; ++q)
+                if (q != p)
+                    latest += 1_i * e.at(make_pair(candidates[q], j));
+            champion.emplace(make_pair(j, k),
+                std::get<0>(logger.create_proof_flag_reifying(move(latest) >= Integer(static_cast<long long>(k) + 1), "ckpw", ProofLevel::Top)));
+        }
+    }
+
+    auto scan =
+        logger.emit_rup_proof_line(WPBSum{} + 1_i * champion.at(make_pair(candidates[0], size_t{0})) + 1_i * nothing_yet[0] >= 1_i, ProofLevel::Top);
+    for (size_t k = 0; k + 1 < candidates.size(); ++k) {
+        auto next = candidates[k + 1];
+        auto & fresh = champion.at(make_pair(next, k + 1));
+        PolBuilder pol;
+        pol.add(scan);
+        for (size_t p = 0; p <= k; ++p) {
+            auto j = candidates[p];
+            pol.add(logger.emit_rup_proof_line(
+                WPBSum{} + 1_i * ! champion.at(make_pair(j, k)) + 1_i * champion.at(make_pair(j, k + 1)) + 1_i * fresh >= 1_i, ProofLevel::Top));
+        }
+        pol.add(logger.emit_rup_proof_line(WPBSum{} + 1_i * ! nothing_yet[k] + 1_i * fresh + 1_i * nothing_yet[k + 1] >= 1_i, ProofLevel::Top));
+        scan = pol.saturate().emit(logger, ProofLevel::Top);
+    }
+    auto last = candidates.size() - 1;
+
+    // --- literalise the target, so an n-way split over a row stays resolution -
+    auto target = move(load) <= capacity;
+    auto [target_flag, target_forward, target_reverse] = logger.create_proof_flag_reifying(target, "ckpf", ProofLevel::Top);
+
+    // --- each case implies the target ---------------------------------------
+    PolBuilder finish;
+    finish.add(scan);
+    for (auto j : candidates) {
+        auto & w = champion.at(make_pair(j, last));
+        vector<ProofLine> pinned;
+        for (auto i : candidates)
+            if (i != j)
+                pinned.push_back(logger.emit_rup_proof_line(WPBSum{} + 1_i * ! w + 1_i * ! cact(i) + 1_i * sact(i, j) >= 1_i, ProofLevel::Top));
+
+        // Tests only: cite the next candidate's checkpoint instead of this
+        // one's. Everything still checks --- see RecoverFromWrongCheckpoint.
+        auto cite = j;
+        if (std::holds_alternative<cumulative_proof_mutation::RecoverFromWrongCheckpoint>(inputs.proof_mutation))
+            for (size_t q = 0; q < candidates.size(); ++q)
+                if (candidates[q] == j)
+                    cite = candidates[(q + 1) % candidates.size()];
+
+        PolBuilder pol;
+        pol.add(*tracker.constraint_row_label(inputs.owner, Data::checkpoint_row_role(cite)));
+        // A task with no flag at t is not in the row being recovered, so its
+        // checkpoint term is dropped rather than pinned. Weakening, while the
+        // checkpoint row is still the whole of the running total.
+        for (auto i : inputs.active_tasks)
+            if (i != j && (t < inputs.per_task_t_lo[i] || t > inputs.per_task_t_hi[i]))
+                pol.weaken(sact(i, j), tracker);
+        size_t p = 0;
+        for (auto i : candidates)
+            if (i != j)
+                pol.add(pinned[p++], height(i));
+        // j's own term is the one the checkpoint row folded into its right hand
+        // side, so nothing pins it and nothing cancels against it. It belongs on
+        // the row all the same --- j is one of the tasks whose load is being
+        // bounded --- so it goes on as a literal axiom, which adds the term
+        // without moving the degree. What stands now is the target row, guarded
+        // by j being the latest starter.
+        pol.add(! cact(j), height(j), tracker);
+
+        // Turn that into the clause the scan can resolve against, by cancelling
+        // the whole load away against the target's own reverse half. The degree
+        // that leaves is one, because a reverse half guards at exactly the
+        // coefficient that makes its own degree --- so saturating gives a
+        // clause and not something at its own degree. If that ever stops being
+        // the shape, this fails loudly at the resolution below rather than
+        // quietly.
+        pol.add(target_reverse);
+
+        // And the guard itself, which the arithmetic above produces only when
+        // there was another task to pin: a lone task has no pairwise term, so
+        // its case comes out unguarded and would not cancel against the scan.
+        // Adding the axiom costs nothing where the term is already there ---
+        // saturation flattens the coefficient either way.
+        pol.add(! w, tracker);
+
+        finish.add(pol.saturate().emit(logger, ProofLevel::Top));
+    }
+
+    // Nobody has started by t, so nobody is active at t and the row holds on
+    // the flags' own definitions.
+    finish.add(logger.emit_rup_proof_line(WPBSum{} + 1_i * ! nothing_yet[last] + 1_i * target_flag >= 1_i, ProofLevel::Top));
+    auto target_holds = finish.saturate().emit(logger, ProofLevel::Top);
+
+    // --- and out from behind the flag ---------------------------------------
+    PolBuilder unwrap;
+    unwrap.add(target_forward);
+    unwrap.add(target_holds, guard_coefficient(tracker, target, target_flag));
+    auto recovered = unwrap.emit(logger, ProofLevel::Top);
+
+    cache.recovered.emplace(t, recovered);
+    return recovered;
+}
+
+auto gcs::innards::check_recovered_cumulative_capacity_rows(ProofLogger & logger, const CumulativeInputs & inputs) -> void
+{
+    if (! cumulative_checkpoint_recovery_applies(inputs, logger))
+        return;
+
+    // Bracketed, so that run_checkpoint_recovery_leak_check.bash can cut the
+    // proof here and re-check the prefix against an OPB with no per-time
+    // capacity rows in it. That is the only thing that says the recovery is not
+    // quietly leaning, through one of its rups, on a row the encoding is about
+    // to lose.
+    logger.emit_proof_comment("#780 checkpoint recovery begins");
+    CheckpointRecoveryCache cache;
+    for (const auto & [t, model_row] : inputs.capacity_lines) {
+        auto recovered = recover_cumulative_capacity_row(logger, inputs, cache, t);
+        if (! recovered)
+            continue;
+
+        WPBSum load;
+        for (auto i : inputs.active_tasks)
+            if (t >= inputs.per_task_t_lo[i] && t <= inputs.per_task_t_hi[i])
+                load += constant_value_of(inputs.heights[i]) * inputs.active_flags[i][(t - inputs.per_task_t_lo[i]).raw_value];
+        logger.emit(ImpliesProofRule{*recovered}, move(load) <= constant_value_of(inputs.capacity), ProofLevel::Top);
+    }
+    logger.emit_proof_comment("#780 checkpoint recovery ends");
+}

--- a/gcs/constraints/cumulative/checkpoint_recovery.cc
+++ b/gcs/constraints/cumulative/checkpoint_recovery.cc
@@ -43,15 +43,25 @@ namespace
     }
 }
 
+auto gcs::innards::cumulative_shape_supports_checkpoint_recovery(const vector<size_t> & active_tasks,
+    const vector<optional<IntegerVariableID>> & presence, const vector<IntegerVariableID> & lengths, const vector<IntegerVariableID> & heights,
+    IntegerVariableID capacity) -> bool
+{
+    if (active_tasks.empty())
+        return false;
+    if (! is_constant_variable(capacity))
+        return false;
+    for (auto i : active_tasks)
+        if (presence[i] || ! is_constant_variable(lengths[i]) || ! is_constant_variable(heights[i]))
+            return false;
+    return true;
+}
+
 auto gcs::innards::cumulative_checkpoint_recovery_applies(const CumulativeInputs & inputs, const ProofLogger & logger) -> bool
 {
-    if (inputs.active_tasks.empty())
-        return false;
-    if (! is_constant_variable(inputs.capacity))
+    if (! cumulative_shape_supports_checkpoint_recovery(inputs.active_tasks, inputs.presence, inputs.lengths, inputs.heights, inputs.capacity))
         return false;
     for (auto i : inputs.active_tasks) {
-        if (inputs.presence[i] || ! is_constant_variable(inputs.lengths[i]) || ! is_constant_variable(inputs.heights[i]))
-            return false;
         // The block has to be in the model to be recovered from. Asking for one
         // task's row is enough: the encoding writes them for every active task
         // or for none.

--- a/gcs/constraints/cumulative/checkpoint_recovery.hh
+++ b/gcs/constraints/cumulative/checkpoint_recovery.hh
@@ -69,6 +69,34 @@ namespace gcs::innards
      * variable height replaces a task's coefficient with a bit sum, and a
      * presence adds a conjunct to every activity flag; each is a known
      * extension and none of them is done yet.
+     *
+     * **A variable capacity is the one whose extension is not merely undone
+     * but unwritten**, so what is known about it belongs here rather than in
+     * someone's head. The *model* side already handles it --- both the
+     * per-time rows and the checkpoint rows move it to the left as a
+     * `(-1) * capacity` term when it is not constant. It is the recovery that
+     * assumes a constant, in two places, and only one of them is clerical:
+     *
+     * - `target`, the row being recovered, becomes
+     *   `sum h_i * cact_i - capacity <= 0` rather than `... <= capacity`.
+     *   Mechanical: the checkpoint rows the derivation adds up carry the same
+     *   extra term, so it survives every `pol` unchanged.
+     * - `degree = total - capacity` does not survive, and it is load-bearing
+     *   twice over. It decides the trivial case (every candidate at once
+     *   fits, so the row is a tautology over the flags' own bounds and no
+     *   checkpoint is needed), and it is the degree the derivation saturates
+     *   at. With the capacity on the left as a bit sum there is no single
+     *   constant degree: saturating a row whose right-hand side is a number
+     *   and saturating one carrying the capacity's bit coefficients are not
+     *   the same operation, and the guard coefficients are computed against
+     *   it too.
+     *
+     * So the open question is precisely that one, and it is a question about
+     * saturation rather than about the scheduling argument, which does not
+     * change at all. The obvious first thing to try is the trivial case at
+     * `total <= lb(capacity)` and the general case relativized on the
+     * capacity's bits; nobody has tried it, and this note is not a claim that
+     * it works.
      */
     [[nodiscard]] auto cumulative_checkpoint_recovery_applies(const CumulativeInputs & inputs, const ProofLogger & logger) -> bool;
 

--- a/gcs/constraints/cumulative/checkpoint_recovery.hh
+++ b/gcs/constraints/cumulative/checkpoint_recovery.hh
@@ -1,0 +1,96 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_CUMULATIVE_CHECKPOINT_RECOVERY_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_CUMULATIVE_CHECKPOINT_RECOVERY_HH
+
+#include <gcs/constraints/cumulative/propagate.hh>
+#include <gcs/innards/proofs/proof_line.hh>
+#include <gcs/innards/proofs/proof_logger-fwd.hh>
+#include <gcs/integer.hh>
+
+#include <cstddef>
+#include <map>
+#include <optional>
+#include <tuple>
+#include <utility>
+
+namespace gcs::innards
+{
+    /**
+     * \brief What the start-checkpoint recovery keeps between calls.
+     *
+     * Two kinds of thing. The order facts --- that the start order is total,
+     * and that it is transitive --- say nothing about a time point, so they are
+     * derived once for the constraint and shared by every recovery. The
+     * recovered rows are keyed on the time point, which is the whole cache key:
+     * every rule in the time-table family cites the row for `t` and nothing
+     * finer, so a row derived for one citer serves all of them.
+     *
+     * Everything in here lives at ProofLevel::Top and is reason-free, so
+     * nothing in it is invalidated by backtracking.
+     *
+     * \ingroup Innards
+     */
+    struct CheckpointRecoveryCache
+    {
+        /// `sb_{i,j} \/ sb_{j,i}`, for `i < j`.
+        std::map<std::pair<std::size_t, std::size_t>, ProofLine> totality;
+
+        /// `sb_{a,b} /\ sb_{b,c} -> sb_{a,c}`.
+        std::map<std::tuple<std::size_t, std::size_t, std::size_t>, ProofLine> transitivity;
+
+        /// The recovered capacity row for each time point asked for.
+        std::map<Integer, ProofLine> recovered;
+    };
+
+    /**
+     * \brief Whether recover_cumulative_capacity_row can speak about this
+     * constraint at all.
+     *
+     * Asks for the start-checkpoint block to be in the model (see
+     * CumulativeEncoding), and for the shapes the recovery has been written
+     * for: constant lengths, heights and capacity, and no optional tasks. A
+     * variable length moves the diagonal off the row and onto a flag, a
+     * variable height replaces a task's coefficient with a bit sum, and a
+     * presence adds a conjunct to every activity flag; each is a known
+     * extension and none of them is done yet.
+     */
+    [[nodiscard]] auto cumulative_checkpoint_recovery_applies(const CumulativeInputs & inputs, const ProofLogger & logger) -> bool;
+
+    /**
+     * \brief Derive the capacity row for time point `t` from the
+     * start-checkpoint rows, at ProofLevel::Top and reason-free.
+     *
+     * The argument: let `j` be the candidate with the largest start among those
+     * that have started by `t`. Every candidate `i` active at `t` has
+     * `s_i <= t <= s_j` and `s_i + l_i >= t + 1 >= s_j + 1`, so it is active
+     * when `j` starts, and `j`'s checkpoint row caps exactly the load at `t`.
+     * Note `j` need not itself be active at `t` --- only started --- which is
+     * what keeps the case split off the active set.
+     *
+     * Nullopt when \ref cumulative_checkpoint_recovery_applies says no, or when
+     * no task can be active at `t` at all (there is then no row to recover, and
+     * the model has none either).
+     *
+     * See dev_docs/cumulative-proof-logging.md for the step-by-step derivation
+     * and what it costs.
+     */
+    [[nodiscard]] auto recover_cumulative_capacity_row(
+        ProofLogger & logger, const CumulativeInputs & inputs, CheckpointRecoveryCache & cache, Integer t) -> std::optional<ProofLine>;
+
+    /**
+     * \brief Recover every capacity row the model wrote, and check each against
+     * the row still standing beside it.
+     *
+     * The differential CumulativeEncoding::BothRecovering exists for. Deriving
+     * a row that is *invalid* fails inside the recovery, loudly; deriving a
+     * valid row that is not the one the case wanted --- citing the neighbouring
+     * checkpoint, say --- produces a perfectly good line, and only asking
+     * whether it implies the model's own row catches that.
+     *
+     * Deliberately eager, which the recovery is not meant to be: the point here
+     * is to check every row, not to pay for only the ones a search cites. No-op
+     * when \ref cumulative_checkpoint_recovery_applies says no.
+     */
+    auto check_recovered_cumulative_capacity_rows(ProofLogger & logger, const CumulativeInputs & inputs) -> void;
+}
+
+#endif

--- a/gcs/constraints/cumulative/checkpoint_recovery.hh
+++ b/gcs/constraints/cumulative/checkpoint_recovery.hh
@@ -90,7 +90,7 @@ namespace gcs::innards
      * is to check every row, not to pay for only the ones a search cites. No-op
      * when \ref cumulative_checkpoint_recovery_applies says no.
      */
-    auto check_recovered_cumulative_capacity_rows(ProofLogger & logger, const CumulativeInputs & inputs) -> void;
+    auto check_recovered_cumulative_capacity_rows(ProofLogger & logger, const CumulativeInputs & inputs, CheckpointRecoveryCache & cache) -> void;
 }
 
 #endif

--- a/gcs/constraints/cumulative/checkpoint_recovery.hh
+++ b/gcs/constraints/cumulative/checkpoint_recovery.hh
@@ -11,6 +11,7 @@
 #include <optional>
 #include <tuple>
 #include <utility>
+#include <vector>
 
 namespace gcs::innards
 {
@@ -40,6 +41,22 @@ namespace gcs::innards
         /// The recovered capacity row for each time point asked for.
         std::map<Integer, ProofLine> recovered;
     };
+
+    /**
+     * \brief Whether the recovery could speak about a Cumulative of this
+     * *shape*, without asking whether the checkpoint block is in the model.
+     *
+     * The half of \ref cumulative_checkpoint_recovery_applies that can be
+     * answered before any row has been written, which is what
+     * CumulativeEncoding::StartCheckpoint needs: it has to decide whether to
+     * emit the time-indexed block at all, and it makes that decision while
+     * building the model. Splitting it keeps one statement of what the shape
+     * requirement is, rather than a copy in the encoder that could drift from
+     * the one the recovery enforces.
+     */
+    [[nodiscard]] auto cumulative_shape_supports_checkpoint_recovery(const std::vector<std::size_t> & active_tasks,
+        const std::vector<std::optional<IntegerVariableID>> & presence, const std::vector<IntegerVariableID> & lengths,
+        const std::vector<IntegerVariableID> & heights, IntegerVariableID capacity) -> bool;
 
     /**
      * \brief Whether recover_cumulative_capacity_row can speak about this

--- a/gcs/constraints/cumulative/checkpoint_recovery.hh
+++ b/gcs/constraints/cumulative/checkpoint_recovery.hh
@@ -53,6 +53,15 @@ namespace gcs::innards
      * building the model. Splitting it keeps one statement of what the shape
      * requirement is, rather than a copy in the encoder that could drift from
      * the one the recovery enforces.
+     *
+     * It now turns down only a Cumulative with no active task, every actual
+     * *shape* --- optional tasks, variable lengths, variable heights, a
+     * variable capacity --- having been brought in. The presence, length,
+     * height and capacity parameters stay in the signature anyway: the
+     * question is "could the recovery speak about a Cumulative of this shape",
+     * the answer has merely stopped depending on them, and a caller should not
+     * have to know that. Keeping them also means the next shape the encoder
+     * learns to write has somewhere to be declined from.
      */
     [[nodiscard]] auto cumulative_shape_supports_checkpoint_recovery(const std::vector<std::size_t> & active_tasks,
         const std::vector<std::optional<IntegerVariableID>> & presence, const std::vector<IntegerVariableID> & lengths,
@@ -63,40 +72,48 @@ namespace gcs::innards
      * constraint at all.
      *
      * Asks for the start-checkpoint block to be in the model (see
-     * CumulativeEncoding), and for the shapes the recovery has been written
-     * for: constant lengths, heights and capacity, and no optional tasks. A
-     * variable length moves the diagonal off the row and onto a flag, a
-     * variable height replaces a task's coefficient with a bit sum, and a
-     * presence adds a conjunct to every activity flag; each is a known
-     * extension and none of them is done yet.
+     * CumulativeEncoding). That is now the whole of it: the recovery speaks
+     * about every shape the encoder can write, so the shape half of this
+     * question (\ref cumulative_shape_supports_checkpoint_recovery) only
+     * turns down a Cumulative with no active task, which has no checkpoint row
+     * to recover from.
      *
-     * **A variable capacity is the one whose extension is not merely undone
-     * but unwritten**, so what is known about it belongs here rather than in
-     * someone's head. The *model* side already handles it --- both the
-     * per-time rows and the checkpoint rows move it to the left as a
-     * `(-1) * capacity` term when it is not constant. It is the recovery that
-     * assumes a constant, in two places, and only one of them is clerical:
+     * What each of the four shapes took, since knowing which were hard is
+     * worth more than knowing they are done:
      *
-     * - `target`, the row being recovered, becomes
-     *   `sum h_i * cact_i - capacity <= 0` rather than `... <= capacity`.
-     *   Mechanical: the checkpoint rows the derivation adds up carry the same
-     *   extra term, so it survives every `pol` unchanged.
-     * - `degree = total - capacity` does not survive, and it is load-bearing
-     *   twice over. It decides the trivial case (every candidate at once
-     *   fits, so the row is a tautology over the flags' own bounds and no
-     *   checkpoint is needed), and it is the degree the derivation saturates
-     *   at. With the capacity on the left as a bit sum there is no single
-     *   constant degree: saturating a row whose right-hand side is a number
-     *   and saturating one carrying the capacity's bit coefficients are not
-     *   the same operation, and the guard coefficients are computed against
-     *   it too.
+     * - **An optional task** and **a variable length** took the same one
+     *   change, on the diagonal. Give a task a presence or a variable length
+     *   and the encoder mints `sact_{j,j}` and puts `j`'s own height on the
+     *   checkpoint row; with a constant length and no presence it folds that
+     *   height into the right hand side instead and there is no flag. So the
+     *   recovery pins the diagonal where the flag is there and axiomatises it
+     *   where it is not. Nothing off the diagonal changed: `cact` and `sact`
+     *   both carry the presence conjunct, and `sa_{i,j}` already reified on
+     *   `s_i + l_i` directly when the length varied.
+     * - **A variable height** needed an argument. It is a coefficient on
+     *   neither flag --- the checkpoint row carries the pair's bit-linearised
+     *   contribution and the target carries the per-time one --- so `~cact`
+     *   stops being the load term and becomes a guard residue, and a residue
+     *   left on a case clause is a literal the scan cannot resolve away. The
+     *   swap therefore goes through a fact that holds either side of `cact`,
+     *   for two different reasons, and is proved by a case split relativized
+     *   on a flag of its own. See the comment at the swap.
+     * - **A variable capacity** turned out to be nearly free, and an earlier
+     *   version of this note was wrong about why it would not be. It said
+     *   `degree = total - capacity` was "the degree the derivation saturates
+     *   at" and that the guard coefficients were computed against it. Neither
+     *   is so: `degree` was only ever the test for the trivial case. The
+     *   capacity itself needs no special handling, because it cancels between
+     *   the checkpoint row and the target's own reverse half exactly as the
+     *   load does. All it cost was carrying the row in the encoder's own two
+     *   forms, and giving up the trivial-case shortcut where there is no
+     *   single number to compare against.
      *
-     * So the open question is precisely that one, and it is a question about
-     * saturation rather than about the scheduling argument, which does not
-     * change at all. The obvious first thing to try is the trivial case at
-     * `total <= lb(capacity)` and the general case relativized on the
-     * capacity's bits; nobody has tried it, and this note is not a claim that
-     * it works.
+     * The lesson in that last one is worth keeping: the argument was about
+     * *scheduling*, and it never mentioned the capacity's constancy. Guessing
+     * that PB arithmetic would be the obstacle, without following the constant
+     * through the code to see what it actually reached, produced a confident
+     * note that pointed at the wrong thing.
      */
     [[nodiscard]] auto cumulative_checkpoint_recovery_applies(const CumulativeInputs & inputs, const ProofLogger & logger) -> bool;
 

--- a/gcs/constraints/cumulative/checkpoint_recovery_leak_check.scp
+++ b/gcs/constraints/cumulative/checkpoint_recovery_leak_check.scp
@@ -1,0 +1,1 @@
+( (version 1) (variables (S0 0 4) (S1 0 4) (S2 0 4) (S3 0 4)) (constraints (_1 cumulative (S0 S1 S2 S3) (1 2 3 2) (1 2 1 1) 3)) (prob_type enumerate) )

--- a/gcs/constraints/cumulative/checkpoint_recovery_overflow_only.scp
+++ b/gcs/constraints/cumulative/checkpoint_recovery_overflow_only.scp
@@ -1,0 +1,1 @@
+( (version 1) (variables (S0 0 1) (S1 0 1)) (constraints (_1 cumulative (S0 S1) (2 2) (1 1) 1)) (prob_type enumerate) )

--- a/gcs/constraints/cumulative/checkpoint_recovery_overload.scp
+++ b/gcs/constraints/cumulative/checkpoint_recovery_overload.scp
@@ -1,0 +1,1 @@
+( (version 1) (variables (S0 0 2) (S1 0 2) (S2 0 2)) (constraints (_1 cumulative (S0 S1 S2) (2 2 2) (1 1 1) 1)) (prob_type enumerate) )

--- a/gcs/constraints/cumulative/checkpoint_recovery_ttoc.scp
+++ b/gcs/constraints/cumulative/checkpoint_recovery_ttoc.scp
@@ -1,0 +1,1 @@
+( (version 1) (variables (S0 2 3) (S1 0 0) (S2 1 2)) (constraints (_1 cumulative (S0 S1 S2) (2 2 2) (2 3 3) 3)) (prob_type enumerate) )

--- a/gcs/constraints/cumulative/cumulative.cc
+++ b/gcs/constraints/cumulative/cumulative.cc
@@ -845,11 +845,14 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
     // it. The recovery declines a Cumulative it cannot yet speak about (a
     // variable height, an optional task), and the model row is what is left.
     //
-    // The time-table family goes through this: the overflow contradiction and
-    // both bound pushes. Every other citer --- the overload check and its
-    // rungs, edge-finding's window rows, published not-first / not-last ---
-    // still reads capacity_lines directly, and moving them over one at a time,
-    // each its own commit and each verified on its own, is the rest of #780.
+    // The time-table family goes through this --- the overflow contradiction
+    // and both bound pushes --- and so does the overload check's (OC)/(TTOC)
+    // window supply, which is the first citer to want a row at every time point
+    // of a window rather than at one. What is left --- the elastic and knapsack
+    // availability lines, edge-finding's window rows, published not-first /
+    // not-last --- still reads capacity_lines directly, and moving them over
+    // one at a time, each its own commit and each verified on its own, is the
+    // rest of #780.
     auto capacity_row = [&](Integer t) -> std::optional<ProofLine> {
         if (logger && inputs.checkpoint_recovery)
             if (auto recovered = recover_cumulative_capacity_row(*logger, inputs, *inputs.checkpoint_recovery, t))
@@ -2433,13 +2436,25 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
                     // terms in the capacity lines, leaving a constraint
                     // with nothing but negative coefficients on the
                     // left and a positive right hand side.
+                    //
+                    // The rows come from `capacity_row`, so under #780's
+                    // recovering encoding the whole window is supplied from the
+                    // start-checkpoint block. The cancellation is unaffected
+                    // either way: a recovered row is the *same inequality* as
+                    // the model's, over the same candidates at `t` and the same
+                    // activity flags, so what a contained task cancels against
+                    // does not depend on which of the two produced it. This is
+                    // the first citer to want a row at every point of a window
+                    // rather than at one, so it is where the recovery's
+                    // per-point cost is first paid many times over --- but each
+                    // row is derived once for the constraint and cached, so a
+                    // second window overlapping the first pays nothing.
                     PolBuilder pol;
                     for (Integer t = a; t < b; ++t) {
                         if (omit_capacity_line && t == b - 1_i)
                             continue;
-                        auto line = capacity_lines.find(t);
-                        if (line != capacity_lines.end())
-                            pol.add(line->second);
+                        if (auto line = capacity_row(t))
+                            pol.add(*line);
                     }
 
                     for (auto i : inside_tasks) {

--- a/gcs/constraints/cumulative/cumulative.cc
+++ b/gcs/constraints/cumulative/cumulative.cc
@@ -8,6 +8,7 @@
 #include <gcs/innards/inference_tracker.hh>
 #include <gcs/innards/power.hh>
 #include <gcs/innards/proofs/bits_encoding.hh>
+#include <gcs/innards/proofs/flag_bridge.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
 #include <gcs/innards/proofs/pol_builder.hh>
 #include <gcs/innards/proofs/proof_error.hh>
@@ -794,7 +795,7 @@ auto Cumulative::install_propagators(Propagators & propagators) -> void
                 // ConstraintID to key them. Getting it the wrong way round is
                 // loud --- there is no such label --- but it is worth not
                 // having to find that out.
-                lemma.add(ProofLineLabel{tracker.name_of(after) + "[f]"});
+                lemma.add(reification_half(tracker, after, ReificationHalf::ImpliedBy));
                 lemma.add(*end_le[i]);
                 lemma.emit(*logger, ProofLevel::Top);
             }

--- a/gcs/constraints/cumulative/cumulative.cc
+++ b/gcs/constraints/cumulative/cumulative.cc
@@ -871,12 +871,12 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
     // sub-derivation rather than summing it straight into a pol, and so does
     // edge-finding's window supply --- and with it TTEF, the energetic form and
     // our own not-first / not-last, which is certified by edge-finding's
-    // certificate unchanged. What is left --- the *published* not-first /
-    // not-last, which has its own citer, and derived_cumulative.cc --- still
-    // reads capacity_lines directly, and moving them over one at a time, each
-    // its own commit and each verified on its own, is the rest of #780. A lane
-    // whose every rule has moved joins the `startcheckpoint` ctest arm, which
-    // is where that progress is measured.
+    // certificate unchanged, and so does the published not-first / not-last,
+    // the only citer that scales the row rather than adding it at one. That is
+    // every citer in this file. What is left is outside it:
+    // derived_cumulative.cc still looks its donors' rows up by label, which is
+    // the rest of #780. A lane whose every rule has moved joins the
+    // `startcheckpoint` ctest arm, which is where that progress is measured.
     auto capacity_row = [&](Integer t) -> std::optional<ProofLine> {
         if (logger && inputs.checkpoint_recovery)
             if (auto recovered = recover_cumulative_capacity_row(*logger, inputs, *inputs.checkpoint_recovery, t))
@@ -1418,10 +1418,10 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
             auto capacity_at = [&](PolBuilder & pol, Integer t, Integer coeff) {
                 if (omit_capacity && t == b - 1_i)
                     return;
-                auto line = capacity_lines.find(t);
-                if (line == capacity_lines.end())
+                auto line = capacity_row(t);
+                if (! line)
                     return;
-                pol.add(line->second, coeff);
+                pol.add(*line, coeff);
                 auto convert = [&](size_t i) {
                     if (h_is_var(i) && t >= per_task_t_lo[i] && t <= per_task_t_hi[i])
                         pol.add(guaranteed_contribution(reason, i, t), coeff);

--- a/gcs/constraints/cumulative/cumulative.cc
+++ b/gcs/constraints/cumulative/cumulative.cc
@@ -766,6 +766,11 @@ auto Cumulative::install_propagators(Propagators & propagators) -> void
         }
     });
 
+    // One cache, shared between the differential check below and the
+    // propagator, so an inference cites the line the check passed on.
+    auto recovery_cache =
+        _encoding.value_or(default_cumulative_encoding()) == CumulativeEncoding::BothRecovering ? make_shared<CheckpointRecoveryCache>() : nullptr;
+
     CumulativeInputs inputs{.owner = constraint_id(),
         .starts = move(_starts),
         .lengths = move(_lengths),
@@ -781,6 +786,7 @@ auto Cumulative::install_propagators(Propagators & propagators) -> void
         .per_task_t_hi = move(_per_task_t_hi),
         .end_ge_lines = end_ge_lines,
         .capacity_lines = move(_capacity_lines),
+        .checkpoint_recovery = recovery_cache,
         .rules = _rules,
         .proof_mutation = _proof_mutation,
         .presence_mutation = _presence_mutation,
@@ -800,7 +806,7 @@ auto Cumulative::install_propagators(Propagators & propagators) -> void
             [recovery_inputs = make_shared<CumulativeInputs>(inputs)](State &, auto &, ProofLogger * const logger) -> void {
                 if (! logger || logger->get_assertion_level() > AssertionLevel::Off)
                     return;
-                check_recovered_cumulative_capacity_rows(*logger, *recovery_inputs);
+                check_recovered_cumulative_capacity_rows(*logger, *recovery_inputs, *recovery_inputs->checkpoint_recovery);
             });
 
     propagators.install(
@@ -830,6 +836,28 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
     const auto & per_task_t_hi = inputs.per_task_t_hi;
     const auto & end_ge_lines = inputs.end_ge_lines;
     const auto & capacity_lines = inputs.capacity_lines;
+
+    // Where a citer gets the row saying the load at `t` is within the capacity.
+    // Today that is the OPB row the time-indexed block wrote, unless #780's
+    // recovery is on, in which case it is derived from the start-checkpoint
+    // rows instead --- once per time point, cached, and reason-free at Top, so
+    // the second citer of a point pays nothing and backtracking does not lose
+    // it. The recovery declines a Cumulative it cannot yet speak about (a
+    // variable height, an optional task), and the model row is what is left.
+    //
+    // Only the time-table overflow contradiction goes through this so far.
+    // Every other citer still reads capacity_lines directly, and moving them
+    // over one at a time --- each its own commit, each verified on its own ---
+    // is the rest of #780.
+    auto capacity_row = [&](Integer t) -> std::optional<ProofLine> {
+        if (logger && inputs.checkpoint_recovery)
+            if (auto recovered = recover_cumulative_capacity_row(*logger, inputs, *inputs.checkpoint_recovery, t))
+                return recovered;
+        auto line = capacity_lines.find(t);
+        if (line == capacity_lines.end())
+            return std::nullopt;
+        return line->second;
+    };
     const auto & rules = inputs.rules;
     const auto & mutation = inputs.proof_mutation;
     const auto & presence = inputs.presence;
@@ -1554,7 +1582,7 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
                 // reason context (the pinned loads already exceed
                 // ub(capacity)), closing the framework's wrapping RUP.
                 PolBuilder pol;
-                pol.add(capacity_lines.at(violating_t));
+                pol.add(*capacity_row(violating_t));
                 for (auto i : contributing) {
                     auto [line, coeff] = pin_contributor(reason, i, violating_t);
                     pol.add(line, coeff);

--- a/gcs/constraints/cumulative/cumulative.cc
+++ b/gcs/constraints/cumulative/cumulative.cc
@@ -845,10 +845,11 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
     // it. The recovery declines a Cumulative it cannot yet speak about (a
     // variable height, an optional task), and the model row is what is left.
     //
-    // Only the time-table overflow contradiction goes through this so far.
-    // Every other citer still reads capacity_lines directly, and moving them
-    // over one at a time --- each its own commit, each verified on its own ---
-    // is the rest of #780.
+    // The time-table family goes through this: the overflow contradiction and
+    // both bound pushes. Every other citer --- the overload check and its
+    // rungs, edge-finding's window rows, published not-first / not-last ---
+    // still reads capacity_lines directly, and moving them over one at a time,
+    // each its own commit and each verified on its own, is the rest of #780.
     auto capacity_row = [&](Integer t) -> std::optional<ProofLine> {
         if (logger && inputs.checkpoint_recovery)
             if (auto recovered = recover_cumulative_capacity_row(*logger, inputs, *inputs.checkpoint_recovery, t))
@@ -2520,7 +2521,7 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
         // cancellation the pol is dominated by (load − capacity)·Σext,
         // forcing the ext disjunction under the reason context.
         PolBuilder pol;
-        pol.add(capacity_lines.at(t));
+        pol.add(*capacity_row(t));
         for (auto i : contributing) {
             auto [line, coeff] = pin_contributor(reason, i, t);
             pol.add(line, coeff);

--- a/gcs/constraints/cumulative/cumulative.cc
+++ b/gcs/constraints/cumulative/cumulative.cc
@@ -517,8 +517,9 @@ auto Cumulative::define_proof_model(ProofModel & model, const State &) -> void
     // Note this gates the capacity *rows* only. The per-(task, time) flags
     // above stay: every rule's activity vocabulary is still stated over them,
     // and moving them to lazily-minted objects is its own step of #780.
-    auto omit_per_time_capacity_rows = _encoding.value_or(default_cumulative_encoding()) == CumulativeEncoding::StartCheckpoint &&
-        cumulative_shape_supports_checkpoint_recovery(_active_tasks, _presence, _lengths, _heights, _capacity);
+    auto encoding = _encoding.value_or(default_cumulative_encoding());
+    auto shape_supports_recovery = cumulative_shape_supports_checkpoint_recovery(_active_tasks, _presence, _lengths, _heights, _capacity);
+    auto omit_per_time_capacity_rows = encoding == CumulativeEncoding::StartCheckpoint && shape_supports_recovery;
 
     for (Integer t = global_lo; t <= global_hi && ! omit_per_time_capacity_rows; ++t) {
         WPBSum load;
@@ -550,7 +551,24 @@ auto Cumulative::define_proof_model(ProofModel & model, const State &) -> void
         }
     }
 
-    if (_encoding.value_or(default_cumulative_encoding()) == CumulativeEncoding::TimeIndexed)
+    if (encoding == CumulativeEncoding::TimeIndexed)
+        return;
+
+    // #780: under CumulativeEncoding::StartCheckpoint a shape the recovery
+    // cannot speak about has just kept its per-time block, above. Writing the
+    // checkpoint block beside it as well would be pure growth: no rule can
+    // cite it, because every citer goes through a recovery that declines this
+    // shape before it looks at the model at all. So StartCheckpoint on a
+    // declined shape *is* TimeIndexed, which is what "start-checkpoint
+    // wherever the recovery reaches" has to mean once the default flips ---
+    // otherwise every variable-length, variable-height, variable-capacity or
+    // optional-task model would silently start paying for two encodings.
+    //
+    // Both and BothRecovering keep writing it for every shape. They are the
+    // differential arms, and a checkpoint row over a shape the recovery
+    // declines is still a row veripb checks against the solutions, which is
+    // how the block was soundness-checked in the first place.
+    if (encoding == CumulativeEncoding::StartCheckpoint && ! shape_supports_recovery)
         return;
 
     // Start-checkpoint encoding (issue #780), emitted *alongside* the

--- a/gcs/constraints/cumulative/cumulative.cc
+++ b/gcs/constraints/cumulative/cumulative.cc
@@ -1,3 +1,4 @@
+#include <gcs/constraints/cumulative/checkpoint_recovery.hh>
 #include <gcs/constraints/cumulative/cumulative.hh>
 #include <gcs/constraints/cumulative/hints.hh>
 #include <gcs/constraints/cumulative/propagate.hh>
@@ -86,6 +87,8 @@ namespace
                 return CumulativeEncoding::TimeIndexed;
             else if (spelling == "both")
                 return CumulativeEncoding::Both;
+            else if (spelling == "both-recovering")
+                return CumulativeEncoding::BothRecovering;
             throw UnexpectedException{"unrecognised GCS_CUMULATIVE_ENCODING value '" + spelling + "'"};
         }();
         return value;
@@ -786,6 +789,19 @@ auto Cumulative::install_propagators(Propagators & propagators) -> void
         .time_slot_lo = _time_slot_lo,
         .guarded_energy =
             std::make_shared<std::map<std::tuple<size_t, Integer, Integer, Integer, Integer, Integer>, window_energy::GuardedWindowEnergy>>()};
+
+    // #780's differential, under CumulativeEncoding::BothRecovering: derive
+    // every capacity row from the start-checkpoint rows and check it against
+    // the one the model still carries. A copy of the inputs rather than a
+    // reference into the propagator's, which is about to be moved from --- the
+    // check runs once, before search, and the copy dies with it.
+    if (_encoding.value_or(default_cumulative_encoding()) == CumulativeEncoding::BothRecovering)
+        propagators.install_initialiser(
+            [recovery_inputs = make_shared<CumulativeInputs>(inputs)](State &, auto &, ProofLogger * const logger) -> void {
+                if (! logger || logger->get_assertion_level() > AssertionLevel::Off)
+                    return;
+                check_recovered_cumulative_capacity_rows(*logger, *recovery_inputs);
+            });
 
     propagators.install(
         constraint_id(),

--- a/gcs/constraints/cumulative/cumulative.cc
+++ b/gcs/constraints/cumulative/cumulative.cc
@@ -24,6 +24,7 @@
 #include <cstdlib>
 #include <memory>
 #include <optional>
+#include <ranges>
 #include <sstream>
 #include <string>
 #include <utility>
@@ -271,11 +272,13 @@ auto Cumulative::prepare(Propagators &, State & initial_state, ProofModel * cons
     _length_lb.clear();
     _length_ub.clear();
     _height_vals.clear();
+    _height_lb.clear();
     _height_ub.clear();
     _length_vals.reserve(n);
     _length_lb.reserve(n);
     _length_ub.reserve(n);
     _height_vals.reserve(n);
+    _height_lb.reserve(n);
     _height_ub.reserve(n);
     for (const auto & l : _lengths) {
         _length_vals.push_back(is_constant_variable(l) ? constant_value_of(l) : 0_i);
@@ -284,10 +287,28 @@ auto Cumulative::prepare(Propagators &, State & initial_state, ProofModel * cons
     }
     for (const auto & h : _heights) {
         _height_vals.push_back(is_constant_variable(h) ? constant_value_of(h) : 0_i);
+        // The lower bound is the *declared* one, which is what decides whether
+        // the variable's bit encoding carries a sign bit --- and so whether
+        // bit k of it has weight 2^k, which #780 step 10 needs when it defines
+        // a contribution bit as a conjunction with one. Heights are
+        // non-negative by the time prepare is done, but a declared bound below
+        // zero would still shift every weight.
+        _height_lb.push_back(initial_state.lower_bound(h));
         _height_ub.push_back(initial_state.upper_bound(h));
     }
     if (is_constant_variable(_capacity))
         _capacity_val = constant_value_of(_capacity);
+
+    // #780: can every height's own bits be cited? A constant needs none; a
+    // plain variable with a declared lower bound of zero or more has bit k at
+    // weight 2^k; a view has no bits of its own, and a declared bound below
+    // zero puts a sign bit in and shifts every weight. Where the answer is no,
+    // a variable height's contribution stays linearised by three rows per
+    // pair, and the per-(task, time) family stays in the model --- see
+    // define_proof_model.
+    _height_bits_citable = std::ranges::all_of(std::views::iota(std::size_t{0}, _heights.size()), [&](std::size_t i) {
+        return is_constant_variable(_heights[i]) || (std::holds_alternative<SimpleIntegerVariableID>(_heights[i]) && _height_lb[i] >= 0_i);
+    });
 
     // Tasks whose length can only ever be 0, or whose height can only ever be 0,
     // or which are constantly absent, never raise the load profile.
@@ -440,12 +461,26 @@ auto Cumulative::define_proof_model(ProofModel & model, const State &) -> void
     // model objects: the per-time capacity rows are what mention them, and that
     // is the block this encoding does without.
     //
-    // Not yet where any task has a variable height. Such a task's contribution
-    // rows are OPB rows *half-reified on its activity flag*, so the flag has to
-    // be in the model for them to exist at all; moving those rows into the
-    // proof too is the next step and this declines rather than half-does it.
-    _per_time_flags_in_proof = _encoding.value_or(default_cumulative_encoding()) == CumulativeEncoding::StartCheckpoint &&
-        std::ranges::all_of(_active_tasks, [&](std::size_t i) { return is_constant_variable(_heights[i]); });
+    // A variable height's contribution bits come too. Out of the model they
+    // stop needing three rows at all: the product h_i * cact_{i,t} linearises
+    // bit by bit into a *conjunction*,
+    //
+    //     cc_{i,t,k}  <->  cact_{i,t}  /\  bit_k(h_i)
+    //
+    // which is one two-way reification of a fresh flag over literals that
+    // already exist --- the same primitive the activity flag itself uses. The
+    // three `cge` / `cle` / `cz` rows then fall out of those definitions rather
+    // than being asserted; see the initialiser, and the recovery's swap, which
+    // got shorter for it.
+    //
+    // It needs the height's own bits, which means a plain variable rather than
+    // a view, and no sign bit --- so a declared lower bound of zero or more.
+    // Heights are non-negative anyway (prepare checks), but a *declared* bound
+    // below zero would still put a sign bit in the encoding and shift every
+    // weight, so this asks rather than assumes. A constraint with a height it
+    // cannot ask about keeps the whole family in the model: the contribution
+    // rows are half-reified on the activity flag, so a mixture is not available.
+    _per_time_flags_in_proof = _encoding.value_or(default_cumulative_encoding()) == CumulativeEncoding::StartCheckpoint && _height_bits_citable;
 
     // Time-table OPB encoding:
     //   for each task i and each time point t in its possible-active range:
@@ -538,13 +573,15 @@ auto Cumulative::define_proof_model(ProofModel & model, const State &) -> void
                 // constraint (recover_constant_argument_row); the other two are
                 // labelled to keep the family whole rather than because
                 // anything cites them yet.
-                auto contrib = contrib_sum_of(cc);
-                model.add_labelled_constraint(_constraint_id, ConstraintProofModelData<Cumulative>::contribution_ge_row_role(i, t),
-                    contrib + -1_i * _heights[i] >= 0_i, HalfReifyOnConjunctionOf{active});
-                model.add_labelled_constraint(_constraint_id, ConstraintProofModelData<Cumulative>::contribution_le_row_role(i, t),
-                    contrib + -1_i * _heights[i] <= 0_i, HalfReifyOnConjunctionOf{active});
-                model.add_labelled_constraint(_constraint_id, ConstraintProofModelData<Cumulative>::contribution_zero_row_role(i, t), contrib <= 0_i,
-                    HalfReifyOnConjunctionOf{! active});
+                if (! _per_time_flags_in_proof) {
+                    auto contrib = contrib_sum_of(cc);
+                    model.add_labelled_constraint(_constraint_id, ConstraintProofModelData<Cumulative>::contribution_ge_row_role(i, t),
+                        contrib + -1_i * _heights[i] >= 0_i, HalfReifyOnConjunctionOf{active});
+                    model.add_labelled_constraint(_constraint_id, ConstraintProofModelData<Cumulative>::contribution_le_row_role(i, t),
+                        contrib + -1_i * _heights[i] <= 0_i, HalfReifyOnConjunctionOf{active});
+                    model.add_labelled_constraint(_constraint_id, ConstraintProofModelData<Cumulative>::contribution_zero_row_role(i, t),
+                        contrib <= 0_i, HalfReifyOnConjunctionOf{! active});
+                }
                 _contrib_flags[i].push_back(move(cc));
             }
         }
@@ -732,18 +769,44 @@ auto Cumulative::define_proof_model(ProofModel & model, const State &) -> void
                 // A variable height's contribution is the product h_i·active,
                 // linearised over per-bit flags exactly as the per-(i,t) block
                 // does it; see there for what the three rows say.
+                // Bit by bit, `contrib = h_i * sact_{i,j}` *is* a conjunction:
+                // scc_{i,j,k} <-> sact_{i,j} /\ bit_k(h_i). Two reification
+                // halves per bit, where the three-row linearisation this
+                // replaced took `scge` / `scle` / `scz` per pair --- and, more
+                // to the point, the halves are what let the recovery swap a
+                // pair bit for a per-time one with a single rup per bit rather
+                // than a case split. The per-time family says the same thing
+                // about the same height, in the proof rather than the model;
+                // see the install initialiser.
+                //
+                // Bit k has weight 2^k because a height with a sign bit is
+                // turned away before we get here; see height_bits_citable.
                 auto highest_bit_shift = std::get<0>(get_bits_encoding_coeffs(0_i, _height_ub[i]));
                 std::vector<ProofFlag> cc;
-                for (Integer k = 0_i; k <= highest_bit_shift; ++k)
-                    cc.push_back(model.names_and_ids_tracker().create_proof_flag_values(
-                        _constraint_id, std::vector<long long>{static_cast<long long>(i), static_cast<long long>(j), k.raw_value}, "scc"));
-                auto contrib = contrib_sum_of(cc);
-                model.add_labelled_constraint(_constraint_id, ConstraintProofModelData<Cumulative>::pair_contribution_ge_row_role(i, j),
-                    contrib + -1_i * _heights[i] >= 0_i, HalfReifyOnConjunctionOf{*active});
-                model.add_labelled_constraint(_constraint_id, ConstraintProofModelData<Cumulative>::pair_contribution_le_row_role(i, j),
-                    contrib + -1_i * _heights[i] <= 0_i, HalfReifyOnConjunctionOf{*active});
-                model.add_labelled_constraint(_constraint_id, ConstraintProofModelData<Cumulative>::pair_contribution_zero_row_role(i, j),
-                    contrib <= 0_i, HalfReifyOnConjunctionOf{! *active});
+                if (_height_bits_citable) {
+                    auto height_var = std::get<SimpleIntegerVariableID>(_heights[i]);
+                    for (Integer k = 0_i; k <= highest_bit_shift; ++k)
+                        cc.push_back(model.create_proof_flag_values_fully_reifying(_constraint_id,
+                            std::vector<long long>{static_cast<long long>(i), static_cast<long long>(j), k.raw_value}, "scc",
+                            WPBSum{} + 1_i * *active + 1_i * ProofBitVariable{height_var, k, true} >= 2_i));
+                }
+                else {
+                    // No bits to conjoin with --- a view height, or one whose
+                    // declared bounds put a sign bit in the encoding --- so the
+                    // product is linearised the long way, three rows per pair.
+                    // The recovery declines such a constraint; see
+                    // CumulativeInputs::pair_contribution_bits_are_conjunctions.
+                    for (Integer k = 0_i; k <= highest_bit_shift; ++k)
+                        cc.push_back(model.names_and_ids_tracker().create_proof_flag_values(
+                            _constraint_id, std::vector<long long>{static_cast<long long>(i), static_cast<long long>(j), k.raw_value}, "scc"));
+                    auto contrib = contrib_sum_of(cc);
+                    model.add_labelled_constraint(_constraint_id, ConstraintProofModelData<Cumulative>::pair_contribution_ge_row_role(i, j),
+                        contrib + -1_i * _heights[i] >= 0_i, HalfReifyOnConjunctionOf{*active});
+                    model.add_labelled_constraint(_constraint_id, ConstraintProofModelData<Cumulative>::pair_contribution_le_row_role(i, j),
+                        contrib + -1_i * _heights[i] <= 0_i, HalfReifyOnConjunctionOf{*active});
+                    model.add_labelled_constraint(_constraint_id, ConstraintProofModelData<Cumulative>::pair_contribution_zero_row_role(i, j),
+                        contrib <= 0_i, HalfReifyOnConjunctionOf{! *active});
+                }
                 for (Integer k = 0_i; k.raw_value < static_cast<long long>(cc.size()); ++k)
                     load += power2(k) * cc[k.raw_value];
             }
@@ -794,8 +857,8 @@ auto Cumulative::install_propagators(Propagators & propagators) -> void
 
     propagators.install_initialiser(
         [id = constraint_id(), starts = _starts, lengths = _lengths, ends = _end, active_tasks = _active_tasks, before_flags = _before_flags,
-            after_flags = _after_flags, active_flags = _active_flags, presence = _presence, per_task_t_lo = _per_task_t_lo,
-            in_proof = _per_time_flags_in_proof, end_ge_lines](State &, auto &, ProofLogger * const logger) -> void {
+            after_flags = _after_flags, active_flags = _active_flags, contrib_flags = _contrib_flags, task_heights = _heights, presence = _presence,
+            per_task_t_lo = _per_task_t_lo, in_proof = _per_time_flags_in_proof, end_ge_lines](State &, auto &, ProofLogger * const logger) -> void {
             if (! logger || logger->get_assertion_level() > AssertionLevel::Off)
                 return;
             auto & tracker = logger->names_and_ids_tracker();
@@ -819,6 +882,51 @@ auto Cumulative::install_propagators(Propagators & propagators) -> void
                         define(before_flags[i][k], per_time_before_says(starts[i], t));
                         define(after_flags[i][k], per_time_after_says(starts[i], lengths[i], t));
                         define(active_flags[i][k], per_time_active_says(before_flags[i][k], after_flags[i][k], presence[i]));
+
+                        // A variable height's contribution bits. In the model
+                        // these need three rows, because `contrib = h * cact`
+                        // is a product and the rows are what linearise it. Here
+                        // they need none: bit by bit the product *is* a
+                        // conjunction,
+                        //
+                        //     cc_{i,t,k}  <->  cact_{i,t}  /\  bit_k(h_i)
+                        //
+                        // --- if the task is active its contribution is its
+                        // height, so bit for bit; if it is not, every bit is
+                        // zero. Each one is then a two-way reification of a
+                        // fresh flag over literals that already exist, the same
+                        // primitive the activity flag above uses, and the three
+                        // rows fall out of these rather than being asserted
+                        // beside them.
+                        //
+                        // Weight 2^k is bit k because the gate on this requires
+                        // a height with no sign bit; see height_bits_citable.
+                        if (! is_constant_variable(task_heights[i])) {
+                            const auto & cc = contrib_flags[i][k];
+                            auto height_var = std::get<SimpleIntegerVariableID>(task_heights[i]);
+                            for (Integer b = 0_i; b.raw_value < static_cast<long long>(cc.size()); ++b)
+                                define(cc[b.raw_value], WPBSum{} + 1_i * active_flags[i][k] + 1_i * ProofBitVariable{height_var, b, true} >= 2_i);
+
+                            // And the `cge` row those definitions imply, for the
+                            // energy rules and donor_view, which ask for it by
+                            // role and should not have to know it is derived
+                            // here rather than asserted in the model.
+                            //
+                            //   ~cact \/ ~bit_b(h) \/ cc_b   (rup, off cc_b's
+                            //                                 own reverse half)
+                            //
+                            // summed at 2^b is `S.~cact - h + Sum cc >= 0`,
+                            // which is that row with S as its guard coefficient.
+                            PolBuilder cge;
+                            for (Integer b = 0_i; b.raw_value < static_cast<long long>(cc.size()); ++b)
+                                cge.add(logger->emit_rup_proof_line(WPBSum{} + 1_i * ! active_flags[i][k] +
+                                                    1_i * ! ProofBitVariable{height_var, b, true} + 1_i * cc[b.raw_value] >=
+                                                1_i,
+                                            ProofLevel::Top),
+                                    power2(b));
+                            tracker.publish_derived_line(
+                                id, ConstraintProofModelData<Cumulative>::contribution_ge_row_role(i, t), cge.emit(*logger, ProofLevel::Top));
+                        }
                     }
             // Bit-define each variable-duration end = s + l as a conservative
             // extension FIRST (introduce_bits_of needs end's bits fresh for its
@@ -892,6 +1000,7 @@ auto Cumulative::install_propagators(Propagators & propagators) -> void
         .end_ge_lines = end_ge_lines,
         .capacity_lines = move(_capacity_lines),
         .checkpoint_recovery = recovery_cache,
+        .pair_contribution_bits_are_conjunctions = _height_bits_citable,
         .rules = _rules,
         .proof_mutation = _proof_mutation,
         .presence_mutation = _presence_mutation,
@@ -1052,7 +1161,7 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
     // reached from here rather than from a donor view.
     auto guaranteed_contribution = [&](const ReasonLiterals & reason, size_t i, Integer t) -> ProofLine {
         auto & tracker = logger->names_and_ids_tracker();
-        auto row = tracker.constraint_row_label(owner, ConstraintProofModelData<Cumulative>::contribution_ge_row_role(i, t));
+        auto row = tracker.constraint_row(owner, ConstraintProofModelData<Cumulative>::contribution_ge_row_role(i, t));
         // Emitted alongside the flags, so a task with a window here has one.
         // Missing means the flags and the rows have come apart, which is worth
         // saying here rather than as a rejected proof later.

--- a/gcs/constraints/cumulative/cumulative.cc
+++ b/gcs/constraints/cumulative/cumulative.cc
@@ -868,12 +868,15 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
     // and both bound pushes --- and so do the overload check's (OC)/(TTOC)
     // window supply and the (TTHE-OC)/(KAOC) per-time availability lines, the
     // latter being the only citer that uses a row as the base of a per-point
-    // sub-derivation rather than summing it straight into a pol. What is left
-    // --- edge-finding's window rows, published not-first / not-last, and
-    // derived_cumulative.cc --- still reads capacity_lines directly, and moving
-    // them over one at a time, each its own commit and each verified on its
-    // own, is the rest of #780. A lane whose every rule has moved joins the
-    // `startcheckpoint` ctest arm, which is where that progress is measured.
+    // sub-derivation rather than summing it straight into a pol, and so does
+    // edge-finding's window supply --- and with it TTEF, the energetic form and
+    // our own not-first / not-last, which is certified by edge-finding's
+    // certificate unchanged. What is left --- the *published* not-first /
+    // not-last, which has its own citer, and derived_cumulative.cc --- still
+    // reads capacity_lines directly, and moving them over one at a time, each
+    // its own commit and each verified on its own, is the rest of #780. A lane
+    // whose every rule has moved joins the `startcheckpoint` ctest arm, which
+    // is where that progress is measured.
     auto capacity_row = [&](Integer t) -> std::optional<ProofLine> {
         if (logger && inputs.checkpoint_recovery)
             if (auto recovered = recover_cumulative_capacity_row(*logger, inputs, *inputs.checkpoint_recovery, t))
@@ -1143,8 +1146,8 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
             for (Integer t = a; t < b; ++t) {
                 if (std::holds_alternative<cumulative_proof_mutation::OmitCapacityLine>(mutation) && t == b - 1_i)
                     continue;
-                if (auto line = capacity_lines.find(t); line != capacity_lines.end())
-                    pol.add(line->second);
+                if (auto line = capacity_row(t))
+                    pol.add(*line);
             }
 
             auto cite = [&](size_t i, Integer low_guard, Integer high_guard, bool discharge_low, bool discharge_high) {

--- a/gcs/constraints/cumulative/cumulative.cc
+++ b/gcs/constraints/cumulative/cumulative.cc
@@ -815,6 +815,36 @@ auto Cumulative::install_propagators(Propagators & propagators) -> void
         .guarded_energy =
             std::make_shared<std::map<std::tuple<size_t, Integer, Integer, Integer, Integer, Integer>, window_energy::GuardedWindowEnergy>>()};
 
+    // #780: let anyone who can name this constraint ask for a capacity row it
+    // no longer has an OPB label for. A derived Cumulative built on this one as
+    // a donor is the consumer that needs it --- under
+    // CumulativeEncoding::StartCheckpoint there is no `cap_<t>` row for it to
+    // find, and without this it would decline and take the presolver's whole
+    // inference with it, quietly, since a decline there is a supported outcome
+    // rather than an error.
+    //
+    // From an initialiser because that is the earliest point with a logger, and
+    // because initialisers run before presolvers (#658) --- the same timing
+    // publish_derived_line relies on. A copy of the inputs, as the differential
+    // below takes: the propagator's own is about to be moved from. The copy is
+    // read-only afterwards, and the cache it shares is a shared_ptr, so a row
+    // derived through here and one derived by the propagator are the same row
+    // and are paid for once.
+    //
+    // Published whenever the recovery is switched on at all, not only under
+    // StartCheckpoint: where the block is still written the label is found
+    // first and this is never reached, so there is nothing to gate.
+    if (recovery_cache)
+        propagators.install_initialiser([family_inputs = make_shared<CumulativeInputs>(inputs)](State &, auto &, ProofLogger * const logger) -> void {
+            if (! logger)
+                return;
+            logger->names_and_ids_tracker().publish_derived_line_family(family_inputs->owner,
+                ConstraintProofModelData<Cumulative>::capacity_row_family(),
+                [family_inputs](ProofLogger & deriver_logger, Integer t) -> std::optional<ProofLine> {
+                    return recover_cumulative_capacity_row(deriver_logger, *family_inputs, *family_inputs->checkpoint_recovery, t);
+                });
+        });
+
     // #780's differential, under CumulativeEncoding::BothRecovering: derive
     // every capacity row from the start-checkpoint rows and check it against
     // the one the model still carries. A copy of the inputs rather than a
@@ -2795,6 +2825,11 @@ auto Cumulative::capacity() const -> IntegerVariableID
 auto ConstraintProofModelData<Cumulative>::primary_row_role(const Cumulative &) -> std::optional<string>
 {
     return std::nullopt;
+}
+
+auto ConstraintProofModelData<Cumulative>::capacity_row_family() -> string
+{
+    return "cap";
 }
 
 auto ConstraintProofModelData<Cumulative>::capacity_row_role(Integer t) -> string

--- a/gcs/constraints/cumulative/cumulative.cc
+++ b/gcs/constraints/cumulative/cumulative.cc
@@ -865,13 +865,15 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
     // variable height, an optional task), and the model row is what is left.
     //
     // The time-table family goes through this --- the overflow contradiction
-    // and both bound pushes --- and so does the overload check's (OC)/(TTOC)
-    // window supply, which is the first citer to want a row at every time point
-    // of a window rather than at one. What is left --- the elastic and knapsack
-    // availability lines, edge-finding's window rows, published not-first /
-    // not-last --- still reads capacity_lines directly, and moving them over
-    // one at a time, each its own commit and each verified on its own, is the
-    // rest of #780.
+    // and both bound pushes --- and so do the overload check's (OC)/(TTOC)
+    // window supply and the (TTHE-OC)/(KAOC) per-time availability lines, the
+    // latter being the only citer that uses a row as the base of a per-point
+    // sub-derivation rather than summing it straight into a pol. What is left
+    // --- edge-finding's window rows, published not-first / not-last, and
+    // derived_cumulative.cc --- still reads capacity_lines directly, and moving
+    // them over one at a time, each its own commit and each verified on its
+    // own, is the rest of #780. A lane whose every rule has moved joins the
+    // `startcheckpoint` ctest arm, which is where that progress is measured.
     auto capacity_row = [&](Integer t) -> std::optional<ProofLine> {
         if (logger && inputs.checkpoint_recovery)
             if (auto recovered = recover_cumulative_capacity_row(*logger, inputs, *inputs.checkpoint_recovery, t))
@@ -2236,8 +2238,21 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
                             for (Integer t = a; t < b; ++t) {
                                 if (omit_capacity_line && t == b - 1_i)
                                     continue;
-                                auto capacity_line = capacity_lines.find(t);
-                                if (capacity_line == capacity_lines.end())
+                                // Asked here rather than below the elastic
+                                // branch, which does not use the row: this is
+                                // also the test for whether the encoding says
+                                // anything about `t` at all, and moving it down
+                                // would let a time point with no row take that
+                                // branch where today it is skipped outright.
+                                // The cost of keeping it here is that a point
+                                // which then takes the elastic branch has paid
+                                // for a recovery it does not cite --- bounded,
+                                // since rows are cached per time point for the
+                                // whole constraint, and worth it against
+                                // changing behaviour on a branch no fixture
+                                // currently reaches.
+                                auto capacity_line = capacity_row(t);
+                                if (! capacity_line)
                                     continue;
 
                                 auto idx = static_cast<size_t>((t - t_lo).raw_value);
@@ -2284,7 +2299,7 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
                                 }
 
                                 PolBuilder avail;
-                                avail.add(capacity_line->second);
+                                avail.add(*capacity_line);
                                 for (auto j : active_tasks) {
                                     if (t < per_task_t_lo[j] || t > per_task_t_hi[j])
                                         continue;

--- a/gcs/constraints/cumulative/cumulative.cc
+++ b/gcs/constraints/cumulative/cumulative.cc
@@ -99,6 +99,50 @@ namespace
 
     // The variable-height contribution h_i·active is linearised over cake's
     // per-bit contribution flags cc_k (weight 2^k): contrib = Σ 2^k · cc_k.
+    // What the three per-(task, time) flags say. One statement each, because
+    // #780 defines them two ways --- as labelled OPB rows under the
+    // time-indexed encodings, and as `red` steps inside the proof under the
+    // start-checkpoint one --- and a second copy that drifted would make a flag
+    // mean one thing to the encoder and another to everything that cites it.
+    //
+    // `operator>=` renders as a WPBSumLE like `operator<=` does, so all three
+    // come back in the one type the reifying calls take.
+    auto per_time_before_says(const IntegerVariableID & start, Integer t) -> WPBSumLE
+    {
+        return WPBSum{} + 1_i * start <= t;
+    }
+
+    // after_{i,t} <-> task i not yet finished at t <-> s_i + l_i >= t + 1.
+    // Constant length: single-variable s_i >= t-l+1. Variable length: reify on
+    // s_i + l_i directly (any constant operand folds in), which matches
+    // cake_pb_cp's after <-> s + l >= t+1. The proof-only end (when both vary)
+    // is NOT used here; it is only the single-variable handle the propagator
+    // pins through, bridged to this flag by the lemma the initialiser emits.
+    auto per_time_after_says(const IntegerVariableID & start, const IntegerVariableID & length, Integer t) -> WPBSumLE
+    {
+        if (is_constant_variable(length))
+            return WPBSum{} + 1_i * start >= t - constant_value_of(length) + 1_i;
+        return WPBSum{} + 1_i * start + 1_i * length >= t + 1_i;
+    }
+
+    // active_{i,t} <-> before /\ after, plus the presence conjunct for an
+    // optional task. The presence literal is the {0,1} variable's single PB
+    // atom, so the three-way AND costs one more term in the same two
+    // reification halves --- no extra flag, and nothing else in the encoding
+    // has to know whether the task is optional. An absent task fails the AND at
+    // every t, so it drops out of every capacity row, which is exactly "an
+    // absent task consumes nothing".
+    auto per_time_active_says(const ProofFlag & before, const ProofFlag & after, const optional<IntegerVariableID> & presence) -> WPBSumLE
+    {
+        auto conjuncts = WPBSum{} + 1_i * before + 1_i * after;
+        auto arity = 2_i;
+        if (presence) {
+            conjuncts += 1_i * (*presence == 1_i);
+            arity = 3_i;
+        }
+        return move(conjuncts) >= arity;
+    }
+
     auto contrib_sum_of(const vector<ProofFlag> & cc) -> WPBSum
     {
         WPBSum sum;
@@ -391,6 +435,18 @@ auto gcs::innards::prepare_cumulative_overload_check(const vector<IntegerVariabl
 
 auto Cumulative::define_proof_model(ProofModel & model, const State &) -> void
 {
+    // #780 step 10. The per-(task, time) flags move out of the OPB and into the
+    // proof under StartCheckpoint, which is where they stop being needed as
+    // model objects: the per-time capacity rows are what mention them, and that
+    // is the block this encoding does without.
+    //
+    // Not yet where any task has a variable height. Such a task's contribution
+    // rows are OPB rows *half-reified on its activity flag*, so the flag has to
+    // be in the model for them to exist at all; moving those rows into the
+    // proof too is the next step and this declines rather than half-does it.
+    _per_time_flags_in_proof = _encoding.value_or(default_cumulative_encoding()) == CumulativeEncoding::StartCheckpoint &&
+        std::ranges::all_of(_active_tasks, [&](std::size_t i) { return is_constant_variable(_heights[i]); });
+
     // Time-table OPB encoding:
     //   for each task i and each time point t in its possible-active range:
     //     before_{i,t}  ⇔  starts[i] ≤ t
@@ -442,31 +498,19 @@ auto Cumulative::define_proof_model(ProofModel & model, const State &) -> void
             // definitions (before ⇔ s≤t, after ⇔ s+l≥t+1, active ⇔ before∧after)
             // make this a naming conform with no propagator change.
             std::vector<long long> it{static_cast<long long>(i), t.raw_value};
-            auto before = model.create_proof_flag_values_fully_reifying(_constraint_id, it, "cb", WPBSum{} + 1_i * _starts[i] <= t);
-            // after_{i,t} ⇔ task i not yet finished at t ⇔ s_i + l_i ≥ t + 1.
-            // Constant length: single-variable s_i ≥ t−l+1. Variable length:
-            // reify on s_i + l_i directly (any constant operand folds in), which
-            // matches cake_pb_cp's after ⇔ s + l ≥ t+1. The proof-only end (when
-            // both vary) is NOT used in this reification; it is only the
-            // single-variable handle the propagator pins through, bridged to this
-            // flag by the lemma the initialiser emits.
-            auto after = is_constant_variable(_lengths[i])
-                ? model.create_proof_flag_values_fully_reifying(_constraint_id, it, "ca", WPBSum{} + 1_i * _starts[i] >= t - _length_vals[i] + 1_i)
-                : model.create_proof_flag_values_fully_reifying(_constraint_id, it, "ca", WPBSum{} + 1_i * _starts[i] + 1_i * _lengths[i] >= t + 1_i);
-            // active_{i,t} ⇔ before ∧ after, plus the presence conjunct for an
-            // optional task. The presence literal is the {0,1} variable's single
-            // PB atom, so the three-way AND costs one more term in the same two
-            // reification halves --- no extra flag, and nothing else in the
-            // encoding has to know whether the task is optional. An absent task
-            // fails the AND at every t, so it drops out of every capacity row,
-            // which is exactly "an absent task consumes nothing".
-            auto active_conjuncts = WPBSum{} + 1_i * before + 1_i * after;
-            auto active_arity = 2_i;
-            if (_presence[i]) {
-                active_conjuncts += 1_i * (*_presence[i] == 1_i);
-                active_arity = 3_i;
-            }
-            auto active = model.create_proof_flag_values_fully_reifying(_constraint_id, it, "cact", move(active_conjuncts) >= active_arity);
+            // Named either way; *defined* here only where the definition is an
+            // OPB row. Under _per_time_flags_in_proof the two halves are
+            // emitted as `red` steps by the install initialiser instead, which
+            // is the whole of #780's step 10: these three rows per (task, time)
+            // are 99.9% of the OPB on the instances the encoding exists for.
+            auto mint = [&](const char * annotation, const WPBSumLE & says) {
+                if (_per_time_flags_in_proof)
+                    return model.names_and_ids_tracker().create_proof_flag_values(_constraint_id, it, annotation);
+                return model.create_proof_flag_values_fully_reifying(_constraint_id, it, annotation, says);
+            };
+            auto before = mint("cb", per_time_before_says(_starts[i], t));
+            auto after = mint("ca", per_time_after_says(_starts[i], _lengths[i], t));
+            auto active = mint("cact", per_time_active_says(before, after, _presence[i]));
             _before_flags[i].push_back(before);
             _after_flags[i].push_back(after);
             _active_flags[i].push_back(active);
@@ -748,59 +792,82 @@ auto Cumulative::install_propagators(Propagators & propagators) -> void
     // initialiser has not derived yet.
     auto end_ge_lines = make_shared<vector<std::optional<ProofLine>>>(_starts.size());
 
-    propagators.install_initialiser([id = constraint_id(), starts = _starts, lengths = _lengths, ends = _end, active_tasks = _active_tasks,
-                                        after_flags = _after_flags, end_ge_lines](State &, auto &, ProofLogger * const logger) -> void {
-        if (! logger || logger->get_assertion_level() > AssertionLevel::Off)
-            return;
-        auto & tracker = logger->names_and_ids_tracker();
-        // Bit-define each variable-duration end = s + l as a conservative
-        // extension FIRST (introduce_bits_of needs end's bits fresh for its
-        // witnesses), caching end's {end_ge, end_le}. cake has no end variable,
-        // so this lives entirely in the proof --- nothing in the OPB to match.
-        //
-        // end_ge is published, because a derived Cumulative over this task pins
-        // its `after` flags the same way and through the same line; end_le is
-        // the bridge lemma's business alone, and stays here.
-        vector<std::optional<ProofLine>> end_le(starts.size());
-        for (auto i : active_tasks)
-            if (ends[i].has_value()) {
-                auto lines = logger->introduce_bits_of(WPBSum{} + 1_i * starts[i] + 1_i * lengths[i], *ends[i], ProofLevel::Top);
-                (*end_ge_lines)[i] = lines.first;
-                end_le[i] = lines.second;
-                tracker.publish_derived_line(id, ConstraintProofModelData<Cumulative>::end_lower_bound_role(i), lines.first);
+    propagators.install_initialiser(
+        [id = constraint_id(), starts = _starts, lengths = _lengths, ends = _end, active_tasks = _active_tasks, before_flags = _before_flags,
+            after_flags = _after_flags, active_flags = _active_flags, presence = _presence, per_task_t_lo = _per_task_t_lo,
+            in_proof = _per_time_flags_in_proof, end_ge_lines](State &, auto &, ProofLogger * const logger) -> void {
+            if (! logger || logger->get_assertion_level() > AssertionLevel::Off)
+                return;
+            auto & tracker = logger->names_and_ids_tracker();
+
+            // #780 step 10: where the per-(task, time) flags were only *named* by
+            // define_proof_model, this is where they are defined --- the same two
+            // halves the encoder would have written as OPB rows, emitted as `red`
+            // steps instead, and registered so that reification_half hands citers
+            // the lines rather than labels that do not exist.
+            //
+            // The order matters: every definition goes out before anything below
+            // cites one, and the bridge lemmas below cite `after`.
+            if (in_proof)
+                for (auto i : active_tasks)
+                    for (std::size_t k = 0; k < active_flags[i].size(); ++k) {
+                        auto t = per_task_t_lo[i] + Integer{static_cast<long long>(k)};
+                        auto define = [&](const ProofFlag & flag, const WPBSumLE & says) {
+                            auto [implies, implied_by] = logger->emit_red_proof_lines_reifying(says, flag, ProofLevel::Top);
+                            tracker.register_in_proof_reification(flag, implies, implied_by);
+                        };
+                        define(before_flags[i][k], per_time_before_says(starts[i], t));
+                        define(after_flags[i][k], per_time_after_says(starts[i], lengths[i], t));
+                        define(active_flags[i][k], per_time_active_says(before_flags[i][k], after_flags[i][k], presence[i]));
+                    }
+            // Bit-define each variable-duration end = s + l as a conservative
+            // extension FIRST (introduce_bits_of needs end's bits fresh for its
+            // witnesses), caching end's {end_ge, end_le}. cake has no end variable,
+            // so this lives entirely in the proof --- nothing in the OPB to match.
+            //
+            // end_ge is published, because a derived Cumulative over this task pins
+            // its `after` flags the same way and through the same line; end_le is
+            // the bridge lemma's business alone, and stays here.
+            vector<std::optional<ProofLine>> end_le(starts.size());
+            for (auto i : active_tasks)
+                if (ends[i].has_value()) {
+                    auto lines = logger->introduce_bits_of(WPBSum{} + 1_i * starts[i] + 1_i * lengths[i], *ends[i], ProofLevel::Top);
+                    (*end_ge_lines)[i] = lines.first;
+                    end_le[i] = lines.second;
+                    tracker.publish_derived_line(id, ConstraintProofModelData<Cumulative>::end_lower_bound_role(i), lines.first);
+                }
+            // Then, per (i, t), emit the bridge lemma `end ≥ t+1 → after`:
+            //   pol( @v[id][i_t][ca][f] : ¬after → s+l ≤ t )  +  ( end ≤ s+l )
+            //   = ( M·after − end + t ≥ 0 ).
+            // The s+l bits cancel exactly, leaving a single-variable-in-end handle
+            // that makes the propagator's after pin RUP-closable even though after
+            // is reified on the two-variable s+l. end_le is the cancelling term.
+            //
+            // These need no publishing at all: they go out at ProofLevel::Top over
+            // exactly the (i, t) pairs this constraint gave the task a window for,
+            // so unit propagation finds them for whoever pins one of those flags,
+            // and a citer that could ask about a wider window would already have
+            // been turned away by the flag lookup.
+            for (auto i : active_tasks) {
+                if (! ends[i].has_value())
+                    continue;
+                for (const auto & after : after_flags[i]) {
+                    PolBuilder lemma;
+                    // `name_of` and not `pb_file_string_for`, which is the other
+                    // base a flag's reification halves can be labelled under: these
+                    // flags come from create_proof_flag_values_fully_reifying, and
+                    // that is the overload whose `[r]` / `[f]` labels are built off
+                    // `name_of`. `pb_file_string_for` is the base
+                    // add_two_way_reified_constraint uses, for flags with no
+                    // ConstraintID to key them. Getting it the wrong way round is
+                    // loud --- there is no such label --- but it is worth not
+                    // having to find that out.
+                    lemma.add(reification_half(tracker, after, ReificationHalf::ImpliedBy));
+                    lemma.add(*end_le[i]);
+                    lemma.emit(*logger, ProofLevel::Top);
+                }
             }
-        // Then, per (i, t), emit the bridge lemma `end ≥ t+1 → after`:
-        //   pol( @v[id][i_t][ca][f] : ¬after → s+l ≤ t )  +  ( end ≤ s+l )
-        //   = ( M·after − end + t ≥ 0 ).
-        // The s+l bits cancel exactly, leaving a single-variable-in-end handle
-        // that makes the propagator's after pin RUP-closable even though after
-        // is reified on the two-variable s+l. end_le is the cancelling term.
-        //
-        // These need no publishing at all: they go out at ProofLevel::Top over
-        // exactly the (i, t) pairs this constraint gave the task a window for,
-        // so unit propagation finds them for whoever pins one of those flags,
-        // and a citer that could ask about a wider window would already have
-        // been turned away by the flag lookup.
-        for (auto i : active_tasks) {
-            if (! ends[i].has_value())
-                continue;
-            for (const auto & after : after_flags[i]) {
-                PolBuilder lemma;
-                // `name_of` and not `pb_file_string_for`, which is the other
-                // base a flag's reification halves can be labelled under: these
-                // flags come from create_proof_flag_values_fully_reifying, and
-                // that is the overload whose `[r]` / `[f]` labels are built off
-                // `name_of`. `pb_file_string_for` is the base
-                // add_two_way_reified_constraint uses, for flags with no
-                // ConstraintID to key them. Getting it the wrong way round is
-                // loud --- there is no such label --- but it is worth not
-                // having to find that out.
-                lemma.add(reification_half(tracker, after, ReificationHalf::ImpliedBy));
-                lemma.add(*end_le[i]);
-                lemma.emit(*logger, ProofLevel::Top);
-            }
-        }
-    });
+        });
 
     // One cache, shared between the differential check below and the
     // propagator, so an inference cites the line the check passed on.

--- a/gcs/constraints/cumulative/cumulative.cc
+++ b/gcs/constraints/cumulative/cumulative.cc
@@ -89,6 +89,8 @@ namespace
                 return CumulativeEncoding::Both;
             else if (spelling == "both-recovering")
                 return CumulativeEncoding::BothRecovering;
+            else if (spelling == "start-checkpoint")
+                return CumulativeEncoding::StartCheckpoint;
             throw UnexpectedException{"unrecognised GCS_CUMULATIVE_ENCODING value '" + spelling + "'"};
         }();
         return value;
@@ -503,7 +505,22 @@ auto Cumulative::define_proof_model(ProofModel & model, const State &) -> void
         }
     }
 
-    for (Integer t = global_lo; t <= global_hi; ++t) {
+    // #780: under CumulativeEncoding::StartCheckpoint the per-time capacity
+    // rows are not written at all, so that a rule which still reads
+    // `capacity_lines` finds nothing and its certificate fails loudly rather
+    // than quietly keeping a dependency on a block that is going away. Only
+    // where the recovery can actually supply a replacement, though --- a
+    // variable height or an optional task has no recovered row to fall back on,
+    // and dropping the model's would leave the constraint with no capacity row
+    // at all rather than merely an unconverted one.
+    //
+    // Note this gates the capacity *rows* only. The per-(task, time) flags
+    // above stay: every rule's activity vocabulary is still stated over them,
+    // and moving them to lazily-minted objects is its own step of #780.
+    auto omit_per_time_capacity_rows = _encoding.value_or(default_cumulative_encoding()) == CumulativeEncoding::StartCheckpoint &&
+        cumulative_shape_supports_checkpoint_recovery(_active_tasks, _presence, _lengths, _heights, _capacity);
+
+    for (Integer t = global_lo; t <= global_hi && ! omit_per_time_capacity_rows; ++t) {
         WPBSum load;
         bool any = false;
         for (auto i : _active_tasks) {
@@ -768,8 +785,10 @@ auto Cumulative::install_propagators(Propagators & propagators) -> void
 
     // One cache, shared between the differential check below and the
     // propagator, so an inference cites the line the check passed on.
-    auto recovery_cache =
-        _encoding.value_or(default_cumulative_encoding()) == CumulativeEncoding::BothRecovering ? make_shared<CheckpointRecoveryCache>() : nullptr;
+    auto encoding = _encoding.value_or(default_cumulative_encoding());
+    auto recovery_cache = (encoding == CumulativeEncoding::BothRecovering || encoding == CumulativeEncoding::StartCheckpoint)
+        ? make_shared<CheckpointRecoveryCache>()
+        : nullptr;
 
     CumulativeInputs inputs{.owner = constraint_id(),
         .starts = move(_starts),
@@ -801,7 +820,7 @@ auto Cumulative::install_propagators(Propagators & propagators) -> void
     // the one the model still carries. A copy of the inputs rather than a
     // reference into the propagator's, which is about to be moved from --- the
     // check runs once, before search, and the copy dies with it.
-    if (_encoding.value_or(default_cumulative_encoding()) == CumulativeEncoding::BothRecovering)
+    if (encoding == CumulativeEncoding::BothRecovering)
         propagators.install_initialiser(
             [recovery_inputs = make_shared<CumulativeInputs>(inputs)](State &, auto &, ProofLogger * const logger) -> void {
                 if (! logger || logger->get_assertion_level() > AssertionLevel::Off)

--- a/gcs/constraints/cumulative/cumulative.cc
+++ b/gcs/constraints/cumulative/cumulative.cc
@@ -19,6 +19,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <cstdlib>
 #include <memory>
 #include <optional>
 #include <sstream>
@@ -64,6 +65,32 @@ using fmt::print;
 
 namespace
 {
+    // The encoding a Cumulative writes when with_encoding() was not called.
+    // The environment rather than a constructor argument because what it is
+    // for is running an existing fixture set --- which builds its Cumulatives
+    // in sixty places --- under the other arm without touching any of them.
+    //
+    // An unrecognised spelling throws, where GCS_ASSERTION_LEVEL's reader
+    // warns and carries on. The difference is what a mistake costs: a mistyped
+    // assertion level writes a proof at the wrong level, which shows up; a
+    // mistyped encoding silently runs the arm that was already covered, and
+    // the run goes green having checked nothing new.
+    auto default_cumulative_encoding() -> CumulativeEncoding
+    {
+        static const auto value = [] {
+            const auto * const env = std::getenv("GCS_CUMULATIVE_ENCODING");
+            if (! env || ! *env)
+                return CumulativeEncoding::TimeIndexed;
+            string spelling{env};
+            if (spelling == "time-indexed")
+                return CumulativeEncoding::TimeIndexed;
+            else if (spelling == "both")
+                return CumulativeEncoding::Both;
+            throw UnexpectedException{"unrecognised GCS_CUMULATIVE_ENCODING value '" + spelling + "'"};
+        }();
+        return value;
+    }
+
     // The variable-height contribution h_i·active is linearised over cake's
     // per-bit contribution flags cc_k (weight 2^k): contrib = Σ 2^k · cc_k.
     auto contrib_sum_of(const vector<ProofFlag> & cc) -> WPBSum
@@ -117,6 +144,12 @@ auto Cumulative::with_rules(CumulativeRules rules) -> Cumulative &
     return *this;
 }
 
+auto Cumulative::with_encoding(CumulativeEncoding encoding) -> Cumulative &
+{
+    _encoding = encoding;
+    return *this;
+}
+
 auto Cumulative::with_proof_mutation(CumulativeProofMutation mutation) -> Cumulative &
 {
     _proof_mutation = mutation;
@@ -134,6 +167,8 @@ auto Cumulative::clone() const -> unique_ptr<Constraint>
     auto result = _presences.empty() ? make_unique<Cumulative>(_starts, _lengths, _heights, _capacity)
                                      : make_unique<Cumulative>(_starts, _lengths, _heights, _presences, _capacity);
     result->with_rules(_rules);
+    if (_encoding)
+        result->with_encoding(*_encoding);
     result->with_proof_mutation(_proof_mutation);
     result->with_presence_mutation(_presence_mutation);
     return result;
@@ -493,6 +528,149 @@ auto Cumulative::define_proof_model(ProofModel & model, const State &) -> void
                                                         : model.add_labelled_constraint(_constraint_id, role, move(load) + -1_i * _capacity <= 0_i);
             _capacity_lines.emplace(t, line);
         }
+    }
+
+    if (_encoding.value_or(default_cumulative_encoding()) == CumulativeEncoding::TimeIndexed)
+        return;
+
+    // Start-checkpoint encoding (issue #780), emitted *alongside* the
+    // time-indexed block above rather than instead of it:
+    //   for each ordered pair (i, j) of tasks that can raise the profile:
+    //     sb_{i,j}   ⇔  starts[i] ≤ starts[j]
+    //     sa_{i,j}   ⇔  starts[i] + lengths[i] ≥ starts[j] + 1
+    //     sact_{i,j} ⇔  sb_{i,j} ∧ sa_{i,j} [ ∧ presences[i] = 1 ]
+    //   for each such task j:
+    //     Σ heights[i]·sact_{i,j} ≤ capacity
+    //
+    // It says the same thing the block above does, in O(n²) rows rather than
+    // O(n × horizon): the load profile is a step function that only rises at
+    // the start of a task which could occupy the resource, so a time point
+    // over capacity is dominated by the last such start at or before it, and
+    // checking every start checks every peak. Lengths, heights and the
+    // capacity are all non-negative (the constructor and prepare check that),
+    // so a checkpoint with nothing active is satisfied rather than merely
+    // vacuous. A checkpoint at a task that turns out to be absent, or to have
+    // length zero, is harmless --- its start is still *some* time point, and
+    // the capacity holds at every time point --- it just does not count
+    // towards sufficiency, which is why the checkpoints are over _active_tasks
+    // and not over every task.
+    //
+    // Nothing cites these yet, and no propagator or rule knows they exist.
+    // They are here to be checked against the family that *is* load-bearing
+    // before anything is derived from them: a checkpoint row that says too
+    // much is a solution VeriPB refuses on the `solx` line of any enumeration
+    // test, which is a soundness check the per-time block cannot dodge for
+    // them. What it does not check is sufficiency --- that these imply the
+    // per-time rows --- and that only gets tested as inferences move over.
+    // Deriving the per-time rows from these, and deleting the block above, is
+    // the rest of #780.
+    //
+    // Not windowed, unlike the block above: every ordered pair gets flags,
+    // including pairs that could never be active together. Whether pruning
+    // those is worth the recovery having to know a pair may be missing is a
+    // measurement, not something to guess at here.
+    for (auto j : _active_tasks) {
+        WPBSum load;
+        // What the diagonal contributes when it needs no flag: a constant
+        // height, taken unconditionally, which belongs on the right hand side
+        // rather than as a term.
+        Integer fixed_load = 0_i;
+        for (auto i : _active_tasks) {
+            std::vector<long long> ij{static_cast<long long>(i), static_cast<long long>(j)};
+            std::optional<ProofFlag> active;
+
+            if (i != j) {
+                auto before =
+                    model.create_proof_flag_values_fully_reifying(_constraint_id, ij, "sb", WPBSum{} + 1_i * _starts[i] + -1_i * _starts[j] <= 0_i);
+                // after_{i,j} ⇔ task i has not finished by the time j starts ⇔
+                // s_i + l_i ≥ s_j + 1. A constant length folds into the right
+                // hand side, exactly as it does per (i, t); a variable one
+                // stays on the left, which makes this a three-variable row.
+                // That costs nothing here --- a PB row does not care how many
+                // variables it names --- but it is why the per-(i,t) family
+                // needed the proof-only `end` proxy, and a pin of this flag
+                // will need the same treatment per pair rather than per time.
+                auto after = is_constant_variable(_lengths[i]) ? model.create_proof_flag_values_fully_reifying(_constraint_id, ij, "sa",
+                                                                     WPBSum{} + 1_i * _starts[i] + -1_i * _starts[j] >= 1_i - _length_vals[i])
+                                                               : model.create_proof_flag_values_fully_reifying(_constraint_id, ij, "sa",
+                                                                     WPBSum{} + 1_i * _starts[i] + 1_i * _lengths[i] + -1_i * _starts[j] >= 1_i);
+                auto conjuncts = WPBSum{} + 1_i * before + 1_i * after;
+                auto arity = 2_i;
+                if (_presence[i]) {
+                    conjuncts += 1_i * (*_presence[i] == 1_i);
+                    arity = 3_i;
+                }
+                active = model.create_proof_flag_values_fully_reifying(_constraint_id, ij, "sact", move(conjuncts) >= arity);
+            }
+            else {
+                // The diagonal: is j running at the moment j starts? before is
+                // a tautology and after reduces to lengths[j] ≥ 1, so what is
+                // left is that conjunct and the presence. Both matter: a task
+                // that can have length zero, or that can be absent, must not
+                // be charged for a resource it never takes, which is what
+                // putting a bare h_j on the row would do.
+                //
+                // Where neither says anything --- a constant length, which is
+                // at least 1 for an active task, and no presence --- the term
+                // *is* unconditional, so it goes on the row as itself and no
+                // flag is minted. That is what the nullopt from
+                // pair_active_flag_key means on a diagonal.
+                auto conjuncts = WPBSum{};
+                auto arity = 0_i;
+                if (! is_constant_variable(_lengths[j])) {
+                    conjuncts += 1_i * _lengths[j];
+                    arity += 1_i;
+                }
+                if (_presence[j]) {
+                    // Scaled to the length's own arity so that one term cannot
+                    // stand in for the other: with a variable length the row
+                    // is lengths[j] + ub(lengths[j])·present ≥ 1 + ub, which
+                    // needs both.
+                    auto weight = (arity == 0_i) ? 1_i : _length_ub[j];
+                    conjuncts += weight * (*_presence[j] == 1_i);
+                    arity += weight;
+                }
+                if (arity > 0_i)
+                    active = model.create_proof_flag_values_fully_reifying(_constraint_id, ij, "sact", move(conjuncts) >= arity);
+            }
+
+            if (! active) {
+                // Unconditional: the height itself, constant or not.
+                if (is_constant_variable(_heights[i]))
+                    fixed_load += _height_vals[i];
+                else
+                    load += 1_i * _heights[i];
+                continue;
+            }
+
+            if (is_constant_variable(_heights[i]))
+                load += _height_vals[i] * *active;
+            else {
+                // A variable height's contribution is the product h_i·active,
+                // linearised over per-bit flags exactly as the per-(i,t) block
+                // does it; see there for what the three rows say.
+                auto highest_bit_shift = std::get<0>(get_bits_encoding_coeffs(0_i, _height_ub[i]));
+                std::vector<ProofFlag> cc;
+                for (Integer k = 0_i; k <= highest_bit_shift; ++k)
+                    cc.push_back(model.names_and_ids_tracker().create_proof_flag_values(
+                        _constraint_id, std::vector<long long>{static_cast<long long>(i), static_cast<long long>(j), k.raw_value}, "scc"));
+                auto contrib = contrib_sum_of(cc);
+                model.add_labelled_constraint(_constraint_id, ConstraintProofModelData<Cumulative>::pair_contribution_ge_row_role(i, j),
+                    contrib + -1_i * _heights[i] >= 0_i, HalfReifyOnConjunctionOf{*active});
+                model.add_labelled_constraint(_constraint_id, ConstraintProofModelData<Cumulative>::pair_contribution_le_row_role(i, j),
+                    contrib + -1_i * _heights[i] <= 0_i, HalfReifyOnConjunctionOf{*active});
+                model.add_labelled_constraint(_constraint_id, ConstraintProofModelData<Cumulative>::pair_contribution_zero_row_role(i, j),
+                    contrib <= 0_i, HalfReifyOnConjunctionOf{! *active});
+                for (Integer k = 0_i; k.raw_value < static_cast<long long>(cc.size()); ++k)
+                    load += power2(k) * cc[k.raw_value];
+            }
+        }
+
+        auto role = ConstraintProofModelData<Cumulative>::checkpoint_row_role(j);
+        if (is_constant_variable(_capacity))
+            model.add_labelled_constraint(_constraint_id, role, move(load) <= _capacity_val - fixed_load);
+        else
+            model.add_labelled_constraint(_constraint_id, role, move(load) + -1_i * _capacity <= -fixed_load);
     }
 }
 
@@ -2569,6 +2747,47 @@ auto ConstraintProofModelData<Cumulative>::end_lower_bound_role(size_t task) -> 
 {
     // Must stay the string install_propagators' initialiser publishes under.
     return "end_ge_" + std::to_string(task);
+}
+
+auto ConstraintProofModelData<Cumulative>::checkpoint_row_role(size_t task) -> string
+{
+    // Must stay the string define_proof_model labels the row with.
+    return "scap_" + std::to_string(task);
+}
+
+auto ConstraintProofModelData<Cumulative>::pair_before_flag_key(size_t i, size_t j) -> ProofFlagKey
+{
+    return ProofFlagKey{{static_cast<long long>(i), static_cast<long long>(j)}, "sb"};
+}
+
+auto ConstraintProofModelData<Cumulative>::pair_after_flag_key(size_t i, size_t j) -> ProofFlagKey
+{
+    return ProofFlagKey{{static_cast<long long>(i), static_cast<long long>(j)}, "sa"};
+}
+
+auto ConstraintProofModelData<Cumulative>::pair_active_flag_key(size_t i, size_t j) -> ProofFlagKey
+{
+    return ProofFlagKey{{static_cast<long long>(i), static_cast<long long>(j)}, "sact"};
+}
+
+auto ConstraintProofModelData<Cumulative>::pair_contribution_flag_key(size_t i, size_t j, Integer bit) -> ProofFlagKey
+{
+    return ProofFlagKey{{static_cast<long long>(i), static_cast<long long>(j), bit.raw_value}, "scc"};
+}
+
+auto ConstraintProofModelData<Cumulative>::pair_contribution_ge_row_role(size_t i, size_t j) -> string
+{
+    return std::to_string(i) + "_" + std::to_string(j) + "_scge";
+}
+
+auto ConstraintProofModelData<Cumulative>::pair_contribution_le_row_role(size_t i, size_t j) -> string
+{
+    return std::to_string(i) + "_" + std::to_string(j) + "_scle";
+}
+
+auto ConstraintProofModelData<Cumulative>::pair_contribution_zero_row_role(size_t i, size_t j) -> string
+{
+    return std::to_string(i) + "_" + std::to_string(j) + "_scz";
 }
 
 auto Cumulative::constraint_type() const -> std::string

--- a/gcs/constraints/cumulative/cumulative.cc
+++ b/gcs/constraints/cumulative/cumulative.cc
@@ -855,127 +855,162 @@ auto Cumulative::install_propagators(Propagators & propagators) -> void
     // initialiser has not derived yet.
     auto end_ge_lines = make_shared<vector<std::optional<ProofLine>>>(_starts.size());
 
-    propagators.install_initialiser(
-        [id = constraint_id(), starts = _starts, lengths = _lengths, ends = _end, active_tasks = _active_tasks, before_flags = _before_flags,
-            after_flags = _after_flags, active_flags = _active_flags, contrib_flags = _contrib_flags, task_heights = _heights, presence = _presence,
-            per_task_t_lo = _per_task_t_lo, in_proof = _per_time_flags_in_proof, end_ge_lines](State &, auto &, ProofLogger * const logger) -> void {
-            if (! logger || logger->get_assertion_level() > AssertionLevel::Off)
-                return;
-            auto & tracker = logger->names_and_ids_tracker();
+    propagators.install_initialiser([id = constraint_id(), starts = _starts, lengths = _lengths, ends = _end, active_tasks = _active_tasks,
+                                        before_flags = _before_flags, after_flags = _after_flags, active_flags = _active_flags,
+                                        contrib_flags = _contrib_flags, task_heights = _heights, presence = _presence, per_task_t_lo = _per_task_t_lo,
+                                        in_proof = _per_time_flags_in_proof, end_ge_lines](State &, auto &, ProofLogger * const logger) -> void {
+        if (! logger || logger->get_assertion_level() > AssertionLevel::Off)
+            return;
+        auto & tracker = logger->names_and_ids_tracker();
 
-            // #780 step 10: where the per-(task, time) flags were only *named* by
-            // define_proof_model, this is where they are defined --- the same two
-            // halves the encoder would have written as OPB rows, emitted as `red`
-            // steps instead, and registered so that reification_half hands citers
-            // the lines rather than labels that do not exist.
-            //
-            // The order matters: every definition goes out before anything below
-            // cites one, and the bridge lemmas below cite `after`.
-            if (in_proof)
-                for (auto i : active_tasks)
-                    for (std::size_t k = 0; k < active_flags[i].size(); ++k) {
-                        auto t = per_task_t_lo[i] + Integer{static_cast<long long>(k)};
-                        auto define = [&](const ProofFlag & flag, const WPBSumLE & says) {
-                            auto [implies, implied_by] = logger->emit_red_proof_lines_reifying(says, flag, ProofLevel::Top);
-                            tracker.register_in_proof_reification(flag, implies, implied_by);
-                        };
-                        define(before_flags[i][k], per_time_before_says(starts[i], t));
-                        define(after_flags[i][k], per_time_after_says(starts[i], lengths[i], t));
-                        define(active_flags[i][k], per_time_active_says(before_flags[i][k], after_flags[i][k], presence[i]));
+        // #780 step 10: where the per-(task, time) flags were only *named* by
+        // define_proof_model, this is where they are defined --- the same two
+        // halves the encoder would have written as OPB rows, emitted as `red`
+        // steps instead, and registered so that reification_half hands citers
+        // the lines rather than labels that do not exist.
+        //
+        // The order matters: every definition goes out before anything below
+        // cites one, and the bridge lemmas below cite `after`.
+        // Bit-define each variable-duration end = s + l as a conservative
+        // extension FIRST (introduce_bits_of needs end's bits fresh for its
+        // witnesses), caching end's {end_ge, end_le}. cake has no end variable,
+        // so this lives entirely in the proof --- nothing in the OPB to match.
+        //
+        // end_ge is published, because a derived Cumulative over this task pins
+        // its `after` flags the same way and through the same line; end_le is
+        // the bridge lemma's business alone, and stays here.
+        vector<std::optional<ProofLine>> end_le(starts.size());
+        for (auto i : active_tasks)
+            if (ends[i].has_value()) {
+                auto lines = logger->introduce_bits_of(WPBSum{} + 1_i * starts[i] + 1_i * lengths[i], *ends[i], ProofLevel::Top);
+                (*end_ge_lines)[i] = lines.first;
+                end_le[i] = lines.second;
+                tracker.publish_derived_line(id, ConstraintProofModelData<Cumulative>::end_lower_bound_role(i), lines.first);
+            }
 
-                        // A variable height's contribution bits. In the model
-                        // these need three rows, because `contrib = h * cact`
-                        // is a product and the rows are what linearise it. Here
-                        // they need none: bit by bit the product *is* a
-                        // conjunction,
-                        //
-                        //     cc_{i,t,k}  <->  cact_{i,t}  /\  bit_k(h_i)
-                        //
-                        // --- if the task is active its contribution is its
-                        // height, so bit for bit; if it is not, every bit is
-                        // zero. Each one is then a two-way reification of a
-                        // fresh flag over literals that already exist, the same
-                        // primitive the activity flag above uses, and the three
-                        // rows fall out of these rather than being asserted
-                        // beside them.
-                        //
-                        // Weight 2^k is bit k because the gate on this requires
-                        // a height with no sign bit; see height_bits_citable.
-                        if (! is_constant_variable(task_heights[i])) {
-                            const auto & cc = contrib_flags[i][k];
-                            auto height_var = std::get<SimpleIntegerVariableID>(task_heights[i]);
-                            for (Integer b = 0_i; b.raw_value < static_cast<long long>(cc.size()); ++b)
-                                define(cc[b.raw_value], WPBSum{} + 1_i * active_flags[i][k] + 1_i * ProofBitVariable{height_var, b, true} >= 2_i);
-
-                            // And the `cge` row those definitions imply, for the
-                            // energy rules and donor_view, which ask for it by
-                            // role and should not have to know it is derived
-                            // here rather than asserted in the model.
-                            //
-                            //   ~cact \/ ~bit_b(h) \/ cc_b   (rup, off cc_b's
-                            //                                 own reverse half)
-                            //
-                            // summed at 2^b is `S.~cact - h + Sum cc >= 0`,
-                            // which is that row with S as its guard coefficient.
-                            PolBuilder cge;
-                            for (Integer b = 0_i; b.raw_value < static_cast<long long>(cc.size()); ++b)
-                                cge.add(logger->emit_rup_proof_line(WPBSum{} + 1_i * ! active_flags[i][k] +
-                                                    1_i * ! ProofBitVariable{height_var, b, true} + 1_i * cc[b.raw_value] >=
-                                                1_i,
-                                            ProofLevel::Top),
-                                    power2(b));
-                            tracker.publish_derived_line(
-                                id, ConstraintProofModelData<Cumulative>::contribution_ge_row_role(i, t), cge.emit(*logger, ProofLevel::Top));
-                        }
-                    }
-            // Bit-define each variable-duration end = s + l as a conservative
-            // extension FIRST (introduce_bits_of needs end's bits fresh for its
-            // witnesses), caching end's {end_ge, end_le}. cake has no end variable,
-            // so this lives entirely in the proof --- nothing in the OPB to match.
-            //
-            // end_ge is published, because a derived Cumulative over this task pins
-            // its `after` flags the same way and through the same line; end_le is
-            // the bridge lemma's business alone, and stays here.
-            vector<std::optional<ProofLine>> end_le(starts.size());
-            for (auto i : active_tasks)
-                if (ends[i].has_value()) {
-                    auto lines = logger->introduce_bits_of(WPBSum{} + 1_i * starts[i] + 1_i * lengths[i], *ends[i], ProofLevel::Top);
-                    (*end_ge_lines)[i] = lines.first;
-                    end_le[i] = lines.second;
-                    tracker.publish_derived_line(id, ConstraintProofModelData<Cumulative>::end_lower_bound_role(i), lines.first);
-                }
-            // Then, per (i, t), emit the bridge lemma `end ≥ t+1 → after`:
-            //   pol( @v[id][i_t][ca][f] : ¬after → s+l ≤ t )  +  ( end ≤ s+l )
-            //   = ( M·after − end + t ≥ 0 ).
-            // The s+l bits cancel exactly, leaving a single-variable-in-end handle
-            // that makes the propagator's after pin RUP-closable even though after
-            // is reified on the two-variable s+l. end_le is the cancelling term.
-            //
-            // These need no publishing at all: they go out at ProofLevel::Top over
-            // exactly the (i, t) pairs this constraint gave the task a window for,
-            // so unit propagation finds them for whoever pins one of those flags,
-            // and a citer that could ask about a wider window would already have
-            // been turned away by the flag lookup.
+        // The bridge lemma `end >= t+1 -> after`, where the flags are model
+        // objects and so all of them exist already:
+        //   pol( after[f] : ~after -> s+l <= t )  +  ( end <= s+l )
+        //   = ( M.after - end + t >= 0 ).
+        // The s+l bits cancel exactly, leaving a single-variable-in-end
+        // handle that makes the propagator's after pin RUP-closable even
+        // though after is reified on the two-variable s+l. end_le is the
+        // cancelling term.
+        //
+        // Nothing publishes these: they go out at Top over exactly the
+        // (i, t) pairs this constraint gave the task a window for, so unit
+        // propagation finds them for whoever pins one of those flags. Under
+        // #780's in-proof flags the same lemma is emitted per point by the
+        // definer below instead, because citing `after` here would drag
+        // every definition into existence.
+        if (! in_proof)
             for (auto i : active_tasks) {
-                if (! ends[i].has_value())
+                if (! ends[i].has_value() || ! end_le[i].has_value())
                     continue;
                 for (const auto & after : after_flags[i]) {
                     PolBuilder lemma;
-                    // `name_of` and not `pb_file_string_for`, which is the other
-                    // base a flag's reification halves can be labelled under: these
-                    // flags come from create_proof_flag_values_fully_reifying, and
-                    // that is the overload whose `[r]` / `[f]` labels are built off
-                    // `name_of`. `pb_file_string_for` is the base
-                    // add_two_way_reified_constraint uses, for flags with no
-                    // ConstraintID to key them. Getting it the wrong way round is
-                    // loud --- there is no such label --- but it is worth not
-                    // having to find that out.
                     lemma.add(reification_half(tracker, after, ReificationHalf::ImpliedBy));
                     lemma.add(*end_le[i]);
                     lemma.emit(*logger, ProofLevel::Top);
                 }
             }
-        });
+
+        // #780 step 10: rather than defining every per-(task, time) flag
+        // here --- a horizon's worth of `red` steps, which is the cost this
+        // encoding exists to remove --- publish a definer and let the
+        // tracker call it for the keys something actually cites. The names
+        // went out with the model and are free; only the definitions are
+        // paid for, and only where a rule reasons.
+        //
+        // Keyed on the activity flag's key, since all three flags and any
+        // contribution bits for one (task, time) are defined together and
+        // any of them being cited means the others are about to be.
+        if (in_proof)
+            tracker.publish_flag_definer(id, [=, &tracker](ProofLogger & definer_logger, const ProofFlagKey & key) {
+                if (key.values.size() != 2)
+                    return;
+                auto i = static_cast<std::size_t>(key.values[0]);
+                auto t = Integer{key.values[1]};
+                if (i >= active_flags.size() || t < per_task_t_lo[i])
+                    return;
+                auto k = static_cast<std::size_t>((t - per_task_t_lo[i]).raw_value);
+                if (k >= active_flags[i].size())
+                    return;
+                auto define = [&](const ProofFlag & flag, const WPBSumLE & says) {
+                    auto [implies, implied_by] = definer_logger.emit_red_proof_lines_reifying(says, flag, ProofLevel::Top);
+                    tracker.register_in_proof_reification(flag, implies, implied_by);
+                };
+                define(before_flags[i][k], per_time_before_says(starts[i], t));
+                define(after_flags[i][k], per_time_after_says(starts[i], lengths[i], t));
+                define(active_flags[i][k], per_time_active_says(before_flags[i][k], after_flags[i][k], presence[i]));
+
+                // A variable height's contribution bits. In the model
+                // these need three rows, because `contrib = h * cact`
+                // is a product and the rows are what linearise it. Here
+                // they need none: bit by bit the product *is* a
+                // conjunction,
+                //
+                //     cc_{i,t,k}  <->  cact_{i,t}  /\  bit_k(h_i)
+                //
+                // --- if the task is active its contribution is its
+                // height, so bit for bit; if it is not, every bit is
+                // zero. Each one is then a two-way reification of a
+                // fresh flag over literals that already exist, the same
+                // primitive the activity flag above uses, and the three
+                // rows fall out of these rather than being asserted
+                // beside them.
+                //
+                // Weight 2^k is bit k because the gate on this requires
+                // a height with no sign bit; see height_bits_citable.
+                if (! is_constant_variable(task_heights[i])) {
+                    const auto & cc = contrib_flags[i][k];
+                    auto height_var = std::get<SimpleIntegerVariableID>(task_heights[i]);
+                    for (Integer b = 0_i; b.raw_value < static_cast<long long>(cc.size()); ++b)
+                        define(cc[b.raw_value], WPBSum{} + 1_i * active_flags[i][k] + 1_i * ProofBitVariable{height_var, b, true} >= 2_i);
+
+                    // And the `cge` row those definitions imply, for the
+                    // energy rules and donor_view, which ask for it by
+                    // role and should not have to know it is derived
+                    // here rather than asserted in the model.
+                    //
+                    //   ~cact \/ ~bit_b(h) \/ cc_b   (rup, off cc_b's
+                    //                                 own reverse half)
+                    //
+                    // summed at 2^b is `S.~cact - h + Sum cc >= 0`,
+                    // which is that row with S as its guard coefficient.
+                    PolBuilder cge;
+                    for (Integer b = 0_i; b.raw_value < static_cast<long long>(cc.size()); ++b)
+                        cge.add(
+                            definer_logger.emit_rup_proof_line(
+                                WPBSum{} + 1_i * ! active_flags[i][k] + 1_i * ! ProofBitVariable{height_var, b, true} + 1_i * cc[b.raw_value] >= 1_i,
+                                ProofLevel::Top),
+                            power2(b));
+                    tracker.publish_derived_line(
+                        id, ConstraintProofModelData<Cumulative>::contribution_ge_row_role(i, t), cge.emit(*logger, ProofLevel::Top));
+                }
+
+                // And the bridge lemma `end >= t+1 -> after` for this point:
+                //   pol( after[f] : ~after -> s+l <= t )  +  ( end <= s+l )
+                //   = ( M.after - end + t >= 0 ).
+                // The s+l bits cancel exactly, leaving a single-variable-in-end
+                // handle that makes the propagator's after pin RUP-closable even
+                // though after is reified on the two-variable s+l. end_le is the
+                // cancelling term.
+                //
+                // It belongs here rather than in a loop of its own: it cites
+                // `after`, so a loop over the window would drag every definition
+                // into existence and there would be nothing left to be lazy about.
+                // Nothing publishes it, because it goes out at Top for exactly
+                // the (i, t) something asked for, and unit propagation finds it
+                // for whoever pins that flag.
+                if (ends[i].has_value() && end_le[i].has_value()) {
+                    PolBuilder lemma;
+                    lemma.add(reification_half(tracker, after_flags[i][k], ReificationHalf::ImpliedBy));
+                    lemma.add(*end_le[i]);
+                    lemma.emit(definer_logger, ProofLevel::Top);
+                }
+            });
+    });
 
     // One cache, shared between the differential check below and the
     // propagator, so an inference cites the line the check passed on.
@@ -1072,10 +1107,47 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
     const auto & heights_var = inputs.heights;
     const auto & capacity_var = inputs.capacity;
     const auto & active_tasks = inputs.active_tasks;
-    const auto & before_flags = inputs.before_flags;
-    const auto & after_flags = inputs.after_flags;
-    const auto & active_flags = inputs.active_flags;
-    const auto & contrib_flags = inputs.contrib_flags;
+    // #780 step 10: the per-(task, time) flags are named with the model but may
+    // only be *defined* on demand, so every use goes through an accessor that
+    // asks for the definition first. The tracker does nothing where there is no
+    // definer, which is every encoding but StartCheckpoint, and nothing on a
+    // second ask. These shadow the raw vectors deliberately: a bare
+    // `before_flags[i][k]` no longer compiles, so the compiler finds a citation
+    // that forgot rather than veripb finding it later.
+    const auto & before_flags_raw = inputs.before_flags;
+    const auto & after_flags_raw = inputs.after_flags;
+    const auto & active_flags_raw = inputs.active_flags;
+    const auto & contrib_flags_raw = inputs.contrib_flags;
+    auto ensure_flags_defined = [&](size_t i, size_t idx) {
+        if (logger)
+            logger->names_and_ids_tracker().ensure_flag_defined(inputs.owner,
+                ConstraintProofModelData<Cumulative>::active_flag_key(i, inputs.per_task_t_lo[i] + Integer{static_cast<long long>(idx)}), *logger);
+    };
+    auto before_flag = [&](size_t i, size_t idx) -> const ProofFlag & {
+        ensure_flags_defined(i, idx);
+        return before_flags_raw[i][idx];
+    };
+    auto after_flag = [&](size_t i, size_t idx) -> const ProofFlag & {
+        ensure_flags_defined(i, idx);
+        return after_flags_raw[i][idx];
+    };
+    auto active_flag = [&](size_t i, size_t idx) -> const ProofFlag & {
+        ensure_flags_defined(i, idx);
+        return active_flags_raw[i][idx];
+    };
+    auto contrib_bits = [&](size_t i, size_t idx) -> const std::vector<ProofFlag> & {
+        ensure_flags_defined(i, idx);
+        return contrib_flags_raw[i][idx];
+    };
+    // A whole task's row, for a caller that hands it to shared machinery which
+    // indexes it itself. Every point of the row is defined first, so this is
+    // the one accessor whose cost is the window rather than a point --- give it
+    // the clipped window where there is one.
+    auto flag_row = [&](const std::vector<std::vector<ProofFlag>> & family, size_t i) -> const std::vector<ProofFlag> & {
+        for (size_t k = 0; k < family[i].size(); ++k)
+            ensure_flags_defined(i, k);
+        return family[i];
+    };
     const auto & per_task_t_lo = inputs.per_task_t_lo;
     const auto & per_task_t_hi = inputs.per_task_t_hi;
     const auto & end_ge_lines = inputs.end_ge_lines;
@@ -1151,8 +1223,9 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
     // read them, while what it counts the task at is still the length the task
     // is guaranteed to run for.
     auto lemma_task = [&](size_t i) {
-        return window_energy::Task{std::get<SimpleIntegerVariableID>(starts[i]), llb(i), per_task_t_lo[i], before_flags[i], after_flags[i],
-            active_flags[i], l_is_var(i) ? make_optional(std::get<SimpleIntegerVariableID>(lengths_var[i])) : optional<SimpleIntegerVariableID>{}};
+        return window_energy::Task{std::get<SimpleIntegerVariableID>(starts[i]), llb(i), per_task_t_lo[i], flag_row(before_flags_raw, i),
+            flag_row(after_flags_raw, i), flag_row(active_flags_raw, i),
+            l_is_var(i) ? make_optional(std::get<SimpleIntegerVariableID>(lengths_var[i])) : optional<SimpleIntegerVariableID>{}};
     };
 
     // What a variable-height task is guaranteed to contribute at one time
@@ -1168,7 +1241,7 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
         if (! row)
             throw ProofError{"cumulative: task " + std::to_string(i) + " has no contribution row at time " + std::to_string(t.raw_value)};
         auto fi = static_cast<size_t>((t - per_task_t_lo[i]).raw_value);
-        return guaranteed_contribution_row(*logger, &reason, contrib_flags[i][fi], active_flags[i][fi],
+        return guaranteed_contribution_row(*logger, &reason, contrib_bits(i, fi), active_flag(i, fi),
             std::get<SimpleIntegerVariableID>(heights_var[i]), hlb(i), ProofLine{*row}, ProofLevel::Temporary);
     };
 
@@ -1268,14 +1341,14 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
     // before/after RUPs give VeriPB the units to chase active's AND-gate.
     auto pin_contributor = [&](const ReasonLiterals & reason, size_t i, Integer t) -> std::pair<ProofLine, Integer> {
         auto fi = (t - per_task_t_lo[i]).raw_value;
-        logger->emit_rup_proof_line_under_reason(reason, WPBSum{} + 1_i * before_flags[i][fi] >= 1_i, ProofLevel::Temporary);
+        logger->emit_rup_proof_line_under_reason(reason, WPBSum{} + 1_i * before_flag(i, fi) >= 1_i, ProofLevel::Temporary);
         // A mandatory task has s_i + l_i ≥ lb(s_i) + lb(l_i) > t.
         materialise_after_sum(i, state.lower_bound(starts[i]));
-        logger->emit_rup_proof_line_under_reason(reason, WPBSum{} + 1_i * after_flags[i][fi] >= 1_i, ProofLevel::Temporary);
-        auto active_line = logger->emit_rup_proof_line_under_reason(reason, WPBSum{} + 1_i * active_flags[i][fi] >= 1_i, ProofLevel::Temporary);
+        logger->emit_rup_proof_line_under_reason(reason, WPBSum{} + 1_i * after_flag(i, fi) >= 1_i, ProofLevel::Temporary);
+        auto active_line = logger->emit_rup_proof_line_under_reason(reason, WPBSum{} + 1_i * active_flag(i, fi) >= 1_i, ProofLevel::Temporary);
         if (! h_is_var(i))
             return {active_line, hlb(i)};
-        auto contrib_line = logger->emit_rup_proof_line_under_reason(reason, contrib_sum_of(contrib_flags[i][fi]) >= hlb(i), ProofLevel::Temporary);
+        auto contrib_line = logger->emit_rup_proof_line_under_reason(reason, contrib_sum_of(contrib_bits(i, fi)) >= hlb(i), ProofLevel::Temporary);
         return {contrib_line, 1_i};
     };
 
@@ -1318,7 +1391,7 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
             throw ProofError{"cumulative edge-finding: task " + std::to_string(i) + " has no derivable window energy over [" +
                 std::to_string(lo.raw_value) + "," + std::to_string(hi.raw_value) + ") guarded by [" + std::to_string(low_guard.raw_value) + "," +
                 std::to_string(high_guard.raw_value) + ") (length " + std::to_string(llb(i).raw_value) + ", flags from " +
-                std::to_string(per_task_t_lo[i].raw_value) + " for " + std::to_string(active_flags[i].size()) + ")"};
+                std::to_string(per_task_t_lo[i].raw_value) + " for " + std::to_string(active_flags_raw[i].size()) + ")"};
         return inputs.guarded_energy->emplace(key, *derived).first->second;
     };
 
@@ -1506,17 +1579,17 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
     auto pin_pushed = [&](const ReasonLiterals & reason, size_t j_idx, Integer t, const ExtLits & ext,
                           Integer s_lo_after) -> std::pair<ProofLine, Integer> {
         auto fj = (t - per_task_t_lo[j_idx]).raw_value;
-        logger->emit_rup_proof_line_under_reason(reason, plus_ext(WPBSum{} + 1_i * before_flags[j_idx][fj], ext, 1_i) >= 1_i, ProofLevel::Temporary);
+        logger->emit_rup_proof_line_under_reason(reason, plus_ext(WPBSum{} + 1_i * before_flag(j_idx, fj), ext, 1_i) >= 1_i, ProofLevel::Temporary);
         // s_lo_after + lb(l_j) ≥ t+1 gives after_{j,t} = 1 (under ¬ext
         // for ub-push, under the running bound for lb-push).
         materialise_after_sum(j_idx, s_lo_after);
-        logger->emit_rup_proof_line_under_reason(reason, plus_ext(WPBSum{} + 1_i * after_flags[j_idx][fj], ext, 1_i) >= 1_i, ProofLevel::Temporary);
+        logger->emit_rup_proof_line_under_reason(reason, plus_ext(WPBSum{} + 1_i * after_flag(j_idx, fj), ext, 1_i) >= 1_i, ProofLevel::Temporary);
         auto active_line = logger->emit_rup_proof_line_under_reason(
-            reason, plus_ext(WPBSum{} + 1_i * active_flags[j_idx][fj], ext, 1_i) >= 1_i, ProofLevel::Temporary);
+            reason, plus_ext(WPBSum{} + 1_i * active_flag(j_idx, fj), ext, 1_i) >= 1_i, ProofLevel::Temporary);
         if (! h_is_var(j_idx))
             return {active_line, hlb(j_idx)};
         auto contrib_line = logger->emit_rup_proof_line_under_reason(
-            reason, plus_ext(contrib_sum_of(contrib_flags[j_idx][fj]), ext, hlb(j_idx)) >= hlb(j_idx), ProofLevel::Temporary);
+            reason, plus_ext(contrib_sum_of(contrib_bits(j_idx, fj)), ext, hlb(j_idx)) >= hlb(j_idx), ProofLevel::Temporary);
         return {contrib_line, 1_i};
     };
 
@@ -1592,13 +1665,13 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
         if (forward) {
             // s_k + l_k >= est_k + p_k = ect_k >= ECT(Omega) > v.
             materialise_after_sum(k.task, k.est);
-            logger->emit_rup_proof_line_under_reason(reason, WPBSum{} + 1_i * after_flags[k.task][fv] >= 1_i, ProofLevel::Temporary);
+            logger->emit_rup_proof_line_under_reason(reason, WPBSum{} + 1_i * after_flag(k.task, fv) >= 1_i, ProofLevel::Temporary);
         }
         else
             // s_k <= ub(s_k) <= LST(Omega) <= v.
-            logger->emit_rup_proof_line_under_reason(reason, WPBSum{} + 1_i * before_flags[k.task][fv] >= 1_i, ProofLevel::Temporary);
+            logger->emit_rup_proof_line_under_reason(reason, WPBSum{} + 1_i * before_flag(k.task, fv) >= 1_i, ProofLevel::Temporary);
         return logger->emit_rup_proof_line_under_reason(
-            reason, WPBSum{} + 1_i * active_flags[k.task][fv] + 1_i * ! active_flags[k.task][fu] >= 1_i, ProofLevel::Temporary);
+            reason, WPBSum{} + 1_i * active_flag(k.task, fv) + 1_i * ! active_flag(k.task, fu) >= 1_i, ProofLevel::Temporary);
     };
 
     // The pushed task pinned active at t, in activity space: `pin_pushed`'s
@@ -1613,11 +1686,11 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
             throw ProofError{
                 "cumulative published not-first / not-last: task " + std::to_string(j_idx) + " has no flag at time " + std::to_string(t.raw_value)};
         auto fj = static_cast<size_t>((t - per_task_t_lo[j_idx]).raw_value);
-        logger->emit_rup_proof_line_under_reason(reason, plus_ext(WPBSum{} + 1_i * before_flags[j_idx][fj], ext, 1_i) >= 1_i, ProofLevel::Temporary);
+        logger->emit_rup_proof_line_under_reason(reason, plus_ext(WPBSum{} + 1_i * before_flag(j_idx, fj), ext, 1_i) >= 1_i, ProofLevel::Temporary);
         materialise_after_sum(j_idx, s_lo_after);
-        logger->emit_rup_proof_line_under_reason(reason, plus_ext(WPBSum{} + 1_i * after_flags[j_idx][fj], ext, 1_i) >= 1_i, ProofLevel::Temporary);
+        logger->emit_rup_proof_line_under_reason(reason, plus_ext(WPBSum{} + 1_i * after_flag(j_idx, fj), ext, 1_i) >= 1_i, ProofLevel::Temporary);
         return logger->emit_rup_proof_line_under_reason(
-            reason, plus_ext(WPBSum{} + 1_i * active_flags[j_idx][fj], ext, 1_i) >= 1_i, ProofLevel::Temporary);
+            reason, plus_ext(WPBSum{} + 1_i * active_flag(j_idx, fj), ext, 1_i) >= 1_i, ProofLevel::Temporary);
     };
 
     auto published_nfnl_justification = [&](Integer a2, Integer b, const vector<PublishedTask> & theta, size_t j, Integer j_lb, Integer j_ub,
@@ -2498,8 +2571,7 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
                                     if (is_present(j) && lst <= t && t < eet)
                                         continue;
                                     if (state.lower_bound(starts[j]) <= t && t < state.upper_bound(starts[j]) + llb(j))
-                                        items.push_back(
-                                            SubsetSumItem{hlb(j), active_flags[j][static_cast<size_t>((t - per_task_t_lo[j]).raw_value)]});
+                                        items.push_back(SubsetSumItem{hlb(j), active_flag(j, static_cast<size_t>((t - per_task_t_lo[j]).raw_value))});
                                 }
 
                                 // Where those heights do not add up to what the
@@ -2531,7 +2603,7 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
                                 for (auto j : active_tasks) {
                                     if (t < per_task_t_lo[j] || t > per_task_t_hi[j])
                                         continue;
-                                    auto flag = active_flags[j][static_cast<size_t>((t - per_task_t_lo[j]).raw_value)];
+                                    auto flag = active_flag(j, static_cast<size_t>((t - per_task_t_lo[j]).raw_value));
                                     auto lst = state.upper_bound(starts[j]), eet = state.lower_bound(starts[j]) + llb(j);
                                     if (is_present(j) && lst <= t && t < eet) {
                                         auto [line, coeff] = pin_contributor(reason, j, t);
@@ -2613,7 +2685,7 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
                                 auto lst = state.upper_bound(starts[i]), eet = state.lower_bound(starts[i]) + llb(i);
                                 for (Integer t = max(lst, a); t < min(eet, b); ++t) {
                                     pol.add(! logger->names_and_ids_tracker().xliteral_for(
-                                                active_flags[i][static_cast<size_t>((t - per_task_t_lo[i]).raw_value)]),
+                                                active_flag(i, static_cast<size_t>((t - per_task_t_lo[i]).raw_value))),
                                         hlb(i), logger->names_and_ids_tracker());
                                     pol_required -= hlb(i);
                                 }
@@ -2737,7 +2809,7 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
                         if (overstate_energy && i == inside_tasks.front()) {
                             WPBSum activity;
                             for (Integer t = energy_line->lo; t < energy_line->hi; ++t)
-                                activity += 1_i * active_flags[i][static_cast<size_t>((t - per_task_t_lo[i]).raw_value)];
+                                activity += 1_i * active_flag(i, static_cast<size_t>((t - per_task_t_lo[i]).raw_value));
                             line =
                                 logger->emit_rup_proof_line_under_reason(reason, move(activity) >= energy_line->bound + 1_i, ProofLevel::Temporary);
                         }

--- a/gcs/constraints/cumulative/cumulative.hh
+++ b/gcs/constraints/cumulative/cumulative.hh
@@ -410,6 +410,13 @@ namespace gcs
         // the environment's, and resolving it here in the constructor would
         // read it before a test had a chance to set it.
         std::optional<CumulativeEncoding> _encoding;
+
+        /// #780 step 10: whether the per-(task, time) flags are defined inside
+        /// the proof rather than by OPB rows. Decided once, in
+        /// define_proof_model, and read again by install_propagators so that
+        /// the initialiser which emits those definitions and the encoder which
+        /// declines to cannot disagree.
+        bool _per_time_flags_in_proof = false;
         innards::CumulativeProofMutation _proof_mutation = innards::cumulative_proof_mutation::None{};
         // Overload checking, resolved in prepare(). _overload_tasks lists the
         // tasks the window-energy lemma can speak about (constant length and

--- a/gcs/constraints/cumulative/cumulative.hh
+++ b/gcs/constraints/cumulative/cumulative.hh
@@ -18,6 +18,49 @@
 namespace gcs
 {
     /**
+     * \brief Which OPB encoding a Cumulative writes.
+     *
+     * Unlike \ref CumulativeRules, this *does* change what goes into the OPB.
+     * It changes nothing else: the solutions found, the inferences made and
+     * the certificates emitted are the same whichever is chosen, because
+     * nothing yet derives anything from what the second arm adds.
+     *
+     * \ingroup Constraints
+     */
+    enum class CumulativeEncoding
+    {
+        /// The per-time family alone: three fully reified flags per (task,
+        /// time point) over each task's possible-active window, and one
+        /// capacity row per time point. `O(n x horizon)`, and what every
+        /// inference cites today.
+        TimeIndexed,
+
+        /// The per-time family, and the start-checkpoint family beside it:
+        /// per ordered pair of tasks, flags saying whether one is running when
+        /// the other starts, and one capacity row per task. `O(n^2)` and free
+        /// of the horizon, which is the point of issue #780.
+        ///
+        /// Emitting both is how the second is checked before anything is
+        /// derived from it --- a checkpoint row that says too much is a
+        /// solution veripb refuses --- and it is not a state to stay in.
+        /// Deriving the per-time rows from the checkpoints, and then dropping
+        /// the per-time family, is the rest of #780; a `StartCheckpoint` arm
+        /// arrives with that recovery, and cannot work before it, since an
+        /// unconverted inference would have no per-time row left to cite.
+        ///
+        /// **What it costs to have both.** More model is more for unit
+        /// propagation to reach, so a certificate step that was load-bearing
+        /// against the per-time family alone need not be against the two
+        /// together. That is not hypothetical: three of Cumulative's mutation
+        /// fixtures write corrupted proofs that veripb rejects under
+        /// \ref TimeIndexed and accepts under this. So a mutation lane is
+        /// registered here only where it still discriminates, and an honest
+        /// certificate developed under this arm has been checked more weakly
+        /// than one developed under \ref TimeIndexed.
+        Both
+    };
+
+    /**
      * \brief Which of Cumulative's propagation rules are enabled.
      *
      * All three are on by default. Turning one off weakens propagation but
@@ -305,6 +348,11 @@ namespace gcs
         std::vector<Integer> _per_task_t_lo;
         std::vector<Integer> _per_task_t_hi;
         CumulativeRules _rules;
+        // nullopt until with_encoding() is called, which is how "take the
+        // default" is told apart from "asked for the default": the default is
+        // the environment's, and resolving it here in the constructor would
+        // read it before a test had a chance to set it.
+        std::optional<CumulativeEncoding> _encoding;
         innards::CumulativeProofMutation _proof_mutation = innards::cumulative_proof_mutation::None{};
         // Overload checking, resolved in prepare(). _overload_tasks lists the
         // tasks the window-energy lemma can speak about (constant length and
@@ -379,6 +427,19 @@ namespace gcs
         /// default). Propagation strength only: the solutions found and the OPB
         /// encoding are the same whatever is selected.
         auto with_rules(CumulativeRules rules) -> Cumulative &;
+
+        /**
+         * \brief Select which OPB encoding is written (see
+         * CumulativeEncoding). Proof model only: the solutions found and the
+         * inferences made are the same either way.
+         *
+         * Takes precedence over the `GCS_CUMULATIVE_ENCODING` environment
+         * variable, which is what selects the encoding for a constraint that
+         * does not call this --- and so is how a whole fixture set is run
+         * under the other arm without touching the places it builds its
+         * Cumulatives.
+         */
+        auto with_encoding(CumulativeEncoding encoding) -> Cumulative &;
 
         /// Corrupt one step of the overload check's derivation. For tests
         /// only, which assert that VeriPB rejects the result; see
@@ -527,6 +588,83 @@ namespace gcs
          * definition along with everything else it asserts.
          */
         [[nodiscard]] static auto end_lower_bound_role(std::size_t task) -> std::string;
+
+        /**
+         * \name The start-checkpoint encoding (issue #780).
+         *
+         * A second, `O(n^2)` and horizon-free statement of the same
+         * constraint, emitted alongside the per-time family above: rather than
+         * checking the capacity at every time point, check it at every time
+         * point that is the start of a task which could occupy the resource.
+         * The load profile is a step function that only rises at such a start,
+         * so a time point over capacity is dominated by the last one at or
+         * before it, and checking every start checks every peak.
+         *
+         * Nothing cites these yet --- they are here to be checked against the
+         * family that is load-bearing before anything is derived from them.
+         * Deriving the per-time rows from these, and deleting the per-time
+         * block, is the rest of #780.
+         *
+         * These are not `cake_pb_cp`'s names, as
+         * \ref capacity_row_role and the contribution roles are: cake has no
+         * start-checkpoint encoder to conform to. When one is asked for, these
+         * are the names to offer it.
+         */
+        ///@{
+
+        /**
+         * \brief The role of the row saying the load at the time task `j`
+         * starts is within the capacity:
+         * `Sum_i heights[i] . active[i,j] <= capacity`.
+         *
+         * A row exists for each task that could raise the load profile at all;
+         * ask NamesAndIDsTracker::constraint_row_label whether this one did.
+         */
+        [[nodiscard]] static auto checkpoint_row_role(std::size_t task) -> std::string;
+
+        /**
+         * \name The keys of the per-(task, task) flags.
+         *
+         * `before[i,j]` is `start[i] <= start[j]`, `after[i,j]` is
+         * `start[i] + length[i] > start[j]`, and `active[i,j]` is their
+         * conjunction (with the presence of `i`, where it has one): task `i`
+         * is running at the moment task `j` starts.
+         *
+         * The diagonal is the exception. `before[j,j]` is a tautology and
+         * `after[j,j]` is `length[j] >= 1`, so neither is minted, and
+         * `active[j,j]` is minted only when it says something --- when `j` has
+         * a variable length, or a presence. Where it says nothing, task `j` is
+         * on its own row unconditionally and there is no flag to ask for. So
+         * nullopt from here carries its usual meaning for `i != j` (the
+         * constraint did not encode that pair) and means "the term is there
+         * without a flag" on the diagonal.
+         */
+        ///@{
+        [[nodiscard]] static auto pair_before_flag_key(std::size_t i, std::size_t j) -> innards::ProofFlagKey;
+        [[nodiscard]] static auto pair_after_flag_key(std::size_t i, std::size_t j) -> innards::ProofFlagKey;
+        [[nodiscard]] static auto pair_active_flag_key(std::size_t i, std::size_t j) -> innards::ProofFlagKey;
+        ///@}
+
+        /**
+         * \brief The key of one bit of a variable-height task's linearised
+         * load contribution at the moment task `j` starts, and the roles of
+         * the three rows defining it.
+         *
+         * The per-time family's counterparts, said over a pair of tasks rather
+         * than over a task and a time; see \ref contribution_flag_key and
+         * \ref contribution_ge_row_role for what they mean. A constant-height
+         * task has none, and neither does a variable-height task on a diagonal
+         * whose activity flag was not minted: its contribution is its height,
+         * unconditionally, and the row carries the height itself.
+         */
+        ///@{
+        [[nodiscard]] static auto pair_contribution_flag_key(std::size_t i, std::size_t j, Integer bit) -> innards::ProofFlagKey;
+        [[nodiscard]] static auto pair_contribution_ge_row_role(std::size_t i, std::size_t j) -> std::string;
+        [[nodiscard]] static auto pair_contribution_le_row_role(std::size_t i, std::size_t j) -> std::string;
+        [[nodiscard]] static auto pair_contribution_zero_row_role(std::size_t i, std::size_t j) -> std::string;
+        ///@}
+
+        ///@}
     };
 }
 

--- a/gcs/constraints/cumulative/cumulative.hh
+++ b/gcs/constraints/cumulative/cumulative.hh
@@ -77,7 +77,35 @@ namespace gcs
         /// than in a solve. It does nothing for a Cumulative the recovery
         /// cannot yet speak about --- see
         /// innards::cumulative_checkpoint_recovery_applies.
-        BothRecovering
+        BothRecovering,
+
+        /// The start-checkpoint family alone, with the per-time block *not*
+        /// written at all --- the end state #780 is walking towards, and today
+        /// the way a converted rule is held to having really been converted.
+        ///
+        /// The check it performs is blunt and total, which is the point: a rule
+        /// that still reads `capacity_lines` finds nothing there, its pol loses
+        /// the supply it was counting on, and veripb rejects the proof. So
+        /// running a fixture under this arm asks "does anything in this still
+        /// touch the old rows" without anyone having to enumerate where the old
+        /// rows are read from. That is what the leak-check script was
+        /// approximating by deleting `cap_t` rows from a finished OPB, and this
+        /// does it at the source instead --- no post-processing, no `.scp`-only
+        /// vehicle, and so available to every C++ test lane and every rule,
+        /// including the ones CumulativeRules leaves off by default.
+        ///
+        /// **The per-time block still appears for a Cumulative the recovery
+        /// cannot speak about** --- a variable height, a variable length, an
+        /// optional task, a variable capacity. There would otherwise be no
+        /// capacity row at all for such a constraint, and every rule over it
+        /// would be uncertifiable rather than merely unconverted. So this is
+        /// "start-checkpoint wherever the recovery reaches", which is also what
+        /// the eventual default has to be: see
+        /// innards::cumulative_shape_supports_checkpoint_recovery for exactly
+        /// where that is. A lane that wants the strict form should use a
+        /// fixture whose shape qualifies, and can confirm it did by the absence
+        /// of `cap_` labels in the OPB.
+        StartCheckpoint
     };
 
     /**

--- a/gcs/constraints/cumulative/cumulative.hh
+++ b/gcs/constraints/cumulative/cumulative.hh
@@ -558,6 +558,24 @@ namespace gcs
         [[nodiscard]] static auto capacity_row_role(Integer t) -> std::string;
 
         /**
+         * \brief The family name under which a Cumulative publishes a deriver
+         * for its per-time capacity rows, indexed by time point.
+         *
+         * Under CumulativeEncoding::StartCheckpoint there is no `cap_<t>` row
+         * to find a label for, and a citer outside the propagator --- a derived
+         * Cumulative building on a donor's rows --- has to be able to ask for
+         * one to be derived instead. Pair with
+         * NamesAndIDsTracker::find_or_derive_line_in_family, and try
+         * \ref capacity_row_role first: a donor that still writes the block
+         * has a label, which costs nothing to cite.
+         *
+         * Published only where innards::cumulative_checkpoint_recovery_applies
+         * would say yes, so a nullopt from the family means the same thing a
+         * missing label does.
+         */
+        [[nodiscard]] static auto capacity_row_family() -> std::string;
+
+        /**
          * \name The keys of the per-(task, time) flags.
          *
          * `before` is `start[i] <= t`, `after` is `start[i] + length[i] > t`,

--- a/gcs/constraints/cumulative/cumulative.hh
+++ b/gcs/constraints/cumulative/cumulative.hh
@@ -94,17 +94,26 @@ namespace gcs
         /// vehicle, and so available to every C++ test lane and every rule,
         /// including the ones CumulativeRules leaves off by default.
         ///
-        /// **The per-time block still appears for a Cumulative the recovery
-        /// cannot speak about** --- a variable height, a variable length, an
-        /// optional task, a variable capacity. There would otherwise be no
-        /// capacity row at all for such a constraint, and every rule over it
-        /// would be uncertifiable rather than merely unconverted. So this is
-        /// "start-checkpoint wherever the recovery reaches", which is also what
-        /// the eventual default has to be: see
+        /// **A Cumulative the recovery cannot speak about gets the per-time
+        /// block instead, and no checkpoint block at all** --- that is a
+        /// variable height, a variable length, an optional task or a variable
+        /// capacity. It keeps the per-time rows because there would otherwise
+        /// be no capacity row for it and every rule over it would be
+        /// uncertifiable rather than merely unconverted; it is denied the
+        /// checkpoint rows because nothing could cite them, every citer going
+        /// through a recovery that declines the shape before it looks at the
+        /// model. So on a declined shape this *is* \ref TimeIndexed, and the
+        /// mode as a whole is "start-checkpoint wherever the recovery reaches",
+        /// which is what a default has to mean: see
         /// innards::cumulative_shape_supports_checkpoint_recovery for exactly
         /// where that is. A lane that wants the strict form should use a
         /// fixture whose shape qualifies, and can confirm it did by the absence
         /// of `cap_` labels in the OPB.
+        ///
+        /// \ref Both and \ref BothRecovering write the checkpoint block for
+        /// every shape, declined ones included: they are the differential arms,
+        /// and a checkpoint row over a declined shape is still one veripb
+        /// checks against the solutions.
         StartCheckpoint
     };
 

--- a/gcs/constraints/cumulative/cumulative.hh
+++ b/gcs/constraints/cumulative/cumulative.hh
@@ -57,7 +57,27 @@ namespace gcs
         /// registered here only where it still discriminates, and an honest
         /// certificate developed under this arm has been checked more weakly
         /// than one developed under \ref TimeIndexed.
-        Both
+        Both,
+
+        /// As \ref Both, and then derive every per-time capacity row from the
+        /// start-checkpoint rows and check it against the row the model still
+        /// carries beside it.
+        ///
+        /// The development arm for the middle of #780, and the answer to "did
+        /// the recovery derive the right thing". A recovery that is *invalid*
+        /// fails where it is emitted; a recovery that is valid but derives the
+        /// *wrong* row --- citing the neighbouring checkpoint, say --- emits a
+        /// perfectly good line, and only the implication check against the
+        /// model's own row rejects it. So the two encodings standing side by
+        /// side buy something here that neither buys alone.
+        ///
+        /// Deliberately eager, which the recovery itself is not meant to be:
+        /// this recovers every row rather than the ones a search cites, so it
+        /// is `O(horizon)` work in the proof and belongs in a test lane rather
+        /// than in a solve. It does nothing for a Cumulative the recovery
+        /// cannot yet speak about --- see
+        /// innards::cumulative_checkpoint_recovery_applies.
+        BothRecovering
     };
 
     /**

--- a/gcs/constraints/cumulative/cumulative.hh
+++ b/gcs/constraints/cumulative/cumulative.hh
@@ -386,6 +386,7 @@ namespace gcs
         std::vector<Integer> _length_lb;
         std::vector<Integer> _length_ub;
         std::vector<Integer> _height_vals;
+        std::vector<Integer> _height_lb;
         std::vector<Integer> _height_ub;
         Integer _capacity_val;
         // Resolved in prepare(). nullopt for a task that is unconditionally
@@ -410,6 +411,17 @@ namespace gcs
         // the environment's, and resolving it here in the constructor would
         // read it before a test had a chance to set it.
         std::optional<CumulativeEncoding> _encoding;
+
+        /// #780: whether every active task's height has bits this encoding can
+        /// cite --- constant, or a plain variable (not a view) whose declared
+        /// lower bound is at least zero, so that bit `k` has weight `2^k` and no
+        /// sign bit shifts the weights. A view has no bits of its own at all.
+        ///
+        /// Decided in prepare(), where the declared bounds are read. It gates
+        /// two things that must agree: whether the pair contribution bits are
+        /// defined as conjunctions with those bits, and whether the per-(task,
+        /// time) family moves into the proof.
+        bool _height_bits_citable = false;
 
         /// #780 step 10: whether the per-(task, time) flags are defined inside
         /// the proof rather than by OPB rows. Decided once, in

--- a/gcs/constraints/cumulative/cumulative_overload_test.cc
+++ b/gcs/constraints/cumulative/cumulative_overload_test.cc
@@ -503,6 +503,11 @@ auto main(int argc, char * argv[]) -> int
                 mutation = cumulative_proof_mutation::OmitCapacityLine{};
             else if (arg == "--mutate=window")
                 mutation = cumulative_proof_mutation::ShrinkLemmaWindow{};
+            // Only does anything under GCS_CUMULATIVE_ENCODING=both-recovering,
+            // which the ctest entry for it sets; under any other encoding the
+            // recovery does not run and the proof comes out honest.
+            else if (arg == "--mutate=recover_wrong_checkpoint")
+                mutation = cumulative_proof_mutation::RecoverFromWrongCheckpoint{};
             else if (arg == "--proof-files-basename" && a + 1 < argc)
                 proof_basename = argv[++a];
         }

--- a/gcs/constraints/cumulative/derived_cumulative.cc
+++ b/gcs/constraints/cumulative/derived_cumulative.cc
@@ -194,10 +194,22 @@ auto gcs::innards::install_derived_cumulative(
             if (! covered)
                 continue;
 
+            // The donor's own OPB row where it wrote one; failing that, ask the
+            // donor to derive it (#780). Under
+            // CumulativeEncoding::StartCheckpoint there is no `cap_<t>` label
+            // to find, and the label lookup alone would come back empty, the
+            // recipe would decline, and this whole constraint would go --- with
+            // no proof failure to say so, since declining is a supported
+            // outcome here. The label is tried first because where it exists it
+            // costs nothing, while a derivation is `O(n^3)` lines.
             DerivedCumulativeRows rows;
-            for (const auto & donor : spec.row_donors)
+            for (const auto & donor : spec.row_donors) {
                 if (auto row = tracker.constraint_row_label(donor, ConstraintProofModelData<Cumulative>::capacity_row_role(t)))
                     rows.emplace(donor, *row);
+                else if (auto derived =
+                             tracker.find_or_derive_line_in_family(donor, ConstraintProofModelData<Cumulative>::capacity_row_family(), t, *logger))
+                    rows.emplace(donor, *derived);
+            }
             rows_by_time.emplace_back(t, move(rows));
         }
     }

--- a/gcs/constraints/cumulative/donor_view.cc
+++ b/gcs/constraints/cumulative/donor_view.cc
@@ -259,7 +259,7 @@ auto gcs::innards::recover_constant_argument_row(ProofLogger & logger, const Cum
     for (const auto & [i, cc] : convert) {
         auto height = std::get<SimpleIntegerVariableID>(*view.height_bounded_by[i]);
         auto active = tracker.find_proof_flag_values(donor, ConstraintProofModelData<Cumulative>::active_flag_key(i, t));
-        auto contribution_row = tracker.constraint_row_label(donor, ConstraintProofModelData<Cumulative>::contribution_ge_row_role(i, t));
+        auto contribution_row = tracker.constraint_row(donor, ConstraintProofModelData<Cumulative>::contribution_ge_row_role(i, t));
         // The flags exist, so the donor gave this task a window here and both
         // of these went out with them. Missing means the donor is not the
         // Cumulative these keys were published by.

--- a/gcs/constraints/cumulative/propagate.hh
+++ b/gcs/constraints/cumulative/propagate.hh
@@ -102,6 +102,15 @@ namespace gcs::innards
         /// two live side by side rather than one replacing the other.
         std::shared_ptr<CheckpointRecoveryCache> checkpoint_recovery;
 
+        /// #780: whether a variable-height task's *pair* contribution bits are
+        /// defined as conjunctions with the height's own bits (two reification
+        /// halves each) rather than linearised by three rows per pair. False
+        /// only where some height has no citable bits --- a view, or a declared
+        /// lower bound below zero --- and then the recovery declines any
+        /// constraint with a variable height, because the swap it does is
+        /// stated over those halves.
+        bool pair_contribution_bits_are_conjunctions = false;
+
         CumulativeRules rules;
         CumulativeProofMutation proof_mutation;
         CumulativePresenceMutation presence_mutation;

--- a/gcs/constraints/cumulative/propagate.hh
+++ b/gcs/constraints/cumulative/propagate.hh
@@ -22,6 +22,8 @@
 
 namespace gcs::innards
 {
+    struct CheckpointRecoveryCache;
+
     /**
      * \brief Everything Cumulative's propagator reads: the task data, the
      * per-time proof flags it pins, and the per-time capacity lines it builds
@@ -85,6 +87,20 @@ namespace gcs::innards
         /// constraint's are OPB rows; a derived constraint's are derived from
         /// its donor's, in the proof.
         std::map<Integer, ProofLine> capacity_lines;
+
+        /// Where an inference gets the row for a time point from, when it is
+        /// not \ref capacity_lines: recovered from the start-checkpoint block,
+        /// in the proof, and cached. Null unless
+        /// CumulativeEncoding::BothRecovering asked for it --- and shared with
+        /// the initialiser that checks each recovery against the model row, so
+        /// that an inference cites the same line the check passed on rather
+        /// than deriving its own copy.
+        ///
+        /// Set and non-null does not mean every row comes from here: a
+        /// Cumulative the recovery cannot speak about (a variable height, an
+        /// optional task) falls back to \ref capacity_lines, which is why the
+        /// two live side by side rather than one replacing the other.
+        std::shared_ptr<CheckpointRecoveryCache> checkpoint_recovery;
 
         CumulativeRules rules;
         CumulativeProofMutation proof_mutation;

--- a/gcs/constraints/innards/cumulative_mutations.hh
+++ b/gcs/constraints/innards/cumulative_mutations.hh
@@ -157,6 +157,22 @@ namespace gcs::innards
         // claim is not a certificate of the published rule however VeriPB
         // finishes it.
 
+        /// Recover a capacity row from the wrong task's checkpoint: cite the
+        /// next candidate's row where the case wanted this one's.
+        ///
+        /// The lane #780's differential exists for, and the one corruption in
+        /// this family that no `pol` failure catches. Every step of the
+        /// recovery still checks: the arithmetic is as valid over a
+        /// neighbour's row as over the right one, and what comes out is a
+        /// perfectly good line. It is simply not the row the model says. Only
+        /// asking whether the recovered line implies the model's own row ---
+        /// which is what CumulativeEncoding::BothRecovering does, and the only
+        /// thing the two encodings standing side by side buy that neither buys
+        /// alone --- rejects it. Needs that encoding: under any other, the
+        /// recovery does not run and this does nothing.
+        struct RecoverFromWrongCheckpoint
+        {
+        };
     }
 
     using CumulativeProofMutation = std::variant<cumulative_proof_mutation::None, cumulative_proof_mutation::OverstateWindowEnergy,
@@ -164,7 +180,7 @@ namespace gcs::innards
         cumulative_proof_mutation::PushOneTooFar, cumulative_proof_mutation::DropProfilePin, cumulative_proof_mutation::DropProfilePins,
         cumulative_proof_mutation::ClaimOneBetterAvailability, cumulative_proof_mutation::StrengthenOneFewer,
         cumulative_proof_mutation::DropEnergeticContributor, cumulative_proof_mutation::PublishedEmitNothing,
-        cumulative_proof_mutation::DropPublishedPin>;
+        cumulative_proof_mutation::DropPublishedPin, cumulative_proof_mutation::RecoverFromWrongCheckpoint>;
 
     /**
      * \brief Deliberate corruptions of the presence-falsification derivation,

--- a/gcs/constraints/innards/window_energy.cc
+++ b/gcs/constraints/innards/window_energy.cc
@@ -1,4 +1,5 @@
 #include <gcs/constraints/innards/window_energy.hh>
+#include <gcs/innards/proofs/flag_bridge.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
 #include <gcs/innards/proofs/pol_builder.hh>
 #include <gcs/innards/proofs/proof_error.hh>
@@ -110,13 +111,13 @@ namespace
             auto idx = static_cast<size_t>((t - task.flags_t_lo).raw_value);
 
             PolBuilder before_bridge;
-            before_bridge.add(ProofLineLabel{tracker.name_of(task.before[idx]) + "[f]"});
+            before_bridge.add(reification_half(tracker, task.before[idx], ReificationHalf::ImpliedBy));
             before_bridge.add_for_literal(tracker, start < t + 1_i);
             before_bridge.saturate();
             auto before_clause = before_bridge.emit(logger, level);
 
             PolBuilder after_bridge;
-            after_bridge.add(ProofLineLabel{tracker.name_of(task.after[idx]) + "[f]"});
+            after_bridge.add(reification_half(tracker, task.after[idx], ReificationHalf::ImpliedBy));
             after_bridge.add_for_literal(tracker, start >= t - shape.p + 1_i);
             if (task.length_variable) {
                 after_bridge.add_for_literal(tracker, *task.length_variable >= shape.p);
@@ -138,7 +139,7 @@ namespace
             auto after_clause = after_bridge.emit(logger, level);
 
             PolBuilder step;
-            step.add(ProofLineLabel{tracker.name_of(task.active[idx]) + "[f]"});
+            step.add(reification_half(tracker, task.active[idx], ReificationHalf::ImpliedBy));
             step.add(before_clause);
             step.add(after_clause);
             per_time.push_back(step.emit(logger, level));

--- a/gcs/innards/proofs/flag_bridge.cc
+++ b/gcs/innards/proofs/flag_bridge.cc
@@ -36,15 +36,22 @@ namespace
         return tracker.pb_file_string_for(flag);
     }
 
-    [[nodiscard]] auto implies_condition(const NamesAndIDsTracker & tracker, const ProofFlag & flag) -> ProofLineLabel
+    [[nodiscard]] auto implies_condition(const NamesAndIDsTracker & tracker, const ProofFlag & flag) -> ProofLine
     {
-        return ProofLineLabel{label_base(tracker, flag) + "[r]"};
+        return reification_half(tracker, flag, ReificationHalf::Implies);
     }
 
-    [[nodiscard]] auto implied_by_condition(const NamesAndIDsTracker & tracker, const ProofFlag & flag) -> ProofLineLabel
+    [[nodiscard]] auto implied_by_condition(const NamesAndIDsTracker & tracker, const ProofFlag & flag) -> ProofLine
     {
-        return ProofLineLabel{label_base(tracker, flag) + "[f]"};
+        return reification_half(tracker, flag, ReificationHalf::ImpliedBy);
     }
+}
+
+auto gcs::innards::reification_half(const NamesAndIDsTracker & tracker, const ProofFlag & flag, ReificationHalf which) -> ProofLine
+{
+    if (auto in_proof = tracker.in_proof_reification(flag))
+        return which == ReificationHalf::Implies ? in_proof->first : in_proof->second;
+    return ProofLineLabel{label_base(tracker, flag) + (which == ReificationHalf::Implies ? "[r]" : "[f]")};
 }
 
 auto gcs::innards::recover_flag_bridge(ProofLogger & logger, const ProofFlag & from, const ProofFlag & to, ProofLevel level) -> ProofLine

--- a/gcs/innards/proofs/flag_bridge.hh
+++ b/gcs/innards/proofs/flag_bridge.hh
@@ -11,6 +11,49 @@
 
 namespace gcs::innards
 {
+    class NamesAndIDsTracker;
+
+    /**
+     * \brief Which half of a fully reified flag's definition to cite.
+     *
+     * The names read backwards from the labels, which is ProofModel's doing:
+     * `Implies` is `flag -> ineq` and is labelled `[r]`; `ImpliedBy` is
+     * `ineq -> flag` and is labelled `[f]`.
+     *
+     * \ingroup Innards
+     */
+    enum class ReificationHalf
+    {
+        Implies,
+        ImpliedBy
+    };
+
+    /**
+     * \brief How to cite one half of a fully reified flag's definition,
+     * whichever way that definition was emitted.
+     *
+     * A flag reified by ProofModel has its halves as labelled OPB rows, and
+     * this gives the label. One reified inside the proof
+     * (ProofLogger::emit_red_proof_lines_reifying, recorded with
+     * NamesAndIDsTracker::register_in_proof_reification) has line numbers and
+     * no labels, and this gives the line. ProofLine is already the variant of
+     * the two, so a caller adding the result to a PolBuilder needs to know
+     * neither which it got nor which it was going to get --- which is the
+     * point, because #780 moves Cumulative's per-(task, time) flags from the
+     * first kind to the second under one encoding and not the others.
+     *
+     * The label is built from the flag's full PB rendering rather than from
+     * `name_of`, whose plain-flag form is the bare stem and would name the
+     * wrong row or none. For a ConstraintID-keyed flag --- `v[id][..]`,
+     * `x[id][..]`, which is every flag #780 cares about --- the two coincide.
+     *
+     * \throws ProofError if asked about a negated flag, whose halves are
+     * labelled and recorded under the positive one.
+     *
+     * \ingroup Innards
+     */
+    [[nodiscard]] auto reification_half(const NamesAndIDsTracker &, const ProofFlag &, ReificationHalf) -> ProofLine;
+
     /**
      * \brief Derive `from -> to`, as the line `~from + to >= 1`, for two flags
      * fully reified on inequalities over the same terms.

--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -1766,6 +1766,13 @@ auto NamesAndIDsTracker::find_or_derive_line_in_family(const ConstraintID & id, 
     return derived;
 }
 
+auto NamesAndIDsTracker::constraint_row(const ConstraintID & id, const string & role) const -> optional<ProofLine>
+{
+    if (auto label = constraint_row_label(id, role))
+        return ProofLine{*label};
+    return find_derived_line(id, role);
+}
+
 auto NamesAndIDsTracker::register_in_proof_reification(const ProofFlag & flag, ProofLine implies, ProofLine implied_by) -> void
 {
     // Keyed on the flag's PB rendering, which is what a citer has in hand and

--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -203,6 +203,14 @@ struct NamesAndIDsTracker::Imp
     // written at the same point in the solve, before the search starts.
     map<string, ProofLine> published_derived_lines;
 
+    // #780: derivers for integer-indexed families of lines, and the memo of
+    // what each has produced. Same per-solve story as published_derived_lines
+    // above --- these hold proof line numbers --- but populated lazily, on the
+    // first ask for a member, rather than up front. See
+    // publish_derived_line_family.
+    map<string, function<auto(ProofLogger &, Integer)->optional<ProofLine>>> derived_line_families;
+    map<string, ProofLine> derived_family_lines;
+
     unordered_map<SimpleOrProofOnlyIntegerVariableID, ProofLine, HashSimpleOrProofOnlyVariable> variable_at_least_one_constraints;
     // Indexed by variable index (variables are allocated with sequential
     // indices, so these stay dense), one per id kind.
@@ -1718,6 +1726,36 @@ namespace
     {
         return as_string(id) + "[" + role + "]";
     }
+}
+
+auto NamesAndIDsTracker::publish_derived_line_family(
+    const ConstraintID & id, const string & family, function<auto(ProofLogger &, Integer)->optional<ProofLine>> deriver) -> void
+{
+    if (! _imp->derived_line_families.emplace(derived_line_key(id, family), std::move(deriver)).second)
+        throw ProofError{"two derivers published for the line family '" + derived_line_key(id, family) +
+            "': a family name must say which family it is, so that a member can be derived unambiguously"};
+}
+
+auto NamesAndIDsTracker::find_or_derive_line_in_family(const ConstraintID & id, const string & family, Integer index, ProofLogger & logger)
+    -> optional<ProofLine>
+{
+    auto member = derived_line_key(id, family) + "[" + to_string(index.raw_value) + "]";
+    if (auto already = _imp->derived_family_lines.find(member); already != _imp->derived_family_lines.end())
+        return already->second;
+
+    auto deriver = _imp->derived_line_families.find(derived_line_key(id, family));
+    if (deriver == _imp->derived_line_families.end())
+        return nullopt;
+
+    auto derived = deriver->second(logger, index);
+    if (! derived)
+        return nullopt;
+
+    // Memoised only on success: a deriver that declined once may well be asked
+    // again for a different reason, and caching the decline would turn "not
+    // this time" into "never".
+    _imp->derived_family_lines.emplace(member, *derived);
+    return derived;
 }
 
 auto NamesAndIDsTracker::publish_derived_line(const ConstraintID & id, const string & role, ProofLine line) -> void

--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -211,6 +211,14 @@ struct NamesAndIDsTracker::Imp
     map<string, function<auto(ProofLogger &, Integer)->optional<ProofLine>>> derived_line_families;
     map<string, ProofLine> derived_family_lines;
 
+    // #780 step 10: the two halves of a flag whose reification was emitted
+    // *inside the proof* rather than as OPB rows, keyed by the flag's own PB
+    // name. A model-side flag's halves carry `[r]` and `[f]` labels and are
+    // cited by name; a `red`-minted one has line numbers and nothing else, so
+    // a citer has to be told them. Per-solve state, like the two above and for
+    // the same reason: a line number means nothing outside its own proof file.
+    map<string, pair<ProofLine, ProofLine>> in_proof_reifications;
+
     unordered_map<SimpleOrProofOnlyIntegerVariableID, ProofLine, HashSimpleOrProofOnlyVariable> variable_at_least_one_constraints;
     // Indexed by variable index (variables are allocated with sequential
     // indices, so these stay dense), one per id kind.
@@ -1756,6 +1764,24 @@ auto NamesAndIDsTracker::find_or_derive_line_in_family(const ConstraintID & id, 
     // this time" into "never".
     _imp->derived_family_lines.emplace(member, *derived);
     return derived;
+}
+
+auto NamesAndIDsTracker::register_in_proof_reification(const ProofFlag & flag, ProofLine implies, ProofLine implied_by) -> void
+{
+    // Keyed on the flag's PB rendering, which is what a citer has in hand and
+    // what the model-side labels are built from, so the two ways of defining a
+    // flag are asked about identically.
+    auto [_, inserted] = _imp->in_proof_reifications.emplace(pb_file_string_for(flag), pair{implies, implied_by});
+    if (! inserted)
+        throw ProofError{"flag " + pb_file_string_for(flag) + " had its reification emitted in the proof twice"};
+}
+
+auto NamesAndIDsTracker::in_proof_reification(const ProofFlag & flag) const -> optional<pair<ProofLine, ProofLine>>
+{
+    auto found = _imp->in_proof_reifications.find(pb_file_string_for(flag));
+    if (found == _imp->in_proof_reifications.end())
+        return nullopt;
+    return found->second;
 }
 
 auto NamesAndIDsTracker::publish_derived_line(const ConstraintID & id, const string & role, ProofLine line) -> void

--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -218,12 +218,22 @@ struct NamesAndIDsTracker::Imp
     // a citer has to be told them. Per-solve state, like the two above and for
     // the same reason: a line number means nothing outside its own proof file.
     map<string, pair<ProofLine, ProofLine>> in_proof_reifications;
+    // As any_flag_definers below: reification_half runs on every citation of
+    // any flag's half, and where nothing was reified in the proof it should
+    // cost a bool rather than a map lookup.
+    bool any_in_proof_reifications = false;
 
     // #780 step 10: definers for keyed families of flags, and the set of keys
     // each has already been asked for. Same per-solve story as the two above.
     // See publish_flag_definer.
     map<string, function<auto(ProofLogger &, const ProofFlagKey &)->void>> flag_definers;
     std::set<string> defined_flag_keys;
+    // Whether *any* constraint has published a definer, so that
+    // ensure_flag_defined --- which every citation of anyone's flags now goes
+    // through --- can decline in one bool test rather than formatting a
+    // constraint name and looking it up. No encoding but StartCheckpoint
+    // publishes one, and the time-indexed arm is the benchmark baseline.
+    bool any_flag_definers = false;
 
     unordered_map<SimpleOrProofOnlyIntegerVariableID, ProofLine, HashSimpleOrProofOnlyVariable> variable_at_least_one_constraints;
     // Indexed by variable index (variables are allocated with sequential
@@ -1776,10 +1786,13 @@ auto NamesAndIDsTracker::publish_flag_definer(const ConstraintID & id, function<
 {
     if (! _imp->flag_definers.emplace(as_string(id), std::move(definer)).second)
         throw ProofError{"constraint published a flag definer twice"};
+    _imp->any_flag_definers = true;
 }
 
 auto NamesAndIDsTracker::ensure_flag_defined(const ConstraintID & id, const ProofFlagKey & key, ProofLogger & logger) -> void
 {
+    if (! _imp->any_flag_definers)
+        return;
     auto definer = _imp->flag_definers.find(as_string(id));
     if (definer == _imp->flag_definers.end())
         return;
@@ -1807,10 +1820,13 @@ auto NamesAndIDsTracker::register_in_proof_reification(const ProofFlag & flag, P
     auto [_, inserted] = _imp->in_proof_reifications.emplace(pb_file_string_for(flag), pair{implies, implied_by});
     if (! inserted)
         throw ProofError{"flag " + pb_file_string_for(flag) + " had its reification emitted in the proof twice"};
+    _imp->any_in_proof_reifications = true;
 }
 
 auto NamesAndIDsTracker::in_proof_reification(const ProofFlag & flag) const -> optional<pair<ProofLine, ProofLine>>
 {
+    if (! _imp->any_in_proof_reifications)
+        return nullopt;
     auto found = _imp->in_proof_reifications.find(pb_file_string_for(flag));
     if (found == _imp->in_proof_reifications.end())
         return nullopt;

--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -219,6 +219,12 @@ struct NamesAndIDsTracker::Imp
     // the same reason: a line number means nothing outside its own proof file.
     map<string, pair<ProofLine, ProofLine>> in_proof_reifications;
 
+    // #780 step 10: definers for keyed families of flags, and the set of keys
+    // each has already been asked for. Same per-solve story as the two above.
+    // See publish_flag_definer.
+    map<string, function<auto(ProofLogger &, const ProofFlagKey &)->void>> flag_definers;
+    std::set<string> defined_flag_keys;
+
     unordered_map<SimpleOrProofOnlyIntegerVariableID, ProofLine, HashSimpleOrProofOnlyVariable> variable_at_least_one_constraints;
     // Indexed by variable index (variables are allocated with sequential
     // indices, so these stay dense), one per id kind.
@@ -1764,6 +1770,26 @@ auto NamesAndIDsTracker::find_or_derive_line_in_family(const ConstraintID & id, 
     // this time" into "never".
     _imp->derived_family_lines.emplace(member, *derived);
     return derived;
+}
+
+auto NamesAndIDsTracker::publish_flag_definer(const ConstraintID & id, function<auto(ProofLogger &, const ProofFlagKey &)->void> definer) -> void
+{
+    if (! _imp->flag_definers.emplace(as_string(id), std::move(definer)).second)
+        throw ProofError{"constraint published a flag definer twice"};
+}
+
+auto NamesAndIDsTracker::ensure_flag_defined(const ConstraintID & id, const ProofFlagKey & key, ProofLogger & logger) -> void
+{
+    auto definer = _imp->flag_definers.find(as_string(id));
+    if (definer == _imp->flag_definers.end())
+        return;
+
+    // Keyed on the same string the flag's own name is built from, so a second
+    // ask --- from this constraint or from anyone citing it --- is free.
+    auto memo = bracketed_flag_name('v', id, key.values, key.annotation);
+    if (! _imp->defined_flag_keys.emplace(memo).second)
+        return;
+    definer->second(logger, key);
 }
 
 auto NamesAndIDsTracker::constraint_row(const ConstraintID & id, const string & role) const -> optional<ProofLine>

--- a/gcs/innards/proofs/names_and_ids_tracker.hh
+++ b/gcs/innards/proofs/names_and_ids_tracker.hh
@@ -616,6 +616,39 @@ namespace gcs::innards
         auto publish_derived_line(const ConstraintID & id, const std::string & role, ProofLine line) -> void;
 
         /**
+         * \brief Record that a flag's reification was emitted *inside the
+         * proof*, and under which two lines.
+         *
+         * A flag defined by ProofModel carries `[r]` and `[f]` labels on its
+         * two halves, and every citer references them by name. A flag defined
+         * by ProofLogger::emit_red_proof_lines_reifying has no labels at all,
+         * only line numbers, so a citer has to be told them --- which is what
+         * this is for, and what \ref reification_half then hides.
+         *
+         * The halves are in the order the labels read: `implies` is the `[r]`
+         * half, `flag -> ineq`, and `implied_by` is `[f]`, `ineq -> flag`.
+         *
+         * Per-solve state, like \ref publish_derived_line and for the same
+         * reason: a proof line number is meaningless outside the proof file it
+         * indexes. Registered per install, so it never outlives that.
+         *
+         * \throws ProofError if this flag has already been registered, which
+         * means its definition went out twice.
+         */
+        auto register_in_proof_reification(const ProofFlag & flag, ProofLine implies, ProofLine implied_by) -> void;
+
+        /**
+         * \brief The two halves of a flag reified inside the proof, if it was
+         * reified inside the proof.
+         *
+         * nullopt means it was not, which for a fully reified flag means its
+         * halves are OPB rows and carry labels. Prefer \ref reification_half,
+         * which answers "how do I cite this half" without the caller having to
+         * know which of the two it is.
+         */
+        [[nodiscard]] auto in_proof_reification(const ProofFlag & flag) const -> std::optional<std::pair<ProofLine, ProofLine>>;
+
+        /**
          * \brief The line a constraint published under this role, if it
          * published one.
          *

--- a/gcs/innards/proofs/names_and_ids_tracker.hh
+++ b/gcs/innards/proofs/names_and_ids_tracker.hh
@@ -670,6 +670,23 @@ namespace gcs::innards
         [[nodiscard]] auto find_derived_line(const ConstraintID & id, const std::string & role) const -> std::optional<ProofLine>;
 
         /**
+         * \brief How to cite the row a constraint published under this role,
+         * however it was written.
+         *
+         * The row-side counterpart of \ref reification_half, and the same
+         * answer for the same reason: an OPB row gives its label, a row an
+         * install initialiser derived inside the proof gives its line, and
+         * ProofLine is already the variant of the two, so a citer needs to know
+         * neither. #780 moves Cumulative's per-(task, time) contribution rows
+         * from the first kind to the second under one encoding and not the
+         * others.
+         *
+         * nullopt means the same thing it means in both halves of that: there
+         * is nothing to cite, so do not do the thing that would need citing.
+         */
+        [[nodiscard]] auto constraint_row(const ConstraintID & id, const std::string & role) const -> std::optional<ProofLine>;
+
+        /**
          * \brief A constraint's promise that it can derive, on demand, any line
          * in an integer-indexed family --- rather than publishing them all up
          * front.

--- a/gcs/innards/proofs/names_and_ids_tracker.hh
+++ b/gcs/innards/proofs/names_and_ids_tracker.hh
@@ -18,6 +18,7 @@
 #include <gcs/variable_condition.hh>
 #include <gcs/variable_id.hh>
 
+#include <functional>
 #include <memory>
 #include <optional>
 #include <string>
@@ -634,6 +635,60 @@ namespace gcs::innards
          * constraint publishes which role names the line a citer wants.
          */
         [[nodiscard]] auto find_derived_line(const ConstraintID & id, const std::string & role) const -> std::optional<ProofLine>;
+
+        /**
+         * \brief A constraint's promise that it can derive, on demand, any line
+         * in an integer-indexed family --- rather than publishing them all up
+         * front.
+         *
+         * \ref publish_derived_line is for a fact a constraint decides to
+         * establish once, whatever anyone does with it. This is for a family
+         * whose members are too numerous to derive speculatively and whose
+         * consumers are known only later: Cumulative's per-time capacity rows
+         * under the start-checkpoint encoding (#780) are the first, where each
+         * member costs `O(n^3)` proof lines and a horizon's worth of them would
+         * dwarf the OPB block the encoding exists to delete.
+         *
+         * The deriver is called at most once per `(id, family, index)` and the
+         * result memoised, so a second consumer of the same member pays
+         * nothing. It may return nullopt, meaning this constraint cannot speak
+         * about that member --- read exactly as nullopt from
+         * \ref find_derived_line: there is nothing to cite, so do not do the
+         * thing that would need citing.
+         *
+         * \warning **Whatever the deriver emits must live at ProofLevel::Top.**
+         * The memo hands the same line number out for the rest of the proof,
+         * and a line emitted at any lower level is deleted on backtracking ---
+         * after which the memo is a dangling reference and nothing here can
+         * tell. This is a promise the publisher makes and that nothing checks.
+         *
+         * Registered per install, like everything else that holds proof line
+         * numbers, so it never outlives the proof whose lines it hands out.
+         *
+         * \todo This, \ref publish_derived_line and \ref boundary_pin_line are
+         * three variations on "a per-solve, constraint-keyed memo of proof
+         * lines", and each arrived for one caller. The tracker is meant to
+         * provide general facilities rather than a drawer of specific ones, and
+         * this is the third; #780's step 10 wants a fourth, the same thing for
+         * *flags* rather than lines. Once that one exists there should be
+         * enough examples to see the general requirement, and these should
+         * collapse into it. Deliberately not generalised before then, on the
+         * grounds that three examples are what tells you what the fourth needs.
+         */
+        auto publish_derived_line_family(const ConstraintID & id, const std::string & family,
+            std::function<auto(ProofLogger &, Integer index)->std::optional<ProofLine>> deriver) -> void;
+
+        /**
+         * \brief The line for one member of a family published by
+         * \ref publish_derived_line_family, deriving it if this is the first
+         * ask.
+         *
+         * Nullopt when no deriver was published for `(id, family)` --- the
+         * constraint was not installed, or proofs are off, or it does not have
+         * this family --- or when the deriver itself declines.
+         */
+        [[nodiscard]] auto find_or_derive_line_in_family(const ConstraintID & id, const std::string & family, Integer index, ProofLogger & logger)
+            -> std::optional<ProofLine>;
 
         /**
          * Create a proof flag with a new identifier, named `f[index][stem]`.

--- a/gcs/innards/proofs/names_and_ids_tracker.hh
+++ b/gcs/innards/proofs/names_and_ids_tracker.hh
@@ -638,6 +638,48 @@ namespace gcs::innards
         auto register_in_proof_reification(const ProofFlag & flag, ProofLine implies, ProofLine implied_by) -> void;
 
         /**
+         * \brief A constraint's promise that it can define, on demand, any flag
+         * in a keyed family --- rather than defining them all up front.
+         *
+         * The flag-side counterpart of \ref publish_derived_line_family, and
+         * the fourth of the "per-solve, constraint-keyed memo" facilities the
+         * \todo there predicted. Cumulative's per-(task, time) flags are the
+         * first consumer: their *names* are cheap and go out with the model,
+         * but their definitions are two `red` steps each and a horizon's worth
+         * of them is the whole cost #780 exists to remove.
+         *
+         * The definer is called at most once per `(id, key)` and is expected to
+         * emit whatever that flag needs --- its reification halves, and
+         * anything else keyed the same way --- and to register the halves with
+         * \ref register_in_proof_reification. A key it declines to define is
+         * simply not defined; that is not an error, and a citer of an undefined
+         * flag fails loudly at its own proof step rather than silently.
+         *
+         * \warning **Whatever the definer emits must live at ProofLevel::Top**,
+         * for the same reason \ref publish_derived_line_family says so: the
+         * memo hands out the same lines for the rest of the proof, and a line
+         * emitted lower is deleted on backtracking.
+         *
+         * Registered per install, so it never outlives the proof it writes to.
+         */
+        auto publish_flag_definer(const ConstraintID & id, std::function<auto(ProofLogger &, const ProofFlagKey & key)->void> definer) -> void;
+
+        /**
+         * \brief Make sure a flag from a published family has been defined,
+         * defining it if this is the first ask.
+         *
+         * Does nothing where no definer was published for `id` --- which is the
+         * ordinary case, the flag's definition being OPB rows --- and nothing
+         * on a second ask for the same key.
+         *
+         * Call it before citing a flag from a constraint that might have
+         * published one, which is to say before citing anyone else's flags at
+         * all: it is cheap, and the alternative is a proof step that references
+         * a free variable.
+         */
+        auto ensure_flag_defined(const ConstraintID & id, const ProofFlagKey & key, ProofLogger & logger) -> void;
+
+        /**
          * \brief The two halves of a flag reified inside the proof, if it was
          * reified inside the proof.
          *

--- a/gcs/innards/proofs/pol_builder.cc
+++ b/gcs/innards/proofs/pol_builder.cc
@@ -127,6 +127,27 @@ auto PolBuilder::divide_by(Integer n) -> PolBuilder &
     return *this;
 }
 
+auto PolBuilder::add(const ProofFlag & flag, const NamesAndIDsTracker & tracker) -> PolBuilder &
+{
+    return add(flag, 1_i, tracker);
+}
+
+auto PolBuilder::add(const ProofFlag & flag, Integer coeff, const NamesAndIDsTracker & tracker) -> PolBuilder &
+{
+    if (coeff == 0_i)
+        throw UnexpectedException{"PolBuilder::add called with zero coefficient"};
+    _text += ' ';
+    _text += tracker.pb_file_string_for(flag);
+    if (coeff != 1_i) {
+        _text += ' ';
+        append_number_to(_text, coeff);
+        _text += " *";
+    }
+    separator_if_not_first();
+    _empty = false;
+    return *this;
+}
+
 auto PolBuilder::weaken(const ProofFlag & flag, const NamesAndIDsTracker & tracker) -> PolBuilder &
 {
     _text += ' ';

--- a/gcs/innards/proofs/pol_builder.hh
+++ b/gcs/innards/proofs/pol_builder.hh
@@ -143,6 +143,22 @@ namespace gcs::innards
         auto add(const XLiteral & lit, Integer coeff, const NamesAndIDsTracker & tracker) -> PolBuilder &;
 
         /**
+         * Push a proof flag as a literal axiom (coefficient 1), resolved to its
+         * file-format string via the tracker. The axiom is `flag >= 0`, so
+         * adding it to a running `>=` constraint introduces the term without
+         * moving the degree --- which is how a term the arithmetic did not
+         * produce, but the target row wants, is put back. The mirror of
+         * \ref weaken.
+         */
+        auto add(const ProofFlag & flag, const NamesAndIDsTracker & tracker) -> PolBuilder &;
+
+        /**
+         * Same, weighted by `coeff`. `coeff == 1_i` elides the `1 *`;
+         * `coeff == 0_i` throws.
+         */
+        auto add(const ProofFlag & flag, Integer coeff, const NamesAndIDsTracker & tracker) -> PolBuilder &;
+
+        /**
          * Push the `pol`-side defining item for a literal, dispatching on the
          * `variant<ProofLine, XLiteral>` that
          * `NamesAndIDsTracker::need_pol_item_defining_literal` returns.

--- a/gcs/presolvers/inferred_cumulative/inferred_cumulative.cc
+++ b/gcs/presolvers/inferred_cumulative/inferred_cumulative.cc
@@ -124,17 +124,29 @@ namespace
     /// A task's activity flag on a donor at one time, absent when that donor
     /// never encoded the pair --- which is how a task outside its window looks,
     /// and is also how it looks in the donor's own capacity row.
-    [[nodiscard]] auto active_flag_for(const NamesAndIDsTracker & tracker, const ConstraintID & donor, size_t position, Integer t)
-        -> optional<ProofFlag>
+    /// Asking a donor for a flag is also asking it to define one: #780's
+    /// per-(task, time) flags are named with the model but defined on demand,
+    /// and a citer that skipped this would reference a free variable. Nothing
+    /// happens for a donor whose flags are OPB rows, which is all of them under
+    /// every encoding but StartCheckpoint.
+    auto ensure_donor_flags(ProofLogger & logger, const ConstraintID & donor, size_t position, Integer t) -> void
     {
-        return tracker.find_proof_flag_values(donor, ConstraintProofModelData<Cumulative>::active_flag_key(position, t));
+        logger.names_and_ids_tracker().ensure_flag_defined(donor, ConstraintProofModelData<Cumulative>::active_flag_key(position, t), logger);
+    }
+
+    [[nodiscard]] auto active_flag_for(ProofLogger & logger, const ConstraintID & donor, size_t position, Integer t) -> optional<ProofFlag>
+    {
+        ensure_donor_flags(logger, donor, position, t);
+        return logger.names_and_ids_tracker().find_proof_flag_values(donor, ConstraintProofModelData<Cumulative>::active_flag_key(position, t));
     }
 
     /// The `before` and `after` flags an `active` flag is the conjunction of,
     /// which is what a bridge between two donors' copies of it has to line up.
-    [[nodiscard]] auto active_conjuncts_for(const NamesAndIDsTracker & tracker, const ConstraintID & donor, size_t position, Integer t)
+    [[nodiscard]] auto active_conjuncts_for(ProofLogger & logger, const ConstraintID & donor, size_t position, Integer t)
         -> optional<vector<ProofFlag>>
     {
+        ensure_donor_flags(logger, donor, position, t);
+        auto & tracker = logger.names_and_ids_tracker();
         auto before = tracker.find_proof_flag_values(donor, ConstraintProofModelData<Cumulative>::before_flag_key(position, t));
         auto after = tracker.find_proof_flag_values(donor, ConstraintProofModelData<Cumulative>::after_flag_key(position, t));
         if (! before || ! after)
@@ -838,7 +850,7 @@ auto InferredCumulative::run(Problem & problem, Propagators & propagators, State
                     const auto & member = recipe.members[k];
                     if (t < member.t_lo || t > member.t_hi)
                         continue;
-                    auto flag = active_flag_for(tracker, recipe.donors[member.canonical_donor].id, member.canonical_position, t);
+                    auto flag = active_flag_for(recipe_logger, recipe.donors[member.canonical_donor].id, member.canonical_position, t);
                     if (! flag)
                         return std::nullopt;
                     present.push_back(k);
@@ -953,10 +965,10 @@ auto InferredCumulative::run(Problem & problem, Propagators & propagators, State
                                 onto = j - 1;
                             const auto & carried = recipe.members[present[onto]];
 
-                            auto theirs = active_flag_for(tracker, donor.id, *position, t);
-                            auto their_conjuncts = active_conjuncts_for(tracker, donor.id, *position, t);
+                            auto theirs = active_flag_for(recipe_logger, donor.id, *position, t);
+                            auto their_conjuncts = active_conjuncts_for(recipe_logger, donor.id, *position, t);
                             auto our_conjuncts =
-                                active_conjuncts_for(tracker, recipe.donors[carried.canonical_donor].id, carried.canonical_position, t);
+                                active_conjuncts_for(recipe_logger, recipe.donors[carried.canonical_donor].id, carried.canonical_position, t);
                             if (! theirs || ! their_conjuncts || ! our_conjuncts) {
                                 missing = true;
                                 break;
@@ -981,7 +993,7 @@ auto InferredCumulative::run(Problem & problem, Propagators & propagators, State
                     for (auto position : donor.view.usable) {
                         if (in_the_row.contains(position))
                             continue;
-                        if (auto flag = active_flag_for(tracker, donor.id, position, t))
+                        if (auto flag = active_flag_for(recipe_logger, donor.id, position, t))
                             weaken_out.push_back(*flag);
                     }
 

--- a/run_checkpoint_recovery_leak_check.bash
+++ b/run_checkpoint_recovery_leak_check.bash
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Usage: run_checkpoint_recovery_leak_check.bash SOLVER MODEL.scp
+# Usage: run_checkpoint_recovery_leak_check.bash SOLVER MODEL.scp [prefix|whole]
 #
 # Issue #780: check that Cumulative's start-checkpoint recovery never leans on a
 # per-time capacity row.
@@ -18,6 +18,13 @@
 # an OPB with every per-time capacity row stripped out. Anything the recovery
 # took from one of those rows fails here, and nothing else does.
 #
+# In `whole` mode the proof is not cut at all, so what is checked is the *whole*
+# certificate standing without the per-time block --- which is the end state
+# #780 is walking towards, and which only holds for a model whose every firing
+# rule has been moved over to the recovered rows. Today that is the time-table
+# overflow contradiction and nothing else, so a `whole` model has to be one that
+# fires only that. Each rule moved over is another model that can go in here.
+#
 # Exits 77 (ctest SKIP_RETURN_CODE) when veripb is missing.
 
 set -u
@@ -28,6 +35,7 @@ set -u
 
 solver=$1
 scp=$2
+mode=${3:-prefix}
 
 export PATH=$HOME/.cargo/bin:$PATH
 
@@ -45,12 +53,27 @@ GCS_CUMULATIVE_ENCODING=both-recovering "$solver" --all --prove --proof-files-ba
 ends=$(grep -n '^% #780 checkpoint recovery ends$' "${base}.pbp" | tail -1 | cut -d: -f1)
 [[ -n $ends ]] || { echo "FAIL: no recovery in ${base}.pbp; does the model qualify for it?"; exit 1; }
 
-head -n "$ends" "${base}.pbp" > "${base}.prefix.pbp"
-printf 'output NONE;\nconclusion NONE;\nend pseudo-Boolean proof;\n' >> "${base}.prefix.pbp"
+if [[ $mode == whole ]] ; then
+    cp "${base}.pbp" "${base}.prefix.pbp"
+else
+    head -n "$ends" "${base}.pbp" > "${base}.prefix.pbp"
+    printf 'output NONE;\nconclusion NONE;\nend pseudo-Boolean proof;\n' >> "${base}.prefix.pbp"
+fi
 
 # And that it recovered something: one implication check per row it derived.
 checks=$(grep -c '^ia ' "${base}.prefix.pbp")
 [[ $checks -gt 0 ]] || { echo "FAIL: the recovery derived no rows, so this checks nothing"; exit 1; }
+
+# In whole mode, that no rule cited a per-time row behind the recovery's back.
+# veripb would say so anyway --- the label is gone from the model it is given
+# --- but saying it here names what went wrong.
+if [[ $mode == whole ]] ; then
+    cites=$(grep -c '@c\[[^]]*\]\[cap_' "${base}.pbp")
+    if [[ $cites -gt 0 ]] ; then
+        echo "FAIL: ${cites} citations of a per-time capacity row; this model fires a rule that has not moved over"
+        exit 1
+    fi
+fi
 
 # `[cap_` does not match `[scap_`, so the start-checkpoint rows stay.
 grep -v '\[cap_' "${base}.opb" > "${base}.nocap.opb"
@@ -68,6 +91,6 @@ if ! grep -qE '^s VERIFIED' <<< "$out"; then
     exit 1
 fi
 
-echo "OK: ${checks} recovered rows, all standing without a per-time capacity row in the model"
+echo "OK (${mode}): ${checks} recovered rows, all standing without a per-time capacity row in the model"
 rm -f "${base}.prefix.pbp" "${base}.nocap.opb"
 dispose_proof "${base}"

--- a/run_checkpoint_recovery_leak_check.bash
+++ b/run_checkpoint_recovery_leak_check.bash
@@ -21,9 +21,12 @@
 # In `whole` mode the proof is not cut at all, so what is checked is the *whole*
 # certificate standing without the per-time block --- which is the end state
 # #780 is walking towards, and which only holds for a model whose every firing
-# rule has been moved over to the recovered rows. Today that is the time-table
-# overflow contradiction and nothing else, so a `whole` model has to be one that
-# fires only that. Each rule moved over is another model that can go in here.
+# rule has been moved over to the recovered rows. That is now the whole of the
+# default rule set: time-tabling, the overload check and its (TTOC)
+# strengthening. Every registered case is `whole`; `prefix` stays supported for
+# a model that cannot be, but there is no longer one that can be written here
+# --- the citers that remain are all behind CumulativeRules fields an .scp model
+# has no way to set. See the note in gcs/CMakeLists.txt.
 #
 # Exits 77 (ctest SKIP_RETURN_CODE) when veripb is missing.
 

--- a/run_checkpoint_recovery_leak_check.bash
+++ b/run_checkpoint_recovery_leak_check.bash
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Usage: run_checkpoint_recovery_leak_check.bash SOLVER MODEL.scp [prefix|whole]
+# Usage: run_checkpoint_recovery_leak_check.bash SOLVER MODEL.scp [prefix|whole|no-block]
 #
 # Issue #780: check that Cumulative's start-checkpoint recovery never leans on a
 # per-time capacity row.
@@ -24,9 +24,23 @@
 # rule has been moved over to the recovered rows. That is now the whole of the
 # default rule set: time-tabling, the overload check and its (TTOC)
 # strengthening. Every registered case is `whole`; `prefix` stays supported for
-# a model that cannot be, but there is no longer one that can be written here
-# --- the citers that remain are all behind CumulativeRules fields an .scp model
-# has no way to set. See the note in gcs/CMakeLists.txt.
+# a model that cannot be.
+#
+# `no-block` is the third mode and the one that matters most now. It solves
+# under GCS_CUMULATIVE_ENCODING=start-checkpoint, where the per-time rows are
+# never written in the first place, and requires that the OPB contain none of
+# them and that veripb still verify. Two reasons it exists beside `whole`:
+#
+#   - It is the end state itself rather than a reconstruction of it. `whole`
+#     deletes rows from a finished OPB and rechecks; this never emits them.
+#   - It guards the `startcheckpoint` ctest arm (gcs/CMakeLists.txt) against
+#     going vacuous. That arm is only worth anything if the encoding really does
+#     drop the block for the fixtures it runs --- and the encoding falls back to
+#     the per-time rows for any Cumulative the recovery cannot speak about, so
+#     "no cap_ rows were emitted" is a real thing to assert and not a tautology.
+#     If a change to cumulative_shape_supports_checkpoint_recovery ever made
+#     everything fall back, every lane on that arm would still pass while
+#     checking nothing new. This fails instead.
 #
 # Exits 77 (ctest SKIP_RETURN_CODE) when veripb is missing.
 
@@ -45,7 +59,40 @@ export PATH=$HOME/.cargo/bin:$PATH
 [[ -x "$solver" ]] || { echo "SKIP: solver not built at '$solver'"; exit 77; }
 command -v veripb >/dev/null 2>&1 || { echo "SKIP: veripb not on PATH"; exit 77; }
 
-base=$(basename "$scp" .scp).leakcheck
+# The mode is part of the basename: the same model is registered in more than
+# one mode, the lanes share a working directory, and ctest runs them in
+# parallel --- so without this they race over one set of proof files (#562).
+base=$(basename "$scp" .scp).${mode}.leakcheck
+
+if [[ $mode == no-block ]] ; then
+    GCS_CUMULATIVE_ENCODING=start-checkpoint "$solver" --all --prove --proof-files-basename "$base" "$scp" > /dev/null || {
+        echo "FAIL: the solve itself failed"; exit 1; }
+
+    # The whole claim: the block was never written.
+    caps=$(grep -c '\[cap_' "${base}.opb")
+    if [[ $caps -gt 0 ]] ; then
+        echo "FAIL: ${caps} per-time capacity rows in the OPB under start-checkpoint;"
+        echo "      this model must have fallen back (a variable height, an optional task, ...),"
+        echo "      so the startcheckpoint arm checks nothing on it"
+        exit 1
+    fi
+
+    # And that the replacement is actually there, so an encoder that emitted
+    # nothing at all would not pass this.
+    scaps=$(grep -c '\[scap_' "${base}.opb")
+    [[ $scaps -gt 0 ]] || { echo "FAIL: no start-checkpoint rows in the OPB either"; exit 1; }
+
+    out=$(veripb "${base}.opb" "${base}.pbp" 2>&1)
+    if ! grep -qE '^s VERIFIED' <<< "$out"; then
+        echo "FAIL: the proof does not stand with the per-time block never emitted"
+        tail -8 <<< "$out"
+        exit 1
+    fi
+
+    echo "OK (no-block): ${scaps} start-checkpoint rows, no per-time capacity row emitted at all"
+    dispose_proof "${base}"
+    exit 0
+fi
 
 GCS_CUMULATIVE_ENCODING=both-recovering "$solver" --all --prove --proof-files-basename "$base" "$scp" > /dev/null || {
     echo "FAIL: the solve itself failed"; exit 1; }

--- a/run_checkpoint_recovery_leak_check.bash
+++ b/run_checkpoint_recovery_leak_check.bash
@@ -1,0 +1,73 @@
+#!/bin/bash
+#
+# Usage: run_checkpoint_recovery_leak_check.bash SOLVER MODEL.scp
+#
+# Issue #780: check that Cumulative's start-checkpoint recovery never leans on a
+# per-time capacity row.
+#
+# The recovery derives the per-time capacity rows from the start-checkpoint
+# ones, and the whole point of it is that it keeps working once the per-time
+# block is deleted from the model. While both blocks are there, an ordinary run
+# says nothing about whether it does: the recovery's `rup` steps propagate over
+# the entire database, so one of them could be closing against the very row it
+# claims to be deriving, and the proof would verify just the same. Every `pol`
+# in it is safe --- a pol names its operands --- but the rups are not.
+#
+# So: solve under GCS_CUMULATIVE_ENCODING=both-recovering, cut the proof at the
+# marker the recovery emits when it finishes, and re-check that prefix against
+# an OPB with every per-time capacity row stripped out. Anything the recovery
+# took from one of those rows fails here, and nothing else does.
+#
+# Exits 77 (ctest SKIP_RETURN_CODE) when veripb is missing.
+
+set -u
+
+# shellcheck source-path=SCRIPTDIR
+# shellcheck source=proof_file_disposal.bash
+. "$(dirname "$0")/proof_file_disposal.bash"
+
+solver=$1
+scp=$2
+
+export PATH=$HOME/.cargo/bin:$PATH
+
+[[ -x "$solver" ]] || { echo "SKIP: solver not built at '$solver'"; exit 77; }
+command -v veripb >/dev/null 2>&1 || { echo "SKIP: veripb not on PATH"; exit 77; }
+
+base=$(basename "$scp" .scp).leakcheck
+
+GCS_CUMULATIVE_ENCODING=both-recovering "$solver" --all --prove --proof-files-basename "$base" "$scp" > /dev/null || {
+    echo "FAIL: the solve itself failed"; exit 1; }
+
+# Where the recovery finished. Its absence means the recovery never ran, which
+# would make everything below pass while checking nothing --- the one way this
+# test could go quietly vacuous, so it is an error and not a skip.
+ends=$(grep -n '^% #780 checkpoint recovery ends$' "${base}.pbp" | tail -1 | cut -d: -f1)
+[[ -n $ends ]] || { echo "FAIL: no recovery in ${base}.pbp; does the model qualify for it?"; exit 1; }
+
+head -n "$ends" "${base}.pbp" > "${base}.prefix.pbp"
+printf 'output NONE;\nconclusion NONE;\nend pseudo-Boolean proof;\n' >> "${base}.prefix.pbp"
+
+# And that it recovered something: one implication check per row it derived.
+checks=$(grep -c '^ia ' "${base}.prefix.pbp")
+[[ $checks -gt 0 ]] || { echo "FAIL: the recovery derived no rows, so this checks nothing"; exit 1; }
+
+# `[cap_` does not match `[scap_`, so the start-checkpoint rows stay.
+grep -v '\[cap_' "${base}.opb" > "${base}.nocap.opb"
+
+# If that stripped nothing, the label has moved and this check is vacuous.
+if [[ $(wc -l < "${base}.opb") -le $(wc -l < "${base}.nocap.opb") ]] ; then
+    echo "FAIL: no per-time capacity rows were stripped; has the cap_<t> label changed?"
+    exit 1
+fi
+
+out=$(veripb "${base}.nocap.opb" "${base}.prefix.pbp" 2>&1)
+if ! grep -qE '^s VERIFIED' <<< "$out"; then
+    echo "FAIL: the recovery does not stand without the per-time capacity rows"
+    tail -8 <<< "$out"
+    exit 1
+fi
+
+echo "OK: ${checks} recovered rows, all standing without a per-time capacity row in the model"
+rm -f "${base}.prefix.pbp" "${base}.nocap.opb"
+dispose_proof "${base}"


### PR DESCRIPTION
> **The bottom of a three-PR stack: #781 ← #839 ← #943. Land the three together.**
> Merge top-down: #943 into #839, then #839 into #781, then #781 into `main`.
> Merged bottom-up, #839 and #943 merge into branches `main` has already absorbed,
> so they never reach it, and GitHub still marks them MERGED. #943 is what makes
> start-checkpoint the only encoding and puts cake's chain back on it, so this PR
> alone leaves the default on the old encoding.
>
> Rebased onto `main` at `68332306` (2026-09-19). The only conflict was two
> `#include` lines in `names_and_ids_tracker.hh`. Two sections below are
> superseded by #943, and each is marked where it stands.

Replaces `Cumulative`'s `O(n x horizon)` time-indexed OPB block with an `O(n^2)`
horizon-free one — capacity checked only at time points that are some task's
start — and recovers the per-time rows lazily inside the proof.

Fixes #780.

## What it does

At three tasks with nine possible start times, sweeping the duration:

| `D` | time-indexed OPB | start-checkpoint OPB |
|---|---|---|
| 10,000 | 85,663 lines (8.3 MB) | **56 lines** |
| 100,000 | 854,945 lines (86 MB) | **56 lines** |
| 1,000,000 | 8,547,916 lines (**881 MB**) | **56 lines** |

Fifty-six lines, flat in the duration. These are the instances whose OPB nobody
could write, so no test or example covered them until this branch added
`examples/cumulative --max-length` / `--max-start` to reach them.

There is **no crossover left**: on short-task instances the model is smaller at
every point measured (0.56x at `H = n`, 0.11x at `H = 8n`) and the
start-checkpoint column is constant in `H`, which is what an `O(n^2)` encoding
should look like.

## How it gets there

Not the capacity rows — those turned out to be about 9% of the file. The
`O(n x horizon)` cost was the three fully reified flags per (task, time), and
this moves them out of the model and mints them in the proof, only for the pairs
something actually reasons about. `NamesAndIDsTracker::publish_flag_definer` is
the fourth "per-solve, constraint-keyed memo" facility, and the flag-side
counterpart of `publish_derived_line_family`; `reification_half` and
`constraint_row` hide whether a thing is an OPB label or a derived line, which
`ProofLine` already had the variant for.

A variable height's contribution needed three rows per (task, time) and three
per pair to linearise `contrib = h * active`. Out of the model it needs none:
bit by bit the product *is* a conjunction, `cc <-> cact /\ bit_k(h)` and
`scc <-> sact /\ bit_k(h)`. That also deleted a case split the recovery had
needed, which existed only because the linearisation put a `cact` guard on the
fact that the two bit vectors agree.

Every shape is covered — optional tasks, variable lengths, variable heights, a
variable capacity — so no proof the cumulative binaries write carries a per-time
capacity row or a per-time flag under this encoding (0 of 440, and 0 of 266,
against 149 and 82 partway through).

## The open question, and it is not the model

On search-heavy instances the proof and the runtime cost more, and that cost is
the recovery's `~2m^3` lines per cited time point. On `rcpsp --size 14 --seed 0
--prove`:

| | time-indexed | start-checkpoint | |
|---|---|---|---|
| OPB lines | 2,660 | 1,587 | **0.60x** |
| proof lines | 226,985 | 284,756 | 1.25x |
| wall clock | 423 ms | 604 ms | 1.43x |

Flat on long-duration instances, where almost nothing is cited (42 proof lines
against 133). **The default is deliberately still `TimeIndexed`** pending a
measurement over #777's instances. If that cost is not acceptable the levers are
emitting only the transitivity triples the scan resolves against (a constant
factor; the `m^3` is structural), or choosing per *constraint* rather than
globally — an RCPSP pays the `6n^2` once per resource over one shared horizon.

*Superseded by #943:* the question became which encoding to keep rather than
which to default to, since cake can follow only one per constraint. The answer
was start-checkpoint, and #943 deletes the time-indexed default. The figures for
that decision are in #943's description.

## Caveats worth reading before merging

*Both caveats are superseded by #943.* cake (CakePB-dev `a402078`) now derives the
start-checkpoint block under these labels, and #943 puts the `scp_chain` cases
back on it. A view-valued height is now rejected under proof logging instead of
falling back. The negative-lower-bound arm was already dead: `prepare()`'s
non-negativity check throws first.

- **cake does not verify the new encoding.** The per-(task, time) flags are
  named to match `cake_pb_cp`'s, and minting them in-proof collides with cake's
  own axioms; `scp_chain_cumulative*` therefore stays on the time-indexed arm.
  This is a deliberate call for the development period — at merge decision time
  the old encoding goes and cake switches to the new one — and it means the
  encoding carries a small unverified-by-cake risk until then.
- A height whose bits cannot be cited (a view, or a declared lower bound below
  zero, which puts a sign bit in and shifts every weight) keeps the old
  linearisation and makes the recovery decline. `prepare()` decides that once
  per constraint, a mixture not being available.
- Thirty-one commits, each green on its own. Happy to split it into a stack if
  that reads better.

## Testing

**After the 2026-09-19 rebase:** 981/986 capped (GCC 15.2, with `cake_pb_cp` at CakePB-dev `a402078`, `opbdiff` and MiniZinc 2.9.7 on `PATH`). The five failures are the `scp_chain_cumulative*` lanes, all at step 3, where veripb checks our proof against cake's OPB. cake now writes only the start-checkpoint block, and this PR's default is still time-indexed. `main` at `68332306` fails the same five at the same step, and #943 is what makes them pass again. CI does not run cake, so it will not see them.

899/899 green, capped and with `-DGCS_TEST_CAP_DEFAULTS=OFF`, after every
commit. Four ctest arms (`bare` / `_checkpoint` / `_recovering` /
`_startcheckpoint`) run the cumulative lanes under each encoding; 55 lanes are
on the strict arm.

Each step was checked by breaking it rather than by the suite going green, since
it went green after every one — removing the diagonal pin fails 14 lanes, citing
the wrong contribution row fails 7, an off-by-one in the variable-capacity row
fails 5. The `_recovering` arm is what catches a recovery that is *valid but
derives the wrong row*; the `_startcheckpoint` lanes stayed green through a
sabotage that only it noticed.

`dev_docs/cumulative-proof-logging.md` carries the derivation, every
measurement, and which regime each was taken in — including the sections that
are superseded, kept because the reasoning is what led to the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EH234fj3R28n2D3ofgA1ni

