### PR TITLE
SubCircuit: the tour must reach the anchor, not just be reachable from it

### DIFF
--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -779,6 +779,11 @@ if(GCS_BUILD_TESTS)
     add_test(NAME subcircuit_scc COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:subcircuit_scc_test>)
     add_view_tests(subcircuit_scc subcircuit_scc_test 12)
 
+    add_executable(subcircuit_scc_reaches_anchor_test constraints/circuit/subcircuit_scc_reaches_anchor_test.cc)
+    target_link_libraries(subcircuit_scc_reaches_anchor_test PRIVATE glasgow_constraint_solver)
+    add_test(NAME subcircuit_scc_reaches_anchor COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:subcircuit_scc_reaches_anchor_test>)
+    add_view_tests(subcircuit_scc_reaches_anchor subcircuit_scc_reaches_anchor_test 12)
+
     add_executable(subcircuit_test constraints/circuit/subcircuit_test.cc)
     target_link_libraries(subcircuit_test PRIVATE glasgow_constraint_solver)
     add_test(NAME subcircuit_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:subcircuit_test>)

--- a/gcs/constraints/circuit/subcircuit.cc
+++ b/gcs/constraints/circuit/subcircuit.cc
@@ -321,6 +321,46 @@ namespace
         return layers;
     }
 
+    // The other half of the same fact. The tour is a cycle *through* the anchor, so a node
+    // on it does not merely have to be reachable from the anchor, it has to reach the anchor
+    // back; anything that cannot has to opt out. Between them the two directions say the
+    // tour lies inside the anchor's strongly connected component, which is Francis and
+    // Stuckey's rule for a strongly connected sub-component containing a required node,
+    // specialised to the one component that always has such a node in it.
+    //
+    // Self loops are not followed here either, and for the same reason: a node pointing at
+    // itself is off the tour, so that is not a tour edge to travel along.
+    auto reaches_anchor(const vector<IntegerVariableID> & succ, const long anchor, const State & state) -> vector<bool>
+    {
+        auto n = succ.size();
+
+        // The reverse graph, built once. A breadth-first walk backwards from the anchor is
+        // then one pass over it, where iterating the forward domains to a fixpoint would
+        // walk them once per layer.
+        auto backwards = vector<vector<size_t>>(n);
+        for (size_t i = 0; i < n; ++i)
+            for (const auto & v : state.each_value_immutable(succ[i])) {
+                auto j = static_cast<size_t>(v.raw_value);
+                if (cmp_not_equal(j, i))
+                    backwards[j].emplace_back(i);
+            }
+
+        auto reaches = vector<bool>(n, false);
+        reaches[static_cast<size_t>(anchor)] = true;
+        auto pending = vector<size_t>{static_cast<size_t>(anchor)};
+        while (! pending.empty()) {
+            auto here = pending.back();
+            pending.pop_back();
+            for (const auto & before : backwards[here])
+                if (! reaches[before]) {
+                    reaches[before] = true;
+                    pending.emplace_back(before);
+                }
+        }
+
+        return reaches;
+    }
+
     // At most one of the successors takes value v. The all-different encoding only has the
     // pairwise rows, so the clique inequality over them has to be derived -- which is
     // recover_am1_from_pairs's job, so all there is to do here is emit the pairs it merges
@@ -464,6 +504,61 @@ namespace
             }
     }
 
