### PR TITLE
A SubCircuit constraint, with check and prevent certified

### DIFF
--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -30,6 +30,7 @@ add_library(glasgow_constraint_solver
         constraints/circuit/circuit_base.cc
         constraints/circuit/circuit_prevent.cc
         constraints/circuit/circuit_scc.cc
+        constraints/circuit/subcircuit.cc
         constraints/comparison/comparison.cc
         constraints/count/count.cc
         constraints/cumulative/cumulative.cc
@@ -767,6 +768,20 @@ if(GCS_BUILD_TESTS)
     target_link_libraries(circuit_test PRIVATE glasgow_constraint_solver)
     add_test(NAME circuit_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:circuit_test>)
     add_view_tests(circuit_constraint circuit_test 5)
+
+    add_executable(subcircuit_prevent_test constraints/circuit/subcircuit_prevent_test.cc)
+    target_link_libraries(subcircuit_prevent_test PRIVATE glasgow_constraint_solver)
+    add_test(NAME subcircuit_prevent COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:subcircuit_prevent_test>)
+    add_view_tests(subcircuit_prevent subcircuit_prevent_test 8)
+
+    add_executable(subcircuit_test constraints/circuit/subcircuit_test.cc)
+    target_link_libraries(subcircuit_test PRIVATE glasgow_constraint_solver)
+    add_test(NAME subcircuit_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:subcircuit_test>)
+    add_view_tests(subcircuit_constraint subcircuit_test 5)
+
+    add_executable(subcircuit_dup_test constraints/circuit/subcircuit_dup_test.cc)
+    target_link_libraries(subcircuit_dup_test PRIVATE glasgow_constraint_solver)
+    add_test(NAME subcircuit_dup COMMAND $<TARGET_FILE:subcircuit_dup_test>)
 
     add_executable(circuit_dup_test constraints/circuit/circuit_dup_test.cc)
     target_link_libraries(circuit_dup_test PRIVATE glasgow_constraint_solver)

--- a/gcs/constraints/circuit.hh
+++ b/gcs/constraints/circuit.hh
@@ -2,5 +2,6 @@
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CIRCUIT_HH
 
 #include <gcs/constraints/circuit/circuit.hh>
+#include <gcs/constraints/circuit/subcircuit.hh>
 
 #endif // GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CIRCUIT_HH

--- a/gcs/constraints/circuit/hints.hh
+++ b/gcs/constraints/circuit/hints.hh
@@ -17,6 +17,17 @@ namespace gcs::innards::hints
         ConstraintID originator;
         static constexpr std::string_view hint_name = "circuit";
     };
+
+    /**
+     * \brief SubCircuit's assertion hint: just the owning constraint.
+     *
+     * \ingroup Innards
+     */
+    struct SubCircuit
+    {
+        ConstraintID originator;
+        static constexpr std::string_view hint_name = "subcircuit";
+    };
 }
 
 #endif

