### PR TITLE
SubCircuit: look for a node on the tour instead of waiting to be told about one

### DIFF
--- a/gcs/constraints/circuit/subcircuit.cc
+++ b/gcs/constraints/circuit/subcircuit.cc
@@ -732,6 +732,31 @@ auto SubCircuit::prepare(Propagators & propagators, State & initial_state, Proof
             "SubCircuit: with_required_node() names a node whose own index is still in its successor's domain, so it is not declared "
             "to be on the tour"};
 
+    // A node is on the tour exactly when it does not point at itself, so any node whose own
+    // index is already out of its successor's domain is one, and that is all an anchor has
+    // to be. So look for one rather than waiting to be told: an anchor halves the number of
+    // position rows, gives `check` a contradiction where it would otherwise have to hunt for
+    // an evidence node, and is what the SCC arm needs to say anything at all.
+    //
+    // The lowest-numbered one, because something has to be picked and nothing has measured a
+    // better rule; F&S §5.3.3 report that for `circuit` a *random* root is best for their
+    // `scc`, which is worth revisiting if the pruning rules ever land, but it is a choice
+    // about search and this one is also a choice about the encoding.
+    //
+    // Only the declared domains can be read here, which is why models differ in whether this
+    // finds anything. Both challenge families that use subcircuit pin a node, but only one
+    // pins it where this can see: mario writes `succ[LuigiHouse] = MarioHouse`, which the
+    // flattener folds into the array as a constant, while tpp writes `succ[n] != n`, which
+    // survives as an int_ne over a variable whose declared domain is still full by the time
+    // the redefinition has shifted it to be zero-based.
+    _anchor = _required_node;
+    if (! _anchor)
+        for (size_t i = 0; i < _succ.size(); ++i)
+            if (! initial_state.in_domain(_succ[i], Integer(static_cast<long long>(i)))) {
+                _anchor = static_cast<long>(i);
+                break;
+            }
+
     NonGacAllDifferentUnassigned unassigned{};
     for (auto v : _succ)
         unassigned.emplace_back(v);
@@ -764,7 +789,7 @@ auto SubCircuit::define_proof_model(ProofModel & model, const State &) -> void
     for (long i = 0; i < n; ++i)
         data.pos.emplace(i, model.create_proof_only_integer_variable(0_i, Integer{n - 1}, "subpos", IntegerVariableProofRepresentation::Bits));
 
