### PR TITLE
Extensional GAC: hoist the reason, name the selector concretely

### DIFF
--- a/gcs/constraints/extensional_utils.cc
+++ b/gcs/constraints/extensional_utils.cc
@@ -22,6 +22,11 @@ using std::visit;
 using namespace gcs;
 using namespace gcs::innards;
 
+gcs::innards::ExtensionalData::ExtensionalData(SimpleIntegerVariableID selector, vector<IntegerVariableID> vars, ExtensionalTuples tuples) :
+    selector(selector), vars(move(vars)), tuples(move(tuples)), reason(generic_reason(this->vars))
+{
+}
+
 namespace
 {
     auto feasible(const State & state, const IntegerVariableID & var, const Integer val) -> bool
@@ -88,13 +93,13 @@ auto gcs::innards::propagate_extensional(
                 else if (logger && logger->get_assertion_level() != AssertionLevel::Off && state.has_single_value(table.selector))
                     // Last selector val so infeasible -> we need an explicit contradiction at higher assertion levels
                     // since there's no table for the implicit one.
-                    inference.contradiction(logger, JustifyUsingRUP{hint}, generic_reason(table.vars));
+                    inference.contradiction(logger, JustifyUsingRUP{hint}, table.reason);
                 else
                     inference.infer(logger, table.selector != Integer(tuple_idx), NoJustificationNeeded{}, NoReason{});
             });
             if (none_feasible && logger && logger->get_assertion_level() != AssertionLevel::Off)
                 // selector already empty on entry
-                inference.contradiction(logger, JustifyUsingRUP{hint}, generic_reason(table.vars));
+                inference.contradiction(logger, JustifyUsingRUP{hint}, table.reason);
         },
         table.tuples);
 
@@ -145,7 +150,7 @@ auto gcs::innards::propagate_extensional(
                     });
 
                     if (! supported) {
-                        inference.infer(logger, table.vars[idx] != val, JustifyUsingRUP{hint}, generic_reason(table.vars));
+                        inference.infer(logger, table.vars[idx] != val, JustifyUsingRUP{hint}, table.reason);
                     }
                 });
             }

--- a/gcs/constraints/extensional_utils.hh
+++ b/gcs/constraints/extensional_utils.hh
@@ -6,6 +6,7 @@
 #include <gcs/innards/justification.hh>
 #include <gcs/innards/proofs/proof_logger-fwd.hh>
 #include <gcs/innards/propagators-fwd.hh>
+#include <gcs/innards/reason.hh>
 #include <gcs/innards/state-fwd.hh>
 #include <gcs/integer.hh>
 #include <gcs/variable_id.hh>
@@ -48,10 +49,32 @@ namespace gcs::innards
      */
     struct ExtensionalData
     {
-        IntegerVariableID selector;
+        /**
+         * Always a variable this constraint allocated itself, so it is concrete:
+         * naming it as such lets State's SimpleIntegerVariableID overloads skip
+         * the IntegerVariableID variant visit and the view arithmetic. Pass 2's
+         * residue fast path asks in_domain() about it once per (variable, value)
+         * examined, which is millions of reads on a table of any size.
+         */
+        SimpleIntegerVariableID selector;
         std::vector<IntegerVariableID> vars;
         ExtensionalTuples tuples;
         std::shared_ptr<ExtensionalResidues> residues = std::make_shared<ExtensionalResidues>();
+
+        /**
+         * The reason for every inference this table makes, built once here rather
+         * than by calling generic_reason(vars) at each inference site.
+         *
+         * Sound to hoist because the scope is fixed and Reason is declarative: it
+         * captures the variables and defers reading their domains to
+         * materialise(). The factories take their scope by value, so a per-site
+         * call copies the whole scope vector into a fresh shared_ptr on every
+         * inference -- and does it even with proofs off, where the reason is
+         * never materialised at all.
+         */
+        Reason reason;
+
+        ExtensionalData(SimpleIntegerVariableID selector, std::vector<IntegerVariableID> vars, ExtensionalTuples tuples);
     };
 
     /**


### PR DESCRIPTION
Two small changes to `propagate_extensional`, measured separately.

`generic_reason(table.vars)` was rebuilt at each inference site. The factories
take their scope by value, so every call copied the whole scope vector into a
fresh `shared_ptr` — including with proofs off, where the reason is never
materialised. It is now built once in `ExtensionalData`'s constructor, which is
sound because the scope is fixed and `Reason` is declarative.

`ExtensionalData::selector` is now a `SimpleIntegerVariableID` rather than an
`IntegerVariableID`. It always was one — every caller allocates it via
`State::allocate_integer_variable_with_state` — so this stops the type lying and
lets `State`'s concrete overloads apply.

### Measurements

fataepyc-10 pinned, boost off, median of 3, over the table benchmark matrix
(18 instances, matched search trees):

| | speedup |
|---|---|
| reason hoist alone | 1.0–1.1× |
| plus the concrete selector | **1.2–1.3×** |

The selector's type is worth most of it: pass 2 asks `in_domain()` about the
selector once per (variable, value) whose residue is still valid, and the
`selector != i` prunings go through the concrete `infer_not_equal` path — which
is millions of calls on a mid-sized instance.

### What it does not buy

Nothing on the table variables. `State::in_domain` is 21% of the profile, and
`perf annotate` shows its hot block is a linear scan over the `IntervalSet`'s
interval array with no discriminant test and no indirect branch — GCC had
already lowered that visit away. Specialising the feasibility pass over a
concrete `vector<SimpleIntegerVariableID>` was tried and measures 1.0×; see the
`propagator-performance.md` note in the follow-up PR for the full write-up.

Groundwork for #508. Follows #786.

### Testing

`ctest` 645/645. `recursions`, `propagations` and solution counts unchanged on
every benchmark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012mn99ERAhD4YrAaqZrdjZ3