### PR TITLE
Pass the circuit offset instead of shifting the array in the redefinition

### DIFF
--- a/minizinc/CMakeLists.txt
+++ b/minizinc/CMakeLists.txt
@@ -40,13 +40,13 @@ set_tests_properties(minizinc-boolxor PROPERTIES SKIP_RETURN_CODE 66)
 add_test(NAME minizinc-cake COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ cake false true)
 set_tests_properties(minizinc-cake PROPERTIES SKIP_RETURN_CODE 66)
 
-add_test(NAME minizinc-circuit COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ circuittest true true)
+# --fzn-pattern is load-bearing on all three of these: without it they would pass
+# against the stdlib decomposition, which agrees with the reference solver and
+# verifies its proof just as happily, and nothing else the harness checks would
+# notice that the builtin never ran.
+add_test(NAME minizinc-circuit COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash --fzn-pattern glasgow_circuit $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ circuittest true true)
 set_tests_properties(minizinc-circuit PROPERTIES SKIP_RETURN_CODE 66)
 
-# --fzn-pattern is load-bearing here: without it these would pass against the
-# stdlib decomposition, which agrees with the reference solver and verifies its
-# proof just as happily, and nothing else the harness checks would notice that
-# the builtin never ran.
 add_test(NAME minizinc-subcircuit COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash --fzn-pattern glasgow_subcircuit $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ subcircuittest true true)
 set_tests_properties(minizinc-subcircuit PROPERTIES SKIP_RETURN_CODE 66)
 

--- a/minizinc/fzn_glasgow.cc
+++ b/minizinc/fzn_glasgow.cc
@@ -254,6 +254,37 @@ namespace
         }
     }
 
