### PR TITLE
Extensional GAC: rasterise the domains pass 1 tests against

### DIFF
--- a/gcs/constraints/extensional_utils.cc
+++ b/gcs/constraints/extensional_utils.cc
@@ -113,21 +113,21 @@ namespace
     }
 
     [[nodiscard]] inline auto bitmap_feasible(const ExtensionalDomainBitmaps & bitmaps, const ExtensionalDomainBitmaps::Position & p,
-        const State & state, const IntegerVariableID & var, const Integer val) -> bool
+        const bool use_bitmaps, const State & state, const IntegerVariableID & var, const Integer val) -> bool
     {
-        return p.usable ? bitmap_contains(bitmaps, p, val) : state.in_domain(var, val);
+        return (use_bitmaps && p.usable) ? bitmap_contains(bitmaps, p, val) : state.in_domain(var, val);
     }
 
-    [[nodiscard]] inline auto bitmap_feasible(const ExtensionalDomainBitmaps &, const ExtensionalDomainBitmaps::Position &, const State &,
+    [[nodiscard]] inline auto bitmap_feasible(const ExtensionalDomainBitmaps &, const ExtensionalDomainBitmaps::Position &, const bool, const State &,
         const IntegerVariableID &, const Wildcard &) -> bool
     {
         return true;
     }
 
     [[nodiscard]] inline auto bitmap_feasible(const ExtensionalDomainBitmaps & bitmaps, const ExtensionalDomainBitmaps::Position & p,
-        const State & state, const IntegerVariableID & var, const IntegerOrWildcard & v) -> bool
+        const bool use_bitmaps, const State & state, const IntegerVariableID & var, const IntegerOrWildcard & v) -> bool
     {
-        return visit([&](auto & v) { return bitmap_feasible(bitmaps, p, state, var, v); }, v);
+        return visit([&](auto & v) { return bitmap_feasible(bitmaps, p, use_bitmaps, state, var, v); }, v);
     }
 }
 
@@ -176,7 +176,13 @@ auto gcs::innards::propagate_extensional(
         bitmaps.initialised = true;
     }
 
