### PR TITLE
Say which constraint type the propagation time went to

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,6 +361,15 @@ autotuner) without recompiling. Each is read once, on first use.
   some backtrackable bookkeeping (default: 8). The test suite runs in both modes by setting
   this.
 
+* ``GCS_PROPAGATOR_STATS``: adds a per-constraint-type propagator breakdown to the statistics ---
+  how many constraints of each type there are, how many propagators they installed, and how many
+  times those propagators were called, changed a domain and contradicted. ``calls`` (or ``1``) is
+  one increment per propagator run, so a run with it on is comparable with a run without;
+  ``time`` (or ``2``) additionally times each run, which costs two clock reads per propagator call
+  and so makes the run's own wall clock and nodes-per-second incomparable with an untimed one ---
+  read shares and per-call figures off it, not throughput. An unrecognised value is ignored with a
+  warning. See ``dev_docs/propagator-performance.md``.
+
 * ``GCS_TABULATION_THRESHOLD``: under ``consistency::Auto``, a constraint tabulates itself for
   generalised arc consistency when the product of its variables' domain sizes is no bigger than
   this (default: 100). A variable that is functionally determined by the others (say, the result

--- a/README.md
+++ b/README.md
@@ -368,7 +368,9 @@ autotuner) without recompiling. Each is read once, on first use.
   ``time`` (or ``2``) additionally times each run, which costs two clock reads per propagator call
   and so makes the run's own wall clock and nodes-per-second incomparable with an untimed one ---
   read shares and per-call figures off it, not throughput. An unrecognised value is ignored with a
-  warning. See ``dev_docs/propagator-performance.md``.
+  warning. The breakdown appears as ``%%%mzn-stat:`` lines from ``fzn-glasgow -s``, as
+  ``d PROPAGATOR CALLS ...`` lines from ``xcsp_glasgow_constraint_solver``, and as a summary
+  line in the default ``Stats`` output. See ``dev_docs/propagator-performance.md``.
 
 * ``GCS_TABULATION_THRESHOLD``: under ``consistency::Auto``, a constraint tabulates itself for
   generalised arc consistency when the product of its variables' domain sizes is no bigger than

--- a/dev_docs/README.md
+++ b/dev_docs/README.md
@@ -46,6 +46,12 @@ library. For an introduction to *using* the solver, start with the top-level
   measuring the wall-time impact of a performance-sensitive change, the
   rationale for each pick, the harness pattern for comparing two builds,
   and what to capture. Use when quantifying a refactor's perf impact.
+- [Making a propagator faster](propagator-performance.md) — what to change
+  once a propagator is correct: the per-constraint-type breakdown
+  (`GCS_PROPAGATOR_STATS`) that says which constraint the time went to, then
+  the levers cheapest first, and the ground rules that keep a performance
+  change from quietly becoming a strength change. The companion to
+  `benchmarking.md`, which is about how to measure instead of what to change.
 - [Proof benchmarks](proof-benchmarks.md) — the counterpart set for when
   the *proof* is what is being measured: proof-writing cost, proof size
   and VeriPB checking time. Groups instances by whether they stress

--- a/dev_docs/propagator-performance.md
+++ b/dev_docs/propagator-performance.md
@@ -81,6 +81,49 @@ idea is worthwhile. Consistency has value: it removes a whole class of avoidable
 work and makes the next propagator's default the good one. Don't use this as a
 loophole for speculative single-constraint cleverness.
 
+### Find out which constraint is spending the time, before optimising one
+
+`GCS_PROPAGATOR_STATS=calls` adds a per-constraint-type block to the stats: how
+many constraints of that type there are, how many propagators they installed,
+and how many times those propagators were called, changed a domain, and
+contradicted. `GCS_PROPAGATOR_STATS=time` adds the elapsed time in each,
+totalled per type. It reaches `%%%mzn-stat:` lines from `fzn-glasgow -s` and
+`xcsp_glasgow_constraint_solver -s`, and the default `operator<<` on `Stats`
+prints the one-line summary, so a sweep harness can tabulate it without any
+per-constraint plumbing.
+
+Read the two rungs for what they are. `calls` is one increment per propagator
+run, so a run with it on is comparable with a run without. `time` reads the
+clock twice per run — around 10% on a propagation-heavy model, but far more if
+the model's propagators are individually tiny — so a timed run's own wall clock
+and nodes-per-second are *not* comparable with an untimed one. Read shares and
+per-call figures off a timed run, never throughput.
+
+The reason this section comes before the levers is that the aggregate
+`propagations:` count cannot tell you which constraint to look at, and the
+answer is regularly not the one you would guess. Two examples, both from the
+subcircuit families of the MiniZinc Challenge corpus (issue #788):
+
+- **A propagator's per-node cost is `calls-per-node` times `cost-per-call`, and
+  the two vary independently.** `SubCircuit`'s reachability arm looked free on
+  `tpp` and crushing on `mario`, at comparable `n`, which read as a per-call
+  cost that was not a function of `n`. It is not: per *call* it costs 7.7 µs at
+  `n = 15` and 30.7 µs at `n = 35`, on `tpp`, growing about as `n²` — it is the
+  most expensive propagator per call in that model. It is woken **676 times in
+  a 7.5-million-node search** there, because `tpp` fixes its 15 successors in
+  the first 15 levels and then spends the whole search below them on
+  `purchaseLoc`. On `mario`, whose search *is* the successors, it is woken 1.5
+  times a node. Optimising the body would have been the right call and the
+  per-node figure alone said the opposite.
+- **A propagator can be 50% of the time while pruning nothing at all.** On
+  `tpp` the twenty `lin_not_equals` constraints are called 17.8 million times,
+  remove a value **once** in the entire search, contradict 3.75 million times,
+  and take half the propagation time. That is a propagator whose wake condition
+  is far looser than the only situation it can act in, which is the first lever
+  below and not a body optimisation.
+
+So: get the per-type breakdown first, and pick the lever from it.
+
 ## Levers, cheapest first
 
 ### Better triggers and idempotence
@@ -322,11 +365,17 @@ When a model is slow, "the propagator is slow" is only one of three
 possibilities, and they have completely different fixes:
 
 1. the propagator is slow **per call** (this document);
-2. the propagator's **strength** is wrong for the problem — too weak (search
+2. the propagator is **called too often** for what it can infer (the triggers
+   lever, and the first thing `GCS_PROPAGATOR_STATS` tells you);
+3. the propagator's **strength** is wrong for the problem — too weak (search
    explores too much) or too strong (propagation costs more than the nodes it
    saves);
