### PR TITLE
Add gcspy PyPI release workflow, docs, and bump to 0.1.10

### DIFF
--- a/.github/workflows/release-gcspy.yml
+++ b/.github/workflows/release-gcspy.yml
@@ -44,14 +44,30 @@ jobs:
       with:
         python-version: '3.12'
 
-    # scikit-build-core builds the sdist in an isolated environment (no compiler
-    # needed here). The package lives in python/, but its cmake.source-dir is the
-    # repo root, so the tarball bundles the whole solver source -- that is what
-    # lets a plain `pip install gcspy` compile on a machine with no wheel.
+    # The sdist must be rooted at the REPO ROOT, not python/: it has to carry the
+    # whole solver source (gcs/, the root CMakeLists.txt, ...) so a from-source
+    # `pip install gcspy` can compile. python/pyproject.toml uses cmake.source-dir
+    # = ".." for the in-tree developer install (`pip install ./python`), but an
+    # sdist cannot include files above its own pyproject, so building from python/
+    # packages python/ alone -- an 8 KB stub that cannot build. Synthesise a root
+    # pyproject from the dev one instead: drop cmake.source-dir (so it defaults to
+    # the repo root, now inside the tarball) and force GCS_BUILD_TESTS=OFF (at the
+    # root it defaults ON and would compile the whole test suite on install). The
+    # two edits are asserted below so a formatting change that breaks them fails
+    # loudly rather than shipping a broken sdist.
+    - name: Assemble the release pyproject at the repo root
+      run: |
+        sed -e '/cmake\.source-dir/d' \
+            -e 's/cmake\.args = \[/cmake.args = ["-DGCS_BUILD_TESTS=OFF", /' \
+            python/pyproject.toml > pyproject.toml
+        echo "--- generated root pyproject.toml ---"; cat pyproject.toml
+        grep -q -- '-DGCS_BUILD_TESTS=OFF' pyproject.toml || { echo "::error::GCS_BUILD_TESTS flag not injected"; exit 1; }
+        ! grep -q 'cmake\.source-dir' pyproject.toml     || { echo "::error::cmake.source-dir not stripped"; exit 1; }
+
     - name: Build sdist
       run: |
         python -m pip install --upgrade build
-        python -m build --sdist --outdir dist python
+        python -m build --sdist --outdir dist .
 
     # Confirm the sdist actually compiles and imports with a stock distro compiler
     # (ubuntu-24.04 ships GCC 13, this project's oldest supported compiler). This
@@ -78,8 +94,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { os: macos-14, archs: arm64 }    # Apple silicon
-          - { os: macos-13, archs: x86_64 }   # Intel Macs (older Apple Clang -- riskier lane)
+          - { os: macos-15, archs: arm64 }         # Apple silicon
+          - { os: macos-15-intel, archs: x86_64 }  # Intel Macs
           - { os: ubuntu-24.04, archs: x86_64 }
 
     steps:

--- a/.github/workflows/release-gcspy.yml
+++ b/.github/workflows/release-gcspy.yml
@@ -1,0 +1,176 @@
+name: Release gcspy
+
+# Builds and publishes the gcspy Python bindings to PyPI. Produces a source
+# distribution (the portable fallback -- anyone with a supported compiler can
+# build it) plus prebuilt wheels for macOS (arm64 + x86_64) and manylinux x86_64,
+# then uploads them.
+#
+# There are two ways to trigger a release:
+#   * Push a tag matching gcspy-v*  (e.g. gcspy-v0.1.10)  -> publishes to real PyPI.
+#   * Run the workflow manually (Actions -> Release gcspy -> Run workflow) and pick
+#     "testpypi" (the default, a safe dry run) or "pypi".
+#
+# The version that gets published is whatever is in python/pyproject.toml, NOT the
+# tag name -- keep them in step. See dev_docs/releasing-gcspy.md for the full
+# procedure, the one-time PyPI Trusted Publishing setup, and how to iterate on a
+# failing wheel build.
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Where to publish"
+        type: choice
+        options: [testpypi, pypi]
+        default: testpypi
+  push:
+    tags: [ "gcspy-v*" ]
+
+# Never let two release runs upload at once.
+concurrency:
+  group: release-gcspy
+  cancel-in-progress: false
+
+jobs:
+  build-sdist:
+    name: Build sdist
+    runs-on: ubuntu-24.04
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+
+    # scikit-build-core builds the sdist in an isolated environment (no compiler
+    # needed here). The package lives in python/, but its cmake.source-dir is the
+    # repo root, so the tarball bundles the whole solver source -- that is what
+    # lets a plain `pip install gcspy` compile on a machine with no wheel.
+    - name: Build sdist
+      run: |
+        python -m pip install --upgrade build
+        python -m build --sdist --outdir dist python
+
+    # Confirm the sdist actually compiles and imports with a stock distro compiler
+    # (ubuntu-24.04 ships GCC 13, this project's oldest supported compiler). This
+    # is the path every from-source user takes, so a red here is a real release
+    # blocker even if the wheels are fine.
+    - name: Smoke-build the sdist from source
+      run: |
+        python -m pip install --verbose dist/*.tar.gz
+        python -c "import gcspy; print('gcspy import OK')"
+
+    - name: Upload sdist artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: dist-sdist
+        path: dist/*.tar.gz
+
+  build-wheels:
+    name: Wheels (${{ matrix.os }} / ${{ matrix.archs }})
+    needs: build-sdist
+    runs-on: ${{ matrix.os }}
+    # Best-effort: one platform failing must not sink the whole release. The
+    # publish job runs whatever wheels succeeded plus the always-present sdist.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { os: macos-14, archs: arm64 }    # Apple silicon
+          - { os: macos-13, archs: x86_64 }   # Intel Macs (older Apple Clang -- riskier lane)
+          - { os: ubuntu-24.04, archs: x86_64 }
+
+    steps:
+    - name: Download the sdist
+      uses: actions/download-artifact@v4
+      with:
+        name: dist-sdist
+        path: sdist
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+
+    # Build wheels FROM the sdist tarball rather than the checkout: it is the exact
+    # source users get, it already contains the parent-dir solver sources, and it
+    # doubles as a check that the sdist builds on every platform.
+    - name: Build wheels
+      run: |
+        python -m pip install --upgrade cibuildwheel
+        python -m cibuildwheel --output-dir wheelhouse sdist/*.tar.gz
+      env:
+        CIBW_ARCHS: ${{ matrix.archs }}
+        # A focused CPython set. PyPy and musl skipped: this is a heavy C++23 build
+        # with a niche audience. Widen the range here if users ask.
+        CIBW_BUILD: "cp310-* cp311-* cp312-* cp313-*"
+        CIBW_SKIP: "*-musllinux*"
+        CIBW_BUILD_VERBOSITY: "1"
+        # Every wheel must import before it is kept.
+        CIBW_TEST_COMMAND: 'python -c "import gcspy; print(\"gcspy import OK\")"'
+        # --- Linux only -------------------------------------------------------
+        # manylinux_2_28's default toolchain (GCC 12) predates our C++23 floor.
+        # AlmaLinux 8 can install gcc-toolset-13 (GCC 13, the oldest compiler we
+        # support). Static-link libstdc++/libgcc so the wheel does not require a
+        # newer libstdc++ than the manylinux_2_28 policy guarantees at runtime.
+        CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
+        CIBW_BEFORE_ALL_LINUX: "dnf install -y gcc-toolset-13"
+        CIBW_ENVIRONMENT_LINUX: >-
+          CC=/opt/rh/gcc-toolset-13/root/usr/bin/gcc
+          CXX=/opt/rh/gcc-toolset-13/root/usr/bin/g++
+          LDFLAGS='-static-libstdc++ -static-libgcc'
+        # --- macOS only -------------------------------------------------------
+        # Match the deployment target of the previously published arm64 wheel.
+        # C++23 pieces libc++ lacks (<generator>, <print>) fall back to the
+        # bundled fmt / generator polyfills, so no special compiler is needed.
+        CIBW_ENVIRONMENT_MACOS: "MACOSX_DEPLOYMENT_TARGET=12.0"
+
+    - name: Upload wheel artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: dist-wheels-${{ matrix.os }}-${{ matrix.archs }}
+        path: wheelhouse/*.whl
+
+  publish:
+    name: Publish to ${{ github.event_name == 'push' && 'pypi' || inputs.target }}
+    needs: [build-sdist, build-wheels]
+    # Publish as long as the sdist exists, even if some wheel lane failed -- ship
+    # the sdist plus whatever wheels succeeded rather than blocking the release.
+    if: ${{ always() && needs.build-sdist.result == 'success' }}
+    runs-on: ubuntu-24.04
+
+    # Trusted Publishing (OIDC): no PyPI token stored anywhere. PyPI is configured
+    # once to trust this repo + workflow + environment, and mints a short-lived
+    # credential per run. The environment name below must match the trusted
+    # publisher registered on PyPI (see dev_docs/releasing-gcspy.md).
+    environment:
+      name: ${{ github.event_name == 'push' && 'pypi' || inputs.target }}
+    permissions:
+      id-token: write
+
+    steps:
+    - name: Collect all artifacts into dist/
+      uses: actions/download-artifact@v4
+      with:
+        pattern: dist-*
+        path: dist
+        merge-multiple: true
+
+    - name: List what will be uploaded
+      run: ls -l dist
+
+    - name: Publish to TestPyPI
+      if: ${{ github.event_name == 'workflow_dispatch' && inputs.target == 'testpypi' }}
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: https://test.pypi.org/legacy/
+
+    - name: Publish to PyPI
+      if: ${{ github.event_name == 'push' || inputs.target == 'pypi' }}
+      uses: pypa/gh-action-pypi-publish@release/v1
+      # To fall back to a stored API token instead of Trusted Publishing, drop the
+      # `environment`/`id-token` config above and uncomment:
+      #   with:
+      #     password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/release-gcspy.yml
+++ b/.github/workflows/release-gcspy.yml
@@ -126,6 +126,13 @@ jobs:
         CIBW_BUILD_VERBOSITY: "1"
         # Every wheel must import before it is kept.
         CIBW_TEST_COMMAND: 'python -c "import gcspy; print(\"gcspy import OK\")"'
+        # CMAKE_ARGS=-DGCS_NATIVE_ARCH=OFF (in each lane's environment below) is the
+        # load-bearing bit for wheels: the Release build tunes with -march=native by
+        # default, which bakes in the build runner's CPU features (AVX-512, ...) with
+        # no fallback -- fine for a local/sdist source build, but a distributed wheel
+        # would then SIGILL on any older CPU. scikit-build-core forwards CMAKE_ARGS to
+        # the CMake configure. (sdist source builds keep the default ON and tune for
+        # the installing machine.)
         # --- Linux only -------------------------------------------------------
         # manylinux_2_28's default toolchain (GCC 12) predates our C++23 floor.
         # AlmaLinux 8 can install gcc-toolset-13 (GCC 13, the oldest compiler we
@@ -137,11 +144,12 @@ jobs:
           CC=/opt/rh/gcc-toolset-13/root/usr/bin/gcc
           CXX=/opt/rh/gcc-toolset-13/root/usr/bin/g++
           LDFLAGS='-static-libstdc++ -static-libgcc'
+          CMAKE_ARGS=-DGCS_NATIVE_ARCH=OFF
         # --- macOS only -------------------------------------------------------
         # Match the deployment target of the previously published arm64 wheel.
         # C++23 pieces libc++ lacks (<generator>, <print>) fall back to the
         # bundled fmt / generator polyfills, so no special compiler is needed.
-        CIBW_ENVIRONMENT_MACOS: "MACOSX_DEPLOYMENT_TARGET=12.0"
+        CIBW_ENVIRONMENT_MACOS: "MACOSX_DEPLOYMENT_TARGET=12.0 CMAKE_ARGS=-DGCS_NATIVE_ARCH=OFF"
 
     - name: Upload wheel artifacts
       uses: actions/upload-artifact@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,15 @@ The `clang-format` CI workflow enforces this on every push and pull request. To
 catch violations before CI, enable the tracked pre-commit hook once per clone
 with `git config core.hooksPath .githooks` (see CONTRIBUTING.md).
 
+## Releasing the Python bindings
+
+`gcspy` (the pybind11 module in `python/`) is published to PyPI. The version
+lives in `python/pyproject.toml`; a tag push matching `gcspy-v*` builds the
+sdist plus macOS/manylinux wheels and publishes via the `release-gcspy.yml`
+workflow. Full procedure, the compiler-floor wheel setup, and the one-time PyPI
+Trusted Publishing configuration are in
+[`dev_docs/releasing-gcspy.md`](dev_docs/releasing-gcspy.md).
+
 ## Compiler and Standard Library Support
 
 The codebase is built with **GCC 15.2.0**, **clang 21**, and **MSVC (Visual Studio

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,6 +157,14 @@ set(GCS_TEST_MAX_RECURSIONS "1500" CACHE STRING "Default per-solve search-node c
 # leaves no warning to promote.)
 option(GCS_WERROR "Treat compiler warnings as errors (CI lane only; not for normal builds)" OFF)
 
+# Native CPU tuning helps Release performance but is unsafe to redistribute:
+# -march=native bakes in whatever instructions the build machine has (AVX-512, ...),
+# with no runtime fallback, so a binary built on one machine SIGILLs on any older
+# one. ON (the default) tunes for the build host, which is what a local or sdist
+# source build wants; the wheel lanes pass -DGCS_NATIVE_ARCH=OFF so the published
+# binaries stay portable across the manylinux / macOS x86-64 baseline.
+option(GCS_NATIVE_ARCH "Tune the Release build for the build machine's CPU with -march=native; turn OFF for redistributable binaries such as wheels" ON)
+
 # Compiler flag checks always run so results are available for target-specific use.
 include(CheckCXXCompilerFlag)
 unset(COMPILER_SUPPORTS_MARCH_NATIVE CACHE)
@@ -259,8 +267,9 @@ if(PROJECT_IS_TOP_LEVEL)
         add_compile_options(-pthread)
         add_link_options(-pthread)
 
-        # Native CPU tuning is worthwhile for release performance but unhelpful for debugging.
-        if(COMPILER_SUPPORTS_MARCH_NATIVE)
+        # Native CPU tuning is worthwhile for release performance but unhelpful for
+        # debugging, and unsafe to redistribute -- see the GCS_NATIVE_ARCH option above.
+        if(GCS_NATIVE_ARCH AND COMPILER_SUPPORTS_MARCH_NATIVE)
             add_compile_options($<$<CONFIG:Release>:-march=native>)
         endif()
     endif()

--- a/dev_docs/README.md
+++ b/dev_docs/README.md
@@ -207,5 +207,14 @@ library. For an introduction to *using* the solver, start with the top-level
   through an `all_different`-style at-most-one recurrence with an exact
   coefficient. Also records what was deliberately left out, and why.
 
+- [Releasing gcspy](releasing-gcspy.md) — the procedure for cutting a `gcspy`
+  (Python bindings) release to PyPI: where the version lives, what the CI
+  workflow produces (portable sdist + best-effort macOS/manylinux wheels), why
+  the C++23 compiler floor forces gcc-toolset inside the manylinux image and
+  static-linked libstdc++, the step-by-step (bump → TestPyPI dry-run → tag), and
+  the one-time PyPI Trusted Publishing setup that keeps the release
+  maintainer-independent. Read when releasing the bindings or touching
+  `.github/workflows/release-gcspy.yml`.
+
 More documents will be added here as we build up coverage of other parts of
 the codebase.

--- a/dev_docs/releasing-gcspy.md
+++ b/dev_docs/releasing-gcspy.md
@@ -13,15 +13,31 @@ note explains the *why* and the human steps around it.
 
 ## What a release produces
 
-- **An sdist** (`gcspy-X.Y.Z.tar.gz`) — the portable artifact. `python/`'s
-  `cmake.source-dir` is the repo root, so the tarball bundles the entire solver
-  source, and anyone with a supported compiler (GCC ≥ 13 / clang 21) can
-  `pip install gcspy` and build it. This is the guaranteed path: every user not
-  covered by a prebuilt wheel gets this.
+- **An sdist** (`gcspy-X.Y.Z.tar.gz`) — the portable artifact. Anyone with a
+  supported compiler (GCC ≥ 13 / clang 21) can `pip install gcspy` and build it.
+  This is the guaranteed path: every user not covered by a prebuilt wheel gets
+  this.
+
+  **The sdist must be rooted at the repo root**, and this is the one genuinely
+  subtle part of the whole setup. `python/pyproject.toml` sets
+  `cmake.source-dir = ".."`, which is correct for the in-tree developer install
+  (`pip install ./python`, where `..` really is the checkout root) but is a trap
+  for packaging: an sdist cannot contain files above its own `pyproject.toml`, so
+  building from `python/` yields an ~8 KB stub with only `python/`'s own files —
+  no `gcs/`, and a `cmake.source-dir` that then resolves *outside* the extracted
+  tarball. It configures against `/tmp` and fails. So the workflow synthesises a
+  root `pyproject.toml` from the dev one (drop `cmake.source-dir`; force
+  `GCS_BUILD_TESTS=OFF`, which at the root would otherwise default ON) and builds
+  the sdist from the repo root — which is exactly what the hand-built 0.1.9
+  release did with an uncommitted root pyproject. If you build a release sdist by
+  hand, do the same (see the manual steps below); `cd python && python -m build`
+  produces the broken stub.
 - **Wheels** for macOS (arm64 + x86_64) and manylinux_2_28 x86_64, CPython
   3.10–3.13. Convenience only — a wheel just spares the user the compile. They
   are **best-effort**: a wheel lane failing does not block the release; the
-  sdist plus whatever wheels succeeded still ship.
+  sdist plus whatever wheels succeeded still ship. (Python 3.14 is not in the
+  wheel set yet — it needs a pybind11 bump; 3.14 users compile from the sdist
+  meanwhile.)
 
 There are no Windows or Linux-aarch64 wheels, and no PyPy/musl wheels. Those
 users compile from the sdist. Widen `CIBW_BUILD` / the job matrix if that
@@ -51,11 +67,15 @@ polyfills via `FetchContent`, so no special compiler wrangling is needed there.
    (E.g. 0.1.9 was published by hand before the CI existed while the repo still
    read 0.1.8; the first CI release skipped to 0.1.10.)
 2. **Commit** the bump on `main` (or via PR).
-3. **Dry-run on TestPyPI.** Actions → *Release gcspy* → *Run workflow*, leave the
-   target as `testpypi`. This builds the sdist and all wheels and uploads them to
-   [test.pypi.org](https://test.pypi.org/project/gcspy/). Confirm the artifact
-   list looks right and, ideally, `pip install -i https://test.pypi.org/simple/
-   gcspy==X.Y.Z` in a clean venv.
+3. **Dry-run on TestPyPI — mandatory, not optional.** Nothing in PR CI exercises
+   this workflow (it triggers only on `workflow_dispatch` and `gcspy-v*` tags), so
+   a green PR says nothing about whether the release path works; the dry-run is
+   the only pre-tag test there is. Actions → *Release gcspy* → *Run workflow*,
+   leave the target as `testpypi`. This builds the sdist and all wheels and
+   uploads them to [test.pypi.org](https://test.pypi.org/project/gcspy/). Confirm
+   the artifact list looks right and `pip install -i
+   https://test.pypi.org/simple/ gcspy==X.Y.Z` in a clean venv. Only tag a real
+   release once a dry-run of the same commit has gone green.
 4. **Release for real** by pushing a tag matching `gcspy-v*`:
    ```shell
    git tag gcspy-v0.1.10
@@ -96,6 +116,31 @@ Trusted Publishing is set up), store it as the `PYPI_API_TOKEN` repo secret and
 follow the commented instructions at the bottom of the workflow. This is the
 worse option for the long term: the token is a long-lived secret tied to whoever
 created it, and it must be rotated when they leave.
+
+## Manual release (when you can't use CI)
+
+The CI is just automating the hand process, and you can still run it by hand
+against your own PyPI token. The one thing you must not skip is rooting the sdist
+at the repo root — `cd python && python -m build` produces the broken 8 KB stub
+(see *What a release produces*). From a clean checkout with the version bumped:
+
+```shell
+# Synthesise the root pyproject the same way the workflow does, then build there.
+sed -e '/cmake\.source-dir/d' \
+    -e 's/cmake\.args = \[/cmake.args = ["-DGCS_BUILD_TESTS=OFF", /' \
+    python/pyproject.toml > pyproject.toml
+rm -rf build dist
+python -m build            # sdist (full source) + one wheel for your local Python
+tar tzf dist/*.tar.gz | grep -q gcs/ || { echo "sdist is missing gcs/ -- do NOT upload"; }
+twine check dist/*
+twine upload dist/*        # your PyPI token
+rm -f pyproject.toml       # the root pyproject is a build artifact; don't commit it
+```
+
+This yields the same shape as the hand-built 0.1.9 (sdist + a single local-Python
+wheel). Verify with `pip install gcspy==X.Y.Z` in a clean venv. Don't also release
+the same version through CI afterwards — the duplicate sdist filename would be
+rejected.
 
 ## When a wheel build goes red
 

--- a/dev_docs/releasing-gcspy.md
+++ b/dev_docs/releasing-gcspy.md
@@ -120,21 +120,36 @@ created it, and it must be rotated when they leave.
 ## Manual release (when you can't use CI)
 
 The CI is just automating the hand process, and you can still run it by hand
-against your own PyPI token. The one thing you must not skip is rooting the sdist
-at the repo root — `cd python && python -m build` produces the broken 8 KB stub
-(see *What a release produces*). From a clean checkout with the version bumped:
+against your own PyPI token. Two things you must not skip:
+
+- **Root the sdist at the repo root.** `cd python && python -m build` produces the
+  broken 8 KB stub (see *What a release produces*).
+- **Build from a clean export of tracked files, not your live checkout.** A
+  working tree accumulates `build/` directories; building there makes
+  `python -m build` pick up the local `build/` dir instead of the package
+  (`'build' is a package and cannot be directly executed`) and makes
+  scikit-build-core walk gigabytes of build output into the sdist (or crash on a
+  stale symlink inside it). `git archive` sidesteps both. CI is immune because a
+  fresh `actions/checkout` is already clean; a hand build is not.
+
+From a checkout with the version bumped and committed:
 
 ```shell
-# Synthesise the root pyproject the same way the workflow does, then build there.
+# 1. clean export of tracked files into a temp dir
+rm -rf /tmp/gcspy-src && mkdir -p /tmp/gcspy-src
+git archive HEAD | tar -x -C /tmp/gcspy-src
+cd /tmp/gcspy-src
+
+# 2. rooted pyproject (drop cmake.source-dir; force GCS_BUILD_TESTS=OFF)
 sed -e '/cmake\.source-dir/d' \
     -e 's/cmake\.args = \[/cmake.args = ["-DGCS_BUILD_TESTS=OFF", /' \
     python/pyproject.toml > pyproject.toml
-rm -rf build dist
+
+# 3. build, then REFUSE to upload a stub
 python -m build            # sdist (full source) + one wheel for your local Python
-tar tzf dist/*.tar.gz | grep -q gcs/ || { echo "sdist is missing gcs/ -- do NOT upload"; }
+test "$(tar tzf dist/*.tar.gz | grep -c '/gcs/')" -gt 0 || { echo "sdist has no gcs/ -- do NOT upload"; exit 1; }
 twine check dist/*
 twine upload dist/*        # your PyPI token
-rm -f pyproject.toml       # the root pyproject is a build artifact; don't commit it
 ```
 
 This yields the same shape as the hand-built 0.1.9 (sdist + a single local-Python

--- a/dev_docs/releasing-gcspy.md
+++ b/dev_docs/releasing-gcspy.md
@@ -59,6 +59,29 @@ macOS builds with the runner's Apple Clang + libc++. C++23 pieces libc++ lacks
 (`<generator>`, `<print>`) fall back to the bundled `fmt` / `generator`
 polyfills via `FetchContent`, so no special compiler wrangling is needed there.
 
+## `-march=native` and portable wheels
+
+A Release build tunes for the build machine's CPU with `-march=native`
+(`CMakeLists.txt`, gated behind the `GCS_NATIVE_ARCH` option, default ON). That
+bakes in whatever instructions the builder had — AVX-512, BMI2, ... — with no
+runtime fallback, so a binary built on one machine `SIGILL`s ("illegal
+instruction", usually at import) on any older CPU. For a source build that is
+exactly right: you compile on your own machine and get a solver tuned for it.
+For a **wheel** — one binary installed on thousands of machines — it is a trap,
+and an invisible one: `auditwheel` only checks libraries/glibc, and the
+build-machine import test always passes because that machine has every
+instruction the wheel uses. So the wheel lanes pass `-DGCS_NATIVE_ARCH=OFF`
+(via `CMAKE_ARGS` in `CIBW_ENVIRONMENT_*`) to build against the portable
+manylinux / macOS x86-64 baseline. Leave that in place; without it a wheel's
+minimum CPU becomes an accident of which runner GitHub allocated.
+
+The sdist path keeps the default ON, which is what you want — except for one
+user-side gotcha worth knowing: `pip install gcspy` inside a `docker build`
+compiles for the *build host* and bakes `-march=native` into the image, so the
+image can `SIGILL` when the container is later run on older hardware. If you
+distribute such an image, build it with `PIP_CONFIG_SETTINGS` /
+`CMAKE_ARGS=-DGCS_NATIVE_ARCH=OFF`, or install the portable wheel instead.
+
 ## Step-by-step: cutting a release
 
 1. **Bump the version.** Edit `version` in `python/pyproject.toml`. This string —

--- a/dev_docs/releasing-gcspy.md
+++ b/dev_docs/releasing-gcspy.md
@@ -1,0 +1,110 @@
+# Releasing gcspy (the Python bindings)
+
+`gcspy` is the pybind11 module built from `python/gcspy.cc`, published to
+[PyPI](https://pypi.org/project/gcspy/). This note is the procedure for cutting
+a release. It exists because none of it is derivable from the code: the version
+lives in one file, the compiler floor makes portable wheels awkward, and the
+publish path relies on out-of-repo configuration on PyPI.
+
+The whole thing is driven by
+[`.github/workflows/release-gcspy.yml`](../.github/workflows/release-gcspy.yml).
+Read that file alongside this note — the comments there explain each job; this
+note explains the *why* and the human steps around it.
+
+## What a release produces
+
+- **An sdist** (`gcspy-X.Y.Z.tar.gz`) — the portable artifact. `python/`'s
+  `cmake.source-dir` is the repo root, so the tarball bundles the entire solver
+  source, and anyone with a supported compiler (GCC ≥ 13 / clang 21) can
+  `pip install gcspy` and build it. This is the guaranteed path: every user not
+  covered by a prebuilt wheel gets this.
+- **Wheels** for macOS (arm64 + x86_64) and manylinux_2_28 x86_64, CPython
+  3.10–3.13. Convenience only — a wheel just spares the user the compile. They
+  are **best-effort**: a wheel lane failing does not block the release; the
+  sdist plus whatever wheels succeeded still ship.
+
+There are no Windows or Linux-aarch64 wheels, and no PyPy/musl wheels. Those
+users compile from the sdist. Widen `CIBW_BUILD` / the job matrix if that
+changes.
+
+## The compiler floor (why Linux wheels are fiddly)
+
+The solver is bleeding-edge C++23. The default toolchain inside a manylinux
+image is far too old. The workflow therefore builds Linux wheels in the
+`manylinux_2_28` image (AlmaLinux 8), `dnf install`s **gcc-toolset-13** (GCC 13
+is the oldest compiler this project supports — see `CLAUDE.md`), and points
+`CC`/`CXX` at it. It also passes `-static-libstdc++ -static-libgcc` so the
+extension does not depend on a newer `libstdc++` than the `manylinux_2_28`
+policy guarantees on the user's machine. If a future compiler bump raises the
+floor above GCC 13, bump the `gcc-toolset-NN` version (14 is also available in
+AlmaLinux 8; beyond that you may need a newer manylinux image).
+
+macOS builds with the runner's Apple Clang + libc++. C++23 pieces libc++ lacks
+(`<generator>`, `<print>`) fall back to the bundled `fmt` / `generator`
+polyfills via `FetchContent`, so no special compiler wrangling is needed there.
+
+## Step-by-step: cutting a release
+
+1. **Bump the version.** Edit `version` in `python/pyproject.toml`. This string —
+   not the git tag — is what gets published. Check PyPI first: versions are
+   immutable and cannot be reused, so a collision means the upload is rejected.
+   (E.g. 0.1.9 was published by hand before the CI existed while the repo still
+   read 0.1.8; the first CI release skipped to 0.1.10.)
+2. **Commit** the bump on `main` (or via PR).
+3. **Dry-run on TestPyPI.** Actions → *Release gcspy* → *Run workflow*, leave the
+   target as `testpypi`. This builds the sdist and all wheels and uploads them to
+   [test.pypi.org](https://test.pypi.org/project/gcspy/). Confirm the artifact
+   list looks right and, ideally, `pip install -i https://test.pypi.org/simple/
+   gcspy==X.Y.Z` in a clean venv.
+4. **Release for real** by pushing a tag matching `gcspy-v*`:
+   ```shell
+   git tag gcspy-v0.1.10
+   git push origin gcspy-v0.1.10
+   ```
+   A tag push publishes to the real PyPI. (Alternatively, *Run workflow* with the
+   target set to `pypi`.)
+5. **Verify** it installs: `pip install gcspy==X.Y.Z` in a clean environment.
+
+Keep the tag and the `pyproject.toml` version in step — the workflow publishes
+the file's version regardless of the tag string, so a mismatched tag just
+mislabels the git history.
+
+## Authentication: Trusted Publishing (one-time PyPI setup)
+
+The workflow uses PyPI **Trusted Publishing** (OIDC): there is no API token
+stored in the repo. PyPI is configured once to trust this repository + workflow
++ environment, and GitHub mints a short-lived credential per run. This is
+deliberately the low-maintenance option — nothing to rotate, and nothing that
+belongs to one person.
+
+To set it up (needed once per index, by a PyPI project owner):
+
+1. On [pypi.org](https://pypi.org/manage/project/gcspy/settings/publishing/) →
+   the `gcspy` project → *Settings* → *Publishing* → *Add a new publisher*
+   (GitHub Actions):
+   - **Owner / repository**: this repo.
+   - **Workflow name**: `release-gcspy.yml`.
+   - **Environment**: `pypi`.
+2. Repeat on [test.pypi.org](https://test.pypi.org/) with environment `testpypi`
+   if you want the TestPyPI dry-run to work.
+3. Optionally create matching GitHub *Environments* named `pypi` and `testpypi`
+   (repo → Settings → Environments) and add required reviewers to `pypi` so a
+   real publish needs a human approval click.
+
+**Token fallback.** If you would rather use a stored API token (e.g. before
+Trusted Publishing is set up), store it as the `PYPI_API_TOKEN` repo secret and
+follow the commented instructions at the bottom of the workflow. This is the
+worse option for the long term: the token is a long-lived secret tied to whoever
+created it, and it must be rotated when they leave.
+
+## When a wheel build goes red
+
+Wheels are best-effort, so a red lane still lets the sdist publish — but you'll
+want to fix it. The Linux lane is the usual suspect (manylinux image contents
+and the C++23 frontier both drift). To iterate without cutting a release, use
+*Run workflow* against `testpypi` and read the failing job's log. The build runs
+`cibuildwheel` over the sdist tarball, so anything that reproduces locally does
+so with `pipx run cibuildwheel <sdist>.tar.gz` and the same `CIBW_*` environment
+the workflow sets. Common fixes: bump `gcc-toolset-NN`, move to a newer
+`manylinux_2_XX` image, or (last resort) drop a platform from the matrix and let
+its users compile from the sdist until it can be restored.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "gcspy"
-version = "0.1.8"
+version = "0.1.10"
 license = "MIT OR Apache-2.0"
 
 [tool.scikit-build]


### PR DESCRIPTION
Adds an automated PyPI release path for the `gcspy` Python bindings, plus docs, and bumps the version to 0.1.10.

## What's here
- **`.github/workflows/release-gcspy.yml`** — builds the sdist (the portable fallback: it bundles the whole solver source, so anyone with a supported compiler can `pip install gcspy`) plus best-effort wheels for macOS (arm64 + x86_64) and manylinux_2_28 x86_64, CPython 3.10–3.13. Publishes via **Trusted Publishing (OIDC)** — no stored token — on a `gcspy-v*` tag push, with a manual TestPyPI dry-run option.
- Linux wheels install **gcc-toolset-13** inside manylinux_2_28 (GCC 13 = our compiler floor) and **static-link libstdc++/libgcc** so the wheel doesn't require a newer runtime than the manylinux policy guarantees. Wheels are built from the sdist tarball, so they double as a check that it builds.
- Wheels are **best-effort**: a failing wheel lane still ships the sdist plus the wheels that built.
- **`dev_docs/releasing-gcspy.md`** — procedure (bump → TestPyPI dry-run → tag), the compiler-floor rationale, and the one-time PyPI Trusted Publishing setup. Indexed in `dev_docs/README.md`, pointed to from `CLAUDE.md`.
- **Version bump to 0.1.10** in `python/pyproject.toml` (0.1.9 is already on PyPI).

## Before the first release
Trusted Publishing needs a one-time PyPI-side config (repo + workflow `release-gcspy.yml` + environment `pypi`/`testpypi`) — see the dev_docs note. Recommend a TestPyPI dry-run first; the manylinux wheel lane is the part most likely to need a first-run fixup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
