### PR TITLE
A tour size for SubCircuit, which is also how to ask for non-empty

### DIFF
--- a/gcs/constraints/circuit/subcircuit.cc
+++ b/gcs/constraints/circuit/subcircuit.cc
@@ -214,6 +214,51 @@ namespace
         combine.emit(logger, ProofLevel::Current);
     }
 
+    // The tour size: how many nodes do not point at themselves. All of this follows from
+    // the one cardinality row define_proof_model() writes, so every inference here is a
+    // plain RUP against it.
+    //
+    // Not inferred, deliberately: the count can never be 1, because a lone node on the
+    // tour has nowhere to point but itself. That is a consequence of the rest of the model
+    // rather than something the encoding says, so it would have to be derived in the proof
+    // rather than read off a row, and nothing needs it yet.
+    auto propagate_tour_size(const vector<IntegerVariableID> & succ, const ConstraintID & owner, const IntegerVariableID & size,
+        const vector<IntegerVariableID> & reason_vars, const State & state, auto & inference, ProofLogger * const logger) -> void
+    {
+        auto n = static_cast<long long>(succ.size());
+        long long on = 0, off = 0;
+        for (const auto & [idx, s] : enumerate(succ)) {
+            auto here = Integer(static_cast<long long>(idx));
+            if (! state.in_domain(s, here))
+                ++on; // cannot be a self loop, so it is on the tour whatever else happens
+            else if (state.optional_single_value(s) == here)
+                ++off; // fixed as a self loop, so it is off the tour
+        }
+
+        auto reason = generic_reason(reason_vars);
+        inference.infer(logger, size >= Integer{on}, JustifyUsingRUP{hints::SubCircuit{owner}}, reason);
+        inference.infer(logger, size <= Integer{n - off}, JustifyUsingRUP{hints::SubCircuit{owner}}, reason);
+
+        // With a bound tight against what is already decided, every undecided node goes
+        // the same way: no room left for another node on the tour, or none left off it.
+        auto force_undecided = [&](bool onto_tour) {
+            vector<Literal> forced;
+            for (const auto & [idx, s] : enumerate(succ)) {
+                auto here = Integer(static_cast<long long>(idx));
+                if (! state.in_domain(s, here) || state.optional_single_value(s) == here)
+                    continue;
+                forced.emplace_back(onto_tour ? Literal{s != here} : Literal{s == here});
+            }
+            if (! forced.empty())
+                inference.infer_all(logger, forced, JustifyUsingRUP{hints::SubCircuit{owner}}, reason);
+        };
+
+        if (state.upper_bound(size) == Integer{on})
+            force_undecided(false);
+        else if (state.lower_bound(size) == Integer{n - off})
+            force_undecided(true);
+    }
+
     auto propagate_subcircuit(const vector<IntegerVariableID> & succ, const ConstraintID & owner, const SubCircuitPosData & pos_data,
         const ConstraintStateHandle & unassigned_handle, const bool prevent, const State & state, auto & inference, ProofLogger * const logger)
         -> void
@@ -316,6 +361,12 @@ auto SubCircuit::with_gac_all_different(optional<bool> enable) -> SubCircuit &
     return *this;
 }
 
