### PR TITLE
Extensional GAC: own the live-tuple set, make the selector proof-only

### DIFF
--- a/dev_docs/propagator-performance.md
+++ b/dev_docs/propagator-performance.md
@@ -316,6 +316,38 @@ it does, two tools help:
 Both are profile-driven: don't pre-emptively specialise. Confirm the dispatch is
 actually costing you first.
 
+**A worked example of confirming it, and of getting the confirmation wrong.** In
+the extensional (table) propagator, `State::in_domain` is 34% of the profile: it
+is called once per (live tuple, position) in the feasibility pass, through the
+`IntegerVariableID` variant. That looks like the textbook case for specialising.
+It is not, and three measurements say so:
+
+- `perf annotate` on `in_domain` shows its hot block is `cmpq %rdx,%rcx` /
+  `cmpq (%rax),%rcx` / `addq $0x10,%rax` — a linear scan over the `IntervalSet`'s
+  interval array, sixteen bytes per step, with **no discriminant test and no
+  indirect branch in it**. GCC had already lowered the visit away.
+- Specialising the pass over a concrete `std::vector<SimpleIntegerVariableID>`
+  moves 1971 of 1995 `in_domain` samples from the variant instantiation to the
+  concrete one, and leaves the total unchanged.
+- End to end it measures 1.0x on all 18 instances of the table benchmark matrix.
+
+The 34% is the intrinsic cost of testing interval membership, and the ways to
+move it are algorithmic — call it less, or find a cheaper test than a scan.
+
+Two traps to avoid when running this experiment, both of which produced a
+confident wrong answer first time:
+
+- **A helper that takes `const IntegerVariableID &` silently un-specialises its
+  caller.** Passing a concrete `SimpleIntegerVariableID` to it converts back into
+  the variant at the call site, so `State::in_domain` is still the variant
+  instantiation and the "specialisation" changes nothing. Check the profile for
+  which instantiation the samples are actually in, rather than assuming the
+  specialisation took.
+- **Make sure the benchmark binary relinked.** If the harness does not depend on
+  the solver library, a before/after comparison measures one build against
+  itself and reports exactly 1.00x for everything. `md5sum` the two binaries when
+  a change reads 1.00x across the board.
+
 ## Is it the propagator, the strength, or the search?
 
 When a model is slow, "the propagator is slow" is only one of three

--- a/gcs/constraints/extensional_utils.cc
+++ b/gcs/constraints/extensional_utils.cc
@@ -1,3 +1,4 @@
+#include <any>
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
@@ -16,14 +17,32 @@
 #include <gcs/innards/state.hh>
 #include <gcs/proof.hh>
 
+using std::any_cast;
+using std::make_shared;
+using std::shared_ptr;
+using std::size_t;
+using std::uint32_t;
 using std::vector;
 using std::visit;
 
 using namespace gcs;
 using namespace gcs::innards;
 
-gcs::innards::ExtensionalData::ExtensionalData(SimpleIntegerVariableID selector, vector<IntegerVariableID> vars, ExtensionalTuples tuples) :
-    selector(selector), vars(move(vars)), tuples(move(tuples)), reason(generic_reason(this->vars))
+auto gcs::innards::ExtensionalLiveTuples::create(State & initial_state, size_t n_tuples) -> shared_ptr<ExtensionalLiveTuples>
+{
+    auto result = make_shared<ExtensionalLiveTuples>();
+    result->dense.resize(n_tuples);
+    result->position.resize(n_tuples);
+    for (size_t i = 0; i < n_tuples; ++i)
+        result->dense[i] = result->position[i] = static_cast<uint32_t>(i);
+    // Only the count backtracks: see the class comment for why restoring it is
+    // enough to re-admit exactly the tuples dropped below this node.
+    result->size_handle = initial_state.add_constraint_state(n_tuples);
+    return result;
+}
+
+gcs::innards::ExtensionalData::ExtensionalData(vector<IntegerVariableID> vars, ExtensionalTuples tuples, shared_ptr<ExtensionalLiveTuples> live) :
+    vars(move(vars)), tuples(move(tuples)), reason(generic_reason(this->vars)), live(move(live))
 {
 }
 