+    // Justify "node m cannot be on the tour" for every m that cannot reach the anchor. The
+    // fact derived for each such node x, at each position t, is
+    //
+    //     G(t, x):  pos[x] = t  ->  succ[x] = x
+    //
+    // the same shape as the forward walk's E(t, x) and the same length of induction, but it
+    // runs the other way: t from n-1 down to 0, because here it is what x's successor does
+    // that settles x, not what its predecessor does.
+    //
+    // Its proof. succ[x] takes some value, and every candidate y other than x cannot reach
+    // the anchor either -- if y could then x could, through y -- so a candidate that can is
+    // excluded by the reason. For one that cannot, the step row puts y at position t+1, and
+    // G(t+1, y) then makes y a self loop; value y would be taken twice, by succ[x] and by
+    // succ[y], which the all-different rows forbid. At t = n-1 the step row asks for
+    // position n, which the position variable's own upper bound refuses, so the top layer
+    // needs nothing above it.
+    //
+    // This direction needs no derivation of its own at all -- no pigeonhole and no cutting
+    // planes anywhere -- because every fact it leans on is a row of the model: the two
+    // halves of the step row, one all-different pair, and the at-least-one-value row for
+    // succ[x]. Following x's own successor is what buys that. The forward walk cannot,
+    // because hunting for x's *predecessor* asks that somebody take the value x, and only
+    // at-most-one of those is written down. So on an instance where both fire, this half is
+    // very nearly free.
+    auto derive_cannot_reach_anchor(ProofLogger & logger, const vector<IntegerVariableID> & succ, const SubCircuitPosData & pos_data,
+        const vector<bool> & reaches, const ReasonLiterals & reason) -> void
+    {
+        auto n = static_cast<long long>(succ.size());
+        logger.emit_proof_comment("everything on the tour reaches the anchor, working down from the last position");
+
+        for (auto t = n - 1; t >= 0; --t)
+            for (long long x = 0; x < n; ++x) {
+                if (reaches[static_cast<size_t>(x)])
+                    continue;
+
+                auto at_t = pos_data.pos.at(static_cast<long>(x)) == Integer{t};
+
+                for (long long y = 0; y < n; ++y) {
+                    // A candidate that reaches the anchor is excluded by the reason, and so
+                    // is anything outside the domain; the anchor itself reaches itself, so it
+                    // is never a candidate here, which is why the step row this leans on is
+                    // always the step row and never the wrap one.
+                    if (y == x || reaches[static_cast<size_t>(y)])
+                        continue;
+
+                    logger.emit_rup_proof_line_under_reason(
+                        reason, WPBSum{} + 1_i * ! at_t + 1_i * ! (succ[static_cast<size_t>(x)] == Integer{y}) >= 1_i, ProofLevel::Temporary);
+                }
+
+                // G(t, x) itself, at ProofLevel::Current so the layer below still has it.
+                logger.emit_rup_proof_line_under_reason(
+                    reason, WPBSum{} + 1_i * ! at_t + 1_i * (succ[static_cast<size_t>(x)] == Integer{x}) >= 1_i, ProofLevel::Current);
+            }
+    }
+
     auto propagate_subcircuit(const vector<IntegerVariableID> & succ, const ConstraintID & owner, const SubCircuitPosData & pos_data,
         const ConstraintStateHandle & unassigned_handle, const bool prevent, const optional<long> & scc_anchor,
         const std::shared_ptr<SCCProofCache> & cache, const State & state, auto & inference, ProofLogger * const logger) -> void
@@ -478,6 +573,28 @@ namespace
         // obvious thing to do if this ever shows up in a profile.
         auto edges = walk_fixed_edges(succ, state);
 
+        // Given the nodes that may still be on the tour, the literals saying everything else
+        // is off it. All three rules below end this way, differing only in how they work out
+        // that first set.
+        //
+        // A node already sitting on its own index is the only one skipped: one fixed to
+        // anything else has to go through infer() so that the contradiction is raised and
+        // justified. That is the whole of what makes `check` complete -- Francis and Stuckey
+        // report failure exactly when a node outside the cycle cannot be a self cycle, and a
+        // node fixed elsewhere cannot.
+        auto off_tour = [&](const vector<bool> & maybe_on_tour) {
+            vector<Literal> off;
+            for (size_t m = 0; m < n; ++m) {
+                if (maybe_on_tour[m])
+                    continue;
+                auto here = Integer(static_cast<long long>(m));
+                if (state.optional_single_value(succ[m]) == here)
+                    continue;
+                off.emplace_back(succ[m] == here);
+            }
+            return off;
+        };
+
         // A closed cycle of two or more nodes is the whole tour, so every other node has
         // to be a self loop. This is Francis and Stuckey's `check`: for Circuit a short
         // cycle is a flat contradiction, but here it only pins down everyone else.
@@ -489,23 +606,9 @@ namespace
             for (auto v : cycle)
                 on_cycle[v] = true;
 
-            vector<Literal> off;
-            for (size_t m = 0; m < n; ++m) {
-                if (on_cycle[m])
-                    continue;
-                auto here = Integer(static_cast<long long>(m));
-                // Skip only a node already sitting on its own index: one fixed to anything
-                // else has to go through infer() so that the contradiction is raised and
-                // justified. That is the whole of what makes `check` complete -- Francis
-                // and Stuckey report failure exactly when a node outside the cycle cannot
-                // be a self cycle, and a node fixed elsewhere cannot.
-                if (state.optional_single_value(succ[m]) == here)
-                    continue;
-                off.emplace_back(succ[m] == here);
-            }
-
-            // Nothing left to say: the cycle is the whole graph, or everyone else is
+            // Nothing left to say if the cycle is the whole graph, or everyone else is
             // already a self loop.