+auto SubCircuit::with_tour_size(IntegerVariableID size) -> SubCircuit &
+{
+    _tour_size = size;
+    return *this;
+}
+
 auto SubCircuit::prepare(Propagators & propagators, State & initial_state, ProofModel * const model) -> bool
 {
     for (const auto & s : _succ) {
@@ -346,11 +397,19 @@ auto SubCircuit::define_proof_model(ProofModel & model, const State &) -> void
     if (! _gac_all_different)
         define_clique_not_equals_encoding(model, _constraint_id, _succ);
 
-    if (_succ.empty())
+    if (_succ.empty()) {
+        // No node, so no node is on the tour. Anything else the caller asked for still has
+        // to be said: an empty array with a tour size pins that size to zero.
+        if (_tour_size)
+            model.add_labelled_constraint(_constraint_id, "tour_size_le", "tour_size_ge", WPBSum{} + 1_i * *_tour_size == 0_i);
         return;
+    }
 
     auto n = static_cast<long>(_succ.size());
     auto tour_size = tour_size_sum(_succ);
+
+    if (_tour_size)
+        model.add_labelled_constraint(_constraint_id, "tour_size_le", "tour_size_ge", tour_size + -1_i * *_tour_size == 0_i);
     auto & data = _pos_data;
     data.defined = true;
 
@@ -441,6 +500,26 @@ auto SubCircuit::install_propagators(Propagators & propagators) -> void
 {
     auto prevent = std::holds_alternative<Prevent>(_algorithm);
 
+    if (_tour_size) {
+        // Its own propagator, on its own triggers: this one has to wake on a value being
+        // removed, not just on a successor being fixed, because losing its own index from
+        // a domain is what puts a node on the tour.
+        auto reason_vars = _succ;
+        reason_vars.emplace_back(*_tour_size);
+
+        Triggers size_triggers;
+        size_triggers.on_change = {_succ.begin(), _succ.end()};
+        size_triggers.on_bounds = {*_tour_size};
+        propagators.install(
+            constraint_id(),
+            [succ = _succ, owner = constraint_id(), size = *_tour_size, reason_vars = std::move(reason_vars)](
+                const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+                propagate_tour_size(succ, owner, size, reason_vars, state, inference, logger);
+                return PropagatorState::Enable;
+            },
+            size_triggers);
+    }
+
     Triggers triggers;
     triggers.on_instantiated = {_succ.begin(), _succ.end()};
     propagators.install(
@@ -463,6 +542,8 @@ auto SubCircuit::clone() const -> unique_ptr<Constraint>
     auto cloned = make_unique<SubCircuit>(_succ);
     cloned->with_algorithm(_algorithm);
     cloned->with_gac_all_different(_gac_all_different);
+    if (_tour_size)
+        cloned->with_tour_size(*_tour_size);
     return cloned;
 }
 
@@ -477,5 +558,10 @@ auto SubCircuit::s_expr(const ProofModel * const model) const -> SExpr
     vector<SExpr> vars;
     for (const auto & var : _succ)
         vars.push_back(tracker.s_expr_term_of(var));
-    return SExpr::list({SExpr::atom(as_string(_constraint_id)), SExpr::atom(constraint_type()), SExpr::list(std::move(vars))});
+    // The tour size is a semantic argument, not a tuning knob, so it has to appear here or
+    // a .scp round trip would quietly drop it and read back a weaker constraint.
+    vector<SExpr> terms{SExpr::atom(as_string(_constraint_id)), SExpr::atom(constraint_type()), SExpr::list(std::move(vars))};
+    if (_tour_size)
+        terms.push_back(tracker.s_expr_term_of(*_tour_size));
+    return SExpr::list(std::move(terms));
 }

--- a/gcs/constraints/circuit/subcircuit.hh
+++ b/gcs/constraints/circuit/subcircuit.hh
@@ -89,6 +89,7 @@ namespace gcs
         const std::vector<IntegerVariableID> _succ;
         SubCircuitAlgorithm _algorithm = subcircuit::Prevent{};
         bool _gac_all_different = false;
+        std::optional<IntegerVariableID> _tour_size;
 
         // Backtrackable state allocated by prepare(), consumed by install_propagators().
         innards::subcircuit::SubCircuitStateHandles _state_handles;
@@ -114,6 +115,17 @@ namespace gcs
         /// propagator, in addition to the subcircuit propagation. Off by default (a cheaper
         /// value-consistent all-different is always applied regardless).
         auto with_gac_all_different(std::optional<bool> enable = true) -> SubCircuit &;
+
+        /// Constrain how many nodes are on the tour: `size` is the number that do not
+        /// point at themselves. This is XCSP3's `size` argument, for which MiniZinc's
+        /// spelling has no equivalent.
+        ///
+        /// It is also how to ask for a *non-empty* tour, which XCSP3-core's `<circuit>`
+        /// wants where MiniZinc's `subcircuit` does not: give `size` a lower bound of 2.
+        /// There is no separate option for that, because this one already says it, and
+        /// the count can never be 1 anyway -- a lone node has nowhere to point but itself,
+        /// which is what taking its own index means.
+        auto with_tour_size(IntegerVariableID size) -> SubCircuit &;
 
         [[nodiscard]] virtual auto clone() const -> std::unique_ptr<Constraint> override;
         [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;

--- a/gcs/constraints/circuit/subcircuit_test.cc
+++ b/gcs/constraints/circuit/subcircuit_test.cc
@@ -138,6 +138,46 @@ auto run_empty_test(bool proofs) -> void
     check_results(proof_name, expected, actual);
 }
 
+// The tour size, XCSP3's `size` argument. Enumerated against the same reference check with
+// the count computed alongside it, so the option is pinned to "how many nodes do not point
+// at themselves" and not to some off-by-one reading of it.
+auto run_tour_size_test(bool proofs, int n, int size_lower, int size_upper) -> void
+{
+    println(cerr, "subcircuit/tour_size n={} size={}..{}{}", n, size_lower, size_upper, proofs ? " with proofs:" : ":");
+
+    vector<pair<int, int>> domains(static_cast<std::size_t>(n) + 1, pair{0, n - 1});
+    domains.back() = pair{size_lower, size_upper};
+
+    set<tuple<vector<int>>> expected, actual;
+    build_expected(
+        expected,
+        [&](vector<int> all) {
+            auto succ = vector<int>(all.begin(), all.end() - 1);
+            if (! is_subcircuit(succ))
+                return false;
+            auto on = 0;
+            for (std::size_t i = 0; i < succ.size(); ++i)
+                if (succ[i] != static_cast<int>(i))
+                    ++on;
+            return on == all.back();
+        },
+        domains);
+    println(cerr, " expecting {} solutions", expected.size());
+
+    Problem p;
+    vector<IntegerVariableID> succ;
+    for (int i = 0; i < n; ++i)
+        succ.push_back(p.create_integer_variable(0_i, Integer{n - 1}));
+    auto size = p.create_integer_variable(Integer{size_lower}, Integer{size_upper});
+    p.post(SubCircuit{succ}.with_tour_size(size));
+
+    auto all_vars = succ;
+    all_vars.emplace_back(size);
+    auto proof_name = proofs ? make_optional<std::string>("subcircuit_test_tour_size") : nullopt;
+    solve_for_tests(p, proof_name, actual, tuple{all_vars});
+    check_results(proof_name, expected, actual);
+}
+
 auto main(int argc, char * argv[]) -> int
 {
     establish_and_announce_seed(argc, argv);
@@ -167,8 +207,20 @@ auto main(int argc, char * argv[]) -> int
                 run_subcircuit_test(proofs, view_cfg, 2, propagator);
             }
         }
-        if (view_wrap_config_is_effectively_bare(view_cfg, n_positions))
+        if (view_wrap_config_is_effectively_bare(view_cfg, n_positions)) {
             run_empty_test(proofs);
+            // The full range, so the option constrains nothing and every subcircuit
+            // survives with its own count; then a lower bound of 2, which is how XCSP3's
+            // "exactly one circuit" reading is spelled and rules the empty tour out; then
+            // an exact size, and 1, which nothing can satisfy because a lone node on the
+            // tour has nowhere to point but itself.
+            for (int n : {3, 4}) {
+                run_tour_size_test(proofs, n, 0, n);
+                run_tour_size_test(proofs, n, 2, n);
+                run_tour_size_test(proofs, n, n, n);
+                run_tour_size_test(proofs, n, 1, 1);
+            }
+        }
     }
 
     return EXIT_SUCCESS;

