### PR TITLE
Print an all-par var bool output array as booleans (#785)

### DIFF
--- a/minizinc/CMakeLists.txt
+++ b/minizinc/CMakeLists.txt
@@ -251,6 +251,14 @@ add_test(NAME minizinc-cumulativeopt-fzn COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}
 add_test(NAME minizinc-emptysetin COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_fzn_json_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ empty_set_in)
 add_test(NAME minizinc-emptysetinreif COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_fzn_json_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ empty_set_in_reif)
 
+# A var bool output array whose every element the flattener has fixed (#785).
+# This has to be hand-written JSON: MiniZinc drops such an array from `output`
+# unless something else keeps it alive, so a .mzn model cannot reach it. `ns` is
+# the all-par array that used to print as 1 / 0; `es` keeps one live variable, so
+# it prints correctly either way and shows the two disagreeing in one solution;
+# `ds` is all-par ints, and is here so the fix cannot start calling those bools.
+add_test(NAME minizinc-parboolarrayoutput COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_fzn_json_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ par_bool_array_output)
+
 add_test(NAME minizinc-small COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ small true true)
 set_tests_properties(minizinc-small PROPERTIES SKIP_RETURN_CODE 66)
 

--- a/minizinc/fzn_glasgow.cc
+++ b/minizinc/fzn_glasgow.cc
@@ -463,6 +463,11 @@ auto main(int argc, char * argv[]) -> int
                     seen_a_bool = seen_a_bool || data.integer_variables.at(string{v}).second;
                 }
                 else {
+                    // A literal counts towards seen_a_bool just as a variable reference
+                    // does: the flag decides whether the solution printer says true /
+                    // false or an integer, and if the flattener has fixed every element
+                    // of a var bool array then no variable is left to recover it from.
+                    seen_a_bool = seen_a_bool || v.is_boolean();
                     Integer val = v.is_boolean() ? (static_cast<bool>(v) ? 1_i : 0_i) : Integer{v.get<long long>()};
                     values.push_back(val);
                     variables.push_back(ConstantIntegerVariableID{val});

--- a/minizinc/tests/json/par_bool_array_output.expected
+++ b/minizinc/tests/json/par_bool_array_output.expected
@@ -1,0 +1,11 @@
+----------
+----------
+==========
+ds = [3, 4];
+ds = [3, 4];
+es = [false, true];
+es = [true, true];
+ns = [true, false];
+ns = [true, false];
+x = false;
+x = true;

--- a/minizinc/tests/json/par_bool_array_output.fzn
+++ b/minizinc/tests/json/par_bool_array_output.fzn
@@ -1,0 +1,14 @@
+{
+    "variables": {
+        "x": { "type": "bool" }
+    },
+    "arrays": {
+        "ns": { "a": [true, false] },
+        "es": { "a": ["x", true] },
+        "ds": { "a": [3, 4] }
+    },
+    "constraints": [],
+    "output": ["x", "ns", "es", "ds"],
+    "solve": { "method": "satisfy" },
+    "version": "1.0"
+}


### PR DESCRIPTION
Fixes #785.

## The bug

`fzn-glasgow` printed a `var bool` output array as `1` / `0` whenever the flattener had fixed **every** element of it, and MiniZinc threw the solution out:

```
Error: type error: assignment value for `ns' has invalid type-inst:
expected `array[int] of par bool', actual `array[int] of int'
```

reporting `=====UNKNOWN=====` with `nSolutions=0`, so a correct answer looked like a solver failure.

## The cause and the fix

The solution printer (`minizinc/fzn_glasgow.cc:1227`) picks `true`/`false` over an integer from the `bool` in `variable_arrays`. Reading the `arrays` section only ever set that flag from an element that was a *variable reference*, recovering it from that variable's declared type. A literal `true` or `false` went down the constant branch, which reads `is_boolean()` to pick the right `Integer` but never recorded that the array was Boolean at all. So an array with one live variable left in it printed correctly, and a fully-decided one did not — which is why this needed every element par to show up.

The fix sets the flag on the constant branch too. That `bool` is read in exactly one place, the printer, so nothing else moves; scalar `var bool` outputs were never affected, because those take the flag from `integer_variables`, populated from the variable's declared type.

## Verified end to end

The `dpath` model from the issue — a five-node digraph whose only 1-to-5 path is the single edge `1 -> 5`, so the flattener fixes all of `ns`:

```
$ minizinc --solver Glasgow dpath.mzn dpath.dzn      # before
=====UNKNOWN=====
Error: type error: assignment value for `ns' has invalid type-inst: expected `array[int] of par bool', actual `array[int] of int'

$ minizinc --solver Glasgow dpath.mzn dpath.dzn      # after
ns = [true, false, false, false, true];
es = [false, true, false, false, false, false, false];
s = 1;
t = 5;
----------
```

which is byte-identical to Gecode's answer on the same model.

## The test

It has to be hand-written JSON FlatZinc, fed through the existing `run_fzn_json_test.bash` harness: MiniZinc drops a fully-par array from `output` unless something else keeps it alive, so no `.mzn` model can reach this path. `par_bool_array_output.fzn` carries all three shapes at once, so one fixture pins the whole printer decision:

- `ns`, all-par bool — the bug;
- `es`, bool with one live variable — correct before and after, and disagreeing with `ns` inside a single solution, which is the diagnosis made visible;
- `ds`, all-par int — there so the fix cannot start calling those Booleans.

Without the change it fails on `ns` and nothing else:

```
-ns = [true, false];
-ns = [true, false];
+ns = [1, 0];
+ns = [1, 0];
```

With it, VeriPB reports `s VERIFIED COMPLETE ENUMERATION OF 2 SOLUTIONS`. All 85 `minizinc-*` tests pass, and clang-format is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)