### PR TITLE
Reach SubCircuit from MiniZinc

### DIFF
--- a/dev_docs/frontend-support-matrix.md
+++ b/dev_docs/frontend-support-matrix.md
@@ -53,6 +53,7 @@ equivalent for that frontend's vocabulary).
 | binPacking | `BinPacking` (per-bin GAC)[^bp] | ✓ (`fzn_bin_packing` / `_capa` / `_load`) | ✓ (signatures 1/2/3; per-bin condition list `s UNSUPPORTED`) | ? |
 | knapsack | `Knapsack` | ✓ | ✓ (basic with two `XCondition`s; not yet exercised by a test) | ? |
 | circuit | `Circuit` | ✓ | ✓ (basic; sub-circuit with size param `s UNSUPPORTED`); semantics mismatch with XCSP3 spec, see #167 | ? |
+| subcircuit | `SubCircuit` | ✓ | not yet bound; XCSP3's plain `<circuit>` is *this* constraint's semantics, not `Circuit`'s, and its size-carrying forms are `s UNSUPPORTED` — see #167 and [#788](https://github.com/ciaranm/glasgow-constraint-solver/issues/788) | ? |
 | instantiation | `Equals` to constant | ✓ | ✓ | ? |
 | lex (ordered list) | `LexLessThan` / `LexLessThanEqual` / `LexGreaterThan` / `LexGreaterEqual` | ✓ | ✓ (lists; matrix as lex² over rows + columns) | ? |
 | slide (meta-constraint) | apply template per window | ? | ✓ (parser unfolds into per-window constraints) | ? |
@@ -80,7 +81,7 @@ addressed.
 | graph reachability (`reachable`, `dreachable`, `connected`, `dconnected`) | `Reachable` / `DReachable` | ✓ | n/a | ? | `connected` / `dconnected` ride the same override, being `reachable` / `dreachable` with an existential root; see [^reach] |
 | `subgraph` | `Subgraph` | ✓ | n/a | n/a | Two implications per edge, so the constraint exists for the C++ and `.scp` interfaces rather than to infer anything the decomposition would not |
 | graph trees and paths (`tree`, `dtree`, `path`, `dpath`) | `Tree` / `DTree` / `Path` / `DPath` | ✓ | n/a | n/a | Also reached by `steiner`, `dsteiner`, `bounded_path`, `bounded_dpath` and both `weighted_spanning_tree` spellings, which the stdlib defines in terms of these; see [^treefam] |
