### PR TITLE
Extensional GAC: a compact-table arm, chosen per instance

### DIFF
--- a/benchmarks/positive_table_random/positive_table_random.cc
+++ b/benchmarks/positive_table_random/positive_table_random.cc
@@ -4,8 +4,10 @@
 #include <examples/benchmark_cli.hh>
 
 #include <cstdlib>
+#include <iostream>
 #include <optional>
 #include <random>
+#include <string>
 #include <vector>
 
 #include <version>
@@ -14,15 +16,18 @@
 #include <print>
 #else
 #include <fmt/core.h>
+#include <fmt/ostream.h>
 #endif
 
 #include <cxxopts.hpp>
 
 using namespace gcs;
 
+using std::cerr;
 using std::mt19937;
 using std::nullopt;
 using std::optional;
+using std::string;
 using std::uniform_int_distribution;
 using std::vector;
 
@@ -33,11 +38,12 @@ using fmt::println;
 #endif
 
 // A random binary-CSP benchmark built entirely from Table (allowed
-// tuples), to exercise the negative-table propagator: n variables of domain
-// 0..d-1, and `constraints` random binary allowed-tuple tables
-// each of the d*d value pairs independently with probability `tightness`. Fixed
-// (deterministic) search, so the search tree is identical regardless of how the
-// propagator is triggered -- the interesting number is solve time / time-per-node.
+// tuples), to exercise the table propagator: n variables of domain
+// 0..d-1, and `constraints` random binary allowed-tuple tables, each allowing
+// each of the d*d value pairs independently with probability 1 - `tightness`.
+// Fixed (deterministic) search, so the search tree is identical regardless of
+// how the propagator is triggered -- the interesting number is solve time /
+// time-per-node.
 auto main(int argc, char * argv[]) -> int
 {
     cxxopts::Options options("positive_table_random", "Random allowed-tuple (Table) benchmark");
@@ -47,6 +53,7 @@ auto main(int argc, char * argv[]) -> int
         ("constraints", "Number of binary allowed-tuple tables", cxxopts::value<int>()->default_value("180"))                           //
         ("tightness", "Probability each value pair is forbidden (allowed = 1 - this)", cxxopts::value<double>()->default_value("0.34")) //
         ("seed", "Random seed", cxxopts::value<unsigned>()->default_value("1"))                                                         //
+        ("table", "Table algorithm: auto, live or compact", cxxopts::value<string>()->default_value("auto"))                            //
         ("first", "Stop at the first solution instead of enumerating all")                                                              //
         ("timeout", "Timeout in seconds (0 = none)", cxxopts::value<double>()->default_value("0"))                                      //
         ("help", "Display help");
@@ -62,6 +69,19 @@ auto main(int argc, char * argv[]) -> int
     auto tightness = options_vars["tightness"].as<double>();
     auto seed = options_vars["seed"].as<unsigned>();
     auto first_only = options_vars.contains("first");
+
+    // The in-repo way to reproduce the live-vs-compact comparison: the two are
+    // supposed to make identical inferences, so only the timings should move.
+    // Spelled as on the `tables` example.
+    auto algorithm = TableAlgorithm{table::Auto{}};
+    if (auto choice = options_vars["table"].as<string>(); "live" == choice)
+        algorithm = table::LiveSet{};
+    else if ("compact" == choice)
+        algorithm = table::CompactTable{};
+    else if ("auto" != choice) {
+        println(cerr, "Error: --table must be auto, live or compact");
+        return EXIT_FAILURE;
+    }
 
     mt19937 rng(seed);
     uniform_int_distribution<int> pick_var(0, n - 1);
@@ -82,7 +102,7 @@ auto main(int argc, char * argv[]) -> int
             for (int v = 0; v < d; ++v)
                 if (unit(rng) >= tightness)
                     allowed.push_back({Integer{u}, Integer{v}});
-        p.post(Table{{vars[a], vars[b]}, move(allowed)});
+        p.post(Table{{vars[a], vars[b]}, move(allowed)}.with_algorithm(algorithm));
     }
 
     unsigned long long solutions = 0;

--- a/dev_docs/propagator-performance.md
+++ b/dev_docs/propagator-performance.md
@@ -348,6 +348,39 @@ confident wrong answer first time:
   itself and reports exactly 1.00x for everything. `md5sum` the two binaries when
   a change reads 1.00x across the board.
 
+### Adding a second algorithm to a hot function slows down the first one
+
+The table propagator later grew a compact-table path alongside the live-set one,
+chosen per instance and dispatched on a bool at the top of
+`propagate_extensional`. That should cost the live-set path one predictable
+branch per call. It cost it far more than that, on instances that execute none
+of the new code, and for three unrelated reasons — each worth checking for
+whenever a second path lands in a function that was already hot. The three are
+separate costs on different instances, not three explanations of one number.
+
+- **The inner test stopped being inlined.** `perf record` showed
+  `bitmap_feasible` — pass 1's membership test, previously inlined away — as a
+  separate symbol at 27% of runtime. The function had not changed; the function
+  it was called from had grown past GCC's inlining budget. `[[gnu::always_inline]]`
+  on the test put it back, worth **10% on `srch_k5`** and 25% of the instruction
+  count. The symptom to look for is a helper appearing in the profile that did
+  not use to be there at all.
+- **Instruction footprint, even from code that never runs.** Before the new pass
+  was moved out of line with `[[gnu::noinline]]`, it cost 7% on `Dubois` — an
+  instance whose propagator does almost nothing per call, so its cost is
+  dominated by how much of the function is resident.
+- **Constraint state is not free to declare.** Every slot added with
+  `State::add_constraint_state` is deep-copied into every search node, so two
+  extra integers per table cost `Dubois` 14% and `enum_shared` 24% before the
+  second one was folded into the undo trail and the first was made conditional on
+  the table being large enough to want it. A propagator that ends up not using
+  the state still pays for it at every node.
+
+The general shape: a second algorithm is not free for the first one even when it
+is never executed, and the cost does not show up where you would look for it. Any
+such change needs the *old* path measured against the *unmodified* build, not
+just the new path measured against the old one.
+
 ## Is it the propagator, the strength, or the search?
 
 When a model is slow, "the propagator is slow" is only one of three

--- a/examples/tables/CMakeLists.txt
+++ b/examples/tables/CMakeLists.txt
@@ -5,5 +5,23 @@ target_link_libraries(tables PRIVATE glasgow_constraint_solver)
 target_link_libraries(tables PRIVATE cxxopts)
 target_link_libraries(tables PRIVATE gcs_fmt)
 
+# One lane per algorithm: the library paths are covered by table_test, so what
+# these add is that each algorithm solves this example correctly and writes a
+# proof VeriPB accepts. tables_compact is the only place outside table_test that
+# runs the compact algorithm at all -- this example's tables are all under
+# min_tuples, so auto never switches on them.
+#
+# They do not pin the example's own forwarding of --table, and cannot: all three
+# algorithms write byte-identical proofs by design, so run_test_and_verify.bash
+# has nothing to see. Deleting the forwarding, so that --table compact parses and
+# then selects auto, leaves all three lanes green (checked by mutation).
 add_test(NAME tables COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:tables>)
+# --basename because these share a binary with the lane above, and without
+# distinct proof names a parallel ctest has them racing over one set of files
+# (issue #562).
+foreach(algorithm live compact)
+    add_test(NAME tables_${algorithm}
+        COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash --basename tables_${algorithm}
+        $<TARGET_FILE:tables> --table ${algorithm})
+endforeach()
 

--- a/examples/tables/tables.cc
+++ b/examples/tables/tables.cc
@@ -50,6 +50,8 @@ auto main(int argc, char * argv[]) -> int
             ("proof-files-basename", "Basename for the .opb and .pbp files", //
                 cxxopts::value<string>()->default_value("tables"))           //
             ("stats", "Print solve statistics")                              //
+            ("table", "Table algorithm: auto, live or compact",              //
+                cxxopts::value<string>()->default_value("auto"))             //
             ;
 
         options_vars = options.parse(argc, argv);
@@ -67,6 +69,19 @@ auto main(int argc, char * argv[]) -> int
         return EXIT_SUCCESS;
     }
 
+    // Both directions stay runnable from the example, which is how the two
+    // algorithms are compared: they are supposed to make identical inferences,
+    // so `--prove` under each should write the same proof.
+    auto algorithm = TableAlgorithm{table::Auto{}};
+    if (auto choice = options_vars["table"].as<string>(); "live" == choice)
+        algorithm = table::LiveSet{};
+    else if ("compact" == choice)
+        algorithm = table::CompactTable{};
+    else if ("auto" != choice) {
+        println(cerr, "Error: --table must be auto, live or compact");
+        return EXIT_FAILURE;
+    }
+
     Problem p;
 
     auto v1 = p.create_integer_variable(1_i, 4_i, "v1");
@@ -80,13 +95,15 @@ auto main(int argc, char * argv[]) -> int
             {2_i, 1_i, 3_i},          //
             {2_i, 3_i, 1_i},          //
             {3_i, 1_i, 2_i},          //