-3. the **search heuristic** is making bad decisions, so no propagator speed
+4. the **search heuristic** is making bad decisions, so no propagator speed
    fixes the node count.
+
+The per-type breakdown separates 1 from 2, which the aggregate counts cannot:
+divide the calls by the nodes for how often, and the time by the calls for how
+expensive, and never read one of those off the other.
 
 Comparing against **Gecode** and the **MiniCP benchmarks** is a useful way to
 tell these apart: if we explore far more nodes than Gecode on the same model,

--- a/dev_docs/propagator-performance.md
+++ b/dev_docs/propagator-performance.md
@@ -87,10 +87,11 @@ loophole for speculative single-constraint cleverness.
 many constraints of that type there are, how many propagators they installed,
 and how many times those propagators were called, changed a domain, and
 contradicted. `GCS_PROPAGATOR_STATS=time` adds the elapsed time in each,
-totalled per type. It reaches `%%%mzn-stat:` lines from `fzn-glasgow -s` and
-`xcsp_glasgow_constraint_solver -s`, and the default `operator<<` on `Stats`
-prints the one-line summary, so a sweep harness can tabulate it without any
-per-constraint plumbing.
+totalled per type. It reaches `%%%mzn-stat:` lines from `fzn-glasgow -s`, `d PROPAGATOR CALLS ...`
+lines from `xcsp_glasgow_constraint_solver` (which prints its `d` statistics
+unconditionally), and the one-line summary from the default `operator<<` on
+`Stats`, so a sweep harness can tabulate it without any per-constraint
+plumbing.
 
 Read the two rungs for what they are. `calls` is one increment per propagator
 run, so a run with it on is comparable with a run without. `time` reads the

--- a/dev_docs/propagator-performance.md
+++ b/dev_docs/propagator-performance.md
@@ -95,8 +95,8 @@ plumbing.
 
 Read the two rungs for what they are. `calls` is one increment per propagator
 run, so a run with it on is comparable with a run without. `time` reads the
-clock twice per run — around 10% on a propagation-heavy model, but far more if
-the model's propagators are individually tiny — so a timed run's own wall clock
+clock twice per run — 13% on `tpp_3_5_20_1`, and far more if the model's
+propagators are individually tiny — so a timed run's own wall clock
 and nodes-per-second are *not* comparable with an untimed one. Read shares and
 per-call figures off a timed run, never throughput.
 
@@ -108,9 +108,10 @@ subcircuit families of the MiniZinc Challenge corpus (issue #788):
 - **A propagator's per-node cost is `calls-per-node` times `cost-per-call`, and
   the two vary independently.** `SubCircuit`'s reachability arm looked free on
   `tpp` and crushing on `mario`, at comparable `n`, which read as a per-call
-  cost that was not a function of `n`. It is not: per *call* it costs 7.7 µs at
-  `n = 15` and 30.7 µs at `n = 35`, on `tpp`, growing about as `n²` — it is the
-  most expensive propagator per call in that model. It is woken **676 times in
+  cost that was not a function of `n`. It is not: per *call* it costs 7.4 µs at
+  `n = 15` and 31.2 µs at `n = 30` on `mario`, which is very nearly `n²`, and
+  7.7 µs at `n = 15` against 30.7 µs at `n = 35` on `tpp` — it is the most
+  expensive propagator per call in that model. It is woken **676 times in
   a 7.5-million-node search** there, because `tpp` fixes its 15 successors in
   the first 15 levels and then spends the whole search below them on
   `purchaseLoc`. On `mario`, whose search *is* the successors, it is woken 1.5

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -911,6 +911,10 @@ if(GCS_BUILD_TESTS)
     target_link_libraries(propagators_test PRIVATE glasgow_constraint_solver Catch2::Catch2WithMain)
     add_test(NAME propagators_test COMMAND $<TARGET_FILE:propagators_test>)
 
+    add_executable(propagator_call_stats_test innards/propagator_call_stats_test.cc)
+    target_link_libraries(propagator_call_stats_test PRIVATE glasgow_constraint_solver Catch2::Catch2WithMain)
+    add_test(NAME propagator_call_stats_test COMMAND $<TARGET_FILE:propagator_call_stats_test>)
+
     add_executable(idempotent_claim_checker_test innards/idempotent_claim_checker_test.cc)
     target_link_libraries(idempotent_claim_checker_test PRIVATE glasgow_constraint_solver Catch2::Catch2WithMain)
     add_test(NAME idempotent_claim_checker_test COMMAND $<TARGET_FILE:idempotent_claim_checker_test>)

--- a/gcs/constraint.cc
+++ b/gcs/constraint.cc
@@ -1,5 +1,6 @@
 #include <gcs/constraint.hh>
 #include <gcs/exception.hh>
+#include <gcs/innards/propagators.hh>
 
 using namespace gcs;
 using namespace gcs::innards;
@@ -8,13 +9,25 @@ Constraint::~Constraint() = default;
 
 auto Constraint::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
 {
-    if (! prepare(propagators, initial_state, optional_model))
-        return;
+    const auto propagators_before = propagators.number_of_propagators();
 
-    if (optional_model)
-        define_proof_model(*optional_model, initial_state);
+    if (prepare(propagators, initial_state, optional_model)) {
+        if (optional_model)
+            define_proof_model(*optional_model, initial_state);
 
-    install_propagators(propagators);
+        install_propagators(propagators);
+    }
+
+    // Label whatever got installed with this constraint's type, for the
+    // per-constraint-type propagator report. Here rather than at each
+    // Propagators::install() call site because this is the one function every
+    // install path runs through, and because a child constraint --- installed
+    // from inside prepare(), and so already labelled by its own recursion
+    // through here --- then keeps its own type rather than inheriting ours.
+    // A prepare() that returned false is included: it may have delegated the
+    // whole constraint to a child.
+    if (propagators.number_of_propagators() != propagators_before)
+        propagators.note_propagator_types(propagators_before, constraint_type());
 }
 
 auto gcs::as_string(const ConstraintID & constraint_id) -> std::string

--- a/gcs/constraint.cc
+++ b/gcs/constraint.cc
@@ -26,6 +26,11 @@ auto Constraint::install(Propagators & propagators, State & initial_state, Proof
     // through here --- then keeps its own type rather than inheriting ours.
     // A prepare() that returned false is included: it may have delegated the
     // whole constraint to a child.
+    // The window is a shortcut, not part of the argument: labelling is
+    // first-writer-wins and installation is serial, so passing 0 here would relabel
+    // nothing and only cost a longer scan. What the correctness rests on is the
+    // already-labelled exemption. (Checked by mutation: widening the window to 0
+    // fails no test, dropping the call entirely fails several.)
     if (propagators.number_of_propagators() != propagators_before)
         propagators.note_propagator_types(propagators_before, constraint_type());
 }

--- a/gcs/innards/propagator_call_stats_test.cc
+++ b/gcs/innards/propagator_call_stats_test.cc
@@ -1,6 +1,11 @@
+#include <gcs/constraints/all_different.hh>
+#include <gcs/constraints/comparison.hh>
+#include <gcs/constraints/power.hh>
 #include <gcs/innards/inference_tracker.hh>
 #include <gcs/innards/propagators.hh>
 #include <gcs/innards/state.hh>
+#include <gcs/problem.hh>
+#include <gcs/solve.hh>
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -224,8 +229,10 @@ TEST_CASE("A propagator no constraint claimed is reported as unlabelled")
     REQUIRE(propagators.propagate(Literals{}, state, nullptr));
     propagators.fill_in_constraint_stats(stats);
 
-    // Nothing routed this one through Constraint::install(), which is how the
-    // learned-nogoods store's propagator arrives. It is still counted.
+    // Nothing routed this one through Constraint::install(), which is how AutoTable's
+    // presolver-derived propagator arrives --- it installs under
+    // CurrentlyUnnamedConstraint, having no posted-constraint identity. It is still
+    // counted.
     const auto entries = propagator_call_entries(stats);
     CHECK(entries.at("unlabelled_calls") == 2);
 }
