### PR TITLE
Extensional GAC: iterate domains without coroutine generators

### DIFF
--- a/dev_docs/constraints.md
+++ b/dev_docs/constraints.md
@@ -388,9 +388,20 @@ Inside the propagator body, the `State` parameter exposes:
 - `state.bounds(v)` → `pair<Integer, Integer>` (lower, upper).
 - `state.in_domain(v, val)` → bool.
 - `state.has_single_value(v)` → bool.
+- `state.for_each_value_immutable(v, cb)` / `state.for_each_value_mutable(v, cb)`
+  → call `cb(value)` for each value in the current domain, ascending. Use
+  `_immutable` if you only read; `_mutable` if you might infer a removal
+  mid-iteration. A `cb` returning `bool` stops iteration by returning `false`;
+  one returning `void` runs to completion. **Prefer these anywhere that runs
+  per wake** — see the note below.
 - `state.each_value_immutable(v)` / `state.each_value_mutable(v)` →
-  ranges over the current domain. Use `_immutable` if you only read;
-  `_mutable` if you might infer a removal mid-iteration.
+  the same two contracts as ranges, for a `for (auto val : ...)` loop. They
+  allocate a `std::generator` frame per loop and route each value through a
+  `std::function`, which is real per-call cost in a propagator body: converting
+  the three loops in `propagate_extensional` to the callback forms above was
+  worth 1.4x end-to-end on every shape measured (PR #786), with nothing else
+  changed. Reach for the range form when a propagator runs once, or when the
+  loop genuinely reads better that way.
 - `state.domains_intersect(v1, v2)` → bool. Does the variables' domains
   share any value? Walks both stored interval sets in merge order
   without copying for the common case. Use this instead of

--- a/dev_docs/state-and-variables.md
+++ b/dev_docs/state-and-variables.md
@@ -304,6 +304,16 @@ constants:
   not rely on that, since it is allowed to be optimised in future to
   avoid the copy. `CurrentState` exposes a single `each_value` (forward)
   and `each_value_reversed` (descending) for callback-time consumers.
+- `for_each_value_immutable(var, cb)`, `for_each_value_mutable(var, cb)` —
+  the same two contracts, delivered by calling `cb(value)` in ascending
+  order rather than returning a generator. A `cb` returning `bool` stops
+  iteration on `false`; one returning `void` runs to completion (that is
+  `IntervalSet::for_each`'s contract, selected with `if constexpr`).
+  These skip the coroutine frame, the `std::function` the view
+  application needs in the generator version, and the `IntervalSet`
+  copy, so they are the right default inside a propagator — see
+  [propagator-performance.md](propagator-performance.md), and note that
+  the `_immutable` one does **not** snapshot (below).
 - `copy_of_values(var)` — full snapshot as an `IntervalSet<Integer>`.
 - `domain_intersects_with(var, IntervalSet)` — does the variable's
   domain share any value with the given set? The common case
@@ -337,6 +347,14 @@ after computing the answer in the actual variable's coordinate system.
 
 - **Pick `_immutable` vs `_mutable` by intent, not by what works.**
   Calling `each_value_immutable` with the intention of modifying the
-  domain during iteration happens to work today (both variants
-  snapshot) but is not guaranteed to work in future. Use `_mutable` if
-  you intend to mutate, `_immutable` if you don't.
+  domain during iteration happens to work today (both generator
+  variants snapshot) but is not guaranteed to work in future. Use
+  `_mutable` if you intend to mutate, `_immutable` if you don't.
+
+  **For the callback forms this is not a future-proofing point but a
+  live hazard.** `for_each_value_mutable` copies the `IntervalSet`
+  first; `for_each_value_immutable` walks the stored one directly. So
+  inferring a removal from inside a `for_each_value_immutable` callback
+  mutates the container being iterated — undefined behaviour now, not
+  merely unsupported later. If the callback can reach `inference.infer`
+  on the variable being iterated, it must be `_mutable`.

--- a/gcs/constraints/extensional_utils.cc
+++ b/gcs/constraints/extensional_utils.cc
@@ -75,7 +75,7 @@ auto gcs::innards::propagate_extensional(
     visit(
         [&](const auto & tuples) {
             auto none_feasible = true;
-            for (auto tuple_idx : state.each_value_mutable(table.selector)) {
+            state.for_each_value_mutable(table.selector, [&](Integer tuple_idx) {
                 bool is_feasible = true;
                 for (unsigned idx = 0; idx < table.vars.size(); ++idx)
                     if (! feasible(state, table.vars[idx], get_tuple_value(tuples, tuple_idx.as_index(), idx))) {
@@ -91,7 +91,7 @@ auto gcs::innards::propagate_extensional(
                     inference.contradiction(logger, JustifyUsingRUP{hint}, generic_reason(table.vars));
                 else
                     inference.infer(logger, table.selector != Integer(tuple_idx), NoJustificationNeeded{}, NoReason{});
-            }
+            });
             if (none_feasible && logger && logger->get_assertion_level() != AssertionLevel::Off)
                 // selector already empty on entry
                 inference.contradiction(logger, JustifyUsingRUP{hint}, generic_reason(table.vars));
@@ -121,7 +121,7 @@ auto gcs::innards::propagate_extensional(
             for (unsigned idx = 0; idx < table.vars.size(); ++idx) {
                 auto & residue_row = residues.support[idx];
                 auto base = residues.base[idx];
-                for (auto val : state.each_value_mutable(table.vars[idx])) {
+                state.for_each_value_mutable(table.vars[idx], [&](Integer val) {
                     auto off = static_cast<std::size_t>(val.raw_value - base);
                     bool have_row = off < residue_row.size();
 
@@ -130,23 +130,24 @@ auto gcs::innards::propagate_extensional(
                         auto cached = residue_row[off];
                         if (cached != ExtensionalResidues::none && state.in_domain(table.selector, Integer(static_cast<long long>(cached))) &&
                             match(get_tuple_value(tuples, cached, idx), val))
-                            continue;
+                            return;
                     }
 
                     bool supported = false;
-                    for (auto tuple_idx : state.each_value_immutable(table.selector)) {
+                    state.for_each_value_immutable(table.selector, [&](Integer tuple_idx) -> bool {
                         if (match(get_tuple_value(tuples, tuple_idx.as_index(), idx), val)) {
                             supported = true;
                             if (have_row)
                                 residue_row[off] = static_cast<std::uint32_t>(tuple_idx.as_index());
-                            break;
+                            return false;
                         }
-                    }
+                        return true;
+                    });
 
                     if (! supported) {
                         inference.infer(logger, table.vars[idx] != val, JustifyUsingRUP{hint}, generic_reason(table.vars));
                     }
-                }
+                });
             }
         },
         table.tuples);


### PR DESCRIPTION
`propagate_extensional`'s three domain loops used `each_value_mutable()` /
`each_value_immutable()`, which allocate a `std::generator` frame per loop and
route each value through a `std::function`. The non-coroutine
`for_each_value_*()` alternatives do the same thing with a callback.

Purely mechanical: same values, same order, same inferences. `recursions`,
`propagations` and solution counts are identical on every shape measured, so
this is a pure per-call speed change with no effect on the search.

### Measurements

`positive_table_random`, fataepyc-10 pinned (`numactl --cpunodebind=0 --membind=0
taskset -c 4 setarch -R`), boost disabled, median of 3:

| shape | before | after | speedup |
|---|---|---|---|
| `--domain=12` | 0.241 s | 0.169 s | 1.43x |
| `--domain=15` | 5.649 s | 4.005 s | 1.41x |
| `--domain=18 --vars=25 --constraints=150` | 3.295 s | 2.346 s | 1.40x |
| `--domain=25 --vars=20 --constraints=100 --tightness=0.5` | 0.606 s | 0.433 s | 1.40x |

`recursions` matched exactly on all four (439, 11252, 20528, 659).

A leaf-attribution `perf` profile on `--domain=15` says why: before the change,
coroutine machinery plus the allocations it drives was **37%** of samples
(`each_value_generator` actor frames, `IntervalSet::each()` actor frames, the
`std::function` in the generator's view application, and the promise
allocations). After, it is **0.1%**.

### Scope

This touches the shared helper, so `Table`, the `AutoTable` presolver and every
runtime-tabulated constraint (`Multiply`, `Divide`, `Modulus`, `Power`, `Plus`,
`Minus`, GAC `Linear`) all benefit. It is deliberately separated from the table
propagator work in #508 so that a later compact-table change cannot take credit
for it.

Groundwork for #508; relevant to the throughput audit in #503.

### Testing

- `ctest` 749/749 with `GCS_ENABLE_XCSP=ON` and `GCS_ENABLE_MINIZINC=ON`
- `ctest` 631/631 with `GCS_TEST_CAP_DEFAULTS=OFF`, so enumeration completeness
  is actually checked rather than capped
- full workflow-2 chain re-run with a real `cake_pb_cp` on `table_sat`,
  `table_unsat`, `negative_table_sat` and `negative_table_unsat`: all
  `s VERIFIED`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012mn99ERAhD4YrAaqZrdjZ3