--- a/gcs/constraints/circuit/subcircuit.cc
+++ b/gcs/constraints/circuit/subcircuit.cc
@@ -1,0 +1,481 @@
+#include <gcs/constraints/all_different.hh>
+#include <gcs/constraints/all_different/encoding.hh>
+#include <gcs/constraints/all_different/vc_all_different.hh>
+#include <gcs/constraints/circuit/hints.hh>
+#include <gcs/constraints/circuit/subcircuit.hh>
+#include <gcs/exception.hh>
+#include <gcs/innards/inference_tracker.hh>
+#include <gcs/innards/proofs/names_and_ids_tracker.hh>
+#include <gcs/innards/proofs/pol_builder.hh>
+#include <gcs/innards/proofs/proof_model.hh>
+#include <gcs/innards/propagators.hh>
+#include <gcs/innards/s_expr.hh>
+
+#include <util/enumerate.hh>
+#include <util/overloaded.hh>
+
+#include <algorithm>
+#include <any>
+#include <map>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <variant>
+#include <vector>
+#include <version>
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+#include <format>
+#else
+#include <fmt/core.h>
+#endif
+
+using namespace gcs;
+using namespace gcs::innards;
+using namespace gcs::innards::subcircuit;
+
+using gcs::subcircuit::Check;
+using gcs::subcircuit::Prevent;
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+using std::format;
+#else
+using fmt::format;
+#endif
+
+using std::make_optional;
+using std::make_unique;
+using std::map;
+using std::nullopt;
+using std::optional;
+using std::size_t;
+using std::string;
+using std::to_string;
+using std::unique_ptr;
+using std::vector;
+
+namespace
+{
+    // The membership sum: how many nodes are on the tour. A node off the tour points at
+    // itself, so this is just a count of the "not a self loop" literals, which means the
+    // tour's length is a linear expression over literals the solver already has and needs
+    // no auxiliary variable of its own. That is what keeps the wrap-around row linear.
+    auto tour_size_sum(const vector<IntegerVariableID> & succ) -> WPBSum
+    {
+        WPBSum sum;
+        for (const auto & [idx, s] : enumerate(succ))
+            sum += 1_i * (s != Integer(static_cast<long long>(idx)));
+        return sum;
+    }
+
+    // One walk of the graph of fixed successor edges, splitting it into the closed cycles
+    // and the open chains. Self loops are their own one-node cycles: a node pointing at
+    // itself is off the tour, so it neither closes anything nor blocks anything.
+    struct FixedEdges
+    {
+        // Each cycle, in order, as visited. Length one means a self loop.
+        vector<vector<long>> cycles;
+        // Each maximal open chain, in order: chain.front() has no fixed predecessor and
+        // chain.back()'s successor is not yet fixed.
+        vector<vector<long>> chains;
+    };
+
+    auto walk_fixed_edges(const vector<IntegerVariableID> & succ, const State & state) -> FixedEdges
+    {
+        auto n = static_cast<long>(succ.size());
+        auto fixed = vector<optional<long>>(n, nullopt);
+        auto has_fixed_pred = vector<bool>(n, false);
+        for (long i = 0; i < n; ++i)
+            if (auto v = state.optional_single_value(succ[i])) {
+                fixed[i] = v->raw_value;
+                has_fixed_pred[v->raw_value] = true;
+            }
+
+        FixedEdges result;
+        auto seen = vector<bool>(n, false);
+
+        // Open chains first: they start at a fixed edge whose tail nothing points at.
+        for (long i = 0; i < n; ++i) {
+            if (! fixed[i] || has_fixed_pred[i] || seen[i])
+                continue;
+            vector<long> chain{i};
+            seen[i] = true;
+            auto j = *fixed[i];
+            while (true) {
+                // A node is only ever reached once from a chain start, because a node with
+                // a fixed predecessor is not a chain start -- unless two successors are
+                // fixed to the same value, which the all-different pass above rejects. If
+                // it somehow happens anyway, stop rather than following the loop forever:
+                // circuit_base.cc guards the same spot for the same reason.
+                if (seen[j])
+                    break;
+                chain.emplace_back(j);
+                seen[j] = true;
+                if (! fixed[j])
+                    break;
+                j = *fixed[j];
+            }
+            result.chains.emplace_back(std::move(chain));
+        }
+
+        // Whatever still has a fixed successor and has not been seen is on a cycle.
+        for (long i = 0; i < n; ++i) {
+            if (! fixed[i] || seen[i])
+                continue;
+            vector<long> cycle;
+            auto j = i;
+            auto closed = false;
+            do {
+                cycle.emplace_back(j);
+                seen[j] = true;
+                j = *fixed[j];
+                if (j == i) {
+                    closed = true;
+                    break;
+                }
+            } while (! seen[j]);
+
+            // The walk can only fail to come back to where it started if two successors
+            // are fixed to the same value, which the all-different pass above rejects. Drop
+            // the walk rather than hand a certificate a list of edges that are not all
+            // really there.
+            if (closed)
+                result.cycles.emplace_back(std::move(cycle));
+        }
+
+        return result;
+    }
+
+    // Francis and Stuckey's evidence node: one that cannot be a self loop, and so must be
+    // on the tour. Without one, a closed cycle is not yet wrong -- every other node might
+    // still opt out -- so nothing at all can be inferred. Returns the lowest-numbered such
+    // node outside `exclude`, which is their default choice.
+    auto find_evidence_node(const vector<IntegerVariableID> & succ, const State & state, const vector<bool> & exclude) -> optional<long>
+    {
+        for (const auto & [idx, s] : enumerate(succ)) {
+            auto i = static_cast<long>(idx);
+            if (exclude[i])
+                continue;
+            if (! state.in_domain(s, Integer{i}))
+                return i;
+        }
+        return nullopt;
+    }
+}
+
+namespace
+{
+    // Derive, at the current proof level, that the tour holds at most `cycle.size()` nodes
+    // given the assignments round `cycle`.
+    //
+    // Two cases have to be covered, and they pull in opposite directions:
+    //
+    //  * no node of the cycle is `first`, so every edge takes its step row, and chaining
+    //    those round the cycle telescopes to 0 >= |cycle|, which is absurd;
+    //  * some node a of the cycle is `first`, so the edge into a takes its wrap row
+    //    instead, and chaining telescopes to |tour| <= |cycle|.
+    //
+    // Adding the first row to each of the others resolves away the `first` flags, leaving
+    // the bound with no case still open. Circuit needs none of this: its anchor is node 0,
+    // so it always knows statically which edge is the wrap edge.
+    auto derive_tour_at_most(ProofLogger & logger, const SubCircuitPosData & pos_data, const vector<long> & cycle) -> void
+    {
+        auto k = cycle.size();
+        auto next = [&](size_t t) { return cycle[(t + 1) % k]; };
+
+        // Running-saturate, as circuit_scc.cc does: the first push is plain, every
+        // subsequent one is followed by `s`, because these sums are not clause-shaped and
+        // an intermediate saturation can shrink coefficients usefully.
+        auto add_sat = [](PolBuilder & p, ProofLine line) -> PolBuilder & { return p.empty() ? p.add(line) : p.add(line).saturate(); };
+
+        if (! pos_data.defined)
+            throw UnexpectedException{"SubCircuit tried to justify an inference with no position encoding"};
+
+        // One comment for the whole derivation rather than one per case: there are
+        // |cycle| + 1 cases and a proof comment costs bytes at every firing.
+        logger.emit_proof_comment(format("this cycle of {} bounds the whole tour, whichever of its nodes is first", k));
+
+        PolBuilder no_first;
+        for (size_t t = 0; t < k; ++t)
+            add_sat(no_first, pos_data.edges.at(cycle[t]).at(next(t)).step_ge);
+
+        PolBuilder combine;
+        combine.add(no_first.emit(logger, ProofLevel::Current));
+        for (size_t s = 0; s < k; ++s) {
+            PolBuilder this_first;
+            for (size_t t = 0; t < k; ++t) {
+                const auto & lines = pos_data.edges.at(cycle[t]).at(next(t));
+                add_sat(this_first, next(t) == cycle[s] ? lines.wrap_le : lines.step_le);
+            }
+            add_sat(combine, this_first.emit(logger, ProofLevel::Current));
+        }
+
+        combine.emit(logger, ProofLevel::Current);
+    }
+
+    auto propagate_subcircuit(const vector<IntegerVariableID> & succ, const ConstraintID & owner, const SubCircuitPosData & pos_data,
+        const ConstraintStateHandle & unassigned_handle, const bool prevent, const State & state, auto & inference, ProofLogger * const logger)
+        -> void
+    {
+        if (! propagate_non_gac_alldifferent(unassigned_handle, state, inference, logger, owner))
+            return;
+
+        auto n = succ.size();
+        // One walk per call, from scratch. circuit::Prevent keeps its chain endpoints in
+        // backtrackable state and folds each newly fixed edge in in O(1); nothing here
+        // needs that yet, and a from-scratch walk is much easier to read, but it is the
+        // obvious thing to do if this ever shows up in a profile.
+        auto edges = walk_fixed_edges(succ, state);
+
+        // A closed cycle of two or more nodes is the whole tour, so every other node has
+        // to be a self loop. This is Francis and Stuckey's `check`: for Circuit a short
+        // cycle is a flat contradiction, but here it only pins down everyone else.
+        for (const auto & cycle : edges.cycles) {
+            if (cycle.size() < 2)
+                continue; // a self loop says only that its own node is off the tour
+
+            auto on_cycle = vector<bool>(n, false);
+            for (auto v : cycle)
+                on_cycle[v] = true;
+
+            vector<Literal> off;
+            for (size_t m = 0; m < n; ++m) {
+                if (on_cycle[m])
+                    continue;
+                auto here = Integer(static_cast<long long>(m));
+                // Skip only a node already sitting on its own index: one fixed to anything
+                // else has to go through infer() so that the contradiction is raised and
+                // justified. That is the whole of what makes `check` complete -- Francis
+                // and Stuckey report failure exactly when a node outside the cycle cannot
+                // be a self cycle, and a node fixed elsewhere cannot.
+                if (state.optional_single_value(succ[m]) == here)
+                    continue;
+                off.emplace_back(succ[m] == here);
+            }
+
+            // Nothing left to say: the cycle is the whole graph, or everyone else is
+            // already a self loop.
+            if (off.empty())
+                continue;
+
+            auto justf = [&, cycle](const ReasonLiterals &) { derive_tour_at_most(*logger, pos_data, cycle); };
+            inference.infer_all(logger, off, JustifyExplicitly{justf, ThenRUP::Yes, hints::SubCircuit{owner}}, generic_reason(succ));
+        }
+
+        if (! prevent)
+            return;
+
+        // Now the lookahead. A chain of fixed edges must not close into a cycle while some
+        // node outside it cannot be a self loop -- that node would have nowhere to go. With
+        // no such evidence node there is nothing to infer, because the chain closing and
+        // everyone else opting out is a perfectly good solution.
+        for (const auto & chain : edges.chains) {
+            auto on_chain = vector<bool>(n, false);
+            for (auto v : chain)
+                on_chain[v] = true;
+
+            if (! find_evidence_node(succ, state, on_chain))
+                continue;
+
+            auto start = chain.front();
+            auto end = chain.back();
+            if (! state.in_domain(succ[end], Integer{start}))
+                continue;
+
+            auto closed = chain;
+            auto justf = [&, closed](const ReasonLiterals &) { derive_tour_at_most(*logger, pos_data, closed); };
+            inference.infer(
+                logger, succ[end] != Integer{start}, JustifyExplicitly{justf, ThenRUP::Yes, hints::SubCircuit{owner}}, generic_reason(succ));
+        }
+    }
+}
+
+SubCircuit::SubCircuit(vector<IntegerVariableID> succ) : _succ(std::move(succ))
+{
+    // As Circuit: two slots pinned to the same constant are a valid (if trivially
+    // infeasible) model, so only reject true variable aliasing.
+    for (size_t i = 0; i < _succ.size(); ++i) {
+        if (is_constant_variable(_succ[i]))
+            continue;
+        for (size_t j = i + 1; j < _succ.size(); ++j)
+            if (_succ[i] == _succ[j])
+                throw InvalidProblemDefinitionException{"SubCircuit: successor array contains the same variable handle twice"};
+    }
+}
+
+auto SubCircuit::with_algorithm(SubCircuitAlgorithm algorithm) -> SubCircuit &
+{
+    _algorithm = algorithm;
+    return *this;
+}
+
+auto SubCircuit::with_gac_all_different(optional<bool> enable) -> SubCircuit &
+{
+    _gac_all_different = enable.value_or(true);
+    return *this;
+}
+
+auto SubCircuit::prepare(Propagators & propagators, State & initial_state, ProofModel * const model) -> bool
+{
+    for (const auto & s : _succ) {
+        propagators.define_bound(initial_state, model, s, Bound::Lower, 0_i);
+        propagators.define_bound(initial_state, model, s, Bound::Upper, Integer(static_cast<long long>(_succ.size() - 1)));
+    }
+
+    // As Circuit: the GAC all-different is a child constraint, so it can only be installed
+    // from here, and it must carry this constraint's identity or two SubCircuits in one
+    // problem would share its labelled rows and pair selectors (issue #449). The non-GAC
+    // alternative is pure encoding and lives in define_proof_model().
+    if (_gac_all_different) {
+        AllDifferent all_diff{_succ};
+        all_diff.set_constraint_id(constraint_id());
+        std::move(all_diff).install(propagators, initial_state, model);
+    }
+
+    NonGacAllDifferentUnassigned unassigned{};
+    for (auto v : _succ)
+        unassigned.emplace_back(v);
+    _state_handles.unassigned = initial_state.add_constraint_state(unassigned);
+
+    return true;
+}
+
+auto SubCircuit::define_proof_model(ProofModel & model, const State &) -> void
+{
+    if (! _gac_all_different)
+        define_clique_not_equals_encoding(model, _constraint_id, _succ);
+
+    if (_succ.empty())
+        return;
+
+    auto n = static_cast<long>(_succ.size());
+    auto tour_size = tour_size_sum(_succ);
+    auto & data = _pos_data;
+    data.defined = true;
+
+    for (long i = 0; i < n; ++i)
+        data.pos.emplace(i, model.create_proof_only_integer_variable(0_i, Integer{n - 1}, "subpos", IntegerVariableProofRepresentation::Bits));
+
+    // first[i]: node i is on the tour and every lower-numbered node is off it, written as
+    // "all i+1 of these literals hold". Fully reified, so unit propagation fixes the flag
+    // from the successors -- a half-reified flag would leave it free on a solution and the
+    // rows below that need it would not check.
+    for (long i = 0; i < n; ++i) {
+        auto conjunction = WPBSum{} + 1_i * (_succ[i] != Integer{i});
+        for (long j = 0; j < i; ++j)
+            conjunction += 1_i * (_succ[j] == Integer{j});
+        data.first.emplace(i, model.create_proof_flag_fully_reifying(_constraint_id, {i}, "first", conjunction >= Integer{i + 1}));
+    }
+
+    // The tour starts at whichever node is first...
+    for (long i = 0; i < n; ++i)
+        data.first_is_zero.emplace(i,
+            model.add_labelled_constraint(
+                _constraint_id, "first_pos_" + to_string(i), WPBSum{} + 1_i * data.pos.at(i) <= 0_i, HalfReifyOnConjunctionOf{{data.first.at(i)}}));
+
+    // ...and a node off the tour is given position zero. Nothing here needs the positions to
+    // be a permutation -- no certificate below relies on them being distinct -- and an
+    // off-tour node takes part in no position row at all: it has no successor other than
+    // itself, and by all-different nothing else can point at it either. So the only job
+    // these rows have is to leave `pos` determined by the successors under unit
+    // propagation, which is what solution checking needs, and zero does that as well as
+    // anything.
+    //
+    // The stdlib decomposition instead numbers off-tour nodes after every on-tour one, in
+    // index order, which does make the positions a permutation. That is what to reach for
+    // if the wrap rows below ever move into the proof -- the counting argument they would
+    // need is a pigeonhole over the positions -- but it costs n rows of n+1 terms where
+    // this costs n rows of one, and nothing today buys anything with it.
+    for (long i = 0; i < n; ++i)
+        model.add_labelled_constraint(
+            _constraint_id, "off_pos_" + to_string(i), WPBSum{} + 1_i * data.pos.at(i) <= 0_i, HalfReifyOnConjunctionOf{{_succ[i] == Integer{i}}});
+
+    // Each edge gets two row families rather than Circuit's one, because which edge wraps
+    // around is not known statically: it is the edge into whichever node is `first`, and
+    // that is only pinned down once the membership literals are. Circuit anchors on node 0,
+    // so it writes the `+1` form for every column but 0 and the wrap form for column 0, and
+    // never both for the same edge.
+    //
+    // This is the one place where the encoding carries something for the proof's benefit
+    // rather than saying the constraint as compactly as it could, so it is worth recording
+    // why rather than leaving it to be rediscovered. The wrap rows are what let a
+    // propagator that has found a closed cycle *count*: chaining them gives "the tour is no
+    // longer than this cycle" in a bounded number of steps (see derive_tour_at_most).
+    // Without them the encoding is smaller -- n^2 row families rather than 2n^2, smaller
+    // than the stdlib decomposition -- and still exact, because a cycle avoiding the anchor
+    // still chains to 0 = k. But then that counting fact has to be derived instead, and
+    // deriving it needs "the on-tour positions are exactly 0..L-1", a pigeonhole induction
+    // *conditional on the variable L*. That is the same obstacle that stops circuit_scc.cc's
+    // machinery being ported here, so the smaller encoding is not a free reformulation: it
+    // is blocked on the same open problem.
+    //
+    // The other way out is a statically known anchor, which collapses this to exactly
+    // Circuit's shape, since only the n edges into a nominated on-tour node can wrap. That
+    // needs the caller to name one. The C++ and .scp interfaces could; MiniZinc cannot on
+    // the models that matter, because both challenge models post their "this node is
+    // visited" constraint *after* the subcircuit call and MiniZinc flattens in source order,
+    // so the domain is not yet narrowed when the redefinition runs.
+    for (long i = 0; i < n; ++i)
+        for (long j = 0; j < n; ++j) {
+            if (i == j)
+                continue;
+
+            auto step = WPBSum{} + 1_i * data.pos.at(j) + -1_i * data.pos.at(i);
+            auto [step_le, step_ge] = model.add_labelled_constraint(_constraint_id, "pos_step_" + to_string(i) + "_" + to_string(j) + "_le",
+                "pos_step_" + to_string(i) + "_" + to_string(j) + "_ge", step == 1_i,
+                HalfReifyOnConjunctionOf{{_succ[i] == Integer{j}, ! data.first.at(j)}});
+
+            auto wrap = WPBSum{} + 1_i * data.pos.at(j) + -1_i * data.pos.at(i);
+            for (const auto & term : tour_size.terms)
+                wrap += term;
+            auto [wrap_le, wrap_ge] = model.add_labelled_constraint(_constraint_id, "pos_wrap_" + to_string(i) + "_" + to_string(j) + "_le",
+                "pos_wrap_" + to_string(i) + "_" + to_string(j) + "_ge", wrap == 1_i,
+                HalfReifyOnConjunctionOf{{_succ[i] == Integer{j}, data.first.at(j)}});
+
+            data.edges[i].emplace(j, EdgePosLines{step_le, step_ge, wrap_le, wrap_ge});
+        }
+}
+
+auto SubCircuit::install_propagators(Propagators & propagators) -> void
+{
+    auto prevent = std::holds_alternative<Prevent>(_algorithm);
+
+    Triggers triggers;
+    triggers.on_instantiated = {_succ.begin(), _succ.end()};
+    propagators.install(
+        constraint_id(),
+        [succ = _succ, owner = constraint_id(), pos_data = std::move(_pos_data), unassigned_handle = _state_handles.unassigned, prevent](
+            const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+            propagate_subcircuit(succ, owner, pos_data, unassigned_handle, prevent, state, inference, logger);
+            // Deliberately not claiming idempotence, unlike circuit::Prevent: forcing a
+            // node to be a self loop fixes a successor, which changes the chain structure
+            // this pass walked, and one pass makes no attempt to reach the fixpoint of
+            // that cascade. The triggers cover it -- every inference here instantiates a
+            // successor, so the propagator is re-woken.
+            return PropagatorState::Enable;
+        },
+        triggers);
+}
+
+auto SubCircuit::clone() const -> unique_ptr<Constraint>
+{
+    auto cloned = make_unique<SubCircuit>(_succ);
+    cloned->with_algorithm(_algorithm);
+    cloned->with_gac_all_different(_gac_all_different);
+    return cloned;
+}
+
+auto SubCircuit::constraint_type() const -> string
+{
+    return "subcircuit";
+}
+
+auto SubCircuit::s_expr(const ProofModel * const model) const -> SExpr
+{
+    auto & tracker = model->names_and_ids_tracker();
+    vector<SExpr> vars;
+    for (const auto & var : _succ)
+        vars.push_back(tracker.s_expr_term_of(var));
+    return SExpr::list({SExpr::atom(as_string(_constraint_id)), SExpr::atom(constraint_type()), SExpr::list(std::move(vars))});
+}