-            {3_i, 2_i, 1_i}}});
+            {3_i, 2_i, 1_i}}}
+            .with_algorithm(algorithm));
 
     p.post(Table{{v1, v4},                //
         WildcardTuples{{1_i, Wildcard{}}, //
             {2_i, 2_i},                   //
             {3_i, 3_i},                   //
-            {4_i, 4_i}}});
+            {4_i, 4_i}}}
+            .with_algorithm(algorithm));
 
     p.post(Table{{v1, v2, v3, v4}, //
         WildcardTuples{
@@ -102,7 +119,7 @@ auto main(int argc, char * argv[]) -> int
             {4_i, 4_i, Wildcard{}, Wildcard{}}, //
             {Wildcard{}, 4_i, 4_i, Wildcard{}}, //
             {Wildcard{}, Wildcard{}, 4_i, 4_i}, //
-        }});
+        }}.with_algorithm(algorithm));
 
     auto stats = solve_with(p,
         SolveCallbacks{

--- a/gcs/constraints/extensional_utils.cc
+++ b/gcs/constraints/extensional_utils.cc
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include <any>
+#include <bit>
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
@@ -10,6 +11,7 @@
 #include <gcs/constraints/plus_minus/hints.hh>
 #include <gcs/constraints/power/hints.hh>
 #include <gcs/constraints/table/hints.hh>
+#include <gcs/exception.hh>
 #include <gcs/innards/inference_tracker.hh>
 #include <gcs/innards/justification.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
@@ -17,6 +19,7 @@
 #include <gcs/innards/state-fwd.hh>
 #include <gcs/innards/state.hh>
 #include <gcs/proof.hh>
+#include <limits>
 #include <optional>
 #include <utility>
 
@@ -44,8 +47,20 @@ auto gcs::innards::ExtensionalLiveTuples::create(State & initial_state, size_t n
     return result;
 }
 
-gcs::innards::ExtensionalData::ExtensionalData(vector<IntegerVariableID> vars, ExtensionalTuples tuples, shared_ptr<ExtensionalLiveTuples> live) :
-    vars(move(vars)), tuples(move(tuples)), reason(generic_reason(this->vars)), live(move(live))
+auto gcs::innards::ExtensionalCompactTable::create(State & initial_state, bool forced) -> shared_ptr<ExtensionalCompactTable>
+{
+    auto result = make_shared<ExtensionalCompactTable>();
+    result->forced = forced;
+    // One plain integer, which std::any holds without allocating. Everything
+    // else the compact table owns is restored by unwinding the trail down to
+    // it: the words, the previous domains, and the limit.
+    result->trail_mark_handle = initial_state.add_constraint_state(size_t{0});
+    return result;
+}
+
+gcs::innards::ExtensionalData::ExtensionalData(
+    vector<IntegerVariableID> vars, ExtensionalTuples tuples, shared_ptr<ExtensionalLiveTuples> live, shared_ptr<ExtensionalCompactTable> compact) :
+    vars(move(vars)), tuples(move(tuples)), reason(generic_reason(this->vars)), live(move(live)), compact(move(compact))
 {
 }
 
@@ -103,7 +118,12 @@ namespace
 
     // Membership against a rasterised domain, given the position is usable. The
     // caller has already established that the entry is an Integer.
-    [[nodiscard]] inline auto bitmap_contains(
+    //
+    // always_inline rather than inline: this is pass 1's inner test, and once
+    // propagate_extensional grew the compact-table dispatch GCC stopped
+    // inlining it -- 25% more instructions and 10% of the runtime on srch_k5,
+    // on the live-set path, which runs none of the new code.
+    [[nodiscard]] [[gnu::always_inline]] inline auto bitmap_contains(
         const ExtensionalDomainBitmaps & bitmaps, const ExtensionalDomainBitmaps::Position & p, const Integer val) -> bool
     {
         auto off = static_cast<unsigned long long>(val.raw_value - p.base);
@@ -112,22 +132,363 @@ namespace
         return 0 != (bitmaps.words[p.offset + off / extensional_word_bits] & (ExtensionalWord{1} << (off % extensional_word_bits)));
     }
 
-    [[nodiscard]] inline auto bitmap_feasible(const ExtensionalDomainBitmaps & bitmaps, const ExtensionalDomainBitmaps::Position & p,
-        const bool use_bitmaps, const State & state, const IntegerVariableID & var, const Integer val) -> bool
+    [[nodiscard]] [[gnu::always_inline]] inline auto bitmap_feasible(const ExtensionalDomainBitmaps & bitmaps,
+        const ExtensionalDomainBitmaps::Position & p, const bool use_bitmaps, const State & state, const IntegerVariableID & var, const Integer val)
+        -> bool
     {
         return (use_bitmaps && p.usable) ? bitmap_contains(bitmaps, p, val) : state.in_domain(var, val);
     }
 
-    [[nodiscard]] inline auto bitmap_feasible(const ExtensionalDomainBitmaps &, const ExtensionalDomainBitmaps::Position &, const bool, const State &,
-        const IntegerVariableID &, const Wildcard &) -> bool
+    [[nodiscard]] [[gnu::always_inline]] inline auto bitmap_feasible(const ExtensionalDomainBitmaps &, const ExtensionalDomainBitmaps::Position &,
+        const bool, const State &, const IntegerVariableID &, const Wildcard &) -> bool
     {
         return true;
     }
 
-    [[nodiscard]] inline auto bitmap_feasible(const ExtensionalDomainBitmaps & bitmaps, const ExtensionalDomainBitmaps::Position & p,
-        const bool use_bitmaps, const State & state, const IntegerVariableID & var, const IntegerOrWildcard & v) -> bool
+    [[nodiscard]] [[gnu::always_inline]] inline auto bitmap_feasible(const ExtensionalDomainBitmaps & bitmaps,
+        const ExtensionalDomainBitmaps::Position & p, const bool use_bitmaps, const State & state, const IntegerVariableID & var,
+        const IntegerOrWildcard & v) -> bool
     {
         return visit([&](auto & v) { return bitmap_feasible(bitmaps, p, use_bitmaps, state, var, v); }, v);
+    }
+
+    // The value a tuple holds at a position, for building the support masks.
+    // Only reached once every position has a usable rasterisation, which rules
+    // out wildcards, so the Wildcard arm cannot be taken.
+    [[nodiscard]] inline auto compact_value(const Integer & v) -> long long
+    {
+        return v.raw_value;
+    }
+
+    [[nodiscard]] inline auto compact_value(const Wildcard &) -> long long
+    {
+        throw NonExhaustiveSwitch{};
+    }
+
+    [[nodiscard]] inline auto compact_value(const IntegerOrWildcard & v) -> long long
+    {
+        return visit([](const auto & v) { return compact_value(v); }, v);
+    }
+
+    /**
+     * Lay out and fill the support masks: one bitset of n_words per (position,
+     * value), holding the tuples whose entry at that position is that value.
+     * Returns false, leaving the compact table unusable, if any position could
+     * not be rasterised (a wildcard, or a value range too wide) or if the masks
+     * would be larger than the cap -- in either case the live-set algorithm
+     * runs instead.
+     */
+    auto build_compact_table(
+        ExtensionalCompactTable & ct, const ExtensionalDomainBitmaps & bitmaps, const ExtensionalData & table, const std::size_t n_tuples) -> bool
+    {
+        auto n_vars = table.vars.size();
+        for (unsigned idx = 0; idx < n_vars; ++idx)
+            if (! bitmaps.positions[idx].usable)
+                return false;
+
+        ct.n_words = extensional_words_for(n_tuples);
+        ct.mask_at.assign(n_vars, 0);
+        std::size_t total = 0;
+        for (unsigned idx = 0; idx < n_vars; ++idx) {
+            ct.mask_at[idx] = total;
+            auto here = bitmaps.positions[idx].n_values * ct.n_words;
+            if (here > ExtensionalCompactTable::max_mask_words - total)
+                return false;
+            total += here;
+        }
+        if (total > ExtensionalCompactTable::max_mask_words)
+            return false;
+
+        ct.masks.assign(total, ExtensionalWord{});
+        ct.index.resize(ct.n_words);
+        ct.scratch.assign(ct.n_words, ExtensionalWord{});
+        ct.words.assign(ct.n_words, ExtensionalWord{});
+        ct.previous_domain.assign(bitmaps.words.size(), ExtensionalWord{});
+        visit(
+            [&](const auto & tuples) {
+                const auto & rows = *tuples;
+                for (std::size_t t = 0; t < n_tuples; ++t) {
+                    const auto & row = rows[t];
+                    auto word = t / extensional_word_bits;
+                    auto bit = ExtensionalWord{1} << (t % extensional_word_bits);
+                    for (unsigned idx = 0; idx < n_vars; ++idx) {
+                        const auto & p = bitmaps.positions[idx];
+                        auto off = static_cast<std::size_t>(compact_value(row[idx]) - p.base);
+                        ct.masks[ct.mask_at[idx] + off * ct.n_words + word] |= bit;
+                    }
+                }
+            },
+            table.tuples);
+
+        return true;
+    }
+
+    /// Set every position's previous domain to everything the table uses there,
+    /// so that the next update filters against the current domains from scratch
+    /// rather than against a delta it has no record of.
+    auto seed_compact_previous_domain(ExtensionalCompactTable & ct, const ExtensionalDomainBitmaps & bitmaps, const std::size_t n_vars) -> void
+    {
+        std::fill(ct.previous_domain.begin(), ct.previous_domain.end(), ExtensionalWord{});
+        for (unsigned idx = 0; idx < n_vars; ++idx) {
+            const auto & p = bitmaps.positions[idx];
+            for (std::size_t v = 0; v < p.n_values; ++v)
+                ct.previous_domain[p.offset + v / extensional_word_bits] |= ExtensionalWord{1} << (v % extensional_word_bits);
+        }
+    }
+
+    /// Rebuild the index over whichever words \c words now has bits in.
+    auto reindex_compact_table(ExtensionalCompactTable & ct) -> void
+    {
+        ct.limit = 0;
+        for (std::size_t w = 0; w < ct.n_words; ++w)
+            if (0 != ct.words[w])
+                ct.index[ct.limit++] = static_cast<std::uint32_t>(w);
+        for (std::size_t w = 0, at = ct.limit; w < ct.n_words; ++w)
+            if (0 == ct.words[w])
+                ct.index[at++] = static_cast<std::uint32_t>(w);
+    }
+
+    /**
+     * Take the live set over from the sparse set, at whatever node the decision
+     * to switch was made.
+     *
+     * The sparse set holds what was feasible when the live-set path last ran,
+     * and domains have only shrunk since, so it is a superset of the truth --
+     * which is why the previous domains are seeded wide rather than from the
+     * current ones. Seeding them from the current domains would make the first
+     * update see no change at all and leave the stale tuples in: a loss of
+     * propagation rather than an unsoundness, and it showed up as 3 366 nodes
+     * where the live-set path takes 3 340.
+     */
+    auto seed_compact_table_from_live_set(ExtensionalCompactTable & ct, const ExtensionalDomainBitmaps & bitmaps, const ExtensionalLiveTuples & live,
+        const std::size_t live_count, const std::size_t n_vars) -> void
+    {
+        std::fill(ct.words.begin(), ct.words.end(), ExtensionalWord{});
+        for (std::size_t i = 0; i < live_count; ++i) {
+            auto t = live.dense[i];
+            ct.words[t / extensional_word_bits] |= ExtensionalWord{1} << (t % extensional_word_bits);
+        }
+        reindex_compact_table(ct);
+        seed_compact_previous_domain(ct, bitmaps, n_vars);
+        ct.trail.clear();
+        // So that the published mark is never zero at or below this node: zero
+        // is what says the search has climbed above it.
+        ct.trail.push_back({ExtensionalCompactTable::limit_marker, ct.limit});
+    }
+
+    /**
+     * Start again from the whole table, for when the search has backtracked
+     * above the node the switch happened at. The sparse set stopped being
+     * maintained then, so there is nothing to take the live set over from, and
+     * the update that follows re-derives it by filtering everything against the
+     * current domains -- which is what a first call would have done anyway.
+     */
+    auto seed_compact_table_from_scratch(
+        ExtensionalCompactTable & ct, const ExtensionalDomainBitmaps & bitmaps, const std::size_t n_vars, const std::size_t n_tuples) -> void
+    {
+        std::fill(ct.words.begin(), ct.words.end(), std::numeric_limits<ExtensionalWord>::max());
+        // The tail of the last word holds no tuple, so it must stay clear or an
+        // empty live set would never look empty.
+        if (auto tail = n_tuples % extensional_word_bits)
+            ct.words.back() = (ExtensionalWord{1} << tail) - 1;
+        ct.limit = ct.n_words;
+        for (std::size_t w = 0; w < ct.n_words; ++w)
+            ct.index[w] = static_cast<std::uint32_t>(w);
+
+        seed_compact_previous_domain(ct, bitmaps, n_vars);
+        ct.trail.clear();
+        ct.trail.push_back({ExtensionalCompactTable::limit_marker, ct.limit});
+    }
+}
+
+namespace
+{
+    /**
+     * The compact-table pass, kept out of line from the live-set one on purpose.
+     * Inlined into the same function it cost the live-set path 7% on Dubois and
+     * 14% on Crossword purely in instruction footprint, on instances that never
+     * run a line of it.
+     */
+    template <typename Hint_, typename Inference_>
+    [[gnu::noinline]] auto propagate_compact_table(const ExtensionalData & table, ExtensionalCompactTable & ct, const State & state,
+        Inference_ & inference, ProofLogger * const logger, const Hint_ & hint, ExtensionalDomainBitmaps & bitmaps,
+        const ExtensionalLiveTuples & live, const std::size_t live_count, const bool just_built) -> void
+    {
+        auto & trail_mark = any_cast<size_t &>(state.get_constraint_state(ct.trail_mark_handle));
+        const auto n_vars = static_cast<unsigned>(table.vars.size());
+
+        // Undo everything written at an epoch we have since left. Lazily here
+        // rather than from a backtrack callback, because a propagator's
+        // `const State &` cannot register one -- and lazily is exact, because
+        // nothing reads the words or the previous domains in between and what
+        // goes back is the saved value rather than a reconstruction. Before the
+        // seeding below, not after: the seed leaves a sentinel entry so that the
+        // mark it publishes cannot be zero, and unwinding would take it away
+        // again.
+        while (ct.trail.size() > trail_mark) {
+            const auto & entry = ct.trail.back();
+            if (ExtensionalCompactTable::limit_marker == entry.where)
+                ct.limit = static_cast<std::size_t>(entry.was);
+            else if (entry.where < ct.n_words)
+                ct.words[entry.where] = entry.was;
+            else
+                ct.previous_domain[entry.where - ct.n_words] = entry.was;
+            ct.trail.pop_back();
+        }
+
+        // Climbing back above the node the switch happened at empties the trail,
+        // because nothing below it was recorded at a shallower epoch. The sparse
+        // set stopped being maintained there, so there is nothing to take the
+        // live set over from: start again from the whole table and let the
+        // update below filter it against the current domains, which is what a
+        // first call would have done anyway.
+        if (just_built)
+            seed_compact_table_from_live_set(ct, bitmaps, live, live_count, n_vars);
+        else if (0 == trail_mark)
+            seed_compact_table_from_scratch(ct, bitmaps, n_vars, live.dense.size());
+
+        auto save_word = [&](std::size_t where, ExtensionalWord was) { ct.trail.push_back({static_cast<std::uint32_t>(where), was}); };
+
+        // The limit goes on the trail too, but once per call: unwinding pops
+        // from the back, so the oldest saved value is the one that survives, and
+        // that is the limit as this call found it.
+        bool limit_saved = false;
+
+        // Update: react to what changed, rather than re-testing what is live.
+        // For each position whose domain has lost values, take the union of the
+        // support masks of either the values that went or the values that
+        // remain -- whichever is the smaller set to walk -- and apply it to the
+        // live words in one pass, so each word is written and trailed at most
+        // once per position.
+        for (unsigned idx = 0; idx < n_vars; ++idx) {
+            const auto & p = bitmaps.positions[idx];
+            const auto domain_words = extensional_words_for(p.n_values);
+            const auto * const cur = bitmaps.words.data() + p.offset;
+            auto * const prev = ct.previous_domain.data() + p.offset;
+
+            std::size_t n_removed = 0, n_kept = 0;
+            for (std::size_t k = 0; k < domain_words; ++k) {
+                n_removed += static_cast<std::size_t>(std::popcount(prev[k] & ~cur[k]));
+                n_kept += static_cast<std::size_t>(std::popcount(cur[k]));
+            }
+            if (0 == n_removed)
+                continue;
+
+            const bool by_removals = n_removed <= n_kept;
+            const auto * const masks_here = ct.masks.data() + ct.mask_at[idx];
+            bool any = false;
+            for (std::size_t k = 0; k < domain_words; ++k) {
+                auto bits = by_removals ? (prev[k] & ~cur[k]) : cur[k];
+                while (bits) {
+                    auto v = k * extensional_word_bits + static_cast<std::size_t>(std::countr_zero(bits));
+                    bits &= bits - 1;
+                    const auto * const m = masks_here + v * ct.n_words;
+                    if (! any) {
+                        for (std::size_t i = 0; i < ct.limit; ++i)
+                            ct.scratch[ct.index[i]] = m[ct.index[i]];
+                        any = true;
+                    }
+                    else
+                        for (std::size_t i = 0; i < ct.limit; ++i)
+                            ct.scratch[ct.index[i]] |= m[ct.index[i]];
+                }
+            }
+            if (! any)
+                for (std::size_t i = 0; i < ct.limit; ++i)
+                    ct.scratch[ct.index[i]] = ExtensionalWord{};
+
+            // Downwards, so that swapping an emptied word out to the end never
+            // moves an unvisited one into a slot already passed.
+            for (auto i = ct.limit; i-- > 0;) {
+                auto w = ct.index[i];
+                auto was = ct.words[w];
+                auto now = by_removals ? (was & ~ct.scratch[w]) : (was & ct.scratch[w]);
+                if (now != was) {
+                    save_word(w, was);
+                    ct.words[w] = now;
+                    if (0 == now) {
+                        if (! limit_saved) {
+                            ct.trail.push_back({ExtensionalCompactTable::limit_marker, ct.limit});
+                            limit_saved = true;
+                        }
+                        ct.index[i] = ct.index[ct.limit - 1];
+                        ct.index[ct.limit - 1] = w;
+                        --ct.limit;
+                    }
+                }
+            }
+
+            for (std::size_t k = 0; k < domain_words; ++k)
+                if (prev[k] != cur[k]) {
+                    save_word(ct.n_words + p.offset + k, prev[k]);
+                    prev[k] = cur[k];
+                }
+        }
+
+        if (0 == ct.limit) {
+            // The same two spellings as the live-set path below, and for the
+            // same reason: the dom/wdeg conflict observer reads the reason of a
+            // no-justification contradiction.
+            if (logger && logger->get_assertion_level() != AssertionLevel::Off)
+                inference.contradiction(logger, JustifyUsingRUP{hint}, table.reason);
+            else
+                inference.contradiction(logger, NoJustificationNeeded{}, NoReason{});
+        }
+
+        // Filter: a value survives iff some live tuple supports it. Same
+        // positions in the same order, same values in ascending order, so the
+        // inferences and hence the proof are exactly those the live-set path
+        // would have made.
+        for (unsigned idx = 0; idx < n_vars; ++idx) {
+            const auto & p = bitmaps.positions[idx];
+            const auto * const masks_here = ct.masks.data() + ct.mask_at[idx];
+            state.for_each_value_mutable(table.vars[idx], [&](Integer val) {
+                auto off = static_cast<unsigned long long>(val.raw_value - p.base);
+                bool supported = false;
+                if (off < p.n_values) {
+                    const auto * const m = masks_here + off * ct.n_words;
+                    for (std::size_t i = 0; i < ct.limit; ++i) {
+                        auto w = ct.index[i];
+                        if (0 != (ct.words[w] & m[w])) {
+                            supported = true;
+                            break;
+                        }
+                    }
+                }
+
+                if (! supported) {
+                    // Take it out of the rasterised domain as well, so that the
+                    // record below is what the domain looks like *after* this
+                    // call rather than before it. Otherwise the next call reacts
+                    // to this call's own prunings -- which are already out of
+                    // the live set, so the work is pure waste.
+                    if (off < p.n_values)
+                        bitmaps.words[p.offset + off / extensional_word_bits] &= ~(ExtensionalWord{1} << (off % extensional_word_bits));
+                    inference.infer(logger, table.vars[idx] != val, JustifyUsingRUP{hint}, table.reason);
+                }
+            });
+        }
+
+        // Record the domains as this call leaves them, so the next call reacts only
+        // to what other propagators, or the next decision, take away. Rasterising
+        // them a second time here would be simpler, and cost enum_func 9%: the
+        // filter above already knows every value it removed.
+        for (unsigned idx = 0; idx < n_vars; ++idx) {
+            const auto & p = bitmaps.positions[idx];
+            const auto domain_words = extensional_words_for(p.n_values);
+            const auto * const cur = bitmaps.words.data() + p.offset;
+            auto * const prev = ct.previous_domain.data() + p.offset;
+            for (std::size_t k = 0; k < domain_words; ++k)
+                if (prev[k] != cur[k]) {
+                    save_word(ct.n_words + p.offset + k, prev[k]);
+                    prev[k] = cur[k];
+                }
+        }
+
+        // Publish last, so that a contradiction or a failing inference above
+        // leaves this call's entries on the trail to be undone rather than
+        // committed as if they belonged to an epoch that survived.
+        trail_mark = ct.trail.size();
     }
 }
 
@@ -176,13 +537,46 @@ auto gcs::innards::propagate_extensional(
         bitmaps.initialised = true;
     }
 
+    // The compact table is laid out on the first call, which is at the root, for
+    // the same reason the residues are: everything it indexes is fixed for the
+    // life of the propagator, and the domains it starts from are the widest they
+    // will ever be. A table it cannot rasterise falls back to the live set.
+    // Decide, once, whether this instance runs the compact table. Auto watches
+    // for a while first: the masks are cheap to build but not free, and a table
+    // that is woken 429 times in a whole search -- which is what Renault does --
+    // never gets that back. The three thresholds are read off the measured
+    // suite; see ExtensionalCompactTable.
+    bool just_built = false;
+    if (table.compact && ! table.compact->decided) {
+        auto & ct = *table.compact;
+        ++ct.wakes;
+        ct.total_live += live_count;
+        const bool forced = ct.forced;
+        if (forced || ct.wakes >= ExtensionalCompactTable::decide_after) {
+            ct.decided = true;
+            auto n_tuples = live.dense.size();
+            auto mean_live = static_cast<std::size_t>(ct.total_live / ct.wakes);
+            bool worth_it = forced || (mean_live >= ExtensionalCompactTable::min_mean_live && extensional_word_bits * mean_live >= n_tuples);
+            if (worth_it && build_compact_table(ct, bitmaps, table, n_tuples)) {
+                ct.built = true;
+                just_built = true;
+            }
+        }
+    }
+    const bool compact = table.compact && table.compact->built;
+
     // Rasterising position idx costs a word-clear plus one bit-set per value in
     // its domain, and saves roughly one in_domain() call per live tuple. On a
     // four-tuple table with two live entries that trade loses -- it read 0.9x on
     // enum_bin_d2_n14 and enum_shared_k2_n12 before this gate -- so only do it
-    // when the live set is big enough to amortise it.
+    // when the live set is big enough to amortise it. The compact table has no
+    // choice: the rasterised domain is what it takes the difference against.
+    //
+    // Spelled as two conditions rather than one because the second is what pass
+    // 1 tests per (tuple, position), and GCC only unswitches that loop on it
+    // while it stays this simple.
     const bool use_bitmaps = live_count >= ExtensionalDomainBitmaps::min_live;
-    for (unsigned idx = 0; use_bitmaps && idx < table.vars.size(); ++idx) {
+    for (unsigned idx = 0; (compact || use_bitmaps) && idx < table.vars.size(); ++idx) {
         const auto & p = bitmaps.positions[idx];
         if (! p.usable)
             continue;
@@ -193,6 +587,11 @@ auto gcs::innards::propagate_extensional(
             if (off < p.n_values)
                 bitmaps.words[p.offset + off / extensional_word_bits] |= ExtensionalWord{1} << (off % extensional_word_bits);
         });
+    }
+
+    if (compact) {
+        propagate_compact_table(table, *table.compact, state, inference, logger, hint, bitmaps, live, live_count, just_built);
+        return PropagatorState::EnableButIdempotent;
     }
 
     // Pass 1: drop tuples that are no longer feasible, by swapping them past the

--- a/gcs/constraints/extensional_utils.hh
+++ b/gcs/constraints/extensional_utils.hh
@@ -144,6 +144,152 @@ namespace gcs::innards
     };
 
     /**
+     * \brief Compact-table state for gcs::innards::propagate_extensional().
+     *
+     * The live-set algorithm re-tests every live tuple against every position on
+     * every wake, so pass 1 costs what is *live*. Compact table makes it cost
+     * what *changed*: the live set is a bitset over tuple indices, and for each
+     * value removed from a variable's domain one word-wise `live &= ~support`
+     * takes out every tuple that used it. Measured over this project's suite,
+     * that is 2-13x fewer pass-1 operations, each of them a word AND rather than
+     * a membership test.
+     *
+     * The set of tuples this leaves live, and therefore every inference pass 2
+     * draws from it, is identical to what the live-set algorithm computes: both
+     * end up with the tuples all of whose entries are still in domain. The
+     * proof is unchanged.
+     *
+     * \sa ExtensionalLiveTuples
+     * \ingroup Innards
+     */
+    struct ExtensionalCompactTable
+    {
+        /// Do not build masks larger than this, in words, per constraint.
+        /// The suite's largest is Renault-big at 755 623 words over 332 tables;
+        /// a single table wanting more than this is better served by the
+        /// live-set algorithm than by the memory.
+        static constexpr std::size_t max_mask_words = 16 * 1024 * 1024;
+
+        /**
+         * How long table::Auto watches before deciding, and what it
+         * looks for. Every threshold here is read off the measured suite:
+         *
+         *  - \c decide_after separates the instances that never amortise a mask
+         *    build from the ones that do, and it is counted per propagator, not
+         *    per search. Kakuro wakes a table one to three times in the whole
+         *    search and Renault-megane about four; Crossword wakes one 1 898
+         *    times, srch_k5 3 146, srch_bin_d20 19 068. Nothing sits between, so
+         *    the threshold only has to be small enough that the wait itself does
+         *    not cost anything: at 512 it left srch_k5 running 16% of its calls
+         *    on the slower path, which was worth 36%.
+         *  - \c min_mean_live is where a call starts doing enough work to cover
+         *    the fixed cost of an update. Below it the compact table measured
+         *    0.74-0.96x: Dubois at 2.3 live, enum_shared at 3.0, enum_func at
+         *    12.8. Above it, 1.4x and upwards. It is a mean over the first
+         *    \c decide_after wakes, which early in a search overestimates the
+         *    steady state: srch_bin_d10_n20_s2 settles at 7.7 live but does not
+         *    look like it yet at wake 32, and is the one instance where Auto
+         *    loses (0.96x).
+         *  - the density test is the one that is easy to miss. A bitset is only
+         *    a good shape for the live set if its words are full: the support
+         *    test costs a word per live word, where the live-set scan costs a
+         *    step per tuple until it finds a witness. enum_single_k10_t200k
+         *    keeps 46 tuples live in a 200 000-tuple table -- one per word --
+         *    and measured 1.00x. Requiring \c extensional_word_bits * mean live >=
+         *    tuples asks for at
+         *    least one live tuple per word on average.
+         */
+        static constexpr unsigned long long decide_after = 32;
+        static constexpr std::size_t min_mean_live = 16;
+
+        /// A table whose tuples all fit in one word cannot pay for the compact
+        /// table's per-call bookkeeping -- rasterising the domains twice,
+        /// counting bits, keeping a trail -- however many times it is woken, so
+        /// it does not even get the state that would let it try.
+        static constexpr std::size_t min_tuples = extensional_word_bits;
+
+        /**
+         * Supports: one bitset of \c n_words per (position, value), holding the
+         * tuples whose entry at that position is that value. Values are indexed
+         * from the position's ExtensionalDomainBitmaps::Position, so a value the
+         * table never uses at that position is outside the range and is
+         * unsupported without a lookup.
+         */
+        std::vector<ExtensionalWord> masks;
+        std::vector<std::size_t> mask_at;
+        std::size_t n_words = 0;
+
+        /**
+         * The live tuples, as a sparse bitset: \c words holds the bits, and
+         * \c index[0, limit) names the words that still have any set. Only
+         * \c limit backtracks, by the same argument ExtensionalLiveTuples uses
+         * for its size: a word only ever leaves the live region by swapping with
+         * \c index[limit - 1], so restoring \c limit re-admits exactly the words
+         * dropped below this node.
+         */
+        std::vector<ExtensionalWord> words;
+        std::vector<std::uint32_t> index;
+        std::size_t limit = 0;
+
+        /**
+         * What each position's domain held when this instance last ran on this
+         * path, rasterised exactly as ExtensionalDomainBitmaps rasterises the
+         * current one, so that the difference of the two is the set of values to
+         * react to. It has to backtrack: a stale copy from a deeper node is a
+         * subset of the truth, which would make the update miss removals.
+         */
+        std::vector<ExtensionalWord> previous_domain;
+
+        /// Accumulates the union of the support masks being applied, so that the
+        /// live words are written once per position rather than once per value.
+        std::vector<ExtensionalWord> scratch;
+
+        /**
+         * The undo trail for \c words and \c previous_domain, which are the two
+         * things that change value rather than merely membership.
+         * State::on_backtrack is not reachable from a propagator's
+         * `const State &`, so this follows the difference-logic propagator's
+         * pattern: the trail itself is propagator-owned and never backtracked,
+         * and a single trailed number says how much of it belongs to the current
+         * epoch. It is unwound lazily at the top of the next call, which is safe
+         * because nothing reads either array in between, and what is restored is
+         * exact rather than reconstructed from the current domains.
+         *
+         * \c where indexes \c words below \c n_words and \c previous_domain
+         * above it, so one trail covers both.
+         */
+        struct Undo
+        {
+            std::uint32_t where;
+            ExtensionalWord was;
+        };
+
+        std::vector<Undo> trail;
+
+        /// Sentinel \c where for a trail entry that carries the old \c limit
+        /// rather than a word. Restoring the limit through the trail rather than
+        /// through a second constraint state matters more than it looks: every
+        /// slot is deep-copied into every search node, so a table that never
+        /// ends up using the compact table would still pay for it at each node.
+        /// Two slots cost Dubois 14% and enum_shared 24% before this.
+        static constexpr std::uint32_t limit_marker = ~std::uint32_t{0};
+
+        /// How much of \c trail belongs to the current epoch. A plain integer,
+        /// which std::any holds without allocating.
+        ConstraintStateHandle trail_mark_handle{0};
+
+        /// table::Auto watches this many wakes before deciding; table::CompactTable
+        /// builds at the first one. Once \c decided is set the answer never changes.
+        bool forced = true;
+        unsigned long long wakes = 0;
+        unsigned long long total_live = 0;
+        bool decided = false;
+        bool built = false;
+
+        [[nodiscard]] static auto create(State & initial_state, bool forced) -> std::shared_ptr<ExtensionalCompactTable>;
+    };
+
+    /**
      * \brief Data for gcs::innards::propagate_extensional().
      *
      * \ingroup Innards
@@ -186,7 +332,17 @@ namespace gcs::innards
          */
         std::shared_ptr<ExtensionalLiveTuples> live;
 
-        ExtensionalData(std::vector<IntegerVariableID> vars, ExtensionalTuples tuples, std::shared_ptr<ExtensionalLiveTuples> live);
+        /**
+         * Non-null when this instance may use the compact-table algorithm: the
+         * caller asked for it, or asked for Auto and the table is big enough to
+         * be worth watching. Deliberately the last member, so that adding it
+         * moves nothing the live-set path's hot loops touch -- placed before
+         * \c reason it cost srch_k5 9% and Crossword 13% on the live-set path.
+         */
+        std::shared_ptr<ExtensionalCompactTable> compact = {};
+
+        ExtensionalData(std::vector<IntegerVariableID> vars, ExtensionalTuples tuples, std::shared_ptr<ExtensionalLiveTuples> live,
+            std::shared_ptr<ExtensionalCompactTable> compact = {});
     };
 
     /**

--- a/gcs/constraints/table/table.cc
+++ b/gcs/constraints/table/table.cc
@@ -28,6 +28,7 @@
 using namespace gcs;
 using namespace gcs::innards;
 
+using std::holds_alternative;
 using std::optional;
 using std::string;
 using std::stringstream;
@@ -49,9 +50,17 @@ Table::Table(vector<IntegerVariableID> v, ExtensionalTuples t) : _vars(move(v)),
 {
 }
 
+auto Table::with_algorithm(TableAlgorithm algorithm) -> Table &
+{
+    _algorithm = algorithm;
+    return *this;
+}
+
 auto Table::clone() const -> unique_ptr<Constraint>
 {
-    return make_unique<Table>(_vars, ExtensionalTuples{_tuples});
+    auto result = make_unique<Table>(_vars, ExtensionalTuples{_tuples});
+    result->with_algorithm(_algorithm);
+    return result;
 }
 
 namespace
@@ -126,6 +135,14 @@ auto Table::prepare(Propagators &, State & initial_state, ProofModel * const) ->
                 if (tuple.size() != _vars.size())
                     throw InvalidProblemDefinitionException{"table size mismatch"};
             _live = ExtensionalLiveTuples::create(initial_state, depointinate(tuples).size());
+            // A table whose tuples all fit in one word cannot pay for the
+            // compact table's per-call bookkeeping, so it does not even get the
+            // state that would let it try: every constraint state is
+            // deep-copied into every search node, and two spare integers per
+            // table cost Dubois 14% and enum_shared 24% before this test.
+            const bool forced = holds_alternative<table::CompactTable>(_algorithm);
+            if (! holds_alternative<table::LiveSet>(_algorithm) && (forced || depointinate(tuples).size() >= ExtensionalCompactTable::min_tuples))
+                _compact = ExtensionalCompactTable::create(initial_state, forced);
         },
         _tuples);
 
@@ -187,7 +204,7 @@ auto Table::install_propagators(Propagators & propagators) -> void
 
             propagators.install(
                 constraint_id(),
-                [table = ExtensionalData{move(_vars), move(tuples), move(_live)}, owner = constraint_id()](
+                [table = ExtensionalData{move(_vars), move(tuples), move(_live), move(_compact)}, owner = constraint_id()](
                     const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
                     return propagate_extensional(table, state, inference, logger, hints::Table{owner});
                 },

--- a/gcs/constraints/table/table.hh
+++ b/gcs/constraints/table/table.hh
@@ -15,6 +15,9 @@ namespace gcs
      * \brief Constrain that the specified variables are equal to one of the specified
      * tuples.
      *
+     * The constructor takes only the variables and the tuples; select the
+     * propagation algorithm with the fluent with_algorithm().
+     *
      * \ingroup Constraints
      * \see SmartTable
      */