+    // A plain integer parameter, for the redefinitions that hand gcs a number
+    // rather than folding it into an array.
+    auto arg_as_constant(const auto & args, int idx) -> Integer
+    {
+        auto a = args.at(idx);
+        if (! a.is_number())
+            throw FlatZincInterfaceError{format("Didn't get a number where a constant was needed? arg is \"{}\"", a.dump())};
+        return Integer{static_cast<long long>(a)};
+    }
+
+    // Both circuit predicates hand over the successor array unshifted, with the
+    // offset to subtract from each value, and gcs applies it as a view.
+    //
+    // That is not just tidier than shifting in the redefinition, it keeps
+    // information. A comprehension there introduces a fresh FlatZinc variable per
+    // node, declared over the full range before its defining constraint has
+    // propagated, so every narrowing the model had already made is invisible to the
+    // constraint. SubCircuit cares about exactly one such narrowing -- a node whose
+    // own index has left its domain is a node known to be on the tour, which is what
+    // lets it anchor the position encoding -- and `constraint succ[n] != n`, which is
+    // how the tpp challenge model says it, was being lost that way. A view keeps the
+    // domain, and n variables and n linear constraints never get written at all.
+    auto zero_based_successors(const vector<IntegerVariableID> & vars, Integer offset) -> vector<IntegerVariableID>
+    {
+        vector<IntegerVariableID> succ;
+        succ.reserve(vars.size());
+        for (const auto & v : vars)
+            succ.push_back(v + -offset);
+        return succ;
+    }
+
     auto arg_as_var(ExtractedData & data, const auto & args, int idx) -> IntegerVariableID
     {
         auto a = args.at(idx);
@@ -791,19 +822,15 @@ auto main(int argc, char * argv[]) -> int
                 problem.post(BinPacking{items, *sizes, loads});
             }
             else if (id == "glasgow_circuit") {
-                // The mznlib redefinition has already shifted successors to be
-                // 0-based (Circuit expects a length-n array valued in 0..n-1).
-                const auto & vars = arg_as_array_of_var(data, args, 0);
-                problem.post(Circuit{vars});
+                // Circuit expects a length-n array valued in 0..n-1, which the
+                // second argument's offset turns the model's successors into.
+                problem.post(Circuit{zero_based_successors(arg_as_array_of_var(data, args, 0), arg_as_constant(args, 1))});
             }
             else if (id == "glasgow_subcircuit") {
-                // The mznlib redefinition has already shifted successors to be
-                // 0-based, as for glasgow_circuit. SubCircuit is the opt-out
-                // sibling: a node not on the tour takes its own index, and the
-                // empty tour is a solution, so unlike Circuit this must not
-                // assume every node is visited.
-                const auto & vars = arg_as_array_of_var(data, args, 0);
-                problem.post(SubCircuit{vars});
+                // As glasgow_circuit. SubCircuit is the opt-out sibling: a node not
+                // on the tour takes its own index, and the empty tour is a solution,
+                // so unlike Circuit this must not assume every node is visited.
+                problem.post(SubCircuit{zero_based_successors(arg_as_array_of_var(data, args, 0), arg_as_constant(args, 1))});
             }
             else if (id == "glasgow_reachable" || id == "glasgow_dreachable") {
                 // The mznlib redefinition has already shifted the endpoints and

--- a/minizinc/mznlib/fzn_circuit.mzn
+++ b/minizinc/mznlib/fzn_circuit.mzn
@@ -1,7 +1,15 @@
-predicate glasgow_circuit(array[int] of var int: x);
+predicate glasgow_circuit(array[int] of var int: x, int: offset);
 
 % glasgow_circuit expects 0-based successors (a length-n array whose values are
-% in 0..n-1). FlatZinc circuit is defined over index_set(x) with successor values
-% in that same set, so shift by min(index_set(x)) rather than assuming 1-based.
+% in 0..n-1), and FlatZinc circuit is defined over index_set(x) with successor
+% values in that same set, so there is an offset of min(index_set(x)) rather than
+% an assumed 1. It is passed rather than applied here: see fzn_subcircuit.mzn for
+% why, which is that a comprehension would introduce a fresh full-domain variable
+% per node and lose whatever the model had already narrowed. Circuit has no anchor
+% to lose, since it always anchors on node 0, but the n variables and n linear
+% constraints are worth not writing either way, and the two predicates are better
+% off the same shape.
 predicate fzn_circuit(array[int] of var int: x) =
-    glasgow_circuit([x[i] - min(index_set(x)) | i in index_set(x)]);
+    if length(x) = 0 then true
+    else glasgow_circuit(x, min(index_set(x)))
+    endif;

--- a/minizinc/mznlib/fzn_subcircuit.mzn
+++ b/minizinc/mznlib/fzn_subcircuit.mzn
@@ -1,15 +1,30 @@
-predicate glasgow_subcircuit(array[int] of var int: x);
+predicate glasgow_subcircuit(array[int] of var int: x, int: offset);
 
-% glasgow_subcircuit expects 0-based successors (a length-n array whose values are
-% in 0..n-1). FlatZinc subcircuit is defined over index_set(x) with successor
-% values in that same set, so shift by min(index_set(x)) rather than assuming
-% 1-based. The shift is consistent both ways: a node off the tour has x[i] = i,
-% which after shifting is "the value equals the 0-based position".
+% glasgow_subcircuit expects 0-based successors (a length-n array whose values
+% are in 0..n-1), and FlatZinc subcircuit is defined over index_set(x) with
+% successor values in that same set. So there is an offset, min(index_set(x))
+% rather than an assumed 1, and it is passed rather than applied here.
 %