@@ -271,4 +278,52 @@ TEST_CASE("An unrecognised GCS_PROPAGATOR_STATS value is ignored with a warning"
 
     CHECK(captured.str().find("GCS_PROPAGATOR_STATS") != std::string::npos);
     CHECK(! component_named(stats, "propagator_calls"));
+}
+
+TEST_CASE("The report is built through Constraint::install(), and a child keeps its own type")
+{
+    // Everything above reaches the machinery by calling Propagators::install() and
+    // note_propagator_types() directly. That leaves Constraint::install() --- the one
+    // function that actually wires the feature up, and where the whole design argument
+    // lives: the propagators_before window, the prepare()-returned-false case, and the
+    // child-keeps-its-own-type property --- untested, so a mutation of constraint.cc could
+    // not fail anything. This case goes through Problem::post() and solve() instead.
+    //
+    // Power is the vehicle for the child property, and a neat one: Power::prepare()
+    // installs a Table child and Power installs no propagator of its own, so a posted
+    // Power shows up as a `table` row and there is no `power` row at all. If the parent
+    // overwrote its children's labels it would be the other way round.
+    WithPropagatorStats asked{"calls"};
+
+    Problem p;
+    auto x = p.create_integer_variable_vector(3, 1_i, 3_i);
+    auto b = p.create_integer_variable(1_i, 3_i);
+    auto e = p.create_integer_variable(1_i, 2_i);
+    auto r = p.create_integer_variable(1_i, 9_i);
+    p.post(AllDifferent{x});
+    p.post(LessThan{x[0], b});
+    p.post(Power{b, e, r});
+
+    auto stats = solve(p, [](const CurrentState &) -> bool { return true; }, std::nullopt);
+
+    const auto entries = propagator_call_entries(stats);
+
+    // The child took the label, and the parent did not take it back.
+    CHECK(entries.contains("table_calls"));
+    CHECK(! entries.contains("power_calls"));
+    CHECK(entries.at("table_constraints") == 1);
+
+    // The constraints posted directly are named by their own types.
+    CHECK(entries.at("all_different_calls") > 0);
+    CHECK(entries.at("less_than_calls") > 0);
+
+    // Nothing went unlabelled, and the per-type calls account for every propagation the
+    // aggregate counter saw. That sum is what catches a labelling window that starts or
+    // ends in the wrong place.
+    CHECK(! entries.contains("unlabelled_calls"));
+    long long total = 0;
+    for (const auto & [name, value] : entries)
+        if (name.ends_with("_calls"))
+            total += value;
+    CHECK(total == static_cast<long long>(stats.propagations));
 }