-    for (unsigned idx = 0; idx < table.vars.size(); ++idx) {
+    // Rasterising position idx costs a word-clear plus one bit-set per value in
+    // its domain, and saves roughly one in_domain() call per live tuple. On a
+    // four-tuple table with two live entries that trade loses -- it read 0.9x on
+    // enum_bin_d2_n14 and enum_shared_k2_n12 before this gate -- so only do it
+    // when the live set is big enough to amortise it.
+    const bool use_bitmaps = live_count >= ExtensionalDomainBitmaps::min_live;
+    for (unsigned idx = 0; use_bitmaps && idx < table.vars.size(); ++idx) {
         const auto & p = bitmaps.positions[idx];
         if (! p.usable)
             continue;
@@ -192,13 +198,25 @@ auto gcs::innards::propagate_extensional(
     // Pass 1: drop tuples that are no longer feasible, by swapping them past the
     // live count. Nothing here goes through State, so a dropped tuple costs two
     // stores rather than an inference plus an IntervalSet edit.
+    //
+    // Everything loop-invariant is spelled as a local first. Reaching one tuple
+    // entry is four dependent loads -- the ArrayParam's shared_ptr, the outer
+    // vector's buffer, the row's buffer, the value -- and GCC hoists none of
+    // them out of the inner loop on its own, so `perf annotate` showed the first
+    // two being redone for every (tuple, position) pair. Naming them costs
+    // nothing and leaves two loads: the row, once per tuple, and the value.
     visit(
         [&](const auto & tuples) {
+            const auto & rows = *tuples;
+            const auto n_vars = static_cast<unsigned>(table.vars.size());
+            const auto * const positions = bitmaps.positions.data();
+            const auto * const vars = table.vars.data();
             for (size_t i = 0; i < live_count;) {
                 auto tuple_idx = live.dense[i];
+                const auto & row = rows[tuple_idx];
                 bool is_feasible = true;
-                for (unsigned idx = 0; idx < table.vars.size(); ++idx)
-                    if (! bitmap_feasible(bitmaps, bitmaps.positions[idx], state, table.vars[idx], get_tuple_value(tuples, tuple_idx, idx))) {
+                for (unsigned idx = 0; idx < n_vars; ++idx)
+                    if (! bitmap_feasible(bitmaps, positions[idx], use_bitmaps, state, vars[idx], row[idx])) {
                         is_feasible = false;
                         break;
                     }
@@ -251,25 +269,30 @@ auto gcs::innards::propagate_extensional(
 
     visit(
         [&](const auto & tuples) {
+            // Same hoisting as pass 1: the support scan reaches one tuple entry
+            // per step, and the loads that get there are loop-invariant.
+            const auto & rows = *tuples;
             for (unsigned idx = 0; idx < table.vars.size(); ++idx) {
-                auto & residue_row = residues.support[idx];
-                auto base = residues.base[idx];
+                auto * const residue_row = residues.support[idx].data();
+                const auto residue_row_size = residues.support[idx].size();
+                const auto base = residues.base[idx];
+                const auto * const dense = live.dense.data();
+                const auto * const position = live.position.data();
                 state.for_each_value_mutable(table.vars[idx], [&](Integer val) {
                     auto off = static_cast<std::size_t>(val.raw_value - base);
-                    bool have_row = off < residue_row.size();
+                    bool have_row = off < residue_row_size;
 
                     // O(1) fast path: last witness still selectable and still matching.
                     if (have_row) {
                         auto cached = residue_row[off];
-                        if (cached != ExtensionalResidues::none && live.position[cached] < live_count &&
-                            match(get_tuple_value(tuples, cached, idx), val))
+                        if (cached != ExtensionalResidues::none && position[cached] < live_count && match(rows[cached][idx], val))
                             return;
                     }
 
                     bool supported = false;
                     for (size_t i = 0; i < live_count; ++i) {
-                        auto tuple_idx = live.dense[i];
-                        if (match(get_tuple_value(tuples, tuple_idx, idx), val)) {
+                        auto tuple_idx = dense[i];
+                        if (match(rows[tuple_idx][idx], val)) {
                             supported = true;
                             if (have_row)
                                 residue_row[off] = tuple_idx;

--- a/gcs/constraints/extensional_utils.cc
+++ b/gcs/constraints/extensional_utils.cc
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <any>
 #include <cmath>
 #include <cstddef>
@@ -16,6 +17,8 @@
 #include <gcs/innards/state-fwd.hh>
 #include <gcs/innards/state.hh>
 #include <gcs/proof.hh>
+#include <optional>
+#include <utility>
 
 using std::any_cast;
 using std::make_shared;
@@ -48,21 +51,6 @@ gcs::innards::ExtensionalData::ExtensionalData(vector<IntegerVariableID> vars, E
 
 namespace
 {
-    auto feasible(const State & state, const IntegerVariableID & var, const Integer val) -> bool
-    {
-        return state.in_domain(var, val);
-    }
-
-    auto feasible(const State &, const IntegerVariableID &, const Wildcard &) -> bool
-    {
-        return true;
-    }
-
-    auto feasible(const State & state, const IntegerVariableID & var, const IntegerOrWildcard & v) -> bool
-    {
-        return visit([&](auto & v) { return feasible(state, var, v); }, v);
-    }
-
     auto match(const Integer & a, const Integer & b) -> bool
     {
         return a == b;
@@ -89,6 +77,58 @@ namespace
     {
         return get_tuple_value(*t, tuple_idx, entry);
     }
+
+    // The value range a position can take across the whole table. nullopt if any
+    // tuple has a wildcard there, since then no membership test happens at all.
+    auto tuple_value_range(const Integer & v, std::optional<std::pair<long long, long long>> & range) -> bool
+    {
+        if (! range)
+            range = std::pair{v.raw_value, v.raw_value};
+        else {
+            range->first = std::min(range->first, v.raw_value);
+            range->second = std::max(range->second, v.raw_value);
+        }
+        return true;
+    }
+
+    auto tuple_value_range(const Wildcard &, std::optional<std::pair<long long, long long>> &) -> bool
+    {
+        return false;
+    }
+
+    auto tuple_value_range(const IntegerOrWildcard & v, std::optional<std::pair<long long, long long>> & range) -> bool
+    {
+        return visit([&](auto & v) { return tuple_value_range(v, range); }, v);
+    }
+
+    // Membership against a rasterised domain, given the position is usable. The
+    // caller has already established that the entry is an Integer.
+    [[nodiscard]] inline auto bitmap_contains(
+        const ExtensionalDomainBitmaps & bitmaps, const ExtensionalDomainBitmaps::Position & p, const Integer val) -> bool
+    {
+        auto off = static_cast<unsigned long long>(val.raw_value - p.base);
+        if (off >= p.n_values)
+            return false;
+        return 0 != (bitmaps.words[p.offset + off / extensional_word_bits] & (ExtensionalWord{1} << (off % extensional_word_bits)));
+    }
+
+    [[nodiscard]] inline auto bitmap_feasible(const ExtensionalDomainBitmaps & bitmaps, const ExtensionalDomainBitmaps::Position & p,
+        const State & state, const IntegerVariableID & var, const Integer val) -> bool
+    {
+        return p.usable ? bitmap_contains(bitmaps, p, val) : state.in_domain(var, val);
+    }
+
+    [[nodiscard]] inline auto bitmap_feasible(const ExtensionalDomainBitmaps &, const ExtensionalDomainBitmaps::Position &, const State &,
+        const IntegerVariableID &, const Wildcard &) -> bool
+    {
+        return true;
+    }
+
+    [[nodiscard]] inline auto bitmap_feasible(const ExtensionalDomainBitmaps & bitmaps, const ExtensionalDomainBitmaps::Position & p,
+        const State & state, const IntegerVariableID & var, const IntegerOrWildcard & v) -> bool
+    {
+        return visit([&](auto & v) { return bitmap_feasible(bitmaps, p, state, var, v); }, v);
+    }
 }
 
 template <typename Hint_>
@@ -97,6 +137,57 @@ auto gcs::innards::propagate_extensional(
 {
     auto & live = *table.live;
     auto & live_count = any_cast<size_t &>(state.get_constraint_state(live.size_handle));
+
+    // Rasterise each position's domain once, so pass 1's inner test is a shift
+    // and a mask rather than a call back into State for every (tuple, position)
+    // pair. Laid out on the first call, which is at the root, from the values
+    // the *table* holds at that position: a value outside that range is not in
+    // any tuple, so it can never be asked about.
+    auto & bitmaps = *table.bitmaps;
+    if (! bitmaps.initialised) {
+        bitmaps.positions.assign(table.vars.size(), ExtensionalDomainBitmaps::Position{});
+        size_t next_offset = 0;
+        visit(
+            [&](const auto & tuples) {
+                auto n_tuples = live.dense.size();
+                for (unsigned idx = 0; idx < table.vars.size(); ++idx) {
+                    std::optional<std::pair<long long, long long>> range;
+                    bool all_integers = true;
+                    for (size_t t = 0; t < n_tuples; ++t)
+                        if (! tuple_value_range(get_tuple_value(tuples, static_cast<unsigned>(t), idx), range)) {
+                            all_integers = false;
+                            break;
+                        }
+
+                    if (! all_integers || ! range)
+                        continue;
+
+                    auto n_values = static_cast<size_t>(range->second - range->first) + 1;
+                    auto n_words = extensional_words_for(n_values);
+                    if (n_words > ExtensionalDomainBitmaps::max_words)
+                        continue;
+
+                    bitmaps.positions[idx] = ExtensionalDomainBitmaps::Position{range->first, n_values, next_offset, true};
+                    next_offset += n_words;
+                }
+            },
+            table.tuples);
+        bitmaps.words.resize(next_offset);
+        bitmaps.initialised = true;
+    }
+
+    for (unsigned idx = 0; idx < table.vars.size(); ++idx) {
+        const auto & p = bitmaps.positions[idx];
+        if (! p.usable)
+            continue;
+        auto n_words = extensional_words_for(p.n_values);
+        std::fill_n(bitmaps.words.begin() + static_cast<std::ptrdiff_t>(p.offset), n_words, ExtensionalWord{});
+        state.for_each_value_immutable(table.vars[idx], [&](Integer val) {
+            auto off = static_cast<unsigned long long>(val.raw_value - p.base);
+            if (off < p.n_values)
+                bitmaps.words[p.offset + off / extensional_word_bits] |= ExtensionalWord{1} << (off % extensional_word_bits);
+        });
+    }
 
     // Pass 1: drop tuples that are no longer feasible, by swapping them past the
     // live count. Nothing here goes through State, so a dropped tuple costs two
@@ -107,7 +198,7 @@ auto gcs::innards::propagate_extensional(
                 auto tuple_idx = live.dense[i];
                 bool is_feasible = true;
                 for (unsigned idx = 0; idx < table.vars.size(); ++idx)
-                    if (! feasible(state, table.vars[idx], get_tuple_value(tuples, tuple_idx, idx))) {
+                    if (! bitmap_feasible(bitmaps, bitmaps.positions[idx], state, table.vars[idx], get_tuple_value(tuples, tuple_idx, idx))) {
                         is_feasible = false;
                         break;
                     }

--- a/gcs/constraints/extensional_utils.hh
+++ b/gcs/constraints/extensional_utils.hh
@@ -72,6 +72,74 @@ namespace gcs::innards
     };
 
     /**
+     * \brief The word the extensional propagator's bitsets are built from.
+     *
+     * Every shift, mask and round-up over those bitsets derives its constants
+     * from \c extensional_word_bits, so the width is stated once here rather
+     * than spelled 64 at each use.
+     *
+     * \ingroup Innards
+     */
+    using ExtensionalWord = std::uint64_t;
+
+    /// \see ExtensionalWord
+    /// \ingroup Innards
+    constexpr std::size_t extensional_word_bits = std::numeric_limits<ExtensionalWord>::digits;
+
+    /**
+     * \brief How many ExtensionalWord words it takes to hold \c n_bits bits.
+     *
+     * \ingroup Innards
+     */
+    [[nodiscard]] constexpr auto extensional_words_for(std::size_t n_bits) -> std::size_t
+    {
+        return (n_bits + extensional_word_bits - 1) / extensional_word_bits;
+    }
+
+    /**
+     * \brief Dense per-position membership tests for pass 1.
+     *
+     * Pass 1 asks "is this tuple's entry at position i still in variable i's
+     * domain?" once per (live tuple, position). Answering it with
+     * State::in_domain() means an out-of-line call that re-resolves the
+     * variable's domain out of State and then walks an interval list -- 40% of
+     * total runtime on a binary random instance, 59% on Crossword, measured.
+     * The resolution is loop-invariant: only the value changes.
+     *
+     * So each position's domain is rasterised once per call into a bitmap over
+     * that position's *table* value range (not the variable's, which can be
+     * wider), and the test becomes a bounds check, a shift and a mask. The
+     * number of membership tests is identical, and so are the tuples dropped --
+     * this is only a cheaper way to ask the same question.
+     *
+     * The range comes from the tuples, so every value a tuple can hold is
+     * addressable by construction, and a value outside it is not in the table
+     * at all. A position whose range is wider than \c max_words words, or which
+     * holds a wildcard, keeps the State::in_domain() path.
+     *
+     * \ingroup Innards
+     */
+    struct ExtensionalDomainBitmaps
+    {
+        /// Beyond this many words per position, rasterising costs more than
+        /// the scans it saves, and the fallback is used instead. A measured
+        /// word count, unrelated to extensional_word_bits happening to match.
+        static constexpr std::size_t max_words = 64;
+
+        struct Position
+        {
+            long long base = 0;
+            std::size_t n_values = 0;
+            std::size_t offset = 0;
+            bool usable = false;
+        };
+
+        std::vector<Position> positions;
+        std::vector<ExtensionalWord> words;
+        bool initialised = false;
+    };
+
+    /**
      * \brief Data for gcs::innards::propagate_extensional().
      *
      * \ingroup Innards
@@ -81,6 +149,15 @@ namespace gcs::innards
         std::vector<IntegerVariableID> vars;
         ExtensionalTuples tuples;
         std::shared_ptr<ExtensionalResidues> residues = std::make_shared<ExtensionalResidues>();
+
+        /**
+         * Scratch for the pass-1 membership tests, rebuilt at the top of every
+         * call. Held by shared_ptr like the residues, and for the same reason:
+         * the propagator is called through a const reference, and propagators
+         * are per-thread under parallel search, so a per-instance mutable
+         * buffer is sound and needs no locking.
+         */
+        std::shared_ptr<ExtensionalDomainBitmaps> bitmaps = std::make_shared<ExtensionalDomainBitmaps>();
 
         /**
          * The reason for every inference this table makes, built once here rather

--- a/gcs/constraints/extensional_utils.hh
+++ b/gcs/constraints/extensional_utils.hh
@@ -126,6 +126,10 @@ namespace gcs::innards
         /// word count, unrelated to extensional_word_bits happening to match.
         static constexpr std::size_t max_words = 64;
 
+        /// Below this many live tuples, rasterising costs more than the
+        /// in_domain() calls it replaces.
+        static constexpr std::size_t min_live = 8;
+
         struct Position
         {
             long long base = 0;


### PR DESCRIPTION
Stacked on #796. Two commits, both of which keep the number of membership
tests, the tuples dropped and the inferences bit-for-bit identical — this is
only a cheaper way to ask pass 1 the same question.

`perf record` on the current propagator, uninstrumented:

| | `srch_bin_d20_n20_s1` | `Crossword-10-12` |
|---|---|---|
| `State::in_domain<variant>` | **40.6%** | **58.5%** |
| `propagate_extensional` | 23.4% | 24.2% |
| its pass-2 lambda | 10.9% | 11.0% |

`in_domain` is an out-of-line call that re-resolves the variable's domain out
of `State` and then walks an interval list, once per *(live tuple, position)*
pair — and the resolution is loop-invariant. (This is not the variant-dispatch
question `dev_docs/propagator-performance.md` settled: GCC lowers the visit
away, and specialising the call site measured 1.0×. The cost is the call and
the re-resolution, not the discriminant.)

**Commit 1** rasterises each position's domain once per call into a bitmap
over that position's range of values *in the table* — tighter than the
variable's, and it guarantees every value a tuple can hold is addressable, so
a value outside it is not in the table at all. The test becomes a bounds
check, a shift and a mask. A position holding a wildcard, or needing more than
64 words, keeps the `in_domain` path.

**Commit 2** hoists the loop-invariant loads and gates the rasterising.
Reaching one tuple entry is four dependent loads — the `ArrayParam`'s
`shared_ptr`, the outer vector's buffer, the row's buffer, the value — and
`perf annotate` showed GCC redoing the first two for every (tuple, position)
pair, because it cannot prove they do not alias. Naming them as locals leaves
two. And rasterising costs a word-clear plus a bit-set per domain value while
saving roughly one `in_domain` per live tuple, so on a four-tuple table with
two live entries it *loses* — `enum_bin_d2_n14` and `enum_shared_k2_n12` both
read 0.9× before the `live_count >= 8` gate.

## Measurements

Whole synthetic matrix, median of 5, fataepyc-10 pinned with boost off.
**Nodes and solutions identical on every instance** — the runner gates on that
and would have failed otherwise.

| instance | base | this | | instance | base | this | |
|---|---|---|---|---|---|---|---|
| `srch_bin_d20_n20_s1` | 3.640 | 2.628 | **1.4×** | `srch_bin_d12_n25_s2` | 2.622 | 2.057 | 1.3× |
| `srch_k3_d8_n18` | 0.338 | 0.241 | **1.4×** | `srch_holey_d16_n22` | 0.215 | 0.167 | 1.3× |
| `srch_func_k3_n24` | 0.060 | 0.043 | **1.4×** | `srch_bin_d12_n25_s1` | 3.172 | 2.587 | 1.2× |
| `srch_holey_d20_n25` | 0.441 | 0.326 | **1.4×** | `srch_bin_d10_n20_s1` | 0.342 | 0.295 | 1.2× |
| `srch_k5_d5_n12` | 0.470 | 0.364 | 1.3× | `enum_func_k3_n20` | 6.710 | 6.051 | 1.1× |
| `srch_bin_d12_n30_s1` | 0.943 | 0.700 | 1.3× | `enum_single_k10_t200k` | 1.184 | 1.101 | 1.1× |
| `srch_bin_d12_n30_s2` | 0.113 | 0.087 | 1.3× | `enum_single_k8_t50k` | 0.227 | 0.211 | 1.1× |
| `srch_bin_d20_n20_s2` | 0.586 | 0.439 | 1.3× | `enum_bin_d2`, `enum_shared` | — | — | 1.0× |

No regressions. `in_domain` disappears from the profile entirely; the gain is
1.4× rather than the 3× its share suggested, because the cost moves into the
loop rather than vanishing.

## Why it is not 3×, and where the rest is

Per-pass `rdtsc` instrumentation says `propagate_extensional`'s share of solve
time runs from **8.2%** (Renault-small) to **99.6%** (Crossword), which caps
what any change here can win per instance. Pass 1 is 67–92% of the propagator
on the instances above 90%, and pass 2 is 60–78% on the ones below. This change
is aimed only at pass 1, so it does nothing for the second group — which is
exactly what the table shows.

## Correctness

* `ctest` **775/775**, 176 skipped (MiniZinc).
* The `tables` and `auto_table` proofs are **byte-identical** to the base
  build's `.opb` and `.pbp`. Nothing about the emitted inferences changes, so
  there is nothing for the proof to notice.
* Views and constants go through `for_each_value_immutable` and
  `bounds`, so a view's values are rasterised in view space, matching the
  tuple values — the same space `in_domain` compares in.
* The scratch buffer is held by `shared_ptr` on `ExtensionalData`, like the
  residues and for the same reason: the propagator is called through a const
  reference, and propagators are per-thread under parallel search.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012mn99ERAhD4YrAaqZrdjZ3