@@ -24,10 +27,19 @@ namespace gcs
         const std::vector<IntegerVariableID> _vars;
         ExtensionalTuples _tuples;
         std::shared_ptr<innards::ExtensionalLiveTuples> _live;
+        std::shared_ptr<innards::ExtensionalCompactTable> _compact;
+        TableAlgorithm _algorithm = table::Auto{};
         bool _has_no_tuples = false;
 
     public:
         explicit Table(std::vector<IntegerVariableID> vars, ExtensionalTuples tuples);
+
+        /**
+         * Select the propagation algorithm: table::Auto by default, or
+         * table::LiveSet / table::CompactTable to force one. The choice never
+         * changes the constraint's meaning, its search tree, or its proof.
+         */
+        auto with_algorithm(TableAlgorithm) -> Table &;
 
         virtual auto define_proof_model(innards::ProofModel &, const innards::State &) -> void override;
         virtual auto install_propagators(innards::Propagators &) -> void override;

--- a/gcs/constraints/table/table_test.cc
+++ b/gcs/constraints/table/table_test.cc
@@ -8,6 +8,7 @@
 
 #include <cstdlib>
 #include <iostream>
+#include <random>
 #include <set>
 #include <tuple>
 #include <utility>
@@ -41,7 +42,8 @@ using fmt::println;
 using namespace gcs;
 using namespace gcs::test_innards;
 