--- a/gcs/innards/propagator_call_stats_test.cc
+++ b/gcs/innards/propagator_call_stats_test.cc
@@ -1,0 +1,274 @@
+#include <gcs/innards/inference_tracker.hh>
+#include <gcs/innards/propagators.hh>
+#include <gcs/innards/state.hh>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstdlib>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <sstream>
+#include <string>
+
+using namespace gcs;
+using namespace gcs::innards;
+
+// The per-constraint-type propagator report: GCS_PROPAGATOR_STATS. What is
+// asserted here is the arithmetic and the grouping, on propagators whose
+// behaviour is written out in front of the figures, because a counter wired to
+// the wrong branch reports a plausible number for ever.
+
+namespace
+{
+    // GCS_PROPAGATOR_STATS is read once per Propagators construction rather than
+    // into a static, so a test can set it around the object it wants it to
+    // affect. Restore on the way out: the test binary shares one environment.
+    // MSVC has no POSIX setenv / unsetenv, and on Windows _putenv_s(name, "")
+    // removes the variable.
+    struct WithPropagatorStats final
+    {
+        explicit WithPropagatorStats(const char * const value)
+        {
+#if defined(_WIN32)
+            _putenv_s("GCS_PROPAGATOR_STATS", value);
+#else
+            setenv("GCS_PROPAGATOR_STATS", value, 1);
+#endif
+        }
+
+        ~WithPropagatorStats()
+        {
+#if defined(_WIN32)
+            _putenv_s("GCS_PROPAGATOR_STATS", "");
+#else
+            unsetenv("GCS_PROPAGATOR_STATS");
+#endif
+        }
+
+        WithPropagatorStats(const WithPropagatorStats &) = delete;
+        auto operator=(const WithPropagatorStats &) -> WithPropagatorStats & = delete;
+    };
+
+    [[nodiscard]] auto component_named(const Stats & stats, const std::string & name) -> std::shared_ptr<const ComponentStats>
+    {
+        for (const auto & component : stats.components())
+            if (component->component_name() == name)
+                return component;
+        return nullptr;
+    }
+
+    [[nodiscard]] auto propagator_call_entries(const Stats & stats) -> std::map<std::string, long long>
+    {
+        std::map<std::string, long long> result;
+        const auto block = component_named(stats, "propagator_calls");
+        REQUIRE(block);
+        for (const auto & entry : block->entries())
+            result.emplace(entry.name, entry.value);
+        return result;
+    }
+
+    // Caps x at 5 in one go, and is not idempotent-claiming, so the engine wakes
+    // it a second time with its own inference: one effectful run then one no-op.
+    auto install_capping_propagator(Propagators & propagators, SimpleIntegerVariableID x) -> void
+    {
+        Triggers triggers;
+        triggers.on_change = {x};
+        propagators.install(
+            ConstraintID{NumberedConstraint{1}},
+            [x](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+                if (state.upper_bound(x) > 5_i)
+                    inference.infer(logger, x < 6_i, NoJustificationNeeded{}, NoReason{});
+                return PropagatorState::Enable;
+            },
+            triggers);
+    }
+
+    // Watches y, which nothing here ever changes, so it runs exactly once: the
+    // start-of-search call every propagator gets.
+    auto install_idle_propagator(Propagators & propagators, SimpleIntegerVariableID y) -> void
+    {
+        Triggers triggers;
+        triggers.on_change = {y};
+        propagators.install(
+            ConstraintID{NumberedConstraint{2}},
+            [](const State &, auto &, ProofLogger * const) -> PropagatorState { return PropagatorState::Enable; }, triggers);
+    }
+}
+
+TEST_CASE("No block is registered when GCS_PROPAGATOR_STATS is unset")
+{
+    State state;
+    Stats stats;
+    Propagators propagators{stats};
+    auto x = state.allocate_integer_variable_with_state(0_i, 10_i);
+    install_capping_propagator(propagators, x);
+
+    REQUIRE(propagators.propagate(Literals{}, state, nullptr));
+    propagators.fill_in_constraint_stats(stats);
+
+    // An unasked-for component has not done nothing, it has not run: a line on
+    // every solve naming an environment variable would be noise.
+    CHECK(! component_named(stats, "propagator_calls"));
+    // The aggregate counters are unaffected either way.
+    CHECK(stats.propagations == 2);
+    CHECK(stats.effectful_propagations == 1);
+}
+
+TEST_CASE("Calls, effectful runs and contradictions are counted per constraint type")
+{
+    WithPropagatorStats asked{"calls"};
+
+    State state;
+    Stats stats;
+    Propagators propagators{stats};
+    auto x = state.allocate_integer_variable_with_state(0_i, 10_i);
+    auto y = state.allocate_integer_variable_with_state(0_i, 10_i);
+
+    install_capping_propagator(propagators, x);
+    propagators.note_propagator_types(0, "capper");
+    install_idle_propagator(propagators, y);
+    propagators.note_propagator_types(1, "idler");
+
+    REQUIRE(propagators.propagate(Literals{}, state, nullptr));
+    REQUIRE(state.upper_bound(x) == 5_i);
+    propagators.fill_in_constraint_stats(stats);
+
+    const auto entries = propagator_call_entries(stats);
+    // The capper is woken by its own inference, so it runs twice: once
+    // effectfully and once as the no-op that establishes the fixpoint.
+    CHECK(entries.at("capper_constraints") == 1);
+    CHECK(entries.at("capper_propagators") == 1);
+    CHECK(entries.at("capper_calls") == 2);
+    CHECK(entries.at("capper_effectful") == 1);
+    CHECK(entries.at("capper_contradictions") == 0);
+    // The idler gets the start-of-search call and nothing else.
+    CHECK(entries.at("idler_calls") == 1);
+    CHECK(entries.at("idler_effectful") == 0);
+    // The counts add up to the aggregates, which is the property that catches a
+    // counter wired to the wrong branch.
+    CHECK(entries.at("capper_calls") + entries.at("idler_calls") == static_cast<long long>(stats.propagations));
+    CHECK(entries.at("capper_effectful") + entries.at("idler_effectful") == static_cast<long long>(stats.effectful_propagations));
+    // The calls rung reads no clock, so there is no time column to read.
+    CHECK(! entries.contains("capper_micros"));
+}
+
+TEST_CASE("A contradicting propagator is counted under its own type")
+{
+    WithPropagatorStats asked{"calls"};
+
+    State state;
+    Stats stats;
+    Propagators propagators{stats};
+    auto x = state.allocate_integer_variable_with_state(0_i, 10_i);
+
+    Triggers triggers;
+    triggers.on_change = {x};
+    propagators.install(
+        ConstraintID{NumberedConstraint{1}},
+        [](const State &, auto & inference, ProofLogger * const logger) -> PropagatorState {
+            inference.contradiction(logger, JustifyUsingRUP{}, NoReason{});
+            return PropagatorState::Enable;
+        },
+        triggers);
+    propagators.note_propagator_types(0, "failer");
+
+    REQUIRE(! propagators.propagate(Literals{}, state, nullptr));
+    propagators.fill_in_constraint_stats(stats);
+
+    const auto entries = propagator_call_entries(stats);
+    CHECK(entries.at("failer_calls") == 1);
+    CHECK(entries.at("failer_contradictions") == 1);
+    CHECK(entries.at("failer_effectful") == 0);
+    CHECK(entries.at("failer_contradictions") == static_cast<long long>(stats.contradicting_propagations));
+}
+
+TEST_CASE("An already-labelled propagator keeps its own type")
+{
+    WithPropagatorStats asked{"calls"};
+
+    State state;
+    Stats stats;
+    Propagators propagators{stats};
+    auto x = state.allocate_integer_variable_with_state(0_i, 10_i);
+    auto y = state.allocate_integer_variable_with_state(0_i, 10_i);
+
+    // The shape a child constraint makes: the child's install() labels its own
+    // propagator, and the parent's call then covers a range that includes it.
+    install_capping_propagator(propagators, x);
+    propagators.note_propagator_types(0, "child");
+    install_idle_propagator(propagators, y);
+    propagators.note_propagator_types(0, "parent");
+
+    REQUIRE(propagators.propagate(Literals{}, state, nullptr));
+    propagators.fill_in_constraint_stats(stats);
+
+    const auto entries = propagator_call_entries(stats);
+    CHECK(entries.at("child_calls") == 2);
+    CHECK(entries.at("parent_calls") == 1);
+    // The parent did not swallow the child, which is the whole point of doing
+    // the labelling in Constraint::install() rather than at each install site.
+    CHECK(! entries.contains("child_parent_calls"));
+}
+
+TEST_CASE("A propagator no constraint claimed is reported as unlabelled")
+{
+    WithPropagatorStats asked{"calls"};
+
+    State state;
+    Stats stats;
+    Propagators propagators{stats};
+    auto x = state.allocate_integer_variable_with_state(0_i, 10_i);
+    install_capping_propagator(propagators, x);
+
+    REQUIRE(propagators.propagate(Literals{}, state, nullptr));
+    propagators.fill_in_constraint_stats(stats);
+
+    // Nothing routed this one through Constraint::install(), which is how the
+    // learned-nogoods store's propagator arrives. It is still counted.
+    const auto entries = propagator_call_entries(stats);
+    CHECK(entries.at("unlabelled_calls") == 2);
+}
+
+TEST_CASE("The time rung adds a per-type time the calls rung does not")
+{
+    WithPropagatorStats asked{"time"};
+
+    State state;
+    Stats stats;
+    Propagators propagators{stats};
+    auto x = state.allocate_integer_variable_with_state(0_i, 10_i);
+    install_capping_propagator(propagators, x);
+    propagators.note_propagator_types(0, "capper");
+
+    REQUIRE(propagators.propagate(Literals{}, state, nullptr));
+    propagators.fill_in_constraint_stats(stats);
+
+    // The elapsed time of two trivial runs rounds to zero microseconds on any
+    // machine worth running this on, so what is asserted is that the column is
+    // there at all, and that asking for time did not lose the counts.
+    const auto entries = propagator_call_entries(stats);
+    CHECK(entries.contains("capper_micros"));
+    CHECK(entries.at("capper_micros") >= 0);
+    CHECK(entries.at("capper_calls") == 2);
+}
+
+TEST_CASE("An unrecognised GCS_PROPAGATOR_STATS value is ignored with a warning")
+{
+    WithPropagatorStats asked{"yes please"};
+
+    std::ostringstream captured;
+    auto old = std::cerr.rdbuf(captured.rdbuf());
+    State state;
+    Stats stats;
+    Propagators propagators{stats};
+    std::cerr.rdbuf(old);
+
+    auto x = state.allocate_integer_variable_with_state(0_i, 10_i);
+    install_capping_propagator(propagators, x);
+    REQUIRE(propagators.propagate(Literals{}, state, nullptr));
+    propagators.fill_in_constraint_stats(stats);
+
+    CHECK(captured.str().find("GCS_PROPAGATOR_STATS") != std::string::npos);
+    CHECK(! component_named(stats, "propagator_calls"));
+}