+            auto off = off_tour(on_cycle);
             if (off.empty())
                 continue;
 
@@ -513,21 +616,22 @@ namespace
             inference.infer_all(logger, off, JustifyExplicitly{justf, ThenRUP::Yes, hints::SubCircuit{owner}}, generic_reason(succ));
         }
 
+        // Anything the anchor cannot reach has to opt out, and so does anything that cannot
+        // reach the anchor back. The two are separate arguments over separate walks, so they
+        // are two inferences; the second is taken over the state the first leaves behind,
+        // which is the stronger place to take it from and costs nothing, since a node the
+        // first has just made a self loop cannot reach anything at all.
         if (scc_anchor) {
             auto layers = reachable_layers(succ, *scc_anchor, state);
-            const auto & seen = layers.back();
-            vector<Literal> unreachable;
-            for (size_t m = 0; m < n; ++m) {
-                if (seen[m])
-                    continue;
-                auto here = Integer(static_cast<long long>(m));
-                if (state.optional_single_value(succ[m]) == here)
-                    continue;
-                unreachable.emplace_back(succ[m] == here);
-            }
-            if (! unreachable.empty()) {
+            if (auto unreachable = off_tour(layers.back()); ! unreachable.empty()) {
                 auto justf = [&](const ReasonLiterals & reason) { derive_unreachable(*logger, succ, pos_data, *cache, layers, reason); };
                 inference.infer_all(logger, unreachable, JustifyExplicitly{justf, ThenRUP::Yes, hints::SubCircuit{owner}}, generic_reason(succ));
+            }
+
+            auto reaches = reaches_anchor(succ, *scc_anchor, state);
+            if (auto stranded = off_tour(reaches); ! stranded.empty()) {
+                auto justf = [&](const ReasonLiterals & reason) { derive_cannot_reach_anchor(*logger, succ, pos_data, reaches, reason); };
+                inference.infer_all(logger, stranded, JustifyExplicitly{justf, ThenRUP::Yes, hints::SubCircuit{owner}}, generic_reason(succ));
             }
         }
 

--- a/gcs/constraints/circuit/subcircuit.hh
+++ b/gcs/constraints/circuit/subcircuit.hh
@@ -48,12 +48,20 @@ namespace gcs
 
         /**
          * \brief Propagate SubCircuit by reachability as well: as subcircuit::Prevent, and
-         * additionally require every node on the tour to be reachable from the node the
-         * caller named with with_required_node(), forcing anything unreachable to opt out.
+         * additionally require every node on the tour to lie in the same strongly connected
+         * component as the node the caller named with with_required_node(), forcing anything
+         * else to opt out.
          *
-         * This is the connectivity core of Francis and Stuckey's `scc` algorithm. Their
-         * four extra pruning rules -- prune root, prune skip, fix required edges and prune
-         * within -- are not here yet.
+         * The tour is a cycle through the named node, so a node on it must both be reachable
+         * from that node and reach it back; the two directions are checked by separate walks
+         * and justified by separate arguments, and either can fire without the other.
+         *
+         * This is the connectivity part of Francis and Stuckey's `scc` algorithm -- their
+         * rule for a strongly connected sub-component containing a required node, which is
+         * the one component that always has one. Their four extra pruning rules -- prune
+         * root, prune skip, fix required edges and prune within -- are not here yet; those
+         * need the subtree structure of a depth-first traversal, where these two need only
+         * the component.
          *
          * It needs with_required_node(), and does nothing without it: there is nothing to
          * be reachable *from* until some node is known to be on the tour, which is Francis

--- a/gcs/constraints/circuit/subcircuit_scc_reaches_anchor_test.cc
+++ b/gcs/constraints/circuit/subcircuit_scc_reaches_anchor_test.cc
@@ -1,0 +1,144 @@
+#include <gcs/constraints/circuit.hh>
+#include <gcs/constraints/in.hh>
+#include <gcs/constraints/innards/constraints_test_utils.hh>
+#include <gcs/problem.hh>
+#include <gcs/solve.hh>
+
+#include <cstdlib>
+#include <iostream>
+#include <optional>
+#include <string>
+#include <vector>
+
+using namespace gcs;
+using namespace gcs::test_innards;
+
+using std::cout;
+using std::endl;
+using std::make_optional;
+using std::nullopt;
+using std::pair;
+using std::vector;
+
+// The half of the reachability rule that reads the arrows backwards: a node on the tour has
+// to reach the anchor, not merely be reachable from it.
+//
+// Twelve nodes again, and again the lower six point only within themselves, so none of them
+// can reach the anchor in the upper half. What is different from subcircuit_scc_test is one
+// extra arrow, from node 7 down to node 0: it makes every node in the problem reachable
+// *from* the anchor, so the forward walk has nothing at all to say here, and the six
+// opt-outs at the root can only come from reading the arrows the other way. Delete the
+// backwards walk and this test goes red where subcircuit_scc_test stays green.
+//
+// The solution count is the same 325 as in that test, for the same reason: node 6 cannot
+// point at itself, so the tour must run through the upper half, and the lower half's arrow
+// budget gives it no way back. Node 7's extra arrow is dead on arrival -- once node 0 is a
+// self loop, all-different takes value 0 off node 7 -- which is the point: it changes what
+// the propagator can see without changing what the answer is.
+
+auto post_constraints(Problem & p, vector<IntegerVariableID> & nodes) -> void
+{
+    // The lower half: node i points at itself or at the next one round, and nowhere else.
+    // These are the smallest domains in the problem, so the brancher walks in here first.
+    for (int i = 0; i < 6; ++i)
+        p.post(In{nodes[static_cast<std::size_t>(i)], {Integer{i}, Integer{(i + 1) % 6}}});
+
+    // The upper half points within itself, except that node 7 may also point at node 0,
+    // which is what puts the lower half within the anchor's reach.
+    for (int i = 6; i < 12; ++i) {
+        vector<Integer> values;
+        if (i == 7)
+            values.emplace_back(0_i);
+        for (int v = 6; v < 12; ++v)
+            if (! (i == 6 && v == 6))
+                values.emplace_back(Integer{v});
+        p.post(In{nodes[static_cast<std::size_t>(i)], values});
+    }
+}
+
+// The state at the first search node, which is the root after propagation, and the place
+// where the two algorithms differ crisply.
+auto run(SubCircuitAlgorithm algorithm, const ViewWrapConfig & view_cfg, const std::string & label, long & lower_half_fixed_at_root) -> long
+{
+    constexpr int n_positions = 12;
+    auto wraps = wraps_for_positions(view_cfg, n_positions);
+
+    Problem p;
+    // As in subcircuit_scc_test: the anchor's own index has to be outside its *declared*
+    // domain, since that is what with_required_node() checks, so node 6 starts at 7 -- and a
+    // view keeps that domain, being the same variable seen through an offset, which is what
+    // lets this scenario go through the view sweep.
+    vector<IntegerVariableID> nodes;
+    for (int i = 0; i < n_positions; ++i)
+        nodes.push_back(
+            create_integer_variable_or_constant_with_view(p, pair{i == 6 ? 7 : 0, n_positions - 1}, wraps.at(static_cast<std::size_t>(i))));
+
+    post_constraints(p, nodes);
+    p.post(SubCircuit{nodes}.with_required_node(6).with_algorithm(algorithm));
+
+    bool proofs = can_run_veripb();
+    auto proof_name = proofs ? make_optional("subcircuit_scc_reaches_anchor_test_" + label + "_" + view_wrap_config_label(view_cfg)) : nullopt;
+    long found = 0;
+    auto seen_root = false;
+    lower_half_fixed_at_root = 0;
+    auto stats = solve_with(p, //
+        SolveCallbacks{        //
+            .solution = [&](const CurrentState &) -> bool {
+                ++found;
+                return true;
+            },
+            .trace = [&](const CurrentState & s) -> bool {
+                if (! seen_root) {
+                    seen_root = true;
+                    for (int i = 0; i < 6; ++i)
+                        if (s.has_single_value(nodes[static_cast<std::size_t>(i)]) && s(nodes[static_cast<std::size_t>(i)]) == Integer{i})
+                            ++lower_half_fixed_at_root;
+                }
+                return true;
+            }},
+        proof_name ? make_optional<ProofOptions>(*proof_name) : nullopt);
+
+    cout << label << ": " << found << " solutions, " << stats.recursions << " recursions, " << lower_half_fixed_at_root
+         << " of the stranded half opted out at the root" << endl;
+
+    if (proof_name && ! verify_proof_and_dispose(*proof_name))
+        return -1;
+
+    return found;
+}
+
+auto main(int argc, char * argv[]) -> int
+{
+    establish_and_announce_seed(argc, argv);
+
+    constexpr int n_positions = 12;
+    auto view_cfg = parse_view_wrap_config_from_argv(argc, argv);
+    if (view_cfg.single_position && (*view_cfg.single_position < 0 || *view_cfg.single_position >= n_positions)) {
+        cout << "subcircuit_scc_reaches_anchor view sweep: position " << *view_cfg.single_position
+             << " out of range for n_positions = " << n_positions << "; skipping" << endl;
+        return EXIT_SUCCESS;
+    }
+
+    constexpr long expected_solutions = 325;
+
+    long prevent_at_root = 0, scc_at_root = 0;
+    auto with_prevent = run(subcircuit::Prevent{}, view_cfg, "prevent", prevent_at_root);
+    auto with_scc = run(subcircuit::SCC{}, view_cfg, "scc", scc_at_root);
+
+    if (with_prevent != expected_solutions || with_scc != expected_solutions) {
+        cout << "expected " << expected_solutions << " solutions from each" << endl;
+        return EXIT_FAILURE;
+    }
+
+    if (scc_at_root != 6) {
+        cout << "expected the whole stranded half to opt out at the root, got " << scc_at_root << " of 6" << endl;
+        return EXIT_FAILURE;
+    }
+
+    if (prevent_at_root != 0) {
+        cout << "expected check-and-prevent to opt none of it out at the root, got " << prevent_at_root << endl;
+        return EXIT_FAILURE;
+    }
+
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Stacked on #797. Adds the other half of the SCC arm's connectivity rule.

## What it does

#797 walks forwards from the node `with_required_node()` names and makes everything unreachable opt out. That is half of the fact. The tour is a cycle *through* that node, so a node on the tour must also **reach the anchor back**, and anything that cannot has to opt out as well. Together the two directions say the tour lies inside the anchor's strongly connected component — Francis and Stuckey's rule for a strongly connected sub-component containing a required node, specialised to the one component that is always guaranteed to have such a node in it.

The backwards walk is one pass over the reverse graph, built once, rather than iterating the forward domains to a fixpoint.

## The certificate

The forward argument read the other way round. The layer fact is still

```
G(t, x):  pos[x] = t  ->  succ[x] = x
```

but the induction runs from `t = n-1` down to `0`, because what settles `x` here is what its *successor* does. For each candidate `y` that also cannot reach the anchor, the step row puts `y` at position `t+1`, `G(t+1, y)` makes `y` a self loop, and then value `y` is taken twice — by `succ[x]` and by `succ[y]` — which the all-different rows forbid. At `t = n-1` the step row asks for position `n`, which the position variable's own upper bound refuses.

This direction needs **no derivation of its own at all**: no pigeonhole, no `pol`. Every fact it leans on is already a row of the model — the two halves of the step row, one all-different pair, and the at-least-one-value row for `succ[x]` — because following `x`'s own successor asks only that `succ[x]` take *some* value. The forward walk cannot do that: hunting for `x`'s *predecessor* needs "somebody takes the value `x`", which the pairwise all-different clique does not say, so it has to derive it by pigeonhole. Where both directions fire, this half is very nearly free.

Each of those three model rows was probed: skipping the explicit request for at-most-one-of-value-`y`, and for the at-least-one-value row, both leave every test verifying, because the encoding already carries them. A plain `JustifyUsingRUP` in place of the whole function **is** rejected.

## The test

`subcircuit_scc_reaches_anchor_test` is the same twelve-node shape as `subcircuit_scc_test` with **one arrow added**, from the upper half down into the lower one. That arrow puts every node in the problem within the anchor's reach, so the forward walk has nothing to say here — and the six opt-outs at the root can only come from reading the arrows backwards.

Delete this rule and the new test goes red (0 of 6 at the root) while `subcircuit_scc_test` stays green, which is the property that makes it worth having as a separate test rather than another case in the old one.

```
prevent: 325 solutions, 558 recursions, 0 of the stranded half opted out at the root
scc:     325 solutions, 556 recursions, 6 of the stranded half opted out at the root
```

Both algorithms enumerate the same 325 solutions and both proofs verify.

## Also

Folds the three rules' shared tail — "given who may still be on the tour, say everyone else is off it" — into one lambda. That is where the note about *not* skipping a node fixed to somebody else's index now lives, which is the thing that makes `check` complete.

785/785 tests pass; clean under clang + sanitizers.

Issue #788.