-    data.anchor = _required_node;
+    data.anchor = _anchor;
 
     if (data.anchor) {
         // Anchored: the tour starts at the named node, so the only edges that can wrap are
@@ -868,7 +893,7 @@ auto SubCircuit::define_proof_model(ProofModel & model, const State &) -> void
 auto SubCircuit::install_propagators(Propagators & propagators) -> void
 {
     auto prevent = ! std::holds_alternative<Check>(_algorithm);
-    auto scc_anchor = std::holds_alternative<gcs::subcircuit::SCC>(_algorithm) ? _required_node : nullopt;
+    auto scc_anchor = std::holds_alternative<gcs::subcircuit::SCC>(_algorithm) ? _anchor : nullopt;
     // Proof lines, not search state: they stay valid at every later node, so the cache
     // deliberately does not backtrack, exactly as circuit_scc.cc's does.
     auto cache = std::make_shared<SCCProofCache>();

--- a/gcs/constraints/circuit/subcircuit.hh
+++ b/gcs/constraints/circuit/subcircuit.hh
@@ -119,6 +119,11 @@ namespace gcs
         std::optional<IntegerVariableID> _tour_size;
         std::optional<long> _required_node;
 
+        // The node the position encoding is anchored on, settled by prepare(): what
+        // with_required_node() named, or the lowest-numbered node whose declared domain
+        // already says it is on the tour, or nothing when no node's does.
+        std::optional<long> _anchor;
+
         // Backtrackable state allocated by prepare(), consumed by install_propagators().
         innards::subcircuit::SubCircuitStateHandles _state_handles;
 
@@ -150,15 +155,23 @@ namespace gcs
         /// with and without it, so nothing about it is recorded in the `.scp`, in the same
         /// way the choice of algorithm is not.
         ///
-        /// What it buys is a cheaper proof. Without it, which edge of the tour wraps around
-        /// is not known until the membership literals are, so every edge needs a row for
-        /// each case and every certificate splits over the cycle's nodes. With it, only the
-        /// edges into the named node can wrap, which is exactly the shape Circuit gets for
-        /// free by anchoring on node 0: half the rows, and one polish-notation step per
-        /// certificate rather than one per node of the cycle.
+        /// **Calling this is optional.** The constraint looks for such a node itself, and
+        /// uses the lowest-numbered one it finds; naming one only overrides that choice,
+        /// and turns "no node is declared on the tour" from something silently accepted
+        /// into an error. Neither is a way to declare a node on the tour -- post a
+        /// constraint for that, or give the variable a domain that says so.
         ///
-        /// It is also what the SCC propagation needs, which cannot infer anything at all
-        /// until some node is known to be on the tour.
+        /// What an anchor buys is a cheaper proof. Without one, which edge of the tour
+        /// wraps around is not known until the membership literals are, so every edge needs
+        /// a row for each case and every certificate splits over the cycle's nodes. With
+        /// one, only the edges into that node can wrap, which is exactly the shape Circuit
+        /// gets for free by anchoring on node 0: half the rows, and one polish-notation step
+        /// per certificate rather than one per node of the cycle.
+        ///
+        /// It also strengthens propagation, since a closed cycle that misses the anchor is
+        /// a contradiction outright rather than something needing an evidence node, and it
+        /// is what the SCC propagation needs, which cannot infer anything at all until some
+        /// node is known to be on the tour.
         auto with_required_node(long node) -> SubCircuit &;
 
         /// Constrain how many nodes are on the tour: `size` is the number that do not

--- a/gcs/constraints/circuit/subcircuit_scc_reaches_anchor_test.cc
+++ b/gcs/constraints/circuit/subcircuit_scc_reaches_anchor_test.cc
@@ -8,6 +8,7 @@
 #include <iostream>
 #include <optional>
 #include <string>
+#include <utility>
 #include <vector>
 
 using namespace gcs;
@@ -58,7 +59,8 @@ auto post_constraints(Problem & p, vector<IntegerVariableID> & nodes) -> void
 
 // The state at the first search node, which is the root after propagation, and the place
 // where the two algorithms differ crisply.
-auto run(SubCircuitAlgorithm algorithm, const ViewWrapConfig & view_cfg, const std::string & label, long & lower_half_fixed_at_root) -> long
+auto run(SubCircuitAlgorithm algorithm, bool name_the_anchor, const ViewWrapConfig & view_cfg, const std::string & label,
+    long & lower_half_fixed_at_root) -> long
 {
     constexpr int n_positions = 12;
     auto wraps = wraps_for_positions(view_cfg, n_positions);
@@ -74,7 +76,10 @@ auto run(SubCircuitAlgorithm algorithm, const ViewWrapConfig & view_cfg, const s
             create_integer_variable_or_constant_with_view(p, pair{i == 6 ? 7 : 0, n_positions - 1}, wraps.at(static_cast<std::size_t>(i))));
 
     post_constraints(p, nodes);
-    p.post(SubCircuit{nodes}.with_required_node(6).with_algorithm(algorithm));
+    auto constraint = SubCircuit{nodes}.with_algorithm(algorithm);
+    if (name_the_anchor)
+        constraint.with_required_node(6);
+    p.post(std::move(constraint));
 
     bool proofs = can_run_veripb();
     auto proof_name = proofs ? make_optional("subcircuit_scc_reaches_anchor_test_" + label + "_" + view_wrap_config_label(view_cfg)) : nullopt;
@@ -121,12 +126,22 @@ auto main(int argc, char * argv[]) -> int
 
     constexpr long expected_solutions = 325;
 
-    long prevent_at_root = 0, scc_at_root = 0;
-    auto with_prevent = run(subcircuit::Prevent{}, view_cfg, "prevent", prevent_at_root);
-    auto with_scc = run(subcircuit::SCC{}, view_cfg, "scc", scc_at_root);
+    long prevent_at_root = 0, scc_at_root = 0, found_at_root = 0;
+    auto with_prevent = run(subcircuit::Prevent{}, true, view_cfg, "prevent", prevent_at_root);
+    auto with_scc = run(subcircuit::SCC{}, true, view_cfg, "scc", scc_at_root);
+    // And once more with nobody named, because node 6 was *declared* to be on the tour and
+    // the constraint looks for such a node itself. Without that, the SCC arm would have
+    // nothing to be reachable from and would sit inert, so this run coming out the same as
+    // the one above is what says the search for an anchor found it.
+    auto with_found = run(subcircuit::SCC{}, false, view_cfg, "scc-anchor-found", found_at_root);
 
-    if (with_prevent != expected_solutions || with_scc != expected_solutions) {
+    if (with_prevent != expected_solutions || with_scc != expected_solutions || with_found != expected_solutions) {
         cout << "expected " << expected_solutions << " solutions from each" << endl;
+        return EXIT_FAILURE;
+    }
+
+    if (found_at_root != scc_at_root) {
+        cout << "expected the same root state with the anchor found as with it named, got " << found_at_root << " against " << scc_at_root << endl;
         return EXIT_FAILURE;
     }
 

--- a/gcs/constraints/circuit/subcircuit_scc_test.cc
+++ b/gcs/constraints/circuit/subcircuit_scc_test.cc
@@ -67,7 +67,8 @@ auto post_constraints(Problem & p, vector<IntegerVariableID> & nodes) -> void
 // the two algorithms differ crisply: reachability has already forced the whole unreachable
 // half to opt out before any decision is taken, and check-and-prevent has not, because
 // nothing is fixed yet for it to reason from.
-auto run(SubCircuitAlgorithm algorithm, const ViewWrapConfig & view_cfg, const std::string & label, long & lower_half_fixed_at_root) -> long
+auto run(SubCircuitAlgorithm algorithm, bool name_the_anchor, const ViewWrapConfig & view_cfg, const std::string & label,
+    long & lower_half_fixed_at_root) -> long
 {
     constexpr int n_positions = 12;
     auto wraps = wraps_for_positions(view_cfg, n_positions);
@@ -86,7 +87,10 @@ auto run(SubCircuitAlgorithm algorithm, const ViewWrapConfig & view_cfg, const s
             create_integer_variable_or_constant_with_view(p, pair{i == 6 ? 7 : 0, n_positions - 1}, wraps.at(static_cast<std::size_t>(i))));
 
     post_constraints(p, nodes);
-    p.post(SubCircuit{nodes}.with_required_node(6).with_algorithm(algorithm));
+    auto constraint = SubCircuit{nodes}.with_algorithm(algorithm);
+    if (name_the_anchor)
+        constraint.with_required_node(6);
+    p.post(std::move(constraint));
 
     bool proofs = can_run_veripb();
     auto proof_name = proofs ? make_optional("subcircuit_scc_test_" + label + "_" + view_wrap_config_label(view_cfg)) : nullopt;
@@ -139,12 +143,22 @@ auto main(int argc, char * argv[]) -> int
     // happily. The recursion counts are printed rather than asserted on: the gap here is two
     // nodes out of 558, because check-and-prevent with an evidence node gets to nearly the
     // same place by another route, and a margin that thin is not something to hold a test to.
-    long prevent_at_root = 0, scc_at_root = 0;
-    auto with_prevent = run(subcircuit::Prevent{}, view_cfg, "prevent", prevent_at_root);
-    auto with_scc = run(subcircuit::SCC{}, view_cfg, "scc", scc_at_root);
+    long prevent_at_root = 0, scc_at_root = 0, found_at_root = 0;
+    auto with_prevent = run(subcircuit::Prevent{}, true, view_cfg, "prevent", prevent_at_root);
+    auto with_scc = run(subcircuit::SCC{}, true, view_cfg, "scc", scc_at_root);
+    // And once more with nobody named, because node 6 was *declared* to be on the tour and
+    // the constraint looks for such a node itself. Without that, the SCC arm would have
+    // nothing to be reachable from and would sit inert, so this run coming out the same as
+    // the one above is what says the search for an anchor found it.
+    auto with_found = run(subcircuit::SCC{}, false, view_cfg, "scc-anchor-found", found_at_root);
 
-    if (with_prevent != expected_solutions || with_scc != expected_solutions) {
+    if (with_prevent != expected_solutions || with_scc != expected_solutions || with_found != expected_solutions) {
         cout << "expected " << expected_solutions << " solutions from each" << endl;
+        return EXIT_FAILURE;
+    }
+
+    if (found_at_root != scc_at_root) {
+        cout << "expected the same root state with the anchor found as with it named, got " << found_at_root << " against " << scc_at_root << endl;
         return EXIT_FAILURE;
     }
 

--- a/gcs/constraints/circuit/subcircuit_test.cc
+++ b/gcs/constraints/circuit/subcircuit_test.cc
@@ -183,9 +183,9 @@ auto run_tour_size_test(bool proofs, int n, int size_lower, int size_upper) -> v
 // certificate instead of one per node of the cycle. Enumerated against the same reference
 // check, restricted to the solutions where the named node is on the tour, since that is the
 // precondition the caller has to have declared.
-auto run_anchored_test(bool proofs, int n, int anchor, SubCircuitAlgorithm algorithm, const std::string & label) -> void
+auto run_anchored_test(bool proofs, int n, int anchor, SubCircuitAlgorithm algorithm, const std::string & label, bool name_the_anchor = true) -> void
 {
-    println(cerr, "subcircuit/anchored/{} n={} anchor={}{}", label, n, anchor, proofs ? " with proofs:" : ":");
+    println(cerr, "subcircuit/anchored/{}{} n={} anchor={}{}", label, name_the_anchor ? "" : "/found", n, anchor, proofs ? " with proofs:" : ":");
 
     vector<pair<int, int>> domains(static_cast<std::size_t>(n), pair{0, n - 1});
 
@@ -198,16 +198,22 @@ auto run_anchored_test(bool proofs, int n, int anchor, SubCircuitAlgorithm algor
     for (int i = 0; i < n; ++i) {
         // The anchor's own index has to be out of its declared domain: with_required_node()
         // takes that as a precondition rather than imposing it, so that the constraint means
-        // the same thing either way and nothing about it has to reach the .scp.
+        // the same thing either way and nothing about it has to reach the .scp. It is also
+        // what prepare() goes looking for, so with name_the_anchor off this same problem
+        // exercises the search for one -- and the search can only land on this node, since
+        // this is the only one whose own index is missing.
         vector<Integer> values;
         for (int v = 0; v < n; ++v)
             if (! (i == anchor && v == anchor))
                 values.emplace_back(Integer{v});
         succ.push_back(p.create_integer_variable(values));
     }
-    p.post(SubCircuit{succ}.with_required_node(anchor).with_algorithm(algorithm));
+    auto constraint = SubCircuit{succ}.with_algorithm(algorithm);
+    if (name_the_anchor)
+        constraint.with_required_node(anchor);
+    p.post(std::move(constraint));
 
-    auto proof_name = proofs ? make_optional("subcircuit_test_anchored_" + label) : nullopt;
+    auto proof_name = proofs ? make_optional("subcircuit_test_anchored_" + label + (name_the_anchor ? "" : "_found")) : nullopt;
     solve_for_tests(p, proof_name, actual, tuple{succ});
     check_results(proof_name, expected, actual);
 }
@@ -288,6 +294,10 @@ auto main(int argc, char * argv[]) -> int
                 for (int anchor : {0, n - 1}) {
                     run_anchored_test(proofs, n, anchor, subcircuit::Prevent{}, "prevent");
                     run_anchored_test(proofs, n, anchor, subcircuit::SCC{}, "scc");
+                    // And with nobody named, so the search for an anchor is enumerated and
+                    // certified at every size too, not only asserted on at the root of one
+                    // twelve-node instance.
+                    run_anchored_test(proofs, n, anchor, subcircuit::SCC{}, "scc", false);
                 }
             for (int n : {3, 4}) {
                 run_tour_size_test(proofs, n, 0, n);


### PR DESCRIPTION
Stacked on #798.

## The gap this closes

#797 added `with_required_node()`, which halves the position rows and is what the SCC arm needs to say anything at all — and **nothing in a MiniZinc or XCSP3 model can call it**. So on every real instance the constraint went on writing the unanchored encoding while the answer was sitting in the declared domains.

A node is on the tour exactly when it does not point at itself, so any node whose own index is already out of its successor's domain *is* one, and that is all an anchor has to be. `prepare()` now looks for the lowest-numbered such node when the caller has not named one.

This is not a new precondition and nothing new reaches the `.scp`: it is read off the domains the `.scp` already records. `with_required_node()` stays, for overriding the choice and for turning "no node is declared on the tour" into an error rather than something quietly accepted.

**I had this recorded the wrong way round.** My note from the #792 session says MiniZinc cannot supply an anchor because both challenge models post their pin *after* the `subcircuit` call and MiniZinc flattens in source order. Only the second half of that is the relevant question, and the two families land on either side of it:

- **mario** writes `constraint succ[LuigiHouse] = MarioHouse;`, and the flattener folds it into the successor array as a **constant** — `succ` comes out as `["X_INTRODUCED_0_", 1, "X_INTRODUCED_2_", …]`. The anchor is there to be found, whatever the source order.
- **tpp** writes `constraint succ[numcities] != numcities;`, which survives as an `int_ne`. The original `succ[20]` does get the narrowed declared domain `1..19`, but `fzn_subcircuit.mzn` shifts to zero-based by introducing a fresh variable per node, and those are declared `0..19` before the shift constraints propagate. So no anchor is visible, and tpp is byte-identical.

That second case is worth a follow-up: passing the offset and letting `fzn_glasgow.cc` build views would keep the domain and drop *n* introduced variables and *n* `int_lin_eq` rows per instance. Not in this PR — it touches `Circuit` the same way.

## Measured

Cut-down `2013/mario` (`mario_easy_2` truncated to *k* houses), same models, same script, the two builds differing only in this commit:

| k | `.opb` before | after | | `.pbp` before | after | | verify before | after |
|---|---|---|---|---|---|---|---|---|
| 6 | 108,451 | **87,217** | −19.6% | 114,281 | 112,826 | −1.3% | 0.10 s | 0.10 s |
| 8 | 203,951 | **158,147** | −22.5% | 419,308 | 405,975 | −3.2% | 0.10 s | 0.10 s |
| 10 | 353,212 | **262,694** | −25.6% | 3,179,877 | 3,054,825 | −3.9% | 0.50 s | 0.50 s |
| 12 | 527,583 | **378,458** | −28.3% | 33,800,512 | 31,882,526 | −5.7% | 12.62 s | 12.42 s |

And on the **real** `mario_easy_2`, 15 houses unmodified:

| | nodes | `.opb` | `.pbp` | verify |
|---|---|---|---|---|
| before | 10,021 | 873,418 | 193,641,391 | 174.3 s |
| after | 10,021 | **594,193** (−32.0%) | 186,492,635 (−3.7%) | 176.4 s |

Worth being clear about what that does *not* buy: **verification time is unchanged.** The `.opb` is a third smaller and the `.pbp` only 3.7%, and checking the proof takes the same 175 s either way. The saving is in what has to be written down and read in, not in what the checker has to do.

The saving grows with *n*, as the row count says it should: the unanchored encoding needs four row families per edge because it does not know which edge wraps, and the anchored one needs two. Node counts are identical at every *k* (17 / 47 / 331 / 2549), so nothing here is a search change on this family — the anchor's extra propagation strength (a closed cycle missing the anchor is a contradiction outright) never gets a chance to fire.

### Corpus sweep

All five `subcircuit` families, 27 instances, 60 s cap, this build against its parent:

**Anchor detection is search-neutral.** All nine instances that finish inside the cap visit an **identical** number of nodes either way, and every objective on every capped instance matches. Optimal-in-cap is 9/27 both ways. The anchor's extra propagation strength — a closed cycle missing the anchor is a contradiction outright — never gets a chance to fire on this corpus, so the encoding saving above is the whole of the effect. tpp is unaffected, as predicted: no anchor is visible there, and the uncapped instances agree node for node.

**What it unlocks is measuring `scc` on real instances for the first time**, since that arm is inert without an anchor. Running it as the default instead of `prevent`, same corpus, same cap:

> **These `scc` figures are superseded.** They were taken on this commit, before #802, so they compare `scc` against a `prevent` that was itself throwing away most of its pruning. The re-measurement on the #802 tip is [on the issue](https://github.com/ciaranm/glasgow-constraint-solver/issues/788#issuecomment-5512238939) and in #801's design note: the verdict holds and widens (optimal-in-cap 14/27 against 11/27), but the throughput figures below are wrong in kind, not just in value — see the note after the list.

* **the inference is strong** — mario node counts fall **8× to 30×** (`2013/n_medium_2` 5.85M → 458K, `2014/t_hard_2` 4.33M → 143K);
* **the implementation is slower by about as much** — throughput falls from ~100,000 nodes/s to 7,000–10,000 on the `medium` families and ~2,300 on the two 2014 `t_hard` ones; **but this figure is not a measurement**: it is taken from capped rows, where both configurations ran for the same 60 s, so nodes-per-second is just the node count restated. The real per-node cost is only readable where both finish, and it is 1.0× on tpp at every size up to n = 35 — so the `O(n²)`-per-call story below does not hold up either;
* **so it loses.** Of the 18 instances where either configuration caps, `scc` reaches a worse objective on **12**, an equal one on 7, and a better one on **none**. It also loses a proved optimum: `2013/mario_t_hard_1` goes from OPTIMAL 4783 in 17.5 s to capped at 4723. Optimal-in-cap 9/27 for `prevent`, 8/27 for `scc`. `prevent` stays the default.
* **tpp is byte-identical under `scc`** — every uncapped instance reports the same node count as `prevent`, which is the arm's inertness without an anchor, confirmed rather than assumed.

That reproduces Francis and Stuckey's own conclusion (without learning, `scc` for subcircuit is worse than `check` alone, "too expensive to pay off") and refines the diagnosis: the rule is not weak, **the walk is**. Both walks are recomputed from scratch per call, on a trigger that fires on any value removal, so they cost `O(n²)` a call where F&S run one Tarjan pass. Closing an 8×–30× node gap needs the walks an order of magnitude cheaper — an implementation problem with a known shape.

It is also **not** the answer to the `n_medium` regression that motivated the SCC arm: `scc` makes those objectives worse, not better. Worth knowing before anyone builds the four pruning rules on top.

## Tests

Both SCC tests now run a third configuration with nobody named, and assert the same root state as the run that names node 6. Since the SCC arm sits inert without an anchor, that run agreeing is exactly what says the search found one.

`subcircuit_test`'s anchored enumerations run a third time the same way, so the search for an anchor is enumerated and certified at n = 3, 4 and 5 with both anchor positions, rather than only asserted on at the root of one twelve-node instance. That problem already builds the anchor's domain without its own index, so it needs nothing new to be a detection test — and the search can only land on that node, since it is the only one whose own index is missing.

The unanchored encoding stays covered: `subcircuit_test`'s enumerations declare full domains, so they find no anchor, and `subcircuit_prevent_test` leaves three nodes wide open — its `.opb` still has eight `first_pos_` rows and no `anchor_pos`, checked rather than assumed. `In` constraints posted before the `SubCircuit` do not narrow a declared domain, which is why that test is unaffected.

785/785 tests pass.

Issue #788.