--- a/gcs/innards/propagators.cc
+++ b/gcs/innards/propagators.cc
@@ -1144,9 +1144,13 @@ auto Propagators::fill_in_constraint_stats(Stats & stats) const -> void
     vector<set<int>> constraints_per_type(rows.size());
     for (const auto & [index, name] : enumerate(_imp->constraint_type_names))
         rows[index].type = name;
-    // A propagator installed by something that is not a Constraint --- the
-    // learned-nogoods store is the one today --- never passes through
-    // Constraint::install() and so is labelled by nothing.
+    // A propagator installed on the raw Propagators, rather than by a Constraint
+    // going through Constraint::install(), is labelled by nothing. AutoTable is the
+    // one today: it installs a presolver-derived propagator under
+    // CurrentlyUnnamedConstraint, having no posted-constraint identity to use. (The
+    // learned-nogoods store is *not* an example, though it looks like one: Nogoods is
+    // a Constraint with its own constraint_type(), and solve.cc installs it the
+    // ordinary way, so it gets a `nogoods` row.)
     rows[unknown_type].type = "unlabelled";
 
     for (std::size_t p = 0; p != _imp->propagation_functions.size(); ++p) {

--- a/gcs/innards/propagators.cc
+++ b/gcs/innards/propagators.cc
@@ -12,11 +12,14 @@
 
 #include <algorithm>
 #include <array>
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <cstdlib>
 #include <functional>
+#include <iostream>
 #include <optional>
+#include <set>
 #include <span>
 #include <string>
 #include <unordered_map>
@@ -26,15 +29,23 @@ using namespace gcs;
 using namespace gcs::innards;
 
 using std::atomic;
+using std::make_shared;
 using std::make_unique;
 using std::move;
+using std::nullopt;
 using std::optional;
 using std::pair;
+using std::set;
 using std::string;
 using std::swap;
 using std::to_underlying;
 using std::vector;
 using std::visit;
+using std::chrono::duration_cast;
+using std::chrono::microseconds;
+using std::chrono::milliseconds;
+using std::chrono::nanoseconds;
+using std::chrono::steady_clock;
 using std::ranges::adjacent_find;
 using std::ranges::contains;
 using std::ranges::sort;
@@ -44,6 +55,130 @@ namespace
     struct TriggerIDs
     {
         vector<pair<int, int>> ids_and_masks;
+    };
+
+    // What GCS_PROPAGATOR_STATS asked for. Calls costs one increment per
+    // propagator run; Time additionally reads the clock twice per run, which is
+    // enough overhead that a timed run's own wall clock and nodes-per-second are
+    // not comparable with an uninstrumented one --- hence the two rungs, so that
+    // a sweep can have the counts without paying for the timings.
+    enum class PropagatorStatsWanted
+    {
+        Calls,
+        Time
+    };
+
+    [[nodiscard]] auto propagator_stats_from_env() -> optional<PropagatorStatsWanted>
+    {
+        const auto * const env = std::getenv("GCS_PROPAGATOR_STATS");
+        if (! env || ! *env)
+            return nullopt;
+
+        string value{env};
+        if (value == "calls" || value == "1")
+            return PropagatorStatsWanted::Calls;
+        else if (value == "time" || value == "2")
+            return PropagatorStatsWanted::Time;
+
+        std::cerr << "Ignoring unrecognised GCS_PROPAGATOR_STATS value '" << value << "', expected 'calls' or 'time'\n";
+        return nullopt;
+    }
+
+    // Accumulates one propagator run's elapsed time on the way out, however the
+    // run ends. A contradicting propagator that uses the throwing failure path
+    // leaves by unwinding, and roughly half the runs in a search that is doing
+    // any good are contradictions, so a sample taken only on the fall-through
+    // path would systematically miss exactly the runs most worth timing.
+    // A null accumulator is the not-timing case, which is also the default.
+    //
+    // The sample is the run plus the two clock reads (tens of nanoseconds, which
+    // matters for a propagator whose own body is that cheap) plus the queue
+    // bookkeeping between the call and the end of the enclosing try block. That
+    // bookkeeping includes the GCS_CHECK_IDEMPOTENT_CLAIMS re-run, which is a
+    // whole second run of the propagator, so do not read timings off a run with
+    // both switched on.
+    struct TimedPropagatorRun
+    {
+        unsigned long long * const into;
+        const steady_clock::time_point started;
+
+        explicit TimedPropagatorRun(unsigned long long * const into) : into(into), started(into ? steady_clock::now() : steady_clock::time_point{})
+        {
+        }
+
+        ~TimedPropagatorRun()
+        {
+            if (into)
+                *into += static_cast<unsigned long long>(duration_cast<nanoseconds>(steady_clock::now() - started).count());
+        }
+
+        TimedPropagatorRun(const TimedPropagatorRun &) = delete;
+        auto operator=(const TimedPropagatorRun &) -> TimedPropagatorRun & = delete;
+    };
+
+    // The per-constraint-type propagator report: how much of the propagation a
+    // model does belongs to each kind of constraint in it. Grouped by constraint
+    // *type* rather than by constraint, because a model with ten thousand
+    // linear constraints in it wants one `lin_less_equal` row and not ten
+    // thousand rows; the propagator counts say how many constraints are behind
+    // each row.
+    struct PropagatorCallStats final : ComponentStats
+    {
+        struct Row final
+        {
+            string type;
+            unsigned long long constraints = 0, propagators = 0, calls = 0, effectful = 0, contradictions = 0, nanos = 0;
+        };
+
+        vector<Row> rows;
+        bool timed;
+
+        explicit PropagatorCallStats(vector<Row> && rows, bool timed) : rows(move(rows)), timed(timed)
+        {
+        }
+
+        [[nodiscard]] auto component_name() const -> string override
+        {
+            return "propagator_calls";
+        }
+
+        [[nodiscard]] auto summary() const -> string override
+        {
+            if (rows.empty())
+                return "no propagators were installed";
+
+            unsigned long long total_calls = 0, total_nanos = 0;
+            for (const auto & row : rows) {
+                total_calls += row.calls;
+                total_nanos += row.nanos;
+            }
+
+            // rows is sorted busiest first, so rows.front() is the answer to the
+            // question this report is usually opened to ask.
+            const auto & busiest = rows.front();
+            auto result = std::to_string(total_calls) + " propagator calls over " + std::to_string(rows.size()) + " constraint types, busiest " +
+                busiest.type + " with " + std::to_string(busiest.calls);
+            if (timed && 0 != total_nanos)
+                result += " taking " + std::to_string(busiest.nanos * 100 / total_nanos) + "% of " +
+                    std::to_string(duration_cast<milliseconds>(nanoseconds{total_nanos}).count()) + "ms propagating";
+            return result;
+        }
+
+        [[nodiscard]] auto entries() const -> vector<StatsEntry> override
+        {
+            vector<StatsEntry> result;
+            for (const auto & row : rows) {
+                result.emplace_back(StatsEntry{row.type + "_constraints", static_cast<long long>(row.constraints)});
+                result.emplace_back(StatsEntry{row.type + "_propagators", static_cast<long long>(row.propagators)});
+                result.emplace_back(StatsEntry{row.type + "_calls", static_cast<long long>(row.calls)});
+                result.emplace_back(StatsEntry{row.type + "_effectful", static_cast<long long>(row.effectful)});
+                result.emplace_back(StatsEntry{row.type + "_contradictions", static_cast<long long>(row.contradictions)});
+                if (timed)
+                    result.emplace_back(
+                        StatsEntry{row.type + "_micros", static_cast<long long>(duration_cast<microseconds>(nanoseconds{row.nanos}).count())});
+            }
+            return result;
+        }
     };
 
     // The GCS_CHECK_IDEMPOTENT_CLAIMS re-run: the claim says an immediate
@@ -231,6 +366,24 @@ struct Propagators::Imp : RefinedWatchSink
     vector<TriggerIDs> iv_triggers;
     vector<long> degrees;
 
+    // What the propagation loop is to record per propagator, from
+    // GCS_PROPAGATOR_STATS, decided once at construction; nullopt --- the
+    // default --- means the loop keeps only the three aggregate counters above.
+    // The four vectors are indexed by propagator id and sized in install(), so
+    // that the loop only ever indexes them and never grows one.
+    optional<PropagatorStatsWanted> propagator_stats_wanted;
+    vector<unsigned long long> calls_by_propagator, effectful_by_propagator, contradictions_by_propagator, nanos_by_propagator;
+
+    // The type of the constraint each propagator came from --- `subcircuit`,
+    // `all_different` --- interned: propagator_type_index is indexed by
+    // propagator id into constraint_type_names, and is -1 for a propagator
+    // nothing has claimed (which install() cannot rule out on its own, since it
+    // is note_propagator_types that does the labelling, afterwards). One int per
+    // propagator and one string per distinct type, both install-time only, so
+    // these are kept whether or not any counters are.
+    vector<string> constraint_type_names;
+    vector<int> propagator_type_index;
+
     // The constraint each propagator belongs to. propagator_constraint_index is
     // indexed by propagator id and gives a dense constraint index; constraint_ids
     // is the inverse (dense index -> ConstraintID); constraint_index_of_id assigns
@@ -368,6 +521,7 @@ struct Propagators::Imp : RefinedWatchSink
 Propagators::Propagators(Stats & stats) : _imp(make_unique<Imp>())
 {
     _imp->stats = &stats;
+    _imp->propagator_stats_wanted = propagator_stats_from_env();
 }
 
 Propagators::~Propagators() = default;
@@ -406,6 +560,13 @@ auto Propagators::install(const ConstraintID & constraint_id, PropagationFunctio
     int id = _imp->propagation_functions.size();
     _imp->propagation_functions.emplace_back(move(f));
     _imp->permanently_disabled.push_back(0);
+    _imp->propagator_type_index.push_back(-1);
+    if (_imp->propagator_stats_wanted) {
+        _imp->calls_by_propagator.push_back(0);
+        _imp->effectful_by_propagator.push_back(0);
+        _imp->contradictions_by_propagator.push_back(0);
+        _imp->nanos_by_propagator.push_back(0);
+    }
 
     auto [it, inserted] = _imp->constraint_index_of_id.try_emplace(constraint_id, static_cast<int>(_imp->constraint_ids.size()));
     if (inserted)
@@ -859,6 +1020,12 @@ auto Propagators::propagate(const Literals & guesses, State & state, ProofLogger
                 continue;
             try {
                 ++_imp->total_propagations;
+                if (_imp->propagator_stats_wanted) [[unlikely]]
+                    ++_imp->calls_by_propagator[propagator_id];
+                // Not timing is a null pointer here, so the ordinary path pays a
+                // branch on it and nothing else.
+                TimedPropagatorRun timed{
+                    _imp->propagator_stats_wanted == PropagatorStatsWanted::Time ? &_imp->nanos_by_propagator[propagator_id] : nullptr};
                 tracker.begin_propagator_run();
                 RefinedWatchContext watches{*_imp, propagator_id, _imp->inbox_by_propagator[propagator_id]};
                 auto propagator_state = _imp->propagation_functions[propagator_id](state, tracker, logger, watches);
@@ -872,6 +1039,8 @@ auto Propagators::propagate(const Literals & guesses, State & state, ProofLogger
                     // than by unwinding; throwing propagators are caught below.
                     contradiction = true;
                     ++_imp->contradicting_propagations;
+                    if (_imp->propagator_stats_wanted) [[unlikely]]
+                        ++_imp->contradictions_by_propagator[propagator_id];
                     // Attribute the conflict to observers here too: many constraints
                     // contradict via the non-throwing path, and if only the throwing
                     // catch below notified, a weighting heuristic would never see
@@ -881,8 +1050,11 @@ auto Propagators::propagate(const Literals & guesses, State & state, ProofLogger
                             tracker.last_contradiction_reason(), state);
                 }
                 else {
-                    if (tracker.did_anything_since_last_call_by_propagation_queue())
+                    if (tracker.did_anything_since_last_call_by_propagation_queue()) {
                         ++_imp->effectful_propagations;
+                        if (_imp->propagator_stats_wanted) [[unlikely]]
+                            ++_imp->effectful_by_propagator[propagator_id];
+                    }
                     switch (propagator_state) {
                     case PropagatorState::Enable: break;
                     case PropagatorState::EnableButIdempotent:
@@ -913,6 +1085,8 @@ auto Propagators::propagate(const Literals & guesses, State & state, ProofLogger
             catch (const TrackedPropagationFailed &) {
                 contradiction = true;
                 ++_imp->contradicting_propagations;
+                if (_imp->propagator_stats_wanted) [[unlikely]]
+                    ++_imp->contradictions_by_propagator[propagator_id];
                 // Exactly one propagator contradiction ends each propagate(), so this
                 // fires at most once per call. Non-propagator contradiction paths
                 // (initialisers, the objective bound) never reach here, so they are
@@ -954,6 +1128,47 @@ auto Propagators::fill_in_constraint_stats(Stats & stats) const -> void
     stats.contradicting_propagations += _imp->contradicting_propagations;
     for (const auto & ignored : _imp->idempotence_claims_ignored)
         stats.idempotence_downgrades += ignored;
+
+    // The per-constraint-type block is registered only when it was asked for,
+    // rather than always and empty: an unasked-for component has not done
+    // nothing, it has not run, and a line on every solve saying which
+    // environment variable to set is noise rather than a finding.
+    if (! _imp->propagator_stats_wanted)
+        return;
+
+    // Group by type, and count the distinct constraints behind each group ---
+    // a parent and a child constraint share one ConstraintID but have different
+    // types, so a constraint can legitimately be counted under two of them.
+    const auto unknown_type = _imp->constraint_type_names.size();
+    vector<PropagatorCallStats::Row> rows(unknown_type + 1);
+    vector<set<int>> constraints_per_type(rows.size());
+    for (const auto & [index, name] : enumerate(_imp->constraint_type_names))
+        rows[index].type = name;
+    // A propagator installed by something that is not a Constraint --- the
+    // learned-nogoods store is the one today --- never passes through
+    // Constraint::install() and so is labelled by nothing.
+    rows[unknown_type].type = "unlabelled";
+
+    for (std::size_t p = 0; p != _imp->propagation_functions.size(); ++p) {
+        const auto type = -1 == _imp->propagator_type_index[p] ? unknown_type : static_cast<std::size_t>(_imp->propagator_type_index[p]);
+        auto & row = rows[type];
+        ++row.propagators;
+        row.calls += _imp->calls_by_propagator[p];
+        row.effectful += _imp->effectful_by_propagator[p];
+        row.contradictions += _imp->contradictions_by_propagator[p];
+        row.nanos += _imp->nanos_by_propagator[p];
+        constraints_per_type[type].insert(_imp->propagator_constraint_index[p]);
+    }
+    for (const auto & [index, constraints] : enumerate(constraints_per_type))
+        rows[index].constraints = constraints.size();
+
+    std::erase_if(rows, [](const auto & row) { return 0 == row.propagators; });
+    // Busiest first, by calls and then by name, so that the summary line can
+    // just take the front row and two runs of the same model list their rows in
+    // the same order.
+    sort(rows, [](const auto & a, const auto & b) { return a.calls != b.calls ? a.calls > b.calls : a.type < b.type; });
+
+    stats.add_component(make_shared<PropagatorCallStats>(move(rows), PropagatorStatsWanted::Time == *_imp->propagator_stats_wanted));
 }
 
 auto Propagators::add_component_stats(std::shared_ptr<const ComponentStats> component) -> void
@@ -1043,6 +1258,37 @@ auto Propagators::degree_of(IntegerVariableID var) const -> long
 auto Propagators::number_of_constraints() const -> std::size_t
 {
     return _imp->constraint_ids.size();
+}
+
+auto Propagators::number_of_propagators() const -> std::size_t
+{
+    return _imp->propagation_functions.size();
+}
+
+auto Propagators::note_propagator_types(std::size_t first_propagator, const string & constraint_type) -> void
+{
+    // Installation is serial, so [first_propagator, end) is exactly what this
+    // constraint and its children installed. Anything in there already labelled
+    // is a child's, which has its own type and keeps it; look before interning,
+    // so that a constraint which installed nothing but a child does not put a
+    // name in the table that no row will ever be grouped under.
+    const auto end = _imp->propagator_type_index.size();
+    auto unlabelled = first_propagator;
+    while (unlabelled < end && -1 != _imp->propagator_type_index[unlabelled])
+        ++unlabelled;
+    if (unlabelled == end)
+        return;
+
+    auto found = std::ranges::find(_imp->constraint_type_names, constraint_type);
+    if (found == _imp->constraint_type_names.end()) {
+        _imp->constraint_type_names.push_back(constraint_type);
+        found = _imp->constraint_type_names.end() - 1;
+    }
+    const auto type_index = static_cast<int>(found - _imp->constraint_type_names.begin());
+
+    for (auto p = unlabelled; p != end; ++p)
+        if (-1 == _imp->propagator_type_index[p])
+            _imp->propagator_type_index[p] = type_index;
 }
 
 auto Propagators::constraint_index_of_propagator(int propagator_id) const -> int

--- a/gcs/innards/propagators.hh
+++ b/gcs/innards/propagators.hh
@@ -628,6 +628,24 @@ namespace gcs::innards
         auto fill_in_constraint_stats(Stats &) const -> void;
 
         /**
+         * \brief Label every propagator installed since `first_propagator` that
+         * is not labelled already with the type of the constraint it came from.
+         *
+         * Called by Constraint::install(), which is the one function every
+         * install path runs through and so the only place that knows both a
+         * constraint's type and which propagators it installed. The
+         * already-labelled exemption is what keeps a *child* constraint's
+         * propagators labelled with the child's own type: a child is installed
+         * from within its parent's prepare(), so the child's own install() has
+         * labelled them before the parent's call gets here.
+         *
+         * The labels are what the per-constraint-type propagator report is
+         * grouped by; they carry the type (`subcircuit`, `all_different`), not
+         * the identity, for which see constraint_id_for_index().
+         */
+        auto note_propagator_types(std::size_t first_propagator, const std::string & constraint_type) -> void;
+
+        /**
          * \brief Register a component's stats block with the search's Stats.
          *
          * For a Presolver, or a constraint installed by one, that keeps a block
@@ -655,6 +673,12 @@ namespace gcs::innards
          * How many constraints is this variable involved in?
          */
         auto degree_of(IntegerVariableID) const -> long;
+
+        /**
+         * How many propagators have been installed. Valid propagator ids run
+         * from zero to this minus one.
+         */
+        [[nodiscard]] auto number_of_propagators() const -> std::size_t;
 
         /**
          * How many distinct constraints (by ConstraintID) installed at least

--- a/gcs/innards/propagators.hh
+++ b/gcs/innards/propagators.hh
@@ -631,9 +631,11 @@ namespace gcs::innards
          * \brief Label every propagator installed since `first_propagator` that
          * is not labelled already with the type of the constraint it came from.
          *
-         * Called by Constraint::install(), which is the one function every
-         * install path runs through and so the only place that knows both a
-         * constraint's type and which propagators it installed. The
+         * Called by Constraint::install(), which is the one place that knows both a
+         * constraint's type and which propagators it installed. Every Constraint
+         * runs through it; a propagator installed on the raw Propagators by a
+         * presolver does not, and comes out unlabelled (AutoTable is the one such
+         * today). The
          * already-labelled exemption is what keeps a *child* constraint's
          * propagators labelled with the child's own type: a child is installed
          * from within its parent's prepare(), so the child's own install() has


### PR DESCRIPTION
`GCS_PROPAGATOR_STATS=calls` adds a per-constraint-type block to the statistics — how many constraints of each type there are, how many propagators they installed, and how many times those propagators were called, changed a domain and contradicted. `GCS_PROPAGATOR_STATS=time` adds the elapsed time in each. It is a `ComponentStats` block, so it reaches `%%%mzn-stat:` lines from `fzn-glasgow -s` and `xcsp_glasgow_constraint_solver -s`, and the default `operator<<` on `Stats` prints the summary line, with no per-caller plumbing.

## Why

The aggregate `propagations:` count cannot tell you which constraint to look at, and #788 is the case for why that matters.

`SubCircuit`'s reachability arm looked free on the `tpp` family and crushing on `mario` at comparable `n`, which read as a per-call cost that was not a function of `n`. It is not. Per *call* it costs almost exactly the same on both families at the same `n` — 7.4 µs on `mario` at n=15 against 7.7 µs on `tpp` at n=15, 31.2 µs on `mario` at n=30 against 30.7 µs on `tpp` at n=35. What differs is how often it is woken: **1.4–2.5 times a node on `mario`, and 676 times in a 7.5-million-node search on `tpp`**, because `tpp`'s `seq_search` fixes all `n` successors in the first `n` levels and then spends the entire search on `purchaseLoc` below them. Calls-per-node and cost-per-call vary independently and only their product was visible.

The same run turned up a second thing on `tpp` that the aggregate count hides: the twenty `lin_not_equals` constraints are called 17.8 million times, **remove a value once in the whole search**, contradict 3.75 million times, and take half the propagation time. Their comment already says they only care when one variable is left unassigned, and they wake `on_change`. Filed separately.

## Reading the two rungs

`calls` is one increment per propagator run, so a run with it on is comparable with a run without — verified on a real instance: `GCS_PROPAGATOR_STATS=time` and an uninstrumented run report identical node counts on `mario_n_medium_3` and `mario_t_hard_5` under both algorithms. `time` reads the clock twice a run (about 13% on `tpp_3_5_20_1`, more where the propagators are individually tiny), so read shares and per-call figures off a timed run, never throughput.

## Design

- Grouped by constraint **type**, not by constraint: a model with ten thousand linear constraints wants one `lin_less_equal` row and not ten thousand, and the propagator and constraint counts say how many are behind each row.
- The labels are applied by `Constraint::install()`, the one function every install path runs through and so the only place that knows both a constraint's type and which propagators it installed. Doing it there is also what keeps a **child** constraint's propagators labelled with the child's own type: the child is installed from inside its parent's `prepare()`, so its own recursion through `install()` has already labelled them, and the parent labels only what is left.
- The block is registered only when it was asked for. An unasked-for component has not done nothing, it has not run, and a line on every solve naming an environment variable is noise rather than a finding.
- The default path pays one branch per propagator run and nothing else; the four per-propagator vectors are only allocated when the variable is set.

## Checks

- 789/789 tests pass; warning-free under GCC with `GCS_WERROR=ON`, and clean under clang + sanitizers (the two warnings clang reports are `variable_weighting.hh` and `element.cc`, both pre-existing on main).
- `propagator_call_stats_test` pins the exact figures for propagators whose behaviour is written out in front of them, and asserts the per-type counts sum to the aggregates. Two mutation probes were rejected: letting a parent overwrite a child's label, and dropping the per-propagator effectful increment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)