### PR TITLE
The SCC arm's reachability core, and the anchored encoding it needs

### DIFF
--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -774,6 +774,11 @@ if(GCS_BUILD_TESTS)
     add_test(NAME subcircuit_prevent COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:subcircuit_prevent_test>)
     add_view_tests(subcircuit_prevent subcircuit_prevent_test 8)
 
+    add_executable(subcircuit_scc_test constraints/circuit/subcircuit_scc_test.cc)
+    target_link_libraries(subcircuit_scc_test PRIVATE glasgow_constraint_solver)
+    add_test(NAME subcircuit_scc COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:subcircuit_scc_test>)
+    add_view_tests(subcircuit_scc subcircuit_scc_test 12)
+
     add_executable(subcircuit_test constraints/circuit/subcircuit_test.cc)
     target_link_libraries(subcircuit_test PRIVATE glasgow_constraint_solver)
     add_test(NAME subcircuit_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:subcircuit_test>)

--- a/gcs/constraints/circuit/subcircuit.cc
+++ b/gcs/constraints/circuit/subcircuit.cc
@@ -5,6 +5,7 @@
 #include <gcs/constraints/circuit/subcircuit.hh>
 #include <gcs/exception.hh>
 #include <gcs/innards/inference_tracker.hh>
+#include <gcs/innards/proofs/am1_from_pairs.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
 #include <gcs/innards/proofs/pol_builder.hh>
 #include <gcs/innards/proofs/proof_model.hh>
@@ -44,7 +45,9 @@ using std::format;
 using fmt::format;
 #endif
 
+using std::cmp_equal;
 using std::cmp_greater_equal;
+using std::cmp_not_equal;
 using std::make_optional;
 using std::make_unique;
 using std::map;
@@ -287,9 +290,183 @@ namespace
             force_undecided(true);
     }
 