--- a/gcs/scp_reader.cc
+++ b/gcs/scp_reader.cc
@@ -1086,9 +1086,14 @@ auto gcs::read_scp(Problem & problem, string_view text) -> ScpModel
             post_constraint(problem, Circuit{resolve_variable_list(variables, terms[2], "the circuit successor list")}, label);
         }
         else if (op == "subcircuit") {
-            if (terms.size() != 3)
-                throw ScpReadError{"subcircuit takes one list: (label subcircuit (succ...))"};
-            post_constraint(problem, SubCircuit{resolve_variable_list(variables, terms[2], "the subcircuit successor list")}, label);
+            // The tour size is optional, and semantic when present, so it round-trips as a
+            // trailing term rather than being lost between writer and reader.
+            if (terms.size() != 3 && terms.size() != 4)
+                throw ScpReadError{"subcircuit takes one list and an optional tour size: (label subcircuit (succ...) [size])"};
+            SubCircuit constraint{resolve_variable_list(variables, terms[2], "the subcircuit successor list")};
+            if (terms.size() == 4)
+                constraint.with_tour_size(resolve_variable(variables, terms[3]));
+            post_constraint(problem, std::move(constraint), label);
         }
         else if (op == "array_min" || op == "array_max") {
             // (label array_min (vars...) result): result = min/max of the array.

--- a/gcs/scp_reader_test.cc
+++ b/gcs/scp_reader_test.cc
@@ -1175,6 +1175,37 @@ TEST_CASE("read_scp: subcircuit survives write -> read -> write unchanged")
     CHECK_FALSE(scp_a.empty());
 }
 
