### PR TITLE
Test the successor range guard Circuit and SubCircuit both rely on

### DIFF
--- a/gcs/constraints/circuit/circuit_base.cc
+++ b/gcs/constraints/circuit/circuit_base.cc
@@ -42,8 +42,16 @@ auto gcs::innards::circuit::output_cycle_to_proof(const vector<IntegerVariableID
     if (current_val == nullopt)
         throw UnexpectedException("Circuit propagator tried to output a cycle that doesn't exist");
 
+    // Cannot happen, and is checked because as_index() below is an unchecked cast: a
+    // negative value would index the position map at a vast offset rather than fail.
+    // Circuit::prepare() define_bound()s every successor to 0..n-1, which is one phase
+    // earlier than the constructor could manage (a variable's domain lives in the State,
+    // not in the handle) and long before any propagator runs, so nothing outside that
+    // range survives to be output here. Issue #201 asked for this to become a
+    // problem-definition error hoisted out of proof emission; the hoisted version is
+    // that define_bound, and what is left here is a bug check (#201).
     if (*current_val < 0_i)
-        throw UnimplementedException("Successor encoding for circuit can't have negative values");
+        throw UnexpectedException("Circuit propagator output a successor outside 0..n-1, which prepare() should have ruled out");
 
     PolBuilder pol;
     pol.add(pos_var_data.at(start).plus_one_lines.at(current_val->as_index()).geq_line);

--- a/gcs/constraints/circuit/circuit_base.cc
+++ b/gcs/constraints/circuit/circuit_base.cc
@@ -42,8 +42,11 @@ auto gcs::innards::circuit::output_cycle_to_proof(const vector<IntegerVariableID
     if (current_val == nullopt)
         throw UnexpectedException("Circuit propagator tried to output a cycle that doesn't exist");
 
-    // Cannot happen, and is checked because as_index() below is an unchecked cast: a
-    // negative value would index the position map at a vast offset rather than fail.
+    // Cannot happen, and only the negative side is checked here --- deliberately, because
+    // that is the side as_index() below cannot catch: it is an unchecked cast, so a
+    // negative value would index the position map at a vast offset rather than fail. A
+    // value >= n reaches plus_one_lines.at() instead, which is checked and throws
+    // std::out_of_range on its own.
     // Circuit::prepare() define_bound()s every successor to 0..n-1, which is one phase
     // earlier than the constructor could manage (a variable's domain lives in the State,
     // not in the handle) and long before any propagator runs, so nothing outside that
@@ -51,7 +54,7 @@ auto gcs::innards::circuit::output_cycle_to_proof(const vector<IntegerVariableID
     // problem-definition error hoisted out of proof emission; the hoisted version is
     // that define_bound, and what is left here is a bug check (#201).
     if (*current_val < 0_i)
-        throw UnexpectedException("Circuit propagator output a successor outside 0..n-1, which prepare() should have ruled out");
+        throw UnexpectedException("Circuit propagator output a negative successor, which prepare() should have ruled out");
 
     PolBuilder pol;
     pol.add(pos_var_data.at(start).plus_one_lines.at(current_val->as_index()).geq_line);

--- a/gcs/constraints/circuit/circuit_test.cc
+++ b/gcs/constraints/circuit/circuit_test.cc
@@ -92,6 +92,45 @@ auto run_circuit_test(bool proofs, const ViewWrapConfig & view_cfg, int n, Circu
     check_results(proof_name, expected, actual);
 }
 
+// A caller can hand over successors whose declared domains reach outside 0..n-1 --- a
+// variable sized from a loop bound, or one shared with another constraint that needed a
+// wider range. prepare() narrows them with define_bound() rather than rejecting them, and
+// that guard is what the position encoding's range assumption rests on: `p[i]` rows exist
+// for values 0..n-1 and nothing else keeps succ[i] inside that. Every other test here
+// declares exactly 0..n-1, so without this one the guard is a no-op, and a no-op passes
+// every check.
+//
+// Run bare rather than through the view sweep: a view's own bounds are what would be
+// widened, and the guard is about the successor the constraint sees.
+auto run_circuit_wide_domain_test(bool proofs, int n, CircuitPropagator propagator) -> void
+{
+    auto prop_label = propagator == CircuitPropagator::prevent ? "prevent" : "scc";
+    print(cerr, "circuit/{} wide domains n={}{}", prop_label, n, proofs ? " with proofs:" : ":");
+    cerr << flush;
+
+    // Two either side, so a negative value, a value equal to n, and one beyond it are all
+    // declared. is_single_circuit rejects every one of them, so the expected set is the
+    // same as the 0..n-1 run's --- which is the point: the answer must not change.
+    vector<pair<int, int>> domains(static_cast<std::size_t>(n), pair{-2, n + 1});
+
+    set<tuple<vector<int>>> expected, actual;
+    build_expected(expected, [&](vector<int> succ) { return is_single_circuit(succ); }, domains);
+    println(cerr, " expecting {} solutions", expected.size());
+
+    Problem p;
+    vector<IntegerVariableID> succ;
+    for (int i = 0; i < n; ++i)
+        succ.push_back(p.create_integer_variable(-2_i, Integer{n + 1}));
+    if (propagator == CircuitPropagator::prevent)
+        p.post(Circuit{succ}.with_algorithm(circuit::Prevent{}));
+    else
+        p.post(Circuit{succ}.with_algorithm(circuit::SCC{}));
+
+    auto proof_name = proofs ? make_optional("circuit_test_wide_" + std::string{prop_label}) : nullopt;
+    solve_for_tests(p, proof_name, actual, tuple{succ});
+    check_results(proof_name, expected, actual);
+}
+
 auto main(int argc, char * argv[]) -> int
 {
     establish_and_announce_seed(argc, argv);
@@ -118,6 +157,10 @@ auto main(int argc, char * argv[]) -> int
             if (view_wrap_config_is_effectively_bare(view_cfg, n_positions)) {
                 run_circuit_test(proofs, view_cfg, 1, propagator);
                 run_circuit_test(proofs, view_cfg, 2, propagator);
+                // n = 1 as well: the self-loop is the one solution, and it is the
+                // smallest case where a negative value could reach as_index().
+                run_circuit_wide_domain_test(proofs, 1, propagator);
+                run_circuit_wide_domain_test(proofs, 4, propagator);
             }
         }
     }

--- a/gcs/constraints/circuit/subcircuit.cc
+++ b/gcs/constraints/circuit/subcircuit.cc
@@ -85,6 +85,12 @@ namespace
         vector<vector<long>> chains;
     };
 
+    // Every fixed successor value is assumed to be in 0..n-1, and indexes straight into
+    // has_fixed_pred without a check: this runs on every call, so the range is an
+    // invariant to be established once rather than tested here. SubCircuit::prepare()
+    // establishes it, define_bound()ing each successor to 0..n-1 before search starts.
+    // Losing that guard does not give wrong answers here, it segfaults --- which is what
+    // the wide-domain case in subcircuit_test.cc exists to keep from happening quietly.
     auto walk_fixed_edges(const vector<IntegerVariableID> & succ, const State & state) -> FixedEdges
     {
         auto n = static_cast<long>(succ.size());

--- a/gcs/constraints/circuit/subcircuit_test.cc
+++ b/gcs/constraints/circuit/subcircuit_test.cc
@@ -139,6 +139,47 @@ auto run_empty_test(bool proofs) -> void
     check_results(proof_name, expected, actual);
 }
 
+// A caller can hand over successors whose declared domains reach outside 0..n-1 --- a
+// variable sized from a loop bound, or one shared with another constraint that needed a
+// wider range. prepare() narrows them with define_bound() rather than rejecting them, and
+// that guard is what the position encoding's range assumption rests on: there is a `p[i]`
+// row per value in 0..n-1 and nothing else keeps succ[i] inside that. Every other test
+// here declares exactly 0..n-1, so without this one the guard is a no-op, and a no-op
+// passes every check.
+//
+// Run bare rather than through the view sweep: a view's own bounds are what would be
+// widened, and the guard is about the successor the constraint sees.
+auto run_wide_domain_test(bool proofs, int n, SubCircuitPropagator propagator) -> void
+{
+    auto prop_label = propagator == SubCircuitPropagator::prevent ? "prevent" : "check";
+    print(cerr, "subcircuit/{} wide domains n={}{}", prop_label, n, proofs ? " with proofs:" : ":");
+    cerr << flush;
+
+    // Two either side, so a negative value, a value equal to n, and one beyond it are all
+    // declared. is_subcircuit rejects every one of them, so the expected set is the same as
+    // the 0..n-1 run's --- which is the point: the answer must not change. It also keeps
+    // the anchor search honest, since a node whose own index is out of a *wider* domain is
+    // not thereby on the tour.
+    vector<pair<int, int>> domains(static_cast<std::size_t>(n), pair{-2, n + 1});
+
+    set<tuple<vector<int>>> expected, actual;
+    build_expected(expected, [&](vector<int> succ) { return is_subcircuit(succ); }, domains);
+    println(cerr, " expecting {} solutions", expected.size());
+
+    Problem p;
+    vector<IntegerVariableID> succ;
+    for (int i = 0; i < n; ++i)
+        succ.push_back(p.create_integer_variable(-2_i, Integer{n + 1}));
+    if (propagator == SubCircuitPropagator::prevent)
+        p.post(SubCircuit{succ}.with_algorithm(subcircuit::Prevent{}));
+    else
+        p.post(SubCircuit{succ}.with_algorithm(subcircuit::Check{}));
+
+    auto proof_name = proofs ? make_optional("subcircuit_test_wide_" + std::string{prop_label}) : nullopt;
+    solve_for_tests(p, proof_name, actual, tuple{succ});
+    check_results(proof_name, expected, actual);
+}
+
 // The tour size, XCSP3's `size` argument. Enumerated against the same reference check with
 // the count computed alongside it, so the option is pinned to "how many nodes do not point
 // at themselves" and not to some off-by-one reading of it.
@@ -281,6 +322,10 @@ auto main(int argc, char * argv[]) -> int
             if (view_wrap_config_is_effectively_bare(view_cfg, n_positions)) {
                 run_subcircuit_test(proofs, view_cfg, 1, propagator);
                 run_subcircuit_test(proofs, view_cfg, 2, propagator);
+                // n = 1 as well: its one solution is the self-loop, and it is the smallest
+                // case where an out-of-range value could reach the position encoding.
+                run_wide_domain_test(proofs, 1, propagator);
+                run_wide_domain_test(proofs, 4, propagator);
             }
         }
         if (view_wrap_config_is_effectively_bare(view_cfg, n_positions)) {


### PR DESCRIPTION
Closes #201.

## The gap

`Circuit::prepare()` and `SubCircuit::prepare()` both `define_bound()` every successor to `0..n-1`. Both then index per-node arrays with the fixed successor values through casts that check nothing — a `p[i]` position row per value in `Circuit`'s proof output, `has_fixed_pred` in `SubCircuit`'s fixed-edge walk. **Every existing test declares its successors as exactly `0..n-1`**, so that guard never did anything in the whole suite, and a no-op passes every check.

It is emphatically not a no-op. Deleting it:

- makes `Circuit` at n=1 report `succ = [-2]`, `[-1]`, `[1]` and `[2]` as one-node circuits;
- makes `SubCircuit` **segfault**, because a negative value indexes `has_fixed_pred` at a vast offset.

## The test

One wide-domain case per constraint, declaring two values either side of the range (so a negative value, `n` itself, and one beyond it are all in the declared domain) and asserting **the same solution set** the `0..n-1` runs get — the answer must not change. At n=1, the smallest size where an out-of-range value can reach the position encoding, and n=4; both algorithms; with proofs, so VeriPB checks the bound rows too (`s VERIFIED COMPLETE ENUMERATION`).

Run bare rather than through the view sweep: a view's own bounds are what a wrap would widen, and the guard is about the successor the constraint sees.

Both mutation probes above were run against these tests and are caught.

## What this does about #201

#201 asked for `circuit_base.cc`'s

```cpp
if (*current_val < 0_i)
    throw UnimplementedException("Successor encoding for circuit can't have negative values");
```

to become an `InvalidProblemDefinitionException` hoisted out of proof emission into `prepare()` or the constructor.

**The hoisted version already exists** and is the `define_bound` above — and it is a phase *earlier* than the constructor the issue suggested, because a variable's domain lives in the `State`, not in the `IntegerVariableID` handle the constructor is passed; only a constant successor could be range-checked at construction. So what was left at the emission site was never caller-input validation, it was a bug check standing in front of an unchecked `as_index()`. It now says that, as an `UnexpectedException`, matching the line directly above it. The issue's point 1 (wrong exception class) is fixed; its point 2 (wrong place) turns out already to have been done.

`SubCircuit`'s equivalent site is the per-call fixed-edge walk rather than proof emission, so a runtime check there would be paid on every propagator call. That one gets the invariant and its source written down instead.

## Checks

789/789 tests pass (788 on this branch, which does not carry #806's new test), warning-free under GCC with `GCS_WERROR=ON`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)