+    // Everything on the tour is reachable from the anchor, because the tour is one cycle
+    // through it. So anything the anchor cannot reach has to opt out. This is the
+    // connectivity core of Francis and Stuckey's `scc`, and their observation that this
+    // family cannot say anything until some node is mandatory is why it is guarded on the
+    // anchor: without one there is nothing to be reachable from.
+    //
+    // Self loops are not tour edges -- a node pointing at itself is off the tour -- so they
+    // are not followed, which is the same care F&S call for: "self-cycle edges must be
+    // handled carefully... ignored when finding the children of a node".
+    auto reachable_layers(const vector<IntegerVariableID> & succ, const long anchor, const State & state) -> vector<vector<bool>>
+    {
+        auto n = succ.size();
+        // layers[t][x]: x is reachable from the anchor in at most t steps. The certificate
+        // walks these out one at a time, so it needs each layer and not just the union.
+        auto layers = vector<vector<bool>>(n, vector<bool>(n, false));
+        layers[0][static_cast<size_t>(anchor)] = true;
+        for (size_t t = 1; t < n; ++t) {
+            layers[t] = layers[t - 1];
+            for (size_t i = 0; i < n; ++i) {
+                if (! layers[t - 1][i])
+                    continue;
+                for (const auto & v : state.each_value_immutable(succ[i])) {
+                    auto j = static_cast<size_t>(v.raw_value);
+                    if (cmp_not_equal(j, i))
+                        layers[t][j] = true;
+                }
+            }
+        }
+        return layers;
+    }
+
+    // At most one of the successors takes value v. The all-different encoding only has the
+    // pairwise rows, so the clique inequality over them has to be derived -- which is
+    // recover_am1_from_pairs's job, so all there is to do here is emit the pairs it merges
+    // and remember the answer.
+    //
+    // This was a hand-rolled staircase until it turned out to be the fifth copy of one
+    // derivation, four of which predate the shared version. Not for the reason the shared
+    // version's own documentation gives, though, which is worth recording because the next
+    // caller to switch over will read it: recover_am1_from_pairs pins its result with an
+    // `ia` step, on the grounds that every intermediate is sound whatever it is fed, so a
+    // corrupted merge lands on a weaker line VeriPB is right to accept. *At this call site
+    // that pin buys nothing*, measured rather than assumed -- the pigeonhole below consumes
+    // this line coefficient by coefficient, so a merge that lost an input, summed
+    // everything at once, or skipped the final division is already rejected downstream,
+    // hand-rolled and unpinned, in all four cases tried. What the switch does buy is one
+    // derivation instead of five, a refusal rather than an operandless `pol` below two
+    // members, and the induction's scaffolding deleted rather than left live. It costs 0.7%
+    // more `.pbp`.
+    auto need_value_at_most_one(ProofLogger & logger, const vector<IntegerVariableID> & succ, SCCProofCache & cache, const long v) -> ProofLine
+    {
+        if (auto found = cache.value_at_most_one.find(v); found != cache.value_at_most_one.end())
+            return found->second;
+
+        // The lower triangle, in the order the induction consumes it.
+        vector<ProofLiteralOrFlag> members;
+        auto at_most_ones = vector<vector<ProofLine>>(succ.size());
+        for (size_t j = 0; j < succ.size(); ++j) {
+            members.emplace_back(succ[j] == Integer{v});
+            for (size_t i = 0; i < j; ++i)
+                at_most_ones[j].emplace_back(logger.emit_rup_proof_line(
+                    WPBSum{} + 1_i * ! (succ[i] == Integer{v}) + 1_i * ! (succ[j] == Integer{v}) >= 1_i, ProofLevel::Temporary));
+        }
+
+        auto line = recover_am1_from_pairs(logger, members, at_most_ones, ProofLevel::Top);
+        cache.value_at_most_one.emplace(v, line);
+        return line;
+    }
+
+    // At least one of the successors takes value v: pigeonhole. Every successor takes some
+    // value, and every value other than v can be taken by at most one of them, so with as
+    // many successors as values somebody has to take v. This is what makes the reachability
+    // induction below possible at all -- it is how "the node at position t has a
+    // predecessor" gets said.
+    auto need_value_at_least_one(ProofLogger & logger, const vector<IntegerVariableID> & succ, SCCProofCache & cache, const long v) -> ProofLine
+    {
+        if (auto found = cache.value_at_least_one.find(v); found != cache.value_at_least_one.end())
+            return found->second;
+
+        PolBuilder pigeonhole;
+        for (const auto & s : succ)
+            pigeonhole.add(logger.names_and_ids_tracker().need_constraint_saying_variable_takes_at_least_one_value(s));
+        for (size_t w = 0; w < succ.size(); ++w)
+            if (cmp_not_equal(w, v))
+                pigeonhole.add(need_value_at_most_one(logger, succ, cache, static_cast<long>(w)));
+
+        auto line = pigeonhole.emit(logger, ProofLevel::Top);
+        cache.value_at_least_one.emplace(v, line);
+        return line;
+    }
+
+    // Justify "node m cannot be on the tour" for every m the anchor cannot reach, by walking
+    // out from the anchor one layer at a time.
+    //
+    // The fact derived at each layer t, for each node x the anchor has not reached within t
+    // steps, is
+    //
+    //     E(t, x):  pos[x] = t  ->  succ[x] = x
+    //
+    // "x sitting at position t has to be off the tour". Its proof is the same at every
+    // layer. Somebody is x's predecessor, and for each candidate q either q = x, which is
+    // the conclusion, or the step row puts q at position t-1. A q the anchor *had* reached
+    // within t-1 steps cannot point at x, or x would have been reached within t; that is in
+    // the reason. A q it had not reached carries E(t-1, q), so q at t-1 is off the tour and
+    // cannot point at x either. At t = 0 the step row puts q at position -1, which the
+    // position variable's own lower bound refuses, so the layer needs nothing before it.
+    //
+    // Two things make this work here where circuit_scc.cc's argument would not. Positions
+    // are anchored on the very node the walk starts from, so no shifting to an arbitrary
+    // root is needed -- and that shift would be modulo the tour's length, which is a
+    // variable. And a node off the tour sits at position zero, so position t >= 1 already
+    // means on the tour and nothing has to count how long the tour is.
+    //
+    // The whole thing is a chain of RUP lemmas with exactly one cutting-planes step in it,
+    // the pigeonhole for "somebody is x's predecessor". Nothing else needs a `pol`, and
+    // nothing has to cite a step row either, which is worth stating because the arithmetic
+    // looks as though it should need both: taking "x is at t" through the step row to "q is
+    // at t-1" is unit propagation on the two halves of that row. The row is written over
+    // `pos[x] - pos[q]`, so with `pos[x]` fixed at t the `>=` half gives `pos[q] <= t-1` and
+    // the `<=` half gives `pos[q] >= t-1` -- the `>=` half is the one bounding q from above,
+    // which is the opposite way round from how it reads -- and between them they pin every
+    // bit. Those halves are model rows, so unit propagation reaches them unaided -- and
+    // only because the encoding is anchored, since without an anchor each is guarded on a
+    // `first` flag as well, which nothing here would have fixed. Adding pols to help was
+    // measured and they were dead weight: each one removed leaves every test verifying,
+    // while a plain JustifyUsingRUP in place of this function still gets rejected, so it is
+    // these lemmas and not the arithmetic that is load-bearing. Dropping the pigeonhole
+    // does make VeriPB reject.
+    auto derive_unreachable(ProofLogger & logger, const vector<IntegerVariableID> & succ, const SubCircuitPosData & pos_data, SCCProofCache & cache,
+        const vector<vector<bool>> & reached_within, const ReasonLiterals & reason) -> void
+    {
+        auto n = succ.size();
+        logger.emit_proof_comment("everything on the tour is reachable from the anchor, one layer at a time");
+
+        for (size_t t = 0; t < n; ++t)
+            for (size_t x = 0; x < n; ++x) {
+                if (reached_within[t][x] || cmp_equal(x, *pos_data.anchor))
+                    continue;
+
+                auto at_t = pos_data.pos.at(static_cast<long>(x)) == Integer(static_cast<long long>(t));
+
+                // "Somebody is x's predecessor" is not in the encoding -- the all-different
+                // rows are a pairwise clique, which is at-most-one only -- so it has to be
+                // derived, and it is what the layer's conclusion resolves the candidates
+                // against. Emitted for its place in the database rather than for its line
+                // number, at ProofLevel::Top and cached, so a later layer and a later search
+                // node both reuse it.
+                need_value_at_least_one(logger, succ, cache, static_cast<long>(x));
+
+                for (size_t q = 0; q < n; ++q) {
+                    if (q == x)
+                        continue;
+
+                    // A predecessor the anchor had already reached cannot point at x -- x
+                    // would have been reached too -- and that is in the reason, so unit
+                    // propagation has it without any help.
+                    if (t > 0 && reached_within[t - 1][q])
+                        continue;
+                    // Nor can the anchor itself, for the same reason, and it carries no
+                    // E(t-1, .) of its own.
+                    if (cmp_equal(q, *pos_data.anchor))
+                        continue;
+
+                    logger.emit_rup_proof_line_under_reason(
+                        reason, WPBSum{} + 1_i * ! at_t + 1_i * ! (succ[q] == Integer(static_cast<long long>(x))) >= 1_i, ProofLevel::Temporary);
+                }
+
+                // E(t, x) itself, at ProofLevel::Current so that the next layer still has it:
+                // that is how the layers chain, and why nothing has to restate a layer.
+                logger.emit_rup_proof_line_under_reason(
+                    reason, WPBSum{} + 1_i * ! at_t + 1_i * (succ[x] == Integer(static_cast<long long>(x))) >= 1_i, ProofLevel::Current);
+            }
+    }
+
     auto propagate_subcircuit(const vector<IntegerVariableID> & succ, const ConstraintID & owner, const SubCircuitPosData & pos_data,
-        const ConstraintStateHandle & unassigned_handle, const bool prevent, const State & state, auto & inference, ProofLogger * const logger)
-        -> void
+        const ConstraintStateHandle & unassigned_handle, const bool prevent, const optional<long> & scc_anchor,
+        const std::shared_ptr<SCCProofCache> & cache, const State & state, auto & inference, ProofLogger * const logger) -> void
     {
         if (! propagate_non_gac_alldifferent(unassigned_handle, state, inference, logger, owner))
             return;
@@ -334,6 +511,24 @@ namespace
 
             auto justf = [&, cycle](const ReasonLiterals &) { derive_tour_at_most(*logger, pos_data, cycle); };
             inference.infer_all(logger, off, JustifyExplicitly{justf, ThenRUP::Yes, hints::SubCircuit{owner}}, generic_reason(succ));
+        }
+
+        if (scc_anchor) {
+            auto layers = reachable_layers(succ, *scc_anchor, state);
+            const auto & seen = layers.back();
+            vector<Literal> unreachable;
+            for (size_t m = 0; m < n; ++m) {
+                if (seen[m])
+                    continue;
+                auto here = Integer(static_cast<long long>(m));
+                if (state.optional_single_value(succ[m]) == here)
+                    continue;
+                unreachable.emplace_back(succ[m] == here);
+            }
+            if (! unreachable.empty()) {
+                auto justf = [&](const ReasonLiterals & reason) { derive_unreachable(*logger, succ, pos_data, *cache, layers, reason); };
+                inference.infer_all(logger, unreachable, JustifyExplicitly{justf, ThenRUP::Yes, hints::SubCircuit{owner}}, generic_reason(succ));
+            }
         }
 
         if (! prevent)