+TEST_CASE("read_scp: a subcircuit tour size round-trips and is not silently dropped")
+{
+    // Byte-stability alone would not catch a dropped tour size: the writer would omit it,
+    // the reader would build the weaker constraint, and writing again would match. So
+    // check the term is really in the .scp, and that reading it back still constrains.
+    Problem original;
+    auto a = original.create_integer_variable(0_i, 2_i, "A");
+    auto b = original.create_integer_variable(0_i, 2_i, "B");
+    auto c = original.create_integer_variable(0_i, 2_i, "C");
+    auto size = original.create_integer_variable(3_i, 3_i, "SIZE");
+    original.post(SubCircuit{std::vector<IntegerVariableID>{a, b, c}}.with_tour_size(size));
+    auto scp_a = prove_to_scp(original, "scp_reader_subcircuit_size_roundtrip_a");
+    CHECK(scp_a.find("SIZE") != string::npos);
+
+    Problem rebuilt;
+    read_scp(rebuilt, scp_a);
+    auto scp_b = prove_to_scp(rebuilt, "scp_reader_subcircuit_size_roundtrip_b");
+    CHECK(scp_a == scp_b);
+
+    // A size of exactly three over three nodes leaves only the two 3-cycles, where without
+    // the size there would be all six permutations.
+    auto solutions = enumerate(R"(
+        (
+            (version 1)
+            (variables (A 0 2) (B 0 2) (C 0 2) (SIZE 3 3))
+            (constraints (_1 subcircuit (A B C) SIZE))
+            (prob_type enumerate)
+        ))");
+    CHECK(solutions.size() == 2);
+}
+
 TEST_CASE("read_scp: logical constraints survive write -> read -> write unchanged")
 {
     // The and / or / parity forms write each operand as a reification tuple;


### PR DESCRIPTION
Step 3 of #788, stacked on #792. Groundwork for the XCSP3 binding, which is the next PR.

XCSP3's `<circuit>` carries a `size` argument — a count of the nodes on the circuit — that
MiniZinc's spelling has no equivalent for. `with_tour_size()` is it: the count of successors
that do not point at themselves, tied to a variable by one cardinality row.

## Why there is no `with_non_empty()`

It doubles as the way to ask for a non-empty tour, which XCSP3-core wants ("exactly one
circuit") where MiniZinc's `subcircuit` does not: give the size variable a lower bound of 2.
I wrote a separate `with_non_empty()` first and then took it out — one mechanism covers both,
and a second knob would have to be reflected in `s_expr()` and the `.scp` grammar as well,
for no expressiveness gained.

**The reading is confirmed by enumeration, not by argument.** At n = 3 with size in 2..3 the
test finds 5 solutions — the two 3-cycles plus the three 2-cycles-with-an-isolated-vertex —
which is exactly what #167 records ACE finding for XCSP3's `<circuit>` on K₃, against our
`Circuit`'s 2. That is what the XCSP3 binding will need, and it now has a test saying so
before any binding depends on it.

## The `.scp` trap this avoids

The size is a semantic argument, not a tuning knob, so it appears in `s_expr()` and the
grammar takes it as an optional trailing term. Note that **byte stability alone would not
catch dropping it**: the writer would omit the term, the reader would build the weaker
constraint, and writing again would match. So the round-trip test also checks the term is
really in the `.scp`, and that reading it back still constrains (three nodes with size 3
leaves the two 3-cycles, where without the size there would be all six permutations).

## Propagation

A second propagator on its own triggers, because it has to wake on a value being *removed*,
not just on a successor being fixed: losing its own index from a domain is what puts a node
on the tour. It bounds the size by the nodes already decided either way, and once a bound is
tight it decides all the rest. Every inference is a plain RUP against the cardinality row.

One fact is deliberately **not** inferred: the count can never be 1, because a lone node on
the tour has nowhere to point but itself. That is a consequence of the rest of the model
rather than something a row says, so it would have to be derived in the proof rather than
read off one, and nothing needs it yet. The `size = 1..1` test verifies `UNSATISFIABLE`
through search instead, which is the honest way round.

## Testing

781/781 pass. Enumeration at n = 3 and 4 across four size ranges each — the full range (the
option constrains nothing), a lower bound of 2 (XCSP3's reading), an exact size, and 1
(unsatisfiable) — with the reference check computing the count alongside the subcircuit
property, so the option is pinned to "how many nodes do not point at themselves" and not to
an off-by-one reading of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