--- a/gcs/constraints/circuit/subcircuit.hh
+++ b/gcs/constraints/circuit/subcircuit.hh
@@ -1,0 +1,124 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_CIRCUIT_SUBCIRCUIT_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_CIRCUIT_SUBCIRCUIT_HH
+
+#include <gcs/constraint.hh>
+#include <gcs/constraints/circuit/subcircuit_base.hh>
+#include <gcs/variable_id.hh>
+
+#include <memory>
+#include <optional>
+#include <variant>
+#include <vector>
+
+namespace gcs
+{
+    namespace subcircuit
+    {
+        /**
+         * \brief Propagate SubCircuit by checking only: follow each chain of fixed
+         * successors, and when one closes into a cycle, force every node outside that
+         * cycle to be a self loop.
+         *
+         * This is Francis and Stuckey's `check`. It fires only on instantiation and does
+         * no lookahead, so it is the cheapest option and the weakest.
+         *
+         * \ingroup Constraints
+         */
+        struct Check final
+        {
+        };
+
+        /**
+         * \brief Propagate SubCircuit by checking and preventing: as subcircuit::Check,
+         * and additionally forbid a chain of fixed successors from closing into a cycle
+         * whenever some node outside the chain is already known to be on the circuit.
+         *
+         * This is Francis and Stuckey's `check` plus `prevent`; `prevent` is not complete
+         * on its own, so the two always go together. This is the default.
+         *
+         * The node outside the chain is their *evidence node*: unlike Circuit, where any
+         * short cycle is a contradiction, a short cycle here is only wrong if some other
+         * node cannot be a self loop, so nothing can be inferred until such a node exists.
+         *
+         * \ingroup Constraints
+         */
+        struct Prevent final
+        {
+        };
+    }
+
+    /**
+     * \brief The propagation algorithms supported by SubCircuit: subcircuit::Prevent (the
+     * default) or subcircuit::Check (cheaper and weaker). Requesting anything else is a
+     * compile-time error, and the choice never changes the constraint's meaning or its
+     * proof encoding.
+     *
+     * \ingroup Constraints
+     */
+    using SubCircuitAlgorithm = std::variant<subcircuit::Check, subcircuit::Prevent>;
+
+    /**
+     * \brief SubCircuit constraint: requires the variables, representing graph nodes, to
+     * take values such that each variable's value is the index of the next node on a
+     * single tour, where a node not on the tour takes its own index as its value.
+     *
+     * This is MiniZinc's `subcircuit`, and the semantics have three corners worth stating
+     * outright:
+     *
+     * - the **empty** subcircuit, every node pointing at itself, is a solution;
+     * - the smallest non-empty one has **two** nodes, since a node pointing at itself is
+     *   by definition off the tour, so there is no one-node cycle either to allow or to
+     *   forbid;
+     * - the successors are a permutation whether or not a node is on the tour, so
+     *   all-different holds over the whole array. A node off the tour takes its own index,
+     *   which is exactly what stops it being anyone else's successor.
+     *
+     * Circuit is the stricter constraint that additionally requires every node to be on
+     * the tour; it is not a special case of this one, nor this one of it.
+     *
+     * The constructor takes only the successor array; configure propagation with the
+     * fluent setters. Select the algorithm with with_algorithm() (subcircuit::Prevent by
+     * default, or subcircuit::Check). Neither choice changes the constraint's meaning or
+     * the OPB encoding written for proof logging.
+     *
+     * \ingroup Constraints
+     */
+    class SubCircuit : public Constraint
+    {
+    private:
+        const std::vector<IntegerVariableID> _succ;
+        SubCircuitAlgorithm _algorithm = subcircuit::Prevent{};
+        bool _gac_all_different = false;
+
+        // Backtrackable state allocated by prepare(), consumed by install_propagators().
+        innards::subcircuit::SubCircuitStateHandles _state_handles;
+
+        // The position-variable encoding, built by define_proof_model() and captured by
+        // the algorithm's propagator. Empty when proof logging is off, which is what
+        // both algorithms expect.
+        innards::subcircuit::SubCircuitPosData _pos_data;
+
+        virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
+        virtual auto define_proof_model(innards::ProofModel &, const innards::State &) -> void override;
+        virtual auto install_propagators(innards::Propagators &) -> void override;
+
+    public:
+        explicit SubCircuit(std::vector<IntegerVariableID> succ);
+
+        /// Select the propagation algorithm: subcircuit::Prevent (the default) or
+        /// subcircuit::Check. The choice selects propagation strength only and never
+        /// changes the OPB encoding.
+        auto with_algorithm(SubCircuitAlgorithm algorithm) -> SubCircuit &;
+
+        /// Enforce all-different over the successors with a full generalised-arc-consistent
+        /// propagator, in addition to the subcircuit propagation. Off by default (a cheaper
+        /// value-consistent all-different is always applied regardless).
+        auto with_gac_all_different(std::optional<bool> enable = true) -> SubCircuit &;
+
+        [[nodiscard]] virtual auto clone() const -> std::unique_ptr<Constraint> override;
+        [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
+        [[nodiscard]] virtual auto constraint_type() const -> std::string override;
+    };
+}
+
+#endif // GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_CIRCUIT_SUBCIRCUIT_HH

--- a/gcs/constraints/circuit/subcircuit_base.hh
+++ b/gcs/constraints/circuit/subcircuit_base.hh
@@ -1,0 +1,68 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_CIRCUIT_SUBCIRCUIT_BASE_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_CIRCUIT_SUBCIRCUIT_BASE_HH
+
+#include <gcs/innards/proofs/proof_logger.hh>
+#include <gcs/innards/proofs/proof_only_variables.hh>
+#include <gcs/innards/state.hh>
+
+#include <map>
+#include <optional>
+#include <vector>
+
+namespace gcs::innards::subcircuit
+{
+    /**
+     * \brief The four position rows written for one edge i -> j.
+     *
+     * Circuit needs only one pair per edge, because its tour has a fixed anchor (node 0)
+     * and so the wrap-around edge is known statically. Here the anchor is whichever node
+     * is `first`, which is not known until the membership literals are fixed, so both
+     * cases have to be written and the propagator's certificate splits over them.
+     */
+    struct EdgePosLines
+    {
+        // (succ[i] = j and not first[j]) -> pos[j] - pos[i] = 1
+        ProofLine step_le;
+        ProofLine step_ge;
+        // (succ[i] = j and first[j]) -> pos[j] - pos[i] + |tour| = 1
+        ProofLine wrap_le;
+        ProofLine wrap_ge;
+    };
+
+    /**
+     * \brief The position encoding SubCircuit::define_proof_model() writes, and the proof
+     * lines the propagator's justifications cite.
+     *
+     * `pos[i]` is node i's index along the tour, counting from whichever node is `first`;
+     * a node off the tour is given position **zero**, so the positions are not a
+     * permutation, and `pos[i] >= 1` already says node i is on the tour. Nothing needs them
+     * distinct: an off-tour node takes part in no position row at all, and all these rows
+     * have to do is leave `pos` determined by the successors under unit propagation, which
+     * is what solution checking needs. define_proof_model() says more about why, including
+     * what the permutation the stdlib decomposition does build would be good for.
+     *
+     * Empty when proof logging is off; `defined` says which.
+     */
+    struct SubCircuitPosData
+    {
+        bool defined = false;
+        std::map<long, ProofOnlySimpleIntegerVariableID> pos;
+        // first[i]: node i is on the tour and every lower-numbered node is off it. At most
+        // one of these holds, and exactly one does unless the tour is empty.
+        std::map<long, ProofFlag> first;
+        // first[i] -> pos[i] = 0
+        std::map<long, ProofLine> first_is_zero;
+        std::map<long, std::map<long, EdgePosLines>> edges;
+    };
+
+    /**
+     * \brief The backtrackable state the SubCircuit propagators keep, allocated by
+     * SubCircuit::prepare() and handed to whichever algorithm is installed.
+     */
+    struct SubCircuitStateHandles
+    {
+        ConstraintStateHandle unassigned;
+    };
+}
+
+#endif // GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_CIRCUIT_SUBCIRCUIT_BASE_HH

--- a/gcs/constraints/circuit/subcircuit_dup_test.cc
+++ b/gcs/constraints/circuit/subcircuit_dup_test.cc
@@ -1,0 +1,40 @@
+#include <gcs/constraints/circuit.hh>
+#include <gcs/exception.hh>
+#include <gcs/problem.hh>
+
+#include <cstdlib>
+#include <iostream>
+
+using namespace gcs;
+
+using std::cerr;
+
+namespace
+{
+    auto expect_throw_on_dup(SubCircuitAlgorithm algorithm, const char * which) -> bool
+    {
+        // SubCircuit's successor array must be all-different -- a node off the tour points
+        // at itself, which is what stops anyone else pointing at it -- so aliasing two
+        // slots to the same variable handle is trivially infeasible. As Circuit, we reject
+        // at construction rather than making the user wait for search to say UNSAT. The
+        // rejection is in the constructor, so it fires whichever algorithm is selected.
+        Problem p;
+        auto x = p.create_integer_variable_vector(4, 0_i, 3_i);
+        try {
+            p.post(SubCircuit{{x[0], x[1], x[2], x[1]}}.with_algorithm(algorithm));
+        }
+        catch (const InvalidProblemDefinitionException &) {
+            return true;
+        }
+        cerr << which << ": expected InvalidProblemDefinitionException on duplicate successor var\n";
+        return false;
+    }
+}
+
+auto main(int, char *[]) -> int
+{
+    bool ok = true;
+    ok &= expect_throw_on_dup(subcircuit::Check{}, "subcircuit::Check");
+    ok &= expect_throw_on_dup(subcircuit::Prevent{}, "subcircuit::Prevent");
+    return ok ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/gcs/constraints/circuit/subcircuit_prevent_test.cc
+++ b/gcs/constraints/circuit/subcircuit_prevent_test.cc
@@ -1,0 +1,89 @@
+#include <gcs/constraints/circuit.hh>
+#include <gcs/constraints/in.hh>
+#include <gcs/constraints/innards/constraints_test_utils.hh>
+#include <gcs/problem.hh>
+#include <gcs/solve.hh>
+
+#include <cstdlib>
+#include <iostream>
+#include <optional>
+#include <utility>
+#include <vector>
+
+using namespace gcs;
+using namespace gcs::test_innards;
+
+using std::cout;
+using std::endl;
+using std::make_optional;
+using std::nullopt;
+using std::vector;
+
+// The evidence-node inference, driven directly and with the anchor left undetermined:
+// nodes 0, 1 and 2 stay wide open, so which node is the tour's first is not yet decided
+// when the chain 3 -> 4 -> 5 is stopped from closing.
+//
+// This began life as the test that showed derive_tour_at_most() was load-bearing, because
+// the enumeration in subcircuit_test.cc could not: with off-tour positions numbered after
+// the on-tour ones, unit propagation found the conflict unaided at every n that test runs.
+// Pinning off-tour positions to zero changed that, and the enumeration now catches a
+// missing certificate at n = 5 on its own, so this is no longer the mutation test -- it is
+// a targeted regression test for the evidence-node path and the undetermined anchor, which
+// is worth keeping for its own sake but no longer carries that argument.
+
+auto post_constraints(Problem & p, vector<IntegerVariableID> & nodes) -> void
+{
+    // The forced chain is 3 -> 4 -> 5, and its only closing value is succ[5] = 3.
+    p.post(In{nodes[3], {4_i}});
+    p.post(In{nodes[4], {5_i}});
+    p.post(In{nodes[5], {3_i, 6_i}});
+    // Node 7 cannot be a self loop, so it must be on the tour: it is the evidence node,
+    // and it is outside the chain, so closing the chain would leave it nowhere to go.
+    p.post(In{nodes[7], {0_i, 1_i, 2_i, 3_i, 4_i, 5_i, 6_i}});
+    // Nodes 0, 1 and 2 stay wide open, which is the point: whether each of them is on the
+    // tour is still unknown, so unit propagation cannot tell which node is the tour's
+    // first, and the certificate has to cover every candidate.
+}
+
+auto main(int argc, char * argv[]) -> int
+{
+    establish_and_announce_seed(argc, argv);
+
+    auto view_cfg = parse_view_wrap_config_from_argv(argc, argv);
+
+    constexpr int n_positions = 8;
+    if (view_cfg.single_position && (*view_cfg.single_position < 0 || *view_cfg.single_position >= n_positions)) {
+        cout << "subcircuit_prevent view sweep: position " << *view_cfg.single_position << " out of range for n_positions = " << n_positions
+             << "; skipping" << endl;
+        return EXIT_SUCCESS;
+    }
+    auto wraps = wraps_for_positions(view_cfg, n_positions);
+
+    Problem p;
+    vector<IntegerVariableID> nodes;
+    for (int i = 0; i < n_positions; ++i)
+        nodes.push_back(create_integer_variable_or_constant_with_view(p, std::pair{0, n_positions - 1}, wraps.at(i)));
+
+    post_constraints(p, nodes);
+    p.post(SubCircuit{nodes}.with_algorithm(subcircuit::Prevent{}));
+
+    bool proofs = can_run_veripb();
+    auto proof_name = proofs ? make_optional("subcircuit_prevent_test_" + view_wrap_config_label(view_cfg)) : nullopt;
+    auto stats = solve_with(p, //
+        SolveCallbacks{        //
+            .solution = [&](const CurrentState & s) -> bool {
+                for (const auto & v : nodes)
+                    cout << s(v) << " ";
+                cout << endl;
+                return true;
+            }},
+        proof_name ? make_optional<ProofOptions>(*proof_name) : nullopt);
+
+    cout << stats;
+
+    if (proof_name)
+        if (! verify_proof_and_dispose(*proof_name))
+            return EXIT_FAILURE;
+
+    return EXIT_SUCCESS;
+}

--- a/gcs/constraints/circuit/subcircuit_test.cc
+++ b/gcs/constraints/circuit/subcircuit_test.cc
@@ -1,0 +1,175 @@
+#include <gcs/constraints/circuit.hh>
+#include <gcs/constraints/innards/constraints_test_utils.hh>
+#include <gcs/problem.hh>
+#include <gcs/solve.hh>
+
+#include <cstddef>
+#include <cstdlib>
+#include <iostream>
+#include <set>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+#include <version>
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+#include <print>
+#else
+#include <fmt/core.h>
+#include <fmt/ostream.h>
+#include <fmt/ranges.h>
+#endif
+
+using std::cerr;
+using std::flush;
+using std::make_optional;
+using std::nullopt;
+using std::pair;
+using std::set;
+using std::tuple;
+using std::vector;
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+using std::print;
+using std::println;
+#else
+using fmt::print;
+using fmt::println;
+#endif
+
+using namespace gcs;
+using namespace gcs::test_innards;
+
+// A successor assignment is a subcircuit iff it is a permutation and the nodes that do
+// not point at themselves form at most one cycle. Written straight off MiniZinc's
+// definition, including its two corners: every node pointing at itself (the empty
+// subcircuit) is a solution, and the smallest non-empty tour has two nodes, because a
+// node pointing at itself is by definition off the tour.
+auto is_subcircuit(const vector<int> & succ) -> bool
+{
+    auto n = succ.size();
+
+    vector<bool> used(n, false);
+    for (auto v : succ) {
+        if (v < 0 || std::cmp_greater_equal(v, n))
+            return false;
+        if (used[static_cast<std::size_t>(v)])
+            return false;
+        used[static_cast<std::size_t>(v)] = true;
+    }
+
+    vector<bool> seen(n, false);
+    auto tours = 0;
+    for (std::size_t i = 0; i < n; ++i) {
+        if (seen[i])
+            continue;
+        auto j = i;
+        std::size_t length = 0;
+        do {
+            seen[j] = true;
+            j = static_cast<std::size_t>(succ[j]);
+            ++length;
+        } while (j != i);
+        if (length >= 2)
+            ++tours;
+    }
+
+    return tours <= 1;
+}
+
+enum struct SubCircuitPropagator
+{
+    check,
+    prevent
+};
+
+auto run_subcircuit_test(bool proofs, const ViewWrapConfig & view_cfg, int n, SubCircuitPropagator propagator) -> void
+{
+    auto wraps = wraps_for_positions(view_cfg, n);
+    auto prop_label = propagator == SubCircuitPropagator::prevent ? "prevent" : "check";
+    print(cerr, "subcircuit/{} [{}] n={}{}", prop_label, view_wrap_config_label(view_cfg), n, proofs ? " with proofs:" : ":");
+    cerr << flush;
+
+    vector<pair<int, int>> domains(static_cast<std::size_t>(n), pair{0, n - 1});
+
+    set<tuple<vector<int>>> expected, actual;
+    build_expected(expected, [&](vector<int> succ) { return is_subcircuit(succ); }, domains);
+    println(cerr, " expecting {} solutions", expected.size());
+
+    Problem p;
+    vector<IntegerVariableID> succ;
+    for (int i = 0; i < n; ++i)
+        succ.push_back(create_integer_variable_or_constant_with_view(p, pair{0, n - 1}, wraps.at(static_cast<std::size_t>(i))));
+    if (propagator == SubCircuitPropagator::prevent)
+        p.post(SubCircuit{succ}.with_algorithm(subcircuit::Prevent{}));
+    else
+        p.post(SubCircuit{succ}.with_algorithm(subcircuit::Check{}));
+
+    // Not solve_for_tests_checking_gac: neither algorithm claims arc consistency. Both
+    // wait for a chain of successors to be fixed before they say anything at all, so a
+    // value can easily survive in a domain with no solution behind it.
+    //
+    // This is also the test that keeps derive_tour_at_most() honest, from n = 5 up: swap it
+    // for a plain JustifyUsingRUP and VeriPB rejects the proof here. It did not used to be
+    // -- while off-tour positions were numbered after the on-tour ones, unit propagation
+    // could reach the conflict unaided at these sizes, and only a scenario with the anchor
+    // left undetermined could tell the difference. Pinning off-tour positions to zero made
+    // the cheap test the one that catches it, which is where that check wants to live.
+    auto proof_name = proofs ? make_optional("subcircuit_test_" + std::string{prop_label} + "_" + view_wrap_config_label(view_cfg)) : nullopt;
+    solve_for_tests(p, proof_name, actual, tuple{succ});
+    check_results(proof_name, expected, actual);
+}
+
+// The empty successor array. MiniZinc's own definition special-cases it to `true`, so we
+// are never handed one from there, but a C++ caller can build one out of a loop bound and
+// it should be a no-op rather than a crash: there is no node to be on a tour or off it.
+auto run_empty_test(bool proofs) -> void
+{
+    println(cerr, "subcircuit/empty{}", proofs ? " with proofs:" : ":");
+
+    Problem p;
+    auto witness = p.create_integer_variable(0_i, 1_i);
+    p.post(SubCircuit{vector<IntegerVariableID>{}});
+
+    auto proof_name = proofs ? make_optional<std::string>("subcircuit_test_empty") : nullopt;
+    set<tuple<vector<int>>> expected{tuple{vector<int>{0}}, tuple{vector<int>{1}}}, actual;
+    solve_for_tests(p, proof_name, actual, tuple{vector<IntegerVariableID>{witness}});
+    check_results(proof_name, expected, actual);
+}
+
+auto main(int argc, char * argv[]) -> int
+{
+    establish_and_announce_seed(argc, argv);
+
+    auto view_cfg = parse_view_wrap_config_from_argv(argc, argv);
+
+    // Instances run at n = 3, 4, 5; positions 0..4 cover the largest fully. n = 4 is the
+    // smallest size that says anything beyond all-different: with three nodes every
+    // permutation is a subcircuit, since two disjoint cycles need four nodes between them.
+    constexpr int n_positions = 5;
+    if (view_cfg.single_position && (*view_cfg.single_position < 0 || *view_cfg.single_position >= n_positions)) {
+        println(cerr, "subcircuit view sweep: position {} out of range for n_positions = {}; skipping", *view_cfg.single_position, n_positions);
+        return EXIT_SUCCESS;
+    }
+
+    for (bool proofs : {false, true}) {
+        if (proofs && ! can_run_veripb())
+            continue;
+        for (auto propagator : {SubCircuitPropagator::check, SubCircuitPropagator::prevent}) {
+            for (int n : {3, 4, 5})
+                run_subcircuit_test(proofs, view_cfg, n, propagator);
+            // The degenerate sizes: n=1 has only the empty subcircuit, n=2 has the empty
+            // one and the single 2-cycle. Bare configuration only, as circuit_test does:
+            // the view sweep's positions can exceed these tiny n.
+            if (view_wrap_config_is_effectively_bare(view_cfg, n_positions)) {
+                run_subcircuit_test(proofs, view_cfg, 1, propagator);
+                run_subcircuit_test(proofs, view_cfg, 2, propagator);
+            }
+        }
+        if (view_wrap_config_is_effectively_bare(view_cfg, n_positions))
+            run_empty_test(proofs);
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/gcs/scp_reader.cc
+++ b/gcs/scp_reader.cc
@@ -1085,6 +1085,11 @@ auto gcs::read_scp(Problem & problem, string_view text) -> ScpModel
                 throw ScpReadError{"circuit takes one list: (label circuit (succ...))"};
             post_constraint(problem, Circuit{resolve_variable_list(variables, terms[2], "the circuit successor list")}, label);
         }
+        else if (op == "subcircuit") {
+            if (terms.size() != 3)
+                throw ScpReadError{"subcircuit takes one list: (label subcircuit (succ...))"};
+            post_constraint(problem, SubCircuit{resolve_variable_list(variables, terms[2], "the subcircuit successor list")}, label);
+        }
         else if (op == "array_min" || op == "array_max") {
             // (label array_min (vars...) result): result = min/max of the array.
             if (terms.size() != 4)

--- a/gcs/scp_reader_test.cc
+++ b/gcs/scp_reader_test.cc
@@ -53,6 +53,7 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include <algorithm>
+#include <cstddef>
 #include <cstdio>
 #include <cstdlib>
 #include <fstream>
@@ -69,6 +70,7 @@ using namespace gcs;
 
 using std::map;
 using std::set;
+using std::size_t;
 using std::string;
 using std::string_view;
 using std::vector;
@@ -177,6 +179,47 @@ TEST_CASE("read_scp: circuit enumerates the Hamiltonian cycles")
         ))");
 
     CHECK(solutions == set<map<string, long long>>{{{"A", 1}, {"B", 2}, {"C", 0}}, {{"A", 2}, {"B", 0}, {"C", 1}}});
+}
+
+TEST_CASE("read_scp: subcircuit enumerates the single-tour permutations")
+{
+    // Four nodes is the smallest size that says anything beyond all-different: with three
+    // you cannot fit two disjoint cycles, so every permutation is a subcircuit. Here the
+    // three products of two 2-cycles are the only permutations excluded, leaving 21 --
+    // including the identity, which is the empty subcircuit and a solution.
+    auto solutions = enumerate(R"(
+        (
+            (version 1)
+            (variables (A 0 3) (B 0 3) (C 0 3) (D 0 3))
+            (constraints (_1 subcircuit (A B C D)))
+            (prob_type enumerate)
+        ))");
+
+    CHECK(solutions.size() == 21);
+    for (const auto & s : solutions) {
+        auto succ = vector<long long>{s.at("A"), s.at("B"), s.at("C"), s.at("D")};
+        auto seen = set<long long>{succ.begin(), succ.end()};
+        CHECK(seen.size() == 4);
+        auto tours = 0;
+        auto visited = set<long long>{};
+        for (long long i = 0; i < 4; ++i) {
+            if (visited.contains(i))
+                continue;
+            auto j = i;
+            auto length = 0;
+            do {
+                visited.insert(j);
+                j = succ[static_cast<size_t>(j)];
+                ++length;
+            } while (j != i);
+            if (length >= 2)
+                ++tours;
+        }
+        CHECK(tours <= 1);
+    }
+    // The two products of two 2-cycles that all-different alone would allow.
+    CHECK(! solutions.contains({{"A", 1}, {"B", 0}, {"C", 3}, {"D", 2}}));
+    CHECK(! solutions.contains({{"A", 2}, {"B", 3}, {"C", 0}, {"D", 1}}));
 }
 
 TEST_CASE("read_scp: array_min / array_max enumerate correctly")
@@ -1109,6 +1152,24 @@ TEST_CASE("read_scp: a solver-written .scp survives write -> read -> write uncha
     Problem rebuilt;
     read_scp(rebuilt, scp_a);
     auto scp_b = prove_to_scp(rebuilt, "scp_reader_roundtrip_b");
+
+    CHECK(scp_a == scp_b);
+    CHECK_FALSE(scp_a.empty());
+}
+
+TEST_CASE("read_scp: subcircuit survives write -> read -> write unchanged")
+{
+    Problem original;
+    auto a = original.create_integer_variable(0_i, 3_i, "A");
+    auto b = original.create_integer_variable(0_i, 3_i, "B");
+    auto c = original.create_integer_variable(0_i, 3_i, "C");
+    auto d = original.create_integer_variable(0_i, 3_i, "D");
+    original.post(SubCircuit{std::vector<IntegerVariableID>{a, b, c, d}});
+    auto scp_a = prove_to_scp(original, "scp_reader_subcircuit_roundtrip_a");
+
+    Problem rebuilt;
+    read_scp(rebuilt, scp_a);
+    auto scp_b = prove_to_scp(rebuilt, "scp_reader_subcircuit_roundtrip_b");
 
     CHECK(scp_a == scp_b);
     CHECK_FALSE(scp_a.empty());


### PR DESCRIPTION
Step 1 of #788: `SubCircuit` over a successor array, MiniZinc semantics, with both of
Francis and Stuckey's cheaper propagation algorithms and a VeriPB certificate for each.

The MiniZinc binding, the XCSP3 size-carrying overloads (which subsume #167) and the
certified SCC arm are deliberately not here — see the [step-0
comment](https://github.com/ciaranm/glasgow-constraint-solver/issues/788#issuecomment-5505574380)
for the staging and the measurements behind it.

## What it is

A sibling class in `gcs/constraints/circuit/`, not a mode on `Circuit`. `Circuit`'s opening
inference is `succ[i] != i` for every `i`, which is exactly what this constraint has to
allow: a node off the tour points at itself. The three semantic corners are in the class
documentation, because they are the kind of thing one otherwise discovers later — the empty
subcircuit is a solution, the smallest non-empty one has two nodes, and the successors are a
permutation whether or not a node is on the tour.

`with_algorithm()` selects:

- `subcircuit::Check` — follow each chain of fixed successors and, when one closes into a
  cycle of two or more, force every other node to be a self loop. Where `Circuit` simply
  contradicts, here the cycle only pins down everyone else.
- `subcircuit::Prevent` (the default) — adds the lookahead, and with it Francis and
  Stuckey's *evidence node*: a chain must not close while some node outside it cannot be a
  self loop. With no such node there is nothing to infer at all, because a closing chain
  plus everyone else opting out is a perfectly good solution.

`with_gac_all_different()` as on `Circuit`.

## The encoding

Circuit's position encoding, conditioned on membership, and still linear — the tour's length
is the sum of the "not a self loop" literals, so it needs no auxiliary variable of its own
and the wrap row is

```
(succ[i] = j and first[j]) -> pos[j] - pos[i] + |tour| = 1
```

with `first[j]` a fully reified flag for "j is on the tour and every lower-numbered node is
off it". A node off the tour is given position **zero**: nothing here needs the positions to
be distinct, and an off-tour node takes part in no position row at all — it has no successor
but itself, and by all-different nothing can point at it — so the only job those rows have is
to leave `pos` determined by the successors under unit propagation, which is what solution
checking needs.

**Where this costs more than Circuit, and why that is in the encoding rather than the proof.**
Each edge needs *two* row families rather than one, because which edge wraps is not known
statically: it is the edge into whichever node is `first`, and Circuit anchors on node 0 so it
always knows. `define_proof_model()` carries a comment on this, because it is the one place
here where the encoding carries something for the proof's benefit rather than saying the
constraint as compactly as it could.

Dropping the wrap rows leaves an encoding that is *smaller than the stdlib decomposition's*
and still exact — a cycle avoiding the anchor still chains to `0 = k`. But the counting fact
those rows provide then has to be derived instead, and deriving it needs "the on-tour
positions are exactly `0..L-1`": a pigeonhole induction **conditional on the variable `L`**,
which is precisely the obstacle that stops `circuit_scc.cc`'s machinery being ported here. So
that is not a free reformulation into the proof; it is blocked on the same open problem. The
other way out is a caller-nominated anchor, which collapses this to exactly Circuit's shape,
since only the n edges into a nominated on-tour node can wrap.

On `2013/mario/mario_easy_2` (n = 15), the subcircuit encoding's share of the `.opb` is 1,868
rows against the decomposition's 1,531 — 22% more, and that 22% is the wrap family.

## The certificate, and the test that earns it

Circuit anchors on node 0, so it knows statically which edge wraps around. Here it is the
edge into whichever node is `first`, so each firing pays a case split: sum the step rows
round the cycle for "none of these is first", sum `|cycle|` more times for "this one is",
then add the first to the rest to resolve the flags away, leaving the bound that the tour is
no longer than the cycle.

**The plain enumeration test is what keeps the certificate honest, from n = 5 up**: swap
`derive_tour_at_most` for a plain `JustifyUsingRUP` and VeriPB rejects the proof at
`subcircuit_test.cc`'s n = 5 case. That is worth stating because it was not true of the first
version of this encoding: while off-tour positions were numbered *after* the on-tour ones,
unit propagation could reach the conflict unaided at every size the enumeration runs, and only
a hand-built scenario with the anchor left undetermined could tell the difference. Pinning
off-tour positions to zero moved that check into the cheap test, which is where it belongs.

`subcircuit_prevent_test.cc` still drives the evidence-node inference with the anchor
undetermined, which is a narrower case than the enumeration reaches and worth its own
regression test — but it is no longer the test that carries the argument, and its comment says
so.

## Consistency claim

Neither algorithm is arc consistent — both wait for a chain of successors to be fixed before
saying anything, so a value can easily survive in a domain with no solution behind it. The
enumeration tests therefore use `solve_for_tests`, not `solve_for_tests_checking_gac`, same
as `Circuit`.

## Testing

- `subcircuit_test.cc` — enumeration against a check written straight off MiniZinc's
  definition, `n` = 1..5 for both algorithms, plus the empty array (which MiniZinc
  special-cases to `true` and a C++ caller can still build), all under the view sweep.
  `n = 4` is the smallest size that says anything beyond all-different: with three nodes you
  cannot fit two disjoint cycles, so every permutation is a subcircuit.
- `subcircuit_prevent_test.cc` — the undetermined-anchor scenario above.
- `subcircuit_dup_test.cc` — aliased successor handles rejected at construction, as
  `Circuit` does, for both algorithms.
- `scp_reader_test.cc` — enumeration plus the write → read → write round trip.
- Full suite: 779/779 pass. Clean under `clang++` with `-DCMAKE_BUILD_TYPE=Sanitize`
  (the two pre-existing `-Werror` failures under clang, in `variable_weighting.hh` and
  `element.cc`, are untouched and unrelated). Both cap settings run.

## Known limitations, stated rather than hidden

- The propagator walks the fixed-edge graph from scratch on every call, where
  `circuit::Prevent` keeps its chain endpoints in backtrackable state and folds each new
  edge in in O(1). Nothing here needs that yet and the walk is far easier to read, but it is
  the obvious move if it ever shows up in a profile.
- It does not claim idempotence, unlike `circuit::Prevent`. Forcing a node to be a self loop
  fixes a successor and changes the chain structure the pass just walked, and one pass makes
  no attempt to reach the fixpoint of that cascade; the triggers cover it, since every
  inference here instantiates a successor.
- The evidence node is the lowest-numbered candidate, which is Francis and Stuckey's default.
  They report that choosing the one fixed highest in the search tree is usually a little
  better, and that is a knob worth having later rather than a choice worth guessing now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