@@ -568,7 +763,11 @@ auto SubCircuit::define_proof_model(ProofModel & model, const State &) -> void
 
 auto SubCircuit::install_propagators(Propagators & propagators) -> void
 {
-    auto prevent = std::holds_alternative<Prevent>(_algorithm);
+    auto prevent = ! std::holds_alternative<Check>(_algorithm);
+    auto scc_anchor = std::holds_alternative<gcs::subcircuit::SCC>(_algorithm) ? _required_node : nullopt;
+    // Proof lines, not search state: they stay valid at every later node, so the cache
+    // deliberately does not backtrack, exactly as circuit_scc.cc's does.
+    auto cache = std::make_shared<SCCProofCache>();
 
     if (_tour_size) {
         // Its own propagator, on its own triggers: this one has to wake on a value being
@@ -592,11 +791,15 @@ auto SubCircuit::install_propagators(Propagators & propagators) -> void
 
     Triggers triggers;
     triggers.on_instantiated = {_succ.begin(), _succ.end()};
+    // Reachability shrinks when a value is removed, not only when a successor is fixed, so
+    // the SCC arm needs the wider trigger.
+    if (scc_anchor)
+        triggers.on_change = {_succ.begin(), _succ.end()};
     propagators.install(
         constraint_id(),
-        [succ = _succ, owner = constraint_id(), pos_data = std::move(_pos_data), unassigned_handle = _state_handles.unassigned, prevent](
-            const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
-            propagate_subcircuit(succ, owner, pos_data, unassigned_handle, prevent, state, inference, logger);
+        [succ = _succ, owner = constraint_id(), pos_data = std::move(_pos_data), unassigned_handle = _state_handles.unassigned, prevent, scc_anchor,
+            cache](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+            propagate_subcircuit(succ, owner, pos_data, unassigned_handle, prevent, scc_anchor, cache, state, inference, logger);
             // Deliberately not claiming idempotence, unlike circuit::Prevent: forcing a
             // node to be a self loop fixes a successor, which changes the chain structure
             // this pass walked, and one pass makes no attempt to reach the fixpoint of

--- a/gcs/constraints/circuit/subcircuit.cc
+++ b/gcs/constraints/circuit/subcircuit.cc
@@ -44,6 +44,7 @@ using std::format;
 using fmt::format;
 #endif
 
+using std::cmp_greater_equal;
 using std::make_optional;
 using std::make_unique;
 using std::map;
@@ -194,11 +195,38 @@ namespace
 
         // One comment for the whole derivation rather than one per case: there are
         // |cycle| + 1 cases and a proof comment costs bytes at every firing.
+        if (pos_data.anchor) {
+            // With the tour anchored at a named node, which edge wraps is known, so there
+            // is nothing to split over: one polish-notation step either way.
+            if (std::find(cycle.begin(), cycle.end(), *pos_data.anchor) == cycle.end()) {
+                // Every edge of the cycle steps, and chaining them telescopes to 0 >= k.
+                // The cycle cannot exist at all -- no evidence node needed, because the
+                // anchor is itself a node outside it that has to be on the tour.
+                logger.emit_proof_comment(format("this cycle of {} misses the anchor entirely", k));
+                PolBuilder avoids_anchor;
+                for (size_t t = 0; t < k; ++t)
+                    add_sat(avoids_anchor, *pos_data.edges.at(cycle[t]).at(next(t)).step_ge);
+                avoids_anchor.emit(logger, ProofLevel::Current);
+            }
+            else {
+                // The edge into the anchor is the wrap; chaining the rest bounds the tour.
+                logger.emit_proof_comment(format("this cycle of {} contains the anchor, so it is the whole tour", k));
+                PolBuilder is_whole_tour;
+                for (size_t t = 0; t < k; ++t) {
+                    const auto & lines = pos_data.edges.at(cycle[t]).at(next(t));
+                    add_sat(is_whole_tour, next(t) == *pos_data.anchor ? *lines.wrap_le : *lines.step_le);
+                }
+                is_whole_tour.emit(logger, ProofLevel::Current);
+            }
+            return;
+        }
+
+        // Unanchored, so every node of the cycle is a candidate for being first.
         logger.emit_proof_comment(format("this cycle of {} bounds the whole tour, whichever of its nodes is first", k));
 
         PolBuilder no_first;
         for (size_t t = 0; t < k; ++t)
-            add_sat(no_first, pos_data.edges.at(cycle[t]).at(next(t)).step_ge);
+            add_sat(no_first, *pos_data.edges.at(cycle[t]).at(next(t)).step_ge);
 
         PolBuilder combine;
         combine.add(no_first.emit(logger, ProofLevel::Current));
@@ -206,7 +234,7 @@ namespace
             PolBuilder this_first;
             for (size_t t = 0; t < k; ++t) {
                 const auto & lines = pos_data.edges.at(cycle[t]).at(next(t));
-                add_sat(this_first, next(t) == cycle[s] ? lines.wrap_le : lines.step_le);
+                add_sat(this_first, next(t) == cycle[s] ? *lines.wrap_le : *lines.step_le);
             }
             add_sat(combine, this_first.emit(logger, ProofLevel::Current));
         }
@@ -361,6 +389,17 @@ auto SubCircuit::with_gac_all_different(optional<bool> enable) -> SubCircuit &
     return *this;
 }
 
+auto SubCircuit::with_required_node(long node) -> SubCircuit &
+{
+    // The range is checkable here, so check it here: a caller who has miscounted finds out
+    // at the call rather than when search starts. Whether the node is really declared on
+    // the tour needs the initial domains, so that one waits for prepare().
+    if (node < 0 || cmp_greater_equal(node, _succ.size()))
+        throw InvalidProblemDefinitionException{"SubCircuit: with_required_node() names a node outside the successor array"};
+    _required_node = node;
+    return *this;
+}
+
 auto SubCircuit::with_tour_size(IntegerVariableID size) -> SubCircuit &
 {
     _tour_size = size;
@@ -383,6 +422,16 @@ auto SubCircuit::prepare(Propagators & propagators, State & initial_state, Proof
         all_diff.set_constraint_id(constraint_id());
         std::move(all_diff).install(propagators, initial_state, model);
     }
+
+    // The named node has to be declared on the tour, not merely constrained onto it by
+    // something posted later: the anchored encoding below is only sound if it really is on
+    // the tour, and a constraint posted after this one has not narrowed anything yet when
+    // define_proof_model() runs. A declared domain has, since domains are set when the
+    // variable is created.
+    if (_required_node && initial_state.in_domain(_succ[static_cast<size_t>(*_required_node)], Integer{*_required_node}))
+        throw InvalidProblemDefinitionException{
+            "SubCircuit: with_required_node() names a node whose own index is still in its successor's domain, so it is not declared "
+            "to be on the tour"};
 
     NonGacAllDifferentUnassigned unassigned{};
     for (auto v : _succ)
@@ -416,83 +465,104 @@ auto SubCircuit::define_proof_model(ProofModel & model, const State &) -> void
     for (long i = 0; i < n; ++i)
         data.pos.emplace(i, model.create_proof_only_integer_variable(0_i, Integer{n - 1}, "subpos", IntegerVariableProofRepresentation::Bits));
 
-    // first[i]: node i is on the tour and every lower-numbered node is off it, written as
-    // "all i+1 of these literals hold". Fully reified, so unit propagation fixes the flag
-    // from the successors -- a half-reified flag would leave it free on a solution and the
-    // rows below that need it would not check.
-    for (long i = 0; i < n; ++i) {
-        auto conjunction = WPBSum{} + 1_i * (_succ[i] != Integer{i});
-        for (long j = 0; j < i; ++j)
-            conjunction += 1_i * (_succ[j] == Integer{j});
-        data.first.emplace(i, model.create_proof_flag_fully_reifying(_constraint_id, {i}, "first", conjunction >= Integer{i + 1}));
-    }
+    data.anchor = _required_node;
 
-    // The tour starts at whichever node is first...
-    for (long i = 0; i < n; ++i)
-        data.first_is_zero.emplace(i,
-            model.add_labelled_constraint(
-                _constraint_id, "first_pos_" + to_string(i), WPBSum{} + 1_i * data.pos.at(i) <= 0_i, HalfReifyOnConjunctionOf{{data.first.at(i)}}));
+    if (data.anchor) {
+        // Anchored: the tour starts at the named node, so the only edges that can wrap are
+        // the ones into it. No `first` flags are needed at all.
+        model.add_labelled_constraint(_constraint_id, "anchor_pos", WPBSum{} + 1_i * data.pos.at(*data.anchor) <= 0_i);
+    }
+    else {
+        // first[i]: node i is on the tour and every lower-numbered node is off it, written
+        // as "all i+1 of these literals hold". Fully reified, so unit propagation fixes the
+        // flag from the successors -- a half-reified flag would leave it free on a solution
+        // and the rows below that need it would not check.
+        for (long i = 0; i < n; ++i) {
+            auto conjunction = WPBSum{} + 1_i * (_succ[i] != Integer{i});
+            for (long j = 0; j < i; ++j)
+                conjunction += 1_i * (_succ[j] == Integer{j});
+            data.first.emplace(i, model.create_proof_flag_fully_reifying(_constraint_id, {i}, "first", conjunction >= Integer{i + 1}));
+        }
+
+        // The tour starts at whichever node is first...
+        for (long i = 0; i < n; ++i)
+            data.first_is_zero.emplace(i,
+                model.add_labelled_constraint(_constraint_id, "first_pos_" + to_string(i), WPBSum{} + 1_i * data.pos.at(i) <= 0_i,
+                    HalfReifyOnConjunctionOf{{data.first.at(i)}}));
+    }
 
     // ...and a node off the tour is given position zero. Nothing here needs the positions to
     // be a permutation -- no certificate below relies on them being distinct -- and an
     // off-tour node takes part in no position row at all: it has no successor other than
     // itself, and by all-different nothing else can point at it either. So the only job
-    // these rows have is to leave `pos` determined by the successors under unit
-    // propagation, which is what solution checking needs, and zero does that as well as
-    // anything.
+    // these rows have is to leave `pos` determined by the successors under unit propagation,
+    // which is what solution checking needs, and zero does that as well as anything.
     //
     // The stdlib decomposition instead numbers off-tour nodes after every on-tour one, in
-    // index order, which does make the positions a permutation. That is what to reach for
-    // if the wrap rows below ever move into the proof -- the counting argument they would
-    // need is a pigeonhole over the positions -- but it costs n rows of n+1 terms where
-    // this costs n rows of one, and nothing today buys anything with it.
+    // index order, which does make the positions a permutation. That is what to reach for if
+    // the wrap rows below ever move into the proof -- the counting argument they would need
+    // is a pigeonhole over the positions -- but it costs n rows of n+1 terms where this
+    // costs n rows of one, and nothing today buys anything with it.
     for (long i = 0; i < n; ++i)
         model.add_labelled_constraint(
             _constraint_id, "off_pos_" + to_string(i), WPBSum{} + 1_i * data.pos.at(i) <= 0_i, HalfReifyOnConjunctionOf{{_succ[i] == Integer{i}}});
 
-    // Each edge gets two row families rather than Circuit's one, because which edge wraps
-    // around is not known statically: it is the edge into whichever node is `first`, and
-    // that is only pinned down once the membership literals are. Circuit anchors on node 0,
-    // so it writes the `+1` form for every column but 0 and the wrap form for column 0, and
-    // never both for the same edge.
+    // How many row families an edge needs depends on whether the wrap edge is known.
     //
-    // This is the one place where the encoding carries something for the proof's benefit
-    // rather than saying the constraint as compactly as it could, so it is worth recording
-    // why rather than leaving it to be rediscovered. The wrap rows are what let a
-    // propagator that has found a closed cycle *count*: chaining them gives "the tour is no
-    // longer than this cycle" in a bounded number of steps (see derive_tour_at_most).
-    // Without them the encoding is smaller -- n^2 row families rather than 2n^2, smaller
-    // than the stdlib decomposition -- and still exact, because a cycle avoiding the anchor
-    // still chains to 0 = k. But then that counting fact has to be derived instead, and
-    // deriving it needs "the on-tour positions are exactly 0..L-1", a pigeonhole induction
-    // *conditional on the variable L*. That is the same obstacle that stops circuit_scc.cc's
-    // machinery being ported here, so the smaller encoding is not a free reformulation: it
-    // is blocked on the same open problem.
+    // Anchored, it is: only the edges into the named node wrap, so each edge gets exactly
+    // one family, and this is precisely Circuit's shape -- it writes the `+1` form for
+    // every column but 0 and the wrap form for column 0, because it anchors on node 0.
     //
-    // The other way out is a statically known anchor, which collapses this to exactly
-    // Circuit's shape, since only the n edges into a nominated on-tour node can wrap. That
-    // needs the caller to name one. The C++ and .scp interfaces could; MiniZinc cannot on
-    // the models that matter, because both challenge models post their "this node is
-    // visited" constraint *after* the subcircuit call and MiniZinc flattens in source order,
-    // so the domain is not yet narrowed when the redefinition runs.
+    // Unanchored, it is not: the wrap edge is the one into whichever node is `first`, which
+    // is only pinned down once the membership literals are, so both cases have to be
+    // written and every certificate splits over the candidates. This is the one place where
+    // the encoding carries something for the proof's benefit rather than saying the
+    // constraint as compactly as it could, so it is worth recording why rather than leaving
+    // it to be rediscovered. The wrap rows are what let a propagator that has found a
+    // closed cycle *count*: chaining them gives "the tour is no longer than this cycle" in
+    // a bounded number of steps (see derive_tour_at_most). Without them the encoding is
+    // smaller -- n^2 row families rather than 2n^2, smaller than the stdlib decomposition
+    // -- and still exact, because a cycle avoiding the anchor still chains to 0 = k. But
+    // then that counting fact has to be derived instead, and deriving it needs "the on-tour
+    // positions are exactly 0..L-1", a pigeonhole induction *conditional on the variable
+    // L*. So the smaller encoding is not a free reformulation; naming an anchor is the way
+    // to get it, and that is what with_required_node() is for.
     for (long i = 0; i < n; ++i)
         for (long j = 0; j < n; ++j) {
             if (i == j)
                 continue;
 
-            auto step = WPBSum{} + 1_i * data.pos.at(j) + -1_i * data.pos.at(i);
-            auto [step_le, step_ge] = model.add_labelled_constraint(_constraint_id, "pos_step_" + to_string(i) + "_" + to_string(j) + "_le",
-                "pos_step_" + to_string(i) + "_" + to_string(j) + "_ge", step == 1_i,
-                HalfReifyOnConjunctionOf{{_succ[i] == Integer{j}, ! data.first.at(j)}});
+            EdgePosLines lines;
+            auto pos_difference = [&]() { return WPBSum{} + 1_i * data.pos.at(j) + -1_i * data.pos.at(i); };
+            auto role = to_string(i) + "_" + to_string(j);
 
-            auto wrap = WPBSum{} + 1_i * data.pos.at(j) + -1_i * data.pos.at(i);
-            for (const auto & term : tour_size.terms)
-                wrap += term;
-            auto [wrap_le, wrap_ge] = model.add_labelled_constraint(_constraint_id, "pos_wrap_" + to_string(i) + "_" + to_string(j) + "_le",
-                "pos_wrap_" + to_string(i) + "_" + to_string(j) + "_ge", wrap == 1_i,
-                HalfReifyOnConjunctionOf{{_succ[i] == Integer{j}, data.first.at(j)}});
+            auto wraps_here = data.anchor ? (j == *data.anchor) : true;
+            auto steps_here = data.anchor ? (j != *data.anchor) : true;
 
-            data.edges[i].emplace(j, EdgePosLines{step_le, step_ge, wrap_le, wrap_ge});
+            if (steps_here) {
+                auto guard = HalfReifyOnConjunctionOf{{_succ[i] == Integer{j}}};
+                if (! data.anchor)
+                    guard.emplace_back(! data.first.at(j));
+                auto [le, ge] = model.add_labelled_constraint(
+                    _constraint_id, "pos_step_" + role + "_le", "pos_step_" + role + "_ge", pos_difference() == 1_i, guard);
+                lines.step_le = le;
+                lines.step_ge = ge;
+            }
+
+            if (wraps_here) {
+                auto wrap = pos_difference();
+                for (const auto & term : tour_size.terms)
+                    wrap += term;
+                auto guard = HalfReifyOnConjunctionOf{{_succ[i] == Integer{j}}};
+                if (! data.anchor)
+                    guard.emplace_back(data.first.at(j));
+                auto [le, ge] =
+                    model.add_labelled_constraint(_constraint_id, "pos_wrap_" + role + "_le", "pos_wrap_" + role + "_ge", wrap == 1_i, guard);
+                lines.wrap_le = le;
+                lines.wrap_ge = ge;
+            }
+
+            data.edges[i].emplace(j, lines);
         }
 }
 
@@ -544,6 +614,8 @@ auto SubCircuit::clone() const -> unique_ptr<Constraint>
     cloned->with_gac_all_different(_gac_all_different);
     if (_tour_size)
         cloned->with_tour_size(*_tour_size);
+    if (_required_node)
+        cloned->with_required_node(*_required_node);
     return cloned;
 }
 

--- a/gcs/constraints/circuit/subcircuit.hh
+++ b/gcs/constraints/circuit/subcircuit.hh
@@ -90,6 +90,7 @@ namespace gcs
         SubCircuitAlgorithm _algorithm = subcircuit::Prevent{};
         bool _gac_all_different = false;
         std::optional<IntegerVariableID> _tour_size;
+        std::optional<long> _required_node;
 
         // Backtrackable state allocated by prepare(), consumed by install_propagators().
         innards::subcircuit::SubCircuitStateHandles _state_handles;
@@ -115,6 +116,23 @@ namespace gcs
         /// propagator, in addition to the subcircuit propagation. Off by default (a cheaper
         /// value-consistent all-different is always applied regardless).
         auto with_gac_all_different(std::optional<bool> enable = true) -> SubCircuit &;
+
+        /// Name a node that is already declared to be on the tour -- its own index must
+        /// not be in its successor's domain, and this throws if it is. That is a
+        /// precondition, not a strengthening: the constraint means exactly the same thing
+        /// with and without it, so nothing about it is recorded in the `.scp`, in the same
+        /// way the choice of algorithm is not.
+        ///
+        /// What it buys is a cheaper proof. Without it, which edge of the tour wraps around
+        /// is not known until the membership literals are, so every edge needs a row for
+        /// each case and every certificate splits over the cycle's nodes. With it, only the
+        /// edges into the named node can wrap, which is exactly the shape Circuit gets for
+        /// free by anchoring on node 0: half the rows, and one polish-notation step per
+        /// certificate rather than one per node of the cycle.
+        ///
+        /// It is also what the SCC propagation needs, which cannot infer anything at all
+        /// until some node is known to be on the tour.
+        auto with_required_node(long node) -> SubCircuit &;
 
         /// Constrain how many nodes are on the tour: `size` is the number that do not
         /// point at themselves. This is XCSP3's `size` argument, for which MiniZinc's

--- a/gcs/constraints/circuit/subcircuit.hh
+++ b/gcs/constraints/circuit/subcircuit.hh
@@ -45,17 +45,36 @@ namespace gcs
         struct Prevent final
         {
         };
+
+        /**
+         * \brief Propagate SubCircuit by reachability as well: as subcircuit::Prevent, and
+         * additionally require every node on the tour to be reachable from the node the
+         * caller named with with_required_node(), forcing anything unreachable to opt out.
+         *
+         * This is the connectivity core of Francis and Stuckey's `scc` algorithm. Their
+         * four extra pruning rules -- prune root, prune skip, fix required edges and prune
+         * within -- are not here yet.
+         *
+         * It needs with_required_node(), and does nothing without it: there is nothing to
+         * be reachable *from* until some node is known to be on the tour, which is Francis
+         * and Stuckey's own observation about applying this family to subcircuit at all.
+         *
+         * \ingroup Constraints
+         */
+        struct SCC final
+        {
+        };
     }
 
     /**
      * \brief The propagation algorithms supported by SubCircuit: subcircuit::Prevent (the
-     * default) or subcircuit::Check (cheaper and weaker). Requesting anything else is a
-     * compile-time error, and the choice never changes the constraint's meaning or its
-     * proof encoding.
+     * default), subcircuit::Check (cheaper and weaker) or subcircuit::SCC (stronger, and
+     * only useful with with_required_node()). Requesting anything else is a compile-time
+     * error, and the choice never changes the constraint's meaning or its proof encoding.
      *
      * \ingroup Constraints
      */
-    using SubCircuitAlgorithm = std::variant<subcircuit::Check, subcircuit::Prevent>;
+    using SubCircuitAlgorithm = std::variant<subcircuit::Check, subcircuit::Prevent, subcircuit::SCC>;
 
     /**
      * \brief SubCircuit constraint: requires the variables, representing graph nodes, to

--- a/gcs/constraints/circuit/subcircuit_base.hh
+++ b/gcs/constraints/circuit/subcircuit_base.hh
@@ -21,12 +21,12 @@ namespace gcs::innards::subcircuit
      */
     struct EdgePosLines
     {
-        // (succ[i] = j and not first[j]) -> pos[j] - pos[i] = 1
-        ProofLine step_le;
-        ProofLine step_ge;
-        // (succ[i] = j and first[j]) -> pos[j] - pos[i] + |tour| = 1
-        ProofLine wrap_le;
-        ProofLine wrap_ge;
+        // (succ[i] = j [and not first[j]]) -> pos[j] - pos[i] = 1
+        std::optional<ProofLine> step_le;
+        std::optional<ProofLine> step_ge;
+        // (succ[i] = j [and first[j]]) -> pos[j] - pos[i] + |tour| = 1
+        std::optional<ProofLine> wrap_le;
+        std::optional<ProofLine> wrap_ge;
     };
 
     /**
@@ -46,6 +46,10 @@ namespace gcs::innards::subcircuit
     struct SubCircuitPosData
     {
         bool defined = false;
+        // Set when the caller named a node already known to be on the tour. Then the tour
+        // is anchored there, only the edges into it carry a wrap row, and there are no
+        // `first` flags at all -- Circuit's shape, which it gets by anchoring on node 0.
+        std::optional<long> anchor;
         std::map<long, ProofOnlySimpleIntegerVariableID> pos;
         // first[i]: node i is on the tour and every lower-numbered node is off it. At most
         // one of these holds, and exactly one does unless the tour is empty.

--- a/gcs/constraints/circuit/subcircuit_base.hh
+++ b/gcs/constraints/circuit/subcircuit_base.hh
@@ -12,12 +12,14 @@
 namespace gcs::innards::subcircuit
 {
     /**
-     * \brief The four position rows written for one edge i -> j.
+     * \brief The position rows written for one edge i -> j: a step pair, a wrap pair, or
+     * both.
      *
      * Circuit needs only one pair per edge, because its tour has a fixed anchor (node 0)
-     * and so the wrap-around edge is known statically. Here the anchor is whichever node
-     * is `first`, which is not known until the membership literals are fixed, so both
-     * cases have to be written and the propagator's certificate splits over them.
+     * and so the wrap-around edge is known statically. With with_required_node() this gets
+     * the same shape, on the named node. Without one, the anchor is whichever node is
+     * `first`, which is not known until the membership literals are fixed, so both cases
+     * have to be written and the propagator's certificate splits over them.
      */
     struct EdgePosLines
     {
@@ -33,13 +35,14 @@ namespace gcs::innards::subcircuit
      * \brief The position encoding SubCircuit::define_proof_model() writes, and the proof
      * lines the propagator's justifications cite.
      *
-     * `pos[i]` is node i's index along the tour, counting from whichever node is `first`;
-     * a node off the tour is given position **zero**, so the positions are not a
-     * permutation, and `pos[i] >= 1` already says node i is on the tour. Nothing needs them
-     * distinct: an off-tour node takes part in no position row at all, and all these rows
-     * have to do is leave `pos` determined by the successors under unit propagation, which
-     * is what solution checking needs. define_proof_model() says more about why, including
-     * what the permutation the stdlib decomposition does build would be good for.
+     * `pos[i]` is node i's index along the tour, counting from the anchor if there is one
+     * and otherwise from whichever node is `first`; a node off the tour is given position
+     * **zero**, so the positions are not a permutation, and `pos[i] >= 1` already says node
+     * i is on the tour. Nothing needs them distinct: an off-tour node takes part in no
+     * position row at all, and all these rows have to do is leave `pos` determined by the
+     * successors under unit propagation, which is what solution checking needs.
+     * define_proof_model() says more about why, including what the permutation the stdlib
+     * decomposition does build would be good for.
      *
      * Empty when proof logging is off; `defined` says which.
      */
@@ -57,6 +60,24 @@ namespace gcs::innards::subcircuit
         // first[i] -> pos[i] = 0
         std::map<long, ProofLine> first_is_zero;
         std::map<long, std::map<long, EdgePosLines>> edges;
+    };
+
+    /**
+     * \brief The proof lines the SCC arm derives once and then reuses.
+     *
+     * "Every value is somebody's successor" is not in the encoding -- the all-different
+     * rows are a pairwise clique, which says at most one variable takes a value and nothing
+     * about at least one -- so it has to be derived by pigeonhole over the clique
+     * inequalities recover_am1_from_pairs merges out of those rows. That derivation is O(n) rows per
+     * value and the at-most-ones are shared between values, so it is worth doing once at
+     * ProofLevel::Top and keeping: a proof line stays valid at every later node, and
+     * re-deriving it would only bloat the log. Held by shared_ptr and mutated through it,
+     * as circuit_scc.cc's caches are.
+     */
+    struct SCCProofCache
+    {
+        std::map<long, ProofLine> value_at_most_one;
+        std::map<long, ProofLine> value_at_least_one;
     };
 
     /**

--- a/gcs/constraints/circuit/subcircuit_scc_test.cc
+++ b/gcs/constraints/circuit/subcircuit_scc_test.cc
@@ -1,0 +1,162 @@
+#include <gcs/constraints/circuit.hh>
+#include <gcs/constraints/in.hh>
+#include <gcs/constraints/innards/constraints_test_utils.hh>
+#include <gcs/problem.hh>
+#include <gcs/solve.hh>
+
+#include <cstdlib>
+#include <iostream>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+using namespace gcs;
+using namespace gcs::test_innards;
+
+using std::cout;
+using std::endl;
+using std::make_optional;
+using std::nullopt;
+using std::pair;
+using std::vector;
+
+// A scenario where the reachability rule earns its keep, which took a couple of attempts to
+// build and is worth explaining, because the obvious constructions do not.
+//
+// The twelve nodes split into two halves that point only within themselves, and the anchor
+// is node 6, in the upper half. So the lower half is unreachable from the anchor however the
+// search goes: those six nodes could form a tour of their own, but then there would be two
+// tours, so all six have to opt out. The reachability rule says so before any decision is
+// taken.
+//
+// The trap is that check-and-prevent gets there too, for free, whenever the search happens
+// to close the anchor's tour first: a closed cycle forces everyone outside it to opt out,
+// and that is every bit as strong. So separating the two algorithms takes care. Two earlier
+// versions of this test came out at *exactly* the same recursion count -- once with the
+// halves the other way round, once with them the same size -- because the brancher never
+// entered the unreachable half before the tour closed. Giving that half the smallest domains
+// in the problem is what makes the search walk into it, where only reachability knows the
+// walk is pointless.
+//
+// The tours through node 6 within the upper six number 5 + 20 + 60 + 120 + 120 = 325.
+
+auto post_constraints(Problem & p, vector<IntegerVariableID> & nodes) -> void
+{
+    // The lower half points only within itself, each node at either itself or the next one
+    // round, and the upper half points only within itself. The anchor is in the upper half,
+    // so the lower half is unreachable from it however search goes.
+    //
+    // The lower half's domains are deliberately the *smallest* in the problem, so the
+    // brancher goes there first. That is what makes the two algorithms differ: give the
+    // upper half the smaller domains instead and the tour closes before the search ever
+    // looks at the lower half, whereupon check forces it off for free and reachability adds
+    // nothing at all.
+    for (int i = 0; i < 6; ++i)
+        p.post(In{nodes[static_cast<std::size_t>(i)], {Integer{i}, Integer{(i + 1) % 6}}});
+    for (int i = 6; i < 12; ++i) {
+        vector<Integer> values;
+        for (int v = 6; v < 12; ++v)
+            if (! (i == 6 && v == 6))
+                values.emplace_back(Integer{v});
+        p.post(In{nodes[static_cast<std::size_t>(i)], values});
+    }
+}
+
+// The state at the first search node, which is the root after propagation. That is where
+// the two algorithms differ crisply: reachability has already forced the whole unreachable
+// half to opt out before any decision is taken, and check-and-prevent has not, because
+// nothing is fixed yet for it to reason from.
+auto run(SubCircuitAlgorithm algorithm, const ViewWrapConfig & view_cfg, const std::string & label, long & lower_half_fixed_at_root) -> long
+{
+    constexpr int n_positions = 12;
+    auto wraps = wraps_for_positions(view_cfg, n_positions);
+
+    Problem p;
+    // The anchor's own index has to be out of its declared domain, not merely constrained
+    // out by the In below, since with_required_node() checks the domain as declared. Node 6
+    // therefore starts at 7, and the In narrows it back to the upper half.
+    //
+    // A view keeps that declared domain -- it is the same variable seen through an offset,
+    // not a fresh one -- so the anchor is still declared on the tour under every wrap, which
+    // is what lets this scenario go through the view sweep at all.
+    vector<IntegerVariableID> nodes;
+    for (int i = 0; i < n_positions; ++i)
+        nodes.push_back(
+            create_integer_variable_or_constant_with_view(p, pair{i == 6 ? 7 : 0, n_positions - 1}, wraps.at(static_cast<std::size_t>(i))));
+
+    post_constraints(p, nodes);
+    p.post(SubCircuit{nodes}.with_required_node(6).with_algorithm(algorithm));
+
+    bool proofs = can_run_veripb();
+    auto proof_name = proofs ? make_optional("subcircuit_scc_test_" + label + "_" + view_wrap_config_label(view_cfg)) : nullopt;
+    long found = 0;
+    auto seen_root = false;
+    lower_half_fixed_at_root = 0;
+    auto stats = solve_with(p, //
+        SolveCallbacks{        //
+            .solution = [&](const CurrentState &) -> bool {
+                ++found;
+                return true;
+            },
+            .trace = [&](const CurrentState & s) -> bool {
+                if (! seen_root) {
+                    seen_root = true;
+                    for (int i = 0; i < 6; ++i)
+                        if (s.has_single_value(nodes[static_cast<std::size_t>(i)]) && s(nodes[static_cast<std::size_t>(i)]) == Integer{i})
+                            ++lower_half_fixed_at_root;
+                }
+                return true;
+            }},
+        proof_name ? make_optional<ProofOptions>(*proof_name) : nullopt);
+
+    cout << label << ": " << found << " solutions, " << stats.recursions << " recursions, " << lower_half_fixed_at_root
+         << " of the unreachable half opted out at the root" << endl;
+
+    if (proof_name && ! verify_proof_and_dispose(*proof_name))
+        return -1;
+
+    return found;
+}
+
+auto main(int argc, char * argv[]) -> int
+{
+    establish_and_announce_seed(argc, argv);
+
+    constexpr int n_positions = 12;
+    auto view_cfg = parse_view_wrap_config_from_argv(argc, argv);
+    if (view_cfg.single_position && (*view_cfg.single_position < 0 || *view_cfg.single_position >= n_positions)) {
+        cout << "subcircuit_scc view sweep: position " << *view_cfg.single_position << " out of range for n_positions = " << n_positions
+             << "; skipping" << endl;
+        return EXIT_SUCCESS;
+    }
+
+    constexpr long expected_solutions = 325;
+
+    // Both algorithms, so the reachability rule is pinned to preserving the solution set as
+    // well as to verifying, and then the root-state check pins that it is doing anything at
+    // all -- a rule that inferred nothing would enumerate identically and verify just as
+    // happily. The recursion counts are printed rather than asserted on: the gap here is two
+    // nodes out of 558, because check-and-prevent with an evidence node gets to nearly the
+    // same place by another route, and a margin that thin is not something to hold a test to.
+    long prevent_at_root = 0, scc_at_root = 0;
+    auto with_prevent = run(subcircuit::Prevent{}, view_cfg, "prevent", prevent_at_root);
+    auto with_scc = run(subcircuit::SCC{}, view_cfg, "scc", scc_at_root);
+
+    if (with_prevent != expected_solutions || with_scc != expected_solutions) {
+        cout << "expected " << expected_solutions << " solutions from each" << endl;
+        return EXIT_FAILURE;
+    }
+
+    if (scc_at_root != 6) {
+        cout << "expected reachability to opt the whole unreachable half out at the root, got " << scc_at_root << " of 6" << endl;
+        return EXIT_FAILURE;
+    }
+
+    if (prevent_at_root != 0) {
+        cout << "expected check-and-prevent to opt none of it out at the root, got " << prevent_at_root << endl;
+        return EXIT_FAILURE;
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/gcs/constraints/circuit/subcircuit_test.cc
+++ b/gcs/constraints/circuit/subcircuit_test.cc
@@ -1,5 +1,6 @@
 #include <gcs/constraints/circuit.hh>
 #include <gcs/constraints/innards/constraints_test_utils.hh>
+#include <gcs/exception.hh>
 #include <gcs/problem.hh>
 #include <gcs/solve.hh>
 
@@ -178,6 +179,75 @@ auto run_tour_size_test(bool proofs, int n, int size_lower, int size_upper) -> v
     check_results(proof_name, expected, actual);
 }
 
+// The anchored encoding: same constraint, half the rows, and one polish-notation step per
+// certificate instead of one per node of the cycle. Enumerated against the same reference
+// check, restricted to the solutions where the named node is on the tour, since that is the
+// precondition the caller has to have declared.
+auto run_anchored_test(bool proofs, int n, int anchor) -> void
+{
+    println(cerr, "subcircuit/anchored n={} anchor={}{}", n, anchor, proofs ? " with proofs:" : ":");
+
+    vector<pair<int, int>> domains(static_cast<std::size_t>(n), pair{0, n - 1});
+
+    set<tuple<vector<int>>> expected, actual;
+    build_expected(expected, [&](vector<int> succ) { return is_subcircuit(succ) && succ[static_cast<std::size_t>(anchor)] != anchor; }, domains);
+    println(cerr, " expecting {} solutions", expected.size());
+
+    Problem p;
+    vector<IntegerVariableID> succ;
+    for (int i = 0; i < n; ++i) {
+        // The anchor's own index has to be out of its declared domain: with_required_node()
+        // takes that as a precondition rather than imposing it, so that the constraint means
+        // the same thing either way and nothing about it has to reach the .scp.
+        vector<Integer> values;
+        for (int v = 0; v < n; ++v)
+            if (! (i == anchor && v == anchor))
+                values.emplace_back(Integer{v});
+        succ.push_back(p.create_integer_variable(values));
+    }
+    p.post(SubCircuit{succ}.with_required_node(anchor));
+
+    auto proof_name = proofs ? make_optional<std::string>("subcircuit_test_anchored") : nullopt;
+    solve_for_tests(p, proof_name, actual, tuple{succ});
+    check_results(proof_name, expected, actual);
+}
+
+// with_required_node() is a precondition, so it has to say so rather than quietly building
+// an unsound encoding: the anchored rows force the tour's length to zero if the named node
+// turns out to be off it. The range is checked at the call, the domain when the constraint
+// is installed -- post() only stores it -- so the two are caught in different places.
+auto run_anchor_rejection_tests() -> bool
+{
+    auto ok = true;
+
+    {
+        Problem p;
+        auto x = p.create_integer_variable_vector(4, 0_i, 3_i);
+        try {
+            SubCircuit{x}.with_required_node(4);
+            println(cerr, "out-of-range anchor: expected InvalidProblemDefinitionException from with_required_node");
+            ok = false;
+        }
+        catch (const InvalidProblemDefinitionException &) {
+        }
+    }
+
+    {
+        Problem p;
+        auto x = p.create_integer_variable_vector(4, 0_i, 3_i);
+        p.post(SubCircuit{x}.with_required_node(2));
+        try {
+            solve_with(p, SolveCallbacks{});
+            println(cerr, "anchor still able to be a self loop: expected InvalidProblemDefinitionException from the solve");
+            ok = false;
+        }
+        catch (const InvalidProblemDefinitionException &) {
+        }
+    }
+
+    return ok;
+}
+
 auto main(int argc, char * argv[]) -> int
 {
     establish_and_announce_seed(argc, argv);
@@ -214,6 +284,9 @@ auto main(int argc, char * argv[]) -> int
             // "exactly one circuit" reading is spelled and rules the empty tour out; then
             // an exact size, and 1, which nothing can satisfy because a lone node on the
             // tour has nowhere to point but itself.
+            for (int n : {3, 4, 5})
+                for (int anchor : {0, n - 1})
+                    run_anchored_test(proofs, n, anchor);
             for (int n : {3, 4}) {
                 run_tour_size_test(proofs, n, 0, n);
                 run_tour_size_test(proofs, n, 2, n);
@@ -222,6 +295,9 @@ auto main(int argc, char * argv[]) -> int
             }
         }
     }
+
+    if (view_wrap_config_is_effectively_bare(view_cfg, n_positions) && ! run_anchor_rejection_tests())
+        return EXIT_FAILURE;
 
     return EXIT_SUCCESS;
 }

--- a/gcs/constraints/circuit/subcircuit_test.cc
+++ b/gcs/constraints/circuit/subcircuit_test.cc
@@ -183,9 +183,9 @@ auto run_tour_size_test(bool proofs, int n, int size_lower, int size_upper) -> v
 // certificate instead of one per node of the cycle. Enumerated against the same reference
 // check, restricted to the solutions where the named node is on the tour, since that is the
 // precondition the caller has to have declared.
-auto run_anchored_test(bool proofs, int n, int anchor) -> void
+auto run_anchored_test(bool proofs, int n, int anchor, SubCircuitAlgorithm algorithm, const std::string & label) -> void
 {
-    println(cerr, "subcircuit/anchored n={} anchor={}{}", n, anchor, proofs ? " with proofs:" : ":");
+    println(cerr, "subcircuit/anchored/{} n={} anchor={}{}", label, n, anchor, proofs ? " with proofs:" : ":");
 
     vector<pair<int, int>> domains(static_cast<std::size_t>(n), pair{0, n - 1});
 
@@ -205,9 +205,9 @@ auto run_anchored_test(bool proofs, int n, int anchor) -> void
                 values.emplace_back(Integer{v});
         succ.push_back(p.create_integer_variable(values));
     }
-    p.post(SubCircuit{succ}.with_required_node(anchor));
+    p.post(SubCircuit{succ}.with_required_node(anchor).with_algorithm(algorithm));
 
-    auto proof_name = proofs ? make_optional<std::string>("subcircuit_test_anchored") : nullopt;
+    auto proof_name = proofs ? make_optional("subcircuit_test_anchored_" + label) : nullopt;
     solve_for_tests(p, proof_name, actual, tuple{succ});
     check_results(proof_name, expected, actual);
 }
@@ -285,8 +285,10 @@ auto main(int argc, char * argv[]) -> int
             // an exact size, and 1, which nothing can satisfy because a lone node on the
             // tour has nowhere to point but itself.
             for (int n : {3, 4, 5})
-                for (int anchor : {0, n - 1})
-                    run_anchored_test(proofs, n, anchor);
+                for (int anchor : {0, n - 1}) {
+                    run_anchored_test(proofs, n, anchor, subcircuit::Prevent{}, "prevent");
+                    run_anchored_test(proofs, n, anchor, subcircuit::SCC{}, "scc");
+                }
             for (int n : {3, 4}) {
                 run_tour_size_test(proofs, n, 0, n);
                 run_tour_size_test(proofs, n, 2, n);


### PR DESCRIPTION
Step 5 of #788, stacked on #794. Two commits: a caller-nominated anchor, then the
connectivity core of Francis and Stuckey's `scc` on top of it.

**I told you twice this arm was blocked on the `L·d[r,i]` nonlinearity. It isn't, and the
reason is worth stating**: that term exists to shift positions to an *arbitrary* root, and
this arm never needs an arbitrary root. It cannot infer anything until some node is known to
be on the tour (F&S's own observation), so if the position encoding is anchored on that same
node, the reachability argument is rooted where the positions already start and there is
nothing to shift. The shift, and its variable modulus, simply do not arise.

## `with_required_node()`

Names a node already *declared* on the tour — its own index not in its successor's domain —
and throws if it is not. A precondition, not a strengthening: the constraint means the same
thing either way, so nothing about it reaches the `.scp`, exactly as the choice of algorithm
does not. Range is checked at the call; the domain has to wait for `prepare()`, since
`post()` only stores the constraint.

It buys the encoding `Circuit` gets for free. Unanchored, every edge carries a row family for
each case and every certificate splits over the cycle's nodes; anchored, only the edges into
the named node can wrap — one family per edge, no `first` flags, one `pol` per certificate.
At n = 5 the `.opb` drops from 252 rows to 208, and the saving is 2n(n-1) + 3n lines so it
grows. It also strengthens propagation as a side effect: a closed cycle that misses the
anchor is now an immediate contradiction with no evidence node to find, which is how
`Circuit` reasons.

## The certificate

Walks out from the anchor a layer at a time, deriving for each node `x` unreached within `t`
steps that `pos[x] = t → succ[x] = x`. Same proof every layer: somebody is `x`'s predecessor,
and each candidate `q` either *is* `x` (the conclusion) or sits at `t-1` by the step row —
where a `q` already reached cannot point at `x` (in the reason) and a `q` not reached carries
the previous layer's fact. At `t = 0` the step row puts `q` at position −1, which the
variable's own lower bound refuses, so the first layer stands alone.

Position `t ≥ 1` already means "on the tour", because off-tour nodes sit at zero — so nothing
counts how long the tour is. That is the other half of why this works.

"Somebody is `x`'s predecessor" is *not* in the encoding: the all-different rows are a
pairwise clique, which says at most one variable takes a value and nothing about at least
one. So it is derived by pigeonhole, once per value at `Top` and cached, the same way
`justify_all_different_hall_set_or_violator` does it — via `recover_am1_from_pairs()`, the
shared fold, rather than a fifth hand-rolled copy of the same staircase (see the comment
below and #805).

**That pigeonhole is the only cutting-planes step in the whole certificate**, and I had this
wrong at first in the other direction: I wrote a `pol` per candidate to carry "x is at t"
through the step row to "its predecessor is at t−1", on the assumption that unit propagation
could not do it. It can. The step row is written as two halves, `<=` and `>=`, over
`pos[j] - pos[i]` for the edge `i -> j`; the forward walk's edge is `q -> x`, so with
`pos[x]` fixed at `t` the `>=` half gives `pos[q] <= t-1` and the `<=` half gives
`pos[q] >= t-1`, and between them they pin every bit. It is the `>=` half that bounds the
predecessor from above, which reads the wrong way round — and which half does which flips
with the direction of the walk, since #798's backward walk follows `x -> y` instead. Both pols — the per-candidate one and
the one combining the candidates with the pigeonhole — were probed by deleting them, and
every test still verifies with neither, while a plain `JustifyUsingRUP` in place of the whole
function is still rejected and dropping the pigeonhole *does* make VeriPB reject. So the
lemma chain is what is load-bearing, not the arithmetic. Nothing has to cite a step row
either, since those are model rows; that works only because the encoding is anchored, as
without an anchor each half is guarded on a `first` flag that nothing here would have fixed.
The `.pbp` for `subcircuit_scc_test` drops 6.3% with the dead pols gone.

## On the honest value of the rule

**It saves two search nodes out of 558.** Check and prevent with an evidence node get to
nearly the same place by another route, so plain reachability is close to subsumed by them.
Whatever F&S measure for `scc` on subcircuit must come mostly from the four pruning rules and
from separating multiple components — none of which is here yet.

`subcircuit_scc_test` took three attempts to say anything at all. With the halves the other
way round, or the same size, both algorithms come out at **exactly** the same recursion count,
because the brancher never enters the unreachable half before the tour closes, and then
`check` forces it off for free. Giving that half the smallest domains is what makes the search
walk into it. The test therefore asserts the *root state* — six of six opted out with `SCC`,
zero of six with `Prevent` — rather than a recursion margin, because two nodes out of 558 is
not a number to hold a test to.

## Testing

784/784 pass. Anchored enumeration at n = 3, 4, 5 for the first and last node as anchor,
under both `Prevent` and `SCC`; both rejection paths for the precondition; the scenario above.
Clean under `clang++` with sanitizers. Swapping either certificate for a plain
`JustifyUsingRUP` makes VeriPB reject the proof, which is what keeps them honest.

## What is left of the arm

The four pruning rules, and the multiple-component contradiction. Those are where the value
looks likely to be, on the evidence above — and the `n_medium` regression from #792 is the
thing to point them at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