-| the rest of `globals.graph` (`dag`, `network_flow`, `network_flow_cost`, `subcircuit`) | – | decomposition | n/a | n/a | Not on the reachability ladder: `dag` is an acyclicity labelling, `network_flow` decomposes to plain flow conservation, and `subcircuit` belongs with `Circuit` ([#167](https://github.com/ciaranm/glasgow-constraint-solver/issues/167)). Open under [#637](https://github.com/ciaranm/glasgow-constraint-solver/issues/637) |
+| the rest of `globals.graph` (`dag`, `network_flow`, `network_flow_cost`) | – | decomposition | n/a | n/a | Not on the reachability ladder: `dag` is an acyclicity labelling and `network_flow` decomposes to plain flow conservation. Open under [#637](https://github.com/ciaranm/glasgow-constraint-solver/issues/637). `subcircuit` was listed here too until [#788](https://github.com/ciaranm/glasgow-constraint-solver/issues/788) gave it `SubCircuit`; it has its own row above, beside `circuit`, where it belongs |
 | `SmartTable` | `SmartTable` | ✓ | n/a | ? | Glasgow-specific extension |
 
 ## Solver gaps tracked elsewhere

--- a/minizinc/CMakeLists.txt
+++ b/minizinc/CMakeLists.txt
@@ -43,6 +43,16 @@ set_tests_properties(minizinc-cake PROPERTIES SKIP_RETURN_CODE 66)
 add_test(NAME minizinc-circuit COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ circuittest true true)
 set_tests_properties(minizinc-circuit PROPERTIES SKIP_RETURN_CODE 66)
 
+# --fzn-pattern is load-bearing here: without it these would pass against the
+# stdlib decomposition, which agrees with the reference solver and verifies its
+# proof just as happily, and nothing else the harness checks would notice that
+# the builtin never ran.
+add_test(NAME minizinc-subcircuit COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash --fzn-pattern glasgow_subcircuit $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ subcircuittest true true)
+set_tests_properties(minizinc-subcircuit PROPERTIES SKIP_RETURN_CODE 66)
+
+add_test(NAME minizinc-subcircuit-evidence COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash --fzn-pattern glasgow_subcircuit $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ subcircuitevidencetest true true)
+set_tests_properties(minizinc-subcircuit-evidence PROPERTIES SKIP_RETURN_CODE 66)
+
 # The reachability family. --fzn-pattern is the reachability guard: MiniZinc's
 # connected / dconnected wrappers go through reachable / dreachable, so without
 # it a test would still agree with the reference solver via the stdlib distance

--- a/minizinc/fzn_glasgow.cc
+++ b/minizinc/fzn_glasgow.cc
@@ -796,6 +796,15 @@ auto main(int argc, char * argv[]) -> int
                 const auto & vars = arg_as_array_of_var(data, args, 0);
                 problem.post(Circuit{vars});
             }
+            else if (id == "glasgow_subcircuit") {
+                // The mznlib redefinition has already shifted successors to be
+                // 0-based, as for glasgow_circuit. SubCircuit is the opt-out
+                // sibling: a node not on the tour takes its own index, and the
+                // empty tour is a solution, so unlike Circuit this must not
+                // assume every node is visited.
+                const auto & vars = arg_as_array_of_var(data, args, 0);
+                problem.post(SubCircuit{vars});
+            }
             else if (id == "glasgow_reachable" || id == "glasgow_dreachable") {
                 // The mznlib redefinition has already shifted the endpoints and
                 // the root to be zero-based, matching how Reachable numbers nodes.

--- a/minizinc/mznlib/fzn_subcircuit.mzn
+++ b/minizinc/mznlib/fzn_subcircuit.mzn
@@ -1,0 +1,15 @@
+predicate glasgow_subcircuit(array[int] of var int: x);
+
+% glasgow_subcircuit expects 0-based successors (a length-n array whose values are
+% in 0..n-1). FlatZinc subcircuit is defined over index_set(x) with successor
+% values in that same set, so shift by min(index_set(x)) rather than assuming
+% 1-based. The shift is consistent both ways: a node off the tour has x[i] = i,
+% which after shifting is "the value equals the 0-based position".
+%
+% Keep the min inside the comprehension. The stdlib's fzn_subcircuit guards
+% length(xs) = 0 explicitly and this override replaces that guard, but with an
+% empty index set the comprehension body -- and so the min -- never evaluates, so
+% the empty subcircuit still flattens. Hoisting the min into a let would turn it
+% into a min-of-empty-set error.
+predicate fzn_subcircuit(array[int] of var int: x) =
+    glasgow_subcircuit([x[i] - min(index_set(x)) | i in index_set(x)]);

--- a/minizinc/tests/subcircuitevidencetest.mzn
+++ b/minizinc/tests/subcircuitevidencetest.mzn
@@ -1,0 +1,16 @@
+include "globals.mzn";
+
+% 1-based, so this is the other half of the index-shift check, and node 1 is
+% pinned onto the tour. That pin is what gives the propagator an evidence node:
+% without one, no chain of fixed successors can be stopped from closing, because
+% a closed tour with every other node opting out is a perfectly good solution.
+% This is the case the C++ scenario test drives directly; here it has to survive
+% the whole frontend.
+array[1..5] of var 1..5: succ;
+
+constraint subcircuit(succ);
+constraint succ[1] != 1;
+
+solve satisfy;
+
+output ["ENUMSOL: " ++ show(succ)];

--- a/minizinc/tests/subcircuittest.mzn
+++ b/minizinc/tests/subcircuittest.mzn
@@ -1,0 +1,18 @@
+include "globals.mzn";
+
+% Indexed from 0 on purpose, as circuittest.mzn is: the FlatZinc subcircuit
+% predicate is defined over index_set(x) with successor values in that same set,
+% so a 0-based array must not be shifted as if it were 1-based.
+%
+% Four nodes is the smallest size that says anything beyond all-different: with
+% three you cannot fit two disjoint cycles, so every permutation is a subcircuit.
+% Twenty-one of the twenty-four permutations are solutions -- the three products
+% of two 2-cycles are not -- and the identity is among them, being the empty
+% subcircuit.
+array[0..3] of var 0..3: succ;
+
+constraint subcircuit(succ);
+
+solve satisfy;
+
+output ["ENUMSOL: " ++ show(succ)];


### PR DESCRIPTION
Step 2 of #788, stacked on #790.

`fzn_subcircuit` fell through to the stdlib's position labelling — a variable-indexed element
into `order` per node, a reified guard on it, a second element for the not-in case, a second
`alldifferent`, and `firstin` as a min over *n* reified terms. Every subcircuit instance in
the Challenge corpus got that. Now they get the constraint.

## The override

Shifts successors to 0-based exactly as `fzn_circuit.mzn` does, and the shift is consistent
for the opt-out case too: a node off the tour has `x[i] = i`, which after shifting is "the
value equals the 0-based position".

One thing worth not tidying, and there is a comment saying so: the `min` stays *inside* the
comprehension. This override replaces the stdlib's own `length(xs) = 0` guard, and with an
empty index set the comprehension body — and so the `min` — never evaluates, so
`subcircuit([])` still flattens. Hoisting the `min` into a `let` would turn that into a
min-of-empty-set error, which is what the stdlib guard was there for. (`fzn_circuit.mzn` is
safe for the same accidental reason; Gecode's own `fzn_circuit` is not, but that is not ours.)

## Tests

Both carry `--fzn-pattern glasgow_subcircuit`, and that guard is load-bearing rather than
ceremonial: without it these tests pass against the decomposition, which agrees with the
reference solver and verifies its proof just as happily, and nothing else the harness checks
can tell that the builtin never ran. Verified by removing the override and confirming the
test then fails.

- `subcircuittest` — 0-based, four nodes, so it covers the index shift the way
  `circuittest.mzn` does. Four is the smallest size that says anything beyond
  all-different, since two disjoint cycles need four nodes between them; 21 of the 24
  permutations are solutions, the identity (the empty tour) among them.
- `subcircuitevidencetest` — 1-based, so the other half of the shift, and pins node 1 onto
  the tour. That pin is what gives the propagator an evidence node, without which no chain
  can be stopped from closing. It is the case `subcircuit_prevent_test.cc` drives directly,
  here made to survive the whole frontend.

## Support matrix

`subcircuit` gets its own row beside `circuit`, and loses its mention in the "rest of
`globals.graph`" row, where the reachability ladder had been carrying it. The XCSP3 column
says "not yet bound" and why — XCSP3's plain `<circuit>` is *this* constraint's semantics
rather than `Circuit`'s, which is #167, and that is the next PR.

## Testing

781/781 pass, including all 93 `minizinc-*` entries.

A measurement of this against the decomposition over all 27 `tpp`/`mario` instances is
running and will be added as a comment — it is the acceptance item #788 asks for, and it
belongs on this PR rather than the propagator one, since it is the binding that decides
which of the two the corpus actually gets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