-% Keep the min inside the comprehension. The stdlib's fzn_subcircuit guards
-% length(xs) = 0 explicitly and this override replaces that guard, but with an
-% empty index set the comprehension body -- and so the min -- never evaluates, so
-% the empty subcircuit still flattens. Hoisting the min into a let would turn it
-% into a min-of-empty-set error.
+% Applying it here -- `[x[i] - min(index_set(x)) | i in index_set(x)]` -- is what
+% this used to do, and it is a worse idea than it looks. The comprehension
+% introduces a fresh FlatZinc variable per node, declared over the full range
+% before its defining constraint has propagated, so every narrowing the model had
+% already made to x is invisible to the constraint. SubCircuit cares about
+% precisely one such narrowing: a node whose own index has been taken out of its
+% domain is a node known to be on the tour, which is what lets it anchor the
+% position encoding. `constraint succ[n] != n` -- which is how the tpp challenge
+% model says it -- narrows x and then loses it in the shift.
+%
+% gcs applies the offset as a view instead, so the domains survive, and n
+% variables and n linear constraints do not get written into the FlatZinc at all.
+%
+% The shift is consistent both ways: a node off the tour has x[i] = i, which after
+% shifting is "the value equals the 0-based position".
+%
+% Keep the min inside the call. The stdlib's fzn_subcircuit guards length(xs) = 0
+% explicitly and this override replaces that guard; with an empty index set the
+% min would be a min-of-empty-set error, so it is guarded here instead.
 predicate fzn_subcircuit(array[int] of var int: x) =
-    glasgow_subcircuit([x[i] - min(index_set(x)) | i in index_set(x)]);
+    if length(x) = 0 then true
+    else glasgow_subcircuit(x, min(index_set(x)))
+    endif;


### PR DESCRIPTION
Stacked on #800.

## The bug in the redefinition

`fzn_circuit.mzn` and `fzn_subcircuit.mzn` shifted the successors to be zero-based with a comprehension:

```minizinc
predicate fzn_subcircuit(array[int] of var int: x) =
    glasgow_subcircuit([x[i] - min(index_set(x)) | i in index_set(x)]);
```

That is a worse idea than it looks. The comprehension introduces a **fresh FlatZinc variable per node**, declared over the full range before its defining constraint has propagated, so every narrowing the model had already made to `x` is invisible to the constraint.

`SubCircuit` cares about exactly one such narrowing: a node whose own index has left its domain is a node known to be on the tour, which is what #800 looks for to anchor the position encoding. And `constraint succ[numcities] != numcities;` — which is how the `tpp` challenge model says exactly that — was being lost in the shift. So `tpp` got the unanchored encoding while `mario`, whose pin the flattener folds into the array as a constant, did not. That asymmetry was not a property of the two models; it was this.

Passing the offset and applying it as a view fixes it. The domains survive, and `n` variables and `n` `int_lin_eq` constraints never get written into the FlatZinc at all.

## Measured

`2016/tpp_4_5_20_1`, before → after:

| | before | after | |
|---|---|---|---|
| FlatZinc | 31,534 B | 26,417 B | −16.2% |
| `int_lin_eq` constraints | 21 | 1 | the twenty shifts, gone |
| variables | 121 | 101 | |
| `.opb` | 2,411,111 B | **1,936,718 B** | −19.7% |
| position rows | 1520 | 760 | halved |
| `first_pos` rows | 20 | 0 | the anchor is visible now |

### And it is a propagation bug, not just a size one

I expected the encoding saving and nothing else. The corpus sweep says otherwise, and it is much the bigger half.

`mario`, 15 instances, 60 s cap:

| instance | before | after |
|---|---|---|
| `2013/easy_2` | OPT 628, 10,021 nodes | OPT 628, **3,097** |
| `2013/easy_4` | OPT 545, 53,253 | OPT 545, **15,399** |
| `2013/n_medium_2` | capped, 861 | **OPT 1053 in 23.5 s** |
| `2013/n_medium_4` | capped, 648 | **OPT 832 in 18.6 s** |
| `2013/t_hard_1` | OPT 4783, 17.8 s, 1,133,233 | OPT 4783, **0.7 s, 55,069** |
| `2014/easy_5` | OPT 445, 15,695 | OPT 445, **5,579** |
| `2014/n_medium_3` | capped, 897 | **OPT 943 in 6.3 s** |
| `2014/n_medium_5` | capped, 771 | **OPT 771 in 17.8 s** |
| `2014/t_hard_2` | capped, 4514 | capped, **4602** |
| `2014/t_hard_5` | capped, 4421 | **OPT 4482 in 2.3 s** |
| `2017/medium_1` | capped, 1095 | capped, **1171** |
| `2017/medium_3` | capped, 1016 | capped, **1168** |
| `2017/medium_4` | capped, 885 | capped, **1001** |
| `2017/medium_5` | capped, 900 | capped, **1030** |
| `2017/n_medium_1` | capped, 1006 | capped, **1062** |