-auto run_table_test_2(bool proofs, const ViewWrapConfig & view_cfg, pair<int, int> r1, pair<int, int> r2, SimpleTuples allowed) -> void
+auto run_table_test_2(
+    bool proofs, const ViewWrapConfig & view_cfg, TableAlgorithm algorithm, pair<int, int> r1, pair<int, int> r2, SimpleTuples allowed) -> void
 {
     auto wraps = wraps_for_positions(view_cfg, 2);
     print(cerr, "table 2var [{}] [{},{}] [{},{}] {} tuples{}", view_wrap_config_label(view_cfg), r1.first, r1.second, r2.first, r2.second,
@@ -63,15 +65,15 @@ auto run_table_test_2(bool proofs, const ViewWrapConfig & view_cfg, pair<int, in
     Problem p;
     auto v1 = create_integer_variable_or_constant_with_view(p, r1, wraps.at(0));
     auto v2 = create_integer_variable_or_constant_with_view(p, r2, wraps.at(1));
-    p.post(Table{{v1, v2}, allowed});
+    p.post(Table{{v1, v2}, allowed}.with_algorithm(algorithm));
 
     auto proof_name = proofs ? make_optional("table_test_" + view_wrap_config_label(view_cfg)) : nullopt;
     solve_for_tests_checking_gac(p, proof_name, expected, actual, tuple{v1, v2});
     check_results(proof_name, expected, actual);
 }
 
-auto run_table_test_3(bool proofs, const ViewWrapConfig & view_cfg, pair<int, int> r1, pair<int, int> r2, pair<int, int> r3, SimpleTuples allowed)
-    -> void
+auto run_table_test_3(bool proofs, const ViewWrapConfig & view_cfg, TableAlgorithm algorithm, pair<int, int> r1, pair<int, int> r2, pair<int, int> r3,
+    SimpleTuples allowed) -> void
 {
     auto wraps = wraps_for_positions(view_cfg, 3);
     print(cerr, "table 3var [{}] [{},{}] [{},{}] [{},{}] {} tuples{}", view_wrap_config_label(view_cfg), r1.first, r1.second, r2.first, r2.second,
@@ -94,15 +96,15 @@ auto run_table_test_3(bool proofs, const ViewWrapConfig & view_cfg, pair<int, in
     auto v1 = create_integer_variable_or_constant_with_view(p, r1, wraps.at(0));
     auto v2 = create_integer_variable_or_constant_with_view(p, r2, wraps.at(1));
     auto v3 = create_integer_variable_or_constant_with_view(p, r3, wraps.at(2));
-    p.post(Table{{v1, v2, v3}, allowed});
+    p.post(Table{{v1, v2, v3}, allowed}.with_algorithm(algorithm));
 
     auto proof_name = proofs ? make_optional("table_test_" + view_wrap_config_label(view_cfg)) : nullopt;
     solve_for_tests_checking_gac(p, proof_name, expected, actual, tuple{v1, v2, v3});
     check_results(proof_name, expected, actual);
 }
 
-auto run_wildcard_table_test(
-    bool proofs, const ViewWrapConfig & view_cfg, pair<int, int> r1, pair<int, int> r2, pair<int, int> r3, WildcardTuples allowed) -> void
+auto run_wildcard_table_test(bool proofs, const ViewWrapConfig & view_cfg, TableAlgorithm algorithm, pair<int, int> r1, pair<int, int> r2,
+    pair<int, int> r3, WildcardTuples allowed) -> void
 {
     auto wraps = wraps_for_positions(view_cfg, 3);
     print(cerr, "wildcard table [{}] [{},{}] [{},{}] [{},{}] {} tuples{}", view_wrap_config_label(view_cfg), r1.first, r1.second, r2.first, r2.second,
@@ -133,7 +135,7 @@ auto run_wildcard_table_test(
     auto v1 = create_integer_variable_or_constant_with_view(p, r1, wraps.at(0));
     auto v2 = create_integer_variable_or_constant_with_view(p, r2, wraps.at(1));
     auto v3 = create_integer_variable_or_constant_with_view(p, r3, wraps.at(2));
-    p.post(Table{{v1, v2, v3}, allowed});
+    p.post(Table{{v1, v2, v3}, allowed}.with_algorithm(algorithm));
 
     auto proof_name = proofs ? make_optional("table_test_" + view_wrap_config_label(view_cfg)) : nullopt;
     solve_for_tests_checking_gac(p, proof_name, expected, actual, tuple{v1, v2, v3});
@@ -143,7 +145,8 @@ auto run_wildcard_table_test(
 // Dup-variable test: Table with the same handle in several positions.
 // Tuples where the duplicated positions disagree are infeasible.
 // Consistency isn't checked on dup runs; see tmp/duplicate_var_audit.md.
-auto run_dup_table_test(bool proofs, const vector<pair<int, int>> & unique_domains, const vector<int> & positions, SimpleTuples allowed) -> void
+auto run_dup_table_test(
+    bool proofs, TableAlgorithm algorithm, const vector<pair<int, int>> & unique_domains, const vector<int> & positions, SimpleTuples allowed) -> void
 {
     print(cerr, "table dup unique_doms={} positions={} {} tuples{}", unique_domains, positions, allowed.size(), proofs ? " with proofs:" : ":");
     cerr << flush;
@@ -174,36 +177,90 @@ auto run_dup_table_test(bool proofs, const vector<pair<int, int>> & unique_domai
     vector<IntegerVariableID> vars;
     for (auto pos : positions)
         vars.push_back(unique_vars.at(pos));
-    p.post(Table{vars, allowed});
+    p.post(Table{vars, allowed}.with_algorithm(algorithm));
 
     auto proof_name = proofs ? make_optional("table_test_dup") : nullopt;
     solve_for_tests(p, proof_name, actual, tuple{unique_vars});
     check_results(proof_name, expected, actual);
 }
 
-auto run_all_tests(bool proofs, const ViewWrapConfig & view_cfg) -> void
+auto algorithm_label(TableAlgorithm a) -> const char *
+{
+    return overloaded{                         //
+        [](table::Auto) { return "auto"; },    //
+        [](table::LiveSet) { return "live"; }, //
+        [](table::CompactTable) { return "compact"; }}
+        .visit(a);
+}
+
+/**
+ * A table big and busy enough to make TableAlgorithm::Auto actually switch: it
+ * only builds the compact structure after watching a propagator for a while, so
+ * the small tables above never reach it. This is where the hand-over from the
+ * sparse set is exercised, and -- because the search backtracks above the node
+ * the switch happened at -- so is starting the compact structure again from
+ * scratch. Both were wrong in ways no small table could show.
+ */
+auto run_big_random_table_test(bool proofs, TableAlgorithm algorithm, unsigned n_tuples) -> void
+{
+    constexpr int lo = 0, hi = 7;
+    auto seed = get_seed().value_or(0);
+    std::mt19937 rng(seed + n_tuples);
+    std::uniform_int_distribution<int> pick(lo, hi);
+
+    set<tuple<int, int, int, int>> allowed_set;
+    while (allowed_set.size() < n_tuples)
+        allowed_set.emplace(pick(rng), pick(rng), pick(rng), pick(rng));
+
+    SimpleTuples allowed;
+    for (const auto & [a, b, c, d] : allowed_set)
+        allowed.push_back({Integer(a), Integer(b), Integer(c), Integer(d)});
+
+    print(cerr, "big random table [{}] {} tuples{}", algorithm_label(algorithm), allowed.size(), proofs ? " with proofs:" : ":");
+    cerr << flush;
+
+    set<tuple<int, int, int, int>> expected, actual;
+    build_expected(
+        expected, [&](int a, int b, int c, int d) -> bool { return allowed_set.contains(tuple{a, b, c, d}); }, pair{lo, hi}, pair{lo, hi},
+        pair{lo, hi}, pair{lo, hi});
+    println(cerr, " expecting {} solutions", expected.size());
+
+    Problem p;
+    auto v1 = p.create_integer_variable(Integer(lo), Integer(hi));
+    auto v2 = p.create_integer_variable(Integer(lo), Integer(hi));
+    auto v3 = p.create_integer_variable(Integer(lo), Integer(hi));
+    auto v4 = p.create_integer_variable(Integer(lo), Integer(hi));
+    p.post(Table{{v1, v2, v3, v4}, allowed}.with_algorithm(algorithm));
+
+    auto proof_name = proofs ? make_optional("table_test_big") : nullopt;
+    solve_for_tests_checking_gac(p, proof_name, expected, actual, tuple{v1, v2, v3, v4});
+    check_results(proof_name, expected, actual);
+}
+
+auto run_all_tests(bool proofs, const ViewWrapConfig & view_cfg, TableAlgorithm algorithm) -> void
 {
     // Table, 2 variables
-    run_table_test_2(proofs, view_cfg, {1, 3}, {1, 3}, {{1_i, 1_i}, {1_i, 3_i}, {2_i, 2_i}, {3_i, 1_i}});
-    run_table_test_2(proofs, view_cfg, {1, 4}, {1, 4}, {{1_i, 2_i}, {2_i, 1_i}, {3_i, 4_i}, {4_i, 3_i}});
-    run_table_test_2(proofs, view_cfg, {1, 3}, {1, 3}, {}); // empty table: unsatisfiable
-    run_table_test_2(proofs, view_cfg, {-2, 2}, {-2, 2}, {{-2_i, 2_i}, {0_i, 0_i}, {2_i, -2_i}});
+    run_table_test_2(proofs, view_cfg, algorithm, {1, 3}, {1, 3}, {{1_i, 1_i}, {1_i, 3_i}, {2_i, 2_i}, {3_i, 1_i}});
+    run_table_test_2(proofs, view_cfg, algorithm, {1, 4}, {1, 4}, {{1_i, 2_i}, {2_i, 1_i}, {3_i, 4_i}, {4_i, 3_i}});
+    run_table_test_2(proofs, view_cfg, algorithm, {1, 3}, {1, 3}, {}); // empty table: unsatisfiable
+    run_table_test_2(proofs, view_cfg, algorithm, {-2, 2}, {-2, 2}, {{-2_i, 2_i}, {0_i, 0_i}, {2_i, -2_i}});
     // Degenerate (issue #254): all-fixed variables, both directions, and a
     // mixed fixed+variable case. (Empty tuple list → UNSAT is covered above.)
-    run_table_test_2(proofs, view_cfg, {1, 1}, {1, 1}, {{1_i, 1_i}});             // fixed (1,1) is an allowed tuple (tautology)
-    run_table_test_2(proofs, view_cfg, {2, 2}, {3, 3}, {{1_i, 1_i}});             // fixed (2,3) is not in the table (contradiction)
-    run_table_test_2(proofs, view_cfg, {1, 1}, {1, 3}, {{1_i, 1_i}, {1_i, 2_i}}); // mixed: v1 fixed, v2 variable
+    run_table_test_2(proofs, view_cfg, algorithm, {1, 1}, {1, 1}, {{1_i, 1_i}});             // fixed (1,1) is an allowed tuple (tautology)
+    run_table_test_2(proofs, view_cfg, algorithm, {2, 2}, {3, 3}, {{1_i, 1_i}});             // fixed (2,3) is not in the table (contradiction)
+    run_table_test_2(proofs, view_cfg, algorithm, {1, 1}, {1, 3}, {{1_i, 1_i}, {1_i, 2_i}}); // mixed: v1 fixed, v2 variable
 
     // Table, 3 variables
-    run_table_test_3(proofs, view_cfg, {1, 3}, {1, 3}, {1, 3}, {{1_i, 1_i, 1_i}, {1_i, 2_i, 3_i}, {2_i, 1_i, 3_i}, {3_i, 3_i, 3_i}});
-    run_table_test_3(proofs, view_cfg, {1, 3}, {2, 4}, {1, 2}, {{2_i, 3_i, 1_i}, {2_i, 4_i, 2_i}}); // tight domain: forces propagation
-    run_table_test_3(proofs, view_cfg, {1, 3}, {1, 3}, {1, 3}, {});                                 // empty table: unsatisfiable
-    run_table_test_3(proofs, view_cfg, {-2, 2}, {-2, 2}, {-2, 2}, {{-2_i, 0_i, 2_i}, {0_i, 0_i, 0_i}, {2_i, 0_i, -2_i}});
+    run_table_test_3(proofs, view_cfg, algorithm, {1, 3}, {1, 3}, {1, 3}, {{1_i, 1_i, 1_i}, {1_i, 2_i, 3_i}, {2_i, 1_i, 3_i}, {3_i, 3_i, 3_i}});
+    run_table_test_3(proofs, view_cfg, algorithm, {1, 3}, {2, 4}, {1, 2}, {{2_i, 3_i, 1_i}, {2_i, 4_i, 2_i}}); // tight domain: forces propagation
+    run_table_test_3(proofs, view_cfg, algorithm, {1, 3}, {1, 3}, {1, 3}, {});                                 // empty table: unsatisfiable
+    run_table_test_3(proofs, view_cfg, algorithm, {-2, 2}, {-2, 2}, {-2, 2}, {{-2_i, 0_i, 2_i}, {0_i, 0_i, 0_i}, {2_i, 0_i, -2_i}});
 
     // Wildcard Table
-    run_wildcard_table_test(proofs, view_cfg, {1, 3}, {1, 3}, {1, 3}, {{{Wildcard{}, 2_i, Wildcard{}}}}); // only middle position must be 2
-    run_wildcard_table_test(proofs, view_cfg, {1, 3}, {1, 3}, {1, 3}, {{{1_i, Wildcard{}, 3_i}, {Wildcard{}, 2_i, Wildcard{}}}});
-    run_wildcard_table_test(proofs, view_cfg, {1, 3}, {1, 3}, {1, 3}, {{{Wildcard{}, Wildcard{}, Wildcard{}}}}); // all wildcards: all tuples allowed
+    run_wildcard_table_test(proofs, view_cfg, algorithm, {1, 3}, {1, 3}, {1, 3}, {{{Wildcard{}, 2_i, Wildcard{}}}}); // only middle position must be 2
+    run_wildcard_table_test(proofs, view_cfg, algorithm, {1, 3}, {1, 3}, {1, 3}, {{{1_i, Wildcard{}, 3_i}, {Wildcard{}, 2_i, Wildcard{}}}});
+    run_wildcard_table_test(
+        proofs, view_cfg, algorithm, {1, 3}, {1, 3}, {1, 3}, {{{Wildcard{}, Wildcard{}, Wildcard{}}}}); // all wildcards: all tuples allowed
 }
 
 auto main(int argc, char * argv[]) -> int
@@ -223,13 +280,29 @@ auto main(int argc, char * argv[]) -> int
     for (bool proofs : {false, true}) {
         if (proofs && ! can_run_veripb())
             continue;
-        run_all_tests(proofs, view_cfg);
+        // Every shape under every algorithm: they are supposed to make exactly
+        // the same inferences, so anything that differs is a bug in one of them.
+        for (auto algorithm : {TableAlgorithm{table::LiveSet{}}, TableAlgorithm{table::CompactTable{}}, TableAlgorithm{table::Auto{}}}) {
+            run_all_tests(proofs, view_cfg, algorithm);
+        }
+        // The rest wrap no views, so they run once rather than once per view
+        // lane -- which also keeps their fixed proof basenames from racing
+        // between lanes under a parallel ctest (issue #562).
         if (run_dup) {
-            // {x, y, x} with mixed-match tuples: (1, 2, 1) matches (cols 0
-            // and 2 share x=1), (1, 2, 2) does not (cols 0 and 2 disagree).
-            run_dup_table_test(proofs, {{1, 3}, {1, 3}}, {0, 1, 0}, {{1_i, 2_i, 1_i}, {1_i, 2_i, 2_i}, {2_i, 3_i, 2_i}, {3_i, 3_i, 3_i}});
-            // {x, x} — only diagonal tuples can match.
-            run_dup_table_test(proofs, {{1, 3}}, {0, 0}, {{1_i, 1_i}, {2_i, 3_i}, {3_i, 3_i}});
+            for (auto algorithm : {TableAlgorithm{table::LiveSet{}}, TableAlgorithm{table::CompactTable{}}, TableAlgorithm{table::Auto{}}}) {
+                // Only Auto's threshold makes this interesting, but running it
+                // under all three keeps the comparison honest, and it is the
+                // only test here where the compact structure is handed the live
+                // set mid-search.
+                run_big_random_table_test(proofs, algorithm, 120);
+                run_big_random_table_test(proofs, algorithm, 400);
+                // {x, y, x} with mixed-match tuples: (1, 2, 1) matches (cols 0
+                // and 2 share x=1), (1, 2, 2) does not (cols 0 and 2 disagree).
+                run_dup_table_test(
+                    proofs, algorithm, {{1, 3}, {1, 3}}, {0, 1, 0}, {{1_i, 2_i, 1_i}, {1_i, 2_i, 2_i}, {2_i, 3_i, 2_i}, {3_i, 3_i, 3_i}});
+                // {x, x} -- only diagonal tuples can match.
+                run_dup_table_test(proofs, algorithm, {{1, 3}}, {0, 0}, {{1_i, 1_i}, {2_i, 3_i}, {3_i, 3_i}});
+            }
         }
     }
 

--- a/gcs/extensional.hh
+++ b/gcs/extensional.hh
@@ -85,6 +85,69 @@ namespace gcs
      * \ingroup Extensional
      */
     using ExtensionalTuples = std::variant<ArrayParam<SimpleTuples>, ArrayParam<WildcardTuples>>;
+
+    /**
+     * \brief Tags for the algorithms gcs::Table can propagate with.
+     *
+     * \ingroup Extensional
+     */
+    namespace table
+    {
+        /**
+         * \brief Watch the table for a while, then switch to table::CompactTable
+         * if and only if this instance looks like one that will pay for it:
+         * enough wakes to amortise building the masks, a live set big enough that
+         * a call does real work, and a live set dense enough in its words that a
+         * bitset is the right shape for it.
+         *
+         * The default, and the only setting without a significant regression on
+         * this project's suite -- it is within 2% of the better of the other two
+         * everywhere except `srch_bin_d10_n20_s2`, where it is 4% behind.
+         *
+         * \ingroup Extensional
+         */
+        struct Auto final
+        {
+        };
+
+        /**
+         * \brief Keep the still-selectable tuples in a sparse set, and re-test
+         * each of them against the current domains on every wake. Costs what is
+         * live.
+         *
+         * \ingroup Extensional
+         */
+        struct LiveSet final
+        {
+        };
+
+        /**
+         * \brief Keep them in a bitset with a support mask per (position, value),
+         * and take out the tuples that used a value as it goes. Costs what
+         * changed, which on a large table is far less -- but it builds and holds
+         * the masks, so a table that is woken only a handful of times pays for
+         * something it never uses.
+         *
+         * Forced from the first call, where table::Auto waits and then decides:
+         * this is the setting to benchmark Auto against, not the one to ship.
+         *
+         * \ingroup Extensional
+         */
+        struct CompactTable final
+        {
+        };
+    }
+
+    /**
+     * \brief The propagation algorithms supported by gcs::Table: table::Auto (the
+     * default), table::LiveSet or table::CompactTable. Requesting anything else is
+     * a compile-time error, and the choice never changes the constraint's meaning,
+     * its search tree, or its proof -- all three make exactly the same inferences
+     * in the same order.
+     *
+     * \ingroup Extensional
+     */
+    using TableAlgorithm = std::variant<table::Auto, table::LiveSet, table::CompactTable>;
 }
 
 #endif


### PR DESCRIPTION
Stacked on #799. Closes the algorithmic half of #508.

The live-set algorithm re-tests every live tuple against every position on every
wake, so pass 1 costs what is *live*. Compact table makes it cost what
*changed*: the live set becomes a bitset over tuple indices, with a support mask
per (position, value), and one word-wise `live &= ~support` per removed value
takes out every tuple that used it. Over this suite that is **2–13x fewer pass-1
operations**, each a word AND rather than a membership test.

`Table::with_algorithm()` selects between them, following the fluent-setter
convention `dev_docs/constraints.md` records and the thirteen constraints that
already use it; `TableAlgorithm` is a variant over `table::Auto`,
`table::LiveSet` and `table::CompactTable` tags, as `CircuitAlgorithm` is, so
requesting anything else is a compile-time error. `--table auto|live|compact` on
the `tables` example and on `benchmarks/positive_table_random` keeps both
directions runnable, with a ctest lane per setting on the example.

## The tree and the proof are unchanged

Both are GAC and both make the same inferences in the same order.

* On a 400-tuple table over 573 nodes the `.opb` and `.pbp` are **byte-identical**
  between `live`, `compact` and `auto`, and VeriPB verifies either.
* `ctest` **777/777**. The table tests now run every shape under all three
  settings, plus a random table big enough to make `Auto` switch mid-search —
  the only place the hand-over from the sparse set, and starting again after
  backtracking above it, are exercised at all. Both were wrong in ways no small
  table could show. Those and the duplicate-variable cases run once rather than
  once per view lane: they wrap no views, and their fixed proof basenames were
  racing between lanes under a parallel `ctest` (#562) — a flake this PR
  introduced and has now removed.
* Nodes and solutions identical on all 33 benchmark instances, under all three.

## Auto is the default, and it needs four thresholds

Forced `CompactTable` is **3.7x on srch_k5 and 4.0x on Crossword but 0.74x on
Dubois and 0.82x on Kakuro**, so the choice has to be made per instance. Every
threshold is read off the measured suite rather than picked:

| | |
|---|---|
| `decide_after = 32` | Counted **per propagator**, not per search. Kakuro wakes a table one to three times in the whole search and Renault-megane about four; Crossword wakes one 1 898 times, `srch_k5` 3 146, `srch_bin_d20` 19 068. Nothing sits between. At 512 the wait itself cost `srch_k5` 36%. |
| `min_mean_live = 16` | Below this a call does too little work to cover an update's fixed cost. |
| `word bits * live >= tuples` | A bitset is only the right shape if its words are full: the support test costs a word per live word, where the live-set scan costs a step per tuple until it finds a witness. `enum_single_k10_t200k` keeps 46 tuples live in a 200 000-tuple table — one per word — and forced `CompactTable` measures 1.00x. |
| `min_tuples = one word` | A table that fits in one word never gets the state at all. |

Those last two, and every shift, mask and round-up over the bitsets, take the
width from `extensional_word_bits` — `numeric_limits<ExtensionalWord>::digits` —
rather than spelling 64 at each use. `max_words` keeps its literal: it is a count
of words, and matching 64 is a coincidence.

## Backtracking without a backtrack callback

`State::on_backtrack` is not reachable from a propagator's `const State &`, so
this follows `install_difference_propagator`: a propagator-owned undo trail plus
**one** trailed integer saying how much of it belongs to the current epoch,
unwound lazily at the top of the next call. The limit rides the trail rather
than taking a second slot — see the performance note below for what a slot
costs. `index` needs no trail at all: it uses the same sparse-set argument
`ExtensionalLiveTuples` uses for its size.

Because `Auto` switches mid-search it also has to cope with the search climbing
back above the node it switched at. That empties the trail, which is the signal:
the sparse set stopped being maintained there, so the whole table goes live
again and the next update filters it against the current domains.

## Measured

Median of 3, fataepyc-10 pinned, against the unmodified live-set build. Nodes
and solutions identical on every row.

| instance | live | compact | auto | |
|---|---|---|---|---|
| `Crossword-10-10` | 12.612 | 3.122 | 3.166 | **3.98x** |
| `Crossword-10-11` | 4.097 | 1.076 | 1.109 | **3.70x** |
| `srch_k5_d5_n12` | 0.364 | 0.098 | 0.101 | **3.61x** |
| `srch_k3_d8_n18` | 0.247 | 0.091 | 0.094 | **2.64x** |
| `srch_bin_d12_n30_s1` | 0.699 | 0.360 | 0.374 | 1.87x |
| `srch_bin_d20_n20_s1` | 2.619 | 1.474 | 1.491 | 1.76x |
| `srch_holey_d20_n25` | 0.325 | 0.207 | 0.212 | 1.53x |
| `srch_func_k3_n24` | 0.042 | 0.028 | 0.031 | 1.37x |
| `enum_single_k10_t200k` | 1.139 | 0.988 | 0.998 | 1.14x |
| Dubois, Kakuro, Renault, `enum_*` | | | | 0.97–1.02x |

The only loss is `srch_bin_d10_n20_s2` at **0.96x**, whose steady-state live set
is 7.7 tuples — below the threshold, but not yet at wake 32, when it still looks
like its sibling instance that gains 1.16x.

Against **Gecode 6.3.0** on matched trees, `Crossword` goes **5.0x -> 1.2-1.5x**
(it was 25-33x at this project's first baseline); the synthetic worst case is
4.7x on `enum_func_k3_n20`, which the per-pass budget says is engine-bound and
not a table problem. Renault and Kakuro stay ahead of Gecode end to end
(`total` 0.2-1.6x).

## One note for `dev_docs/propagator-performance.md`

Adding a second algorithm to a hot function cost the **first** one, on
instances that execute none of the new code, for three unrelated reasons —
separate costs on different instances, not three explanations of one number. The
inner membership test stopped being inlined once the function grew past GCC's
budget (27% of runtime as a suddenly-visible symbol; `always_inline` put it back,
worth 10% on `srch_k5` and 25% of the instruction count); instruction footprint
alone cost `Dubois` 7% before the new pass was moved out of line; and two extra
`add_constraint_state` slots cost `Dubois` 14% and `enum_shared` 24%, because
every slot is deep-copied into every search node even for a propagator that ends
up not using it. Written up there, because the
general shape — measure the *old* path against the *unmodified* build, not just
the new path against the old one — applies to any second implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012mn99ERAhD4YrAaqZrdjZ3