@@ -76,32 +95,50 @@ template <typename Hint_>
 auto gcs::innards::propagate_extensional(
     const ExtensionalData & table, const State & state, auto & inference, ProofLogger * const logger, const Hint_ & hint) -> PropagatorState
 {
-    // check whether selectable tuples are still feasible
+    auto & live = *table.live;
+    auto & live_count = any_cast<size_t &>(state.get_constraint_state(live.size_handle));
+
+    // Pass 1: drop tuples that are no longer feasible, by swapping them past the
+    // live count. Nothing here goes through State, so a dropped tuple costs two
+    // stores rather than an inference plus an IntervalSet edit.
     visit(
         [&](const auto & tuples) {
-            auto none_feasible = true;
-            state.for_each_value_mutable(table.selector, [&](Integer tuple_idx) {
+            for (size_t i = 0; i < live_count;) {
+                auto tuple_idx = live.dense[i];
                 bool is_feasible = true;
                 for (unsigned idx = 0; idx < table.vars.size(); ++idx)
-                    if (! feasible(state, table.vars[idx], get_tuple_value(tuples, tuple_idx.as_index(), idx))) {
+                    if (! feasible(state, table.vars[idx], get_tuple_value(tuples, tuple_idx, idx))) {
                         is_feasible = false;
                         break;
                     }
 
                 if (is_feasible)
-                    none_feasible = false;
-                else if (logger && logger->get_assertion_level() != AssertionLevel::Off && state.has_single_value(table.selector))
-                    // Last selector val so infeasible -> we need an explicit contradiction at higher assertion levels
-                    // since there's no table for the implicit one.
-                    inference.contradiction(logger, JustifyUsingRUP{hint}, table.reason);
-                else
-                    inference.infer(logger, table.selector != Integer(tuple_idx), NoJustificationNeeded{}, NoReason{});
-            });
-            if (none_feasible && logger && logger->get_assertion_level() != AssertionLevel::Off)
-                // selector already empty on entry
-                inference.contradiction(logger, JustifyUsingRUP{hint}, table.reason);
+                    ++i;
+                else {
+                    auto last = live_count - 1;
+                    auto moved = live.dense[last];
+                    live.dense[i] = moved;
+                    live.position[moved] = static_cast<uint32_t>(i);
+                    live.dense[last] = tuple_idx;
+                    live.position[tuple_idx] = static_cast<uint32_t>(last);
+                    live_count = last;
+                }
+            }
         },
         table.tuples);
+
+    if (0 == live_count) {
+        // The two spellings the selector used to give us for free, kept exactly:
+        // at higher assertion levels the contradiction must be explicit because
+        // there is no table to derive it from, and otherwise it must carry no
+        // justification and no reason, because that is what emptying the
+        // selector's domain used to report -- and the conflict observer behind
+        // dom/wdeg reads that reason.
+        if (logger && logger->get_assertion_level() != AssertionLevel::Off)
+            inference.contradiction(logger, JustifyUsingRUP{hint}, table.reason);
+        else
+            inference.contradiction(logger, NoJustificationNeeded{}, NoReason{});
+    }
 
     // check for supports in selectable tuples, using residual supports: for each
     // (variable position, value) we remember the last selectable tuple that
@@ -133,21 +170,21 @@ auto gcs::innards::propagate_extensional(
                     // O(1) fast path: last witness still selectable and still matching.
                     if (have_row) {
                         auto cached = residue_row[off];
-                        if (cached != ExtensionalResidues::none && state.in_domain(table.selector, Integer(static_cast<long long>(cached))) &&
+                        if (cached != ExtensionalResidues::none && live.position[cached] < live_count &&
                             match(get_tuple_value(tuples, cached, idx), val))
                             return;
                     }
 
                     bool supported = false;
-                    state.for_each_value_immutable(table.selector, [&](Integer tuple_idx) -> bool {
-                        if (match(get_tuple_value(tuples, tuple_idx.as_index(), idx), val)) {
+                    for (size_t i = 0; i < live_count; ++i) {
+                        auto tuple_idx = live.dense[i];
+                        if (match(get_tuple_value(tuples, tuple_idx, idx), val)) {
                             supported = true;
                             if (have_row)
-                                residue_row[off] = static_cast<std::uint32_t>(tuple_idx.as_index());
-                            return false;
+                                residue_row[off] = tuple_idx;
+                            break;
                         }
-                        return true;
-                    });
+                    }
 
                     if (! supported) {
                         inference.infer(logger, table.vars[idx] != val, JustifyUsingRUP{hint}, table.reason);

--- a/gcs/constraints/extensional_utils.hh
+++ b/gcs/constraints/extensional_utils.hh
@@ -7,7 +7,7 @@
 #include <gcs/innards/proofs/proof_logger-fwd.hh>
 #include <gcs/innards/propagators-fwd.hh>
 #include <gcs/innards/reason.hh>
-#include <gcs/innards/state-fwd.hh>
+#include <gcs/innards/state.hh>
 #include <gcs/integer.hh>
 #include <gcs/variable_id.hh>
 
@@ -43,20 +43,41 @@ namespace gcs::innards
     };
 
     /**
+     * \brief The set of tuples still selectable, owned by the propagator.
+     *
+     * A sparse set: \c dense[0, size) are the live tuple indices and \c position
+     * is its inverse, so membership is a single comparison and removal is a swap
+     * with the last live entry. Only \c size is backtrackable, which is what
+     * makes this cheap: everything ever removed sits at an index at or above
+     * \c size, and every removal at a deeper node swaps within [0, size), so
+     * restoring \c size re-admits exactly the tuples dropped since. The order
+     * within the live region differs after a backtrack, which changes only which
+     * support witness is found first, never which values are supported -- so the
+     * inferences, and the proof, are unchanged.
+     *
+     * This replaces using a selector variable's domain as the live set. That cost
+     * 32 trailed IntervalSet edits per useful inference, because a domain shot
+     * full of holes splits on every removal; here a removal is two stores and a
+     * decrement, and nothing goes through State's inference path at all.
+     *
+     * \ingroup Innards
+     */
+    struct ExtensionalLiveTuples
+    {
+        std::vector<std::uint32_t> dense;
+        std::vector<std::uint32_t> position;
+        ConstraintStateHandle size_handle{0};
+
+        [[nodiscard]] static auto create(State & initial_state, std::size_t n_tuples) -> std::shared_ptr<ExtensionalLiveTuples>;
+    };
+
+    /**
      * \brief Data for gcs::innards::propagate_extensional().
      *
      * \ingroup Innards
      */
     struct ExtensionalData
     {
-        /**
-         * Always a variable this constraint allocated itself, so it is concrete:
-         * naming it as such lets State's SimpleIntegerVariableID overloads skip
-         * the IntegerVariableID variant visit and the view arithmetic. Pass 2's
-         * residue fast path asks in_domain() about it once per (variable, value)
-         * examined, which is millions of reads on a table of any size.
-         */
-        SimpleIntegerVariableID selector;
         std::vector<IntegerVariableID> vars;
         ExtensionalTuples tuples;
         std::shared_ptr<ExtensionalResidues> residues = std::make_shared<ExtensionalResidues>();
@@ -74,7 +95,17 @@ namespace gcs::innards
          */
         Reason reason;
 
-        ExtensionalData(SimpleIntegerVariableID selector, std::vector<IntegerVariableID> vars, ExtensionalTuples tuples);
+        /**
+         * The live-tuple set. There is deliberately no selector variable here: the
+         * selector exists only so that the OPB encoding has something to name, so
+         * it is a proof-only variable owned by define_proof_model and the
+         * propagator never sees it. Nothing this propagator infers mentions it --
+         * the selector prunings were always NoJustificationNeeded, and VeriPB
+         * re-derives them by unit propagation when it checks a `var != val` RUP.
+         */
+        std::shared_ptr<ExtensionalLiveTuples> live;
+
+        ExtensionalData(std::vector<IntegerVariableID> vars, ExtensionalTuples tuples, std::shared_ptr<ExtensionalLiveTuples> live);
     };
 
     /**

--- a/gcs/constraints/innards/tabulation.cc
+++ b/gcs/constraints/innards/tabulation.cc
@@ -180,7 +180,10 @@ auto gcs::innards::build_table_in_proof(const vector<IntegerVariableID> & vars, 
     if (sel != future_var_id)
         throw UnexpectedException{"something went horribly wrong with variable IDs"};
 
-    return ExtensionalData{sel, vector<IntegerVariableID>{vars}, move(permitted)};
+    // `sel` remains a State variable because the derivation above introduced its
+    // literals against that identity; the propagator no longer uses it.
+    auto n_tuples = permitted.size();
+    return ExtensionalData{vector<IntegerVariableID>{vars}, move(permitted), ExtensionalLiveTuples::create(state, n_tuples)};
 }
 
 auto gcs::innards::reify_tabulation(const ReificationCondition & reif, TabulationVariables & enum_vars,

--- a/gcs/constraints/table/table.cc
+++ b/gcs/constraints/table/table.cc
@@ -117,15 +117,15 @@ auto Table::prepare(Propagators &, State & initial_state, ProofModel * const) ->
                 // define_proof_model emit a trivially-false `0 >= 1` constraint
                 // (which is morally what an empty selector domain encodes), and
                 // install_propagators installs a contradiction initialiser. Skip
-                // the selector allocation: an empty range [0, -1] would be
-                // invalid, and the propagator won't run anyway.
+                // building the live-tuple set: it would be empty and the
+                // propagator won't run anyway.
                 _has_no_tuples = true;
                 return;
             }
             for (auto & tuple : depointinate(tuples))
                 if (tuple.size() != _vars.size())
                     throw InvalidProblemDefinitionException{"table size mismatch"};
-            _selector = initial_state.allocate_integer_variable_with_state(0_i, Integer(depointinate(tuples).size() - 1));
+            _live = ExtensionalLiveTuples::create(initial_state, depointinate(tuples).size());
         },
         _tuples);
 
@@ -142,15 +142,20 @@ auto Table::define_proof_model(ProofModel & model, const State &) -> void
 
     visit(
         [&](auto && tuples) {
-            model.set_up_integer_variable(_selector, 0_i, Integer(depointinate(tuples).size() - 1), "aux_table" + to_string(_selector.index),
-                IntegerVariableProofRepresentation::DirectOnly);
+            // Proof-only: the selector exists so the encoding has something to
+            // name, and nothing in the proof ever cites it -- the per-tuple rows
+            // below are all VeriPB needs to re-derive `selector != i` by unit
+            // propagation when it checks one of the propagator's RUP steps. So it
+            // gets no State, no domain, and no propagation cost.
+            auto selector = model.create_proof_only_integer_variable(0_i, Integer(depointinate(tuples).size() - 1),
+                "aux_table" + as_string(_constraint_id), IntegerVariableProofRepresentation::DirectOnly);
 
             // pb encoding, if necessary
             for (const auto & [tuple_idx, tuple] : enumerate(depointinate(tuples))) {
                 // selector == tuple_idx -> /\_i vars[i] == tuple[i]
                 bool infeasible = false;
                 WPBSum lits;
-                lits += Integer(tuple.size()) * (_selector != Integer(tuple_idx));
+                lits += Integer(tuple.size()) * (selector != Integer(tuple_idx));
                 for (const auto & [var_idx, var] : enumerate(_vars)) {
                     if (is_immediately_infeasible(var, tuple[var_idx]))
                         infeasible = true;
@@ -158,7 +163,7 @@ auto Table::define_proof_model(ProofModel & model, const State &) -> void
                         add_lit_unless_immediately_true(lits, var, tuple[var_idx]);
                 }
                 if (infeasible)
-                    model.add_constraint({_selector != Integer(tuple_idx)});
+                    model.add_constraint(WPBSum{} + 1_i * (selector != Integer(tuple_idx)) >= 1_i);
                 else
                     model.add_constraint(lits >= Integer(lits.terms.size() - 1));
             }
@@ -179,11 +184,10 @@ auto Table::install_propagators(Propagators & propagators) -> void
             Triggers triggers;
             for (auto & v : _vars)
                 triggers.on_change.push_back(v);
-            triggers.on_change.push_back(_selector);
 
             propagators.install(
                 constraint_id(),
-                [table = ExtensionalData{_selector, move(_vars), move(tuples)}, owner = constraint_id()](
+                [table = ExtensionalData{move(_vars), move(tuples), move(_live)}, owner = constraint_id()](
                     const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
                     return propagate_extensional(table, state, inference, logger, hints::Table{owner});
                 },

--- a/gcs/constraints/table/table.hh
+++ b/gcs/constraints/table/table.hh
@@ -2,9 +2,11 @@
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_TABLE_TABLE_HH
 
 #include <gcs/constraint.hh>
+#include <gcs/constraints/extensional_utils.hh>
 #include <gcs/extensional.hh>
 #include <gcs/variable_id.hh>
 
+#include <memory>
 #include <vector>
 
 namespace gcs
@@ -21,7 +23,7 @@ namespace gcs
     private:
         const std::vector<IntegerVariableID> _vars;
         ExtensionalTuples _tuples;
-        SimpleIntegerVariableID _selector{0};
+        std::shared_ptr<innards::ExtensionalLiveTuples> _live;
         bool _has_no_tuples = false;
 
     public:

--- a/gcs/innards/proofs/proof_model.cc
+++ b/gcs/innards/proofs/proof_model.cc
@@ -452,8 +452,24 @@ auto ProofModel::set_up_direct_only_variable_encoding(SimpleOrProofOnlyIntegerVa
                 pair<variant<ProofLine, XLiteral>, variant<ProofLine, XLiteral>> names_0{! eqvar, eqvar};
                 names_and_ids_tracker().track_eqvar(id, 0_i, names_0);
             }, //
-            [](const ProofOnlySimpleIntegerVariableID &) {
-                // currently there's no API for asking for literals for these
+            [&](const ProofOnlySimpleIntegerVariableID & id) {
+                // Same aliasing as above: for a {0,1} variable the bit-0 literal
+                // *is* the (== 1)/(== 0) literal. Without these, a caller writing
+                // `id != 0` into an OPB row gets the lazily-built ge/eq ladder
+                // instead of the bit, which is a different (and much larger)
+                // encoding than the same variable would get with State behind it
+                // -- and one whose atoms a `solx` line cannot satisfy, because
+                // nothing assigns them and the model does not force them.
+                //
+                // No track_eqvar: that pair is what need_pol_item_defining_literal
+                // returns, and takes a SimpleIntegerVariableID. Nothing does pol
+                // steps over a proof-only {0,1} variable today, so this stays a
+                // gap to close when something needs it rather than a second
+                // polarity trap to get wrong (issues #554, #559).
+                names_and_ids_tracker().associate_condition_with_xliteral(id == 1_i, eqvar);
+                names_and_ids_tracker().associate_condition_with_xliteral(id != 1_i, ! eqvar);
+                names_and_ids_tracker().associate_condition_with_xliteral(id == 0_i, ! eqvar);
+                names_and_ids_tracker().associate_condition_with_xliteral(id != 0_i, eqvar);
             } //
         }
             .visit(id);

--- a/gcs/presolvers/auto_table/auto_table.cc
+++ b/gcs/presolvers/auto_table/auto_table.cc
@@ -143,7 +143,11 @@ auto AutoTable::run(Problem & problem, Propagators & propagators, State & initia
     if (selector != selector_var_id)
         throw UnexpectedException{"something went horribly wrong with variable IDs when autotabulating"};
 
-    ExtensionalData data{selector, _vars, move(tuples)};
+    // `selector` stays a State variable here only because this presolver's proof
+    // derivation introduces its literals lazily; the propagator itself no longer
+    // sees a selector at all.
+    auto n_tuples = tuples.size();
+    ExtensionalData data{_vars, move(tuples), ExtensionalLiveTuples::create(initial_state, n_tuples)};
 
     Triggers triggers;
     triggers.on_change = {_vars.begin(), _vars.end()};


### PR DESCRIPTION
Stacked on #795.

The positive table propagator used a selector variable's domain as its set of
still-selectable tuples. Measured over 1.41M propagator calls on a d=15 random
table instance, that cost **15,245,666 trailed `IntervalSet` edits to produce
478,209 useful prunings** — 32 domain edits per inference. The live set averaged
26 values spread over 12.1 intervals, so each removal split a fragmented
`small_vector`, making pass 1 nearer quadratic than linear in live tuples.

The selector becomes two separate things that were previously conflated:

* **A sparse set the propagator owns** (`ExtensionalLiveTuples`). `dense[0, size)`
  are the live tuple indices, `position` is its inverse. Membership is one
  comparison, removal is a swap with the last live entry, and only `size`
  backtracks — everything ever removed sits at or above it, and every deeper
  removal swaps within `[0, size)`, so restoring it re-admits exactly the tuples
  dropped since. The order within the live region differs after a backtrack,
  which changes which support witness is found first but never which values are
  supported, so the inferences are unchanged.

* **A `ProofOnlySimpleIntegerVariableID`**, created by `define_proof_model` purely
  so the OPB rows have something to name. No `State`, no domain, no propagation
  cost. Nothing in the proof cites it: the selector prunings were always
  `NoJustificationNeeded`, and VeriPB re-derives `selector != i` by unit
  propagation from the tuple rows when it checks a `var != val` RUP.

This supersedes the concrete-selector half of #795 — that member no longer
exists. The reason hoist stays.

Three `logger && get_assertion_level() != Off` special cases collapse into one
`if (0 == live_count)`, with both contradiction spellings kept exactly: explicit
RUP at higher assertion levels, and otherwise no justification and no reason,
because that is what emptying a domain reported and the conflict observer behind
dom/wdeg reads that reason.

`AutoTable` and `tabulation.cc` keep their `State` selectors, which their proof
derivations introduce literals against; they simply no longer hand one to the
propagator. Removing those needs a proof-only overload of
`NamesAndIdsTracker::create_literals_for_introduced_variable_value`.

### A proof-machinery gap this uncovered

`set_up_direct_only_variable_encoding` special-cases a {0, 1} variable to a
single bit, and registered the eq/ne condition-to-literal aliases only for the
`State` variant — the proof-only arm was a comment saying there was no API for
it. There is; only `track_eqvar` is `State`-only. Without the aliases a two-tuple
table wrote its rows against a lazily-built ge/eq ladder instead of the bit, and
no `solx` line could satisfy those atoms, because nothing assigns them and the
model does not force them. `table_constraint` and `table_constraint_view_mixed`
caught it.

### Measurements

fataepyc-10 pinned, boost off, median of 3, matched trees throughout.

Against #795, over the benchmark matrix: **1.1× to 3.4×**, largest where the gap
to Gecode was worst — 3.4× on functional tables and at arity 5, 2.3× at arity 3,
1.7–2.2× on binary tables.

Against Gecode 6.3.0, worst case over the matrix improves from 32.1× to 9.3×:

| shape | before | after |
|---|---|---|
| arity 5 | 32.1× | **9.3×** |
| functional (one support per input row) | 30.4× | **8.8×** |
| arity 3 | 19.5× | **8.2×** |
| binary tables | 4.0–9.9× | **3.1–5.6×** |

On the real XCSP3 instances, Renault's solve ratio improves from 37–106× to
12–49×. Including the time to post the model, GCS goes from 0.4–2.8× to
0.2–2.0×, so it is now five times faster than Gecode end to end on
`Renault-megane-pos`, where Gecode still spends 95 ms building compact tables to
save a few.

The final commit is documentation: a worked example in
`propagator-performance.md` of confirming that variant dispatch is *not* worth
specialising, since `in_domain` is now 34% of the profile and looks exactly like
a case where it should be.

Towards #508.

### Testing

`ctest` 645/645, and the full workflow-2 chain verifies with a real
`cake_pb_cp` on `table`, `negative_table`, `smart_table` and `element`, sat and
unsat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012mn99ERAhD4YrAaqZrdjZ3