Better or equal on every one. Optimal-in-cap on mario goes **4/15 → 9/15**, and 14/27 over the whole corpus against 9/27. `tpp` is unchanged (node counts within 0.5% on every uncapped instance, identical objectives) and takes only the encoding saving.

**Both of #792's regressions are recovered and beaten.** `2013/n_medium_4` was the decomposition's optimal 832 in 57.8 s against our cap; it is now 832 in 18.6 s. `2014/n_medium_3` was 943 in 30.8 s; it is now 943 in 6.3 s.

### The mechanism, measured rather than guessed

`gcs`'s `LinearEquality` is **bounds consistent by default** (`consistency::BC`, see `linear_equality.hh`), and `fzn_glasgow.cc` posts `int_lin_eq` with the default. So a *hole* punched in a shifted copy never reaches `succ` — only its bounds do. `SubCircuit` prunes almost entirely by removing individual successor values, so almost all of its work was being thrown away before it reached the array that matters.

And it matters a great deal here, because mario's search annotation is

```
seq_search([int_search(succ, first_fail, indomain_min, complete), ...])
```

`first_fail` reads `succ`'s domain **sizes** and `indomain_min` picks from `succ`'s domain: with the pruning stranded on the copies, the heuristic was choosing on stale domains and then trying values the propagator had already ruled out.

The probe that settles it: keep the comprehension exactly as it was, change *nothing* else, and make only the two-variable unit-coefficient equalities GAC.

| instance | shift, `int_lin_eq` at BC | shift, those equalities GAC | this PR (views) |
|---|---|---|---|
| `mario_easy_2` | 10,021 | **3,099** | 3,097 |
| `mario_easy_4` | 53,253 | **15,553** | 15,399 |
| `mario_t_hard_1` | 1,133,233 | **55,157** | 55,069 |

Recovering the search by fixing the equalities' consistency alone confirms the cause; the residual two-node difference is the handful of variables that no longer exist at all. Views are the right fix rather than GAC equalities, since a view shares the domain outright and costs nothing.

**This corrects #792's diagnosis of the `n_medium` regression.** I attributed it to the decomposition's `order` variables helping the brancher, and noted that Chuffed's native propagator showed the same shape as supporting evidence. The real cause was in our own redefinition. (Chuffed's own mznlib shifts the same way, which may be why it looked like agreement.)

### The same bug is in four more redefinitions

`fzn_bin_packing`, `fzn_bin_packing_capa` and `fzn_bin_packing_load` all pass `[bin[i] - lb | i in index_set(bin)]`, and `fzn_regular` passes `[x[i] - 1 | i in index_set(x)]`. `BinPacking` and `Regular` both prune values, so both are losing them the same way. Not touched here — that is #803, with the measurement recipe.

## Circuit gets the same treatment

It has no anchor to lose, since it always anchors on node 0, but the variables and constraints are worth not writing either way, and the two predicates are better off the same shape. As a side effect the `minizinc-circuit` lane now exercises `Circuit` over views rather than over plain variables.

Both redefinitions now guard the empty array explicitly, `if length(x) = 0 then true`, exactly as the stdlib's do. With the `min` inside a comprehension the empty case never evaluated it; passing it needs the guard back or it is a min-of-empty-set error.

785/785 tests pass.

Issue #788.
