### PR TITLE
Implement Francis and Stuckey's scc pruning rules, expensively

### DIFF
--- a/dev_docs/subcircuit-proof-logging.md
+++ b/dev_docs/subcircuit-proof-logging.md
@@ -435,7 +435,7 @@ The graph family shifts *parameters*, which costs nothing.
 
 `with_prune_root()` and `with_prune_within()`, both off by default. Together they are
 Francis and Stuckey's remaining `scc` rules, and they cost between 1x and 95x the
-proof for at most a ten per cent reduction in search. They are here because they are
+proof for about a ten per cent reduction in search. They are here because they are
 *certifiable*, and a corpus of expensive-but-correct rules that a checker can be
 pointed at is worth having on its own account.
 
@@ -491,8 +491,11 @@ small pieces of mechanism:
   uses the *absence* of a value to rule a neighbour out, so a domain that has since
   lost more values makes the reason a stronger premise, not a weaker one.
 
-Both mutation probes are caught by `subcircuit_prune_root_test`: dropping the guard,
-and replacing the induction with a plain `JustifyUsingRUP`.
+Both mutation probes are caught: dropping the guard, and replacing the induction with a
+plain `JustifyUsingRUP`. The guard one is caught three times over --- by
+`subcircuit_prune_root_test`, by `subcircuit_prune_within_test`, and by the anchored
+enumeration sweep in `subcircuit_test.cc`, which reports the signature worth recognising:
+the solution set is still right and VeriPB refuses the certificate.
 
 ### The cost, measured
 
@@ -523,8 +526,9 @@ this machine means it does not fit: the scratchpad is a 16 GB tmpfs and therefor
 *shares the guest's RAM*. Complete enumeration with prune within has a practical
 ceiling somewhere around `n = 11`.
 
-And what it buys: **at most ten per cent fewer search nodes** (8057 → 7461, 25469 →
-22846, 1281 → 1199), and for prune root essentially nothing at all (104134 → 104044).
+And what it buys: **about ten per cent fewer search nodes** (8057 → 7461 is 7.4%,
+25469 → 22846 is 10.3%, 1281 → 1199 is 6.4%), and for prune root essentially nothing at
+all (104134 → 104044).
 Which is consistent with everything else measured on this arm --- the node reduction
 where it is measurable at all is 1.09x to 1.38x --- and is the argument for treating
 the proof-size constant as the thing to attack rather than the propagator.

--- a/dev_docs/subcircuit-proof-logging.md
+++ b/dev_docs/subcircuit-proof-logging.md
@@ -431,99 +431,128 @@ The same shape is in four more redefinitions — the three `bin_packing` ones an
 `fzn_regular` — and is [issue #803](https://github.com/ciaranm/glasgow-constraint-solver/issues/803).
 The graph family shifts *parameters*, which costs nothing.
 
-## Not implemented: F&S's pruning rules, and what certifying them would take
+## The pruning rules: implemented, certified, and expensive
 
-F&S's remaining `scc` rules — prune root, prune skip, fix required edges and prune
-within — with the evidence-node guard each one needs for `subcircuit`. Their
-explanation clauses are §5.3.2 of the paper, numbered 1 to 7 there and referred to
-by those numbers below.
+`with_prune_root()` and `with_prune_within()`, both off by default. Together they are
+Francis and Stuckey's remaining `scc` rules, and they cost between 1x and 95x the
+proof for at most a ten per cent reduction in search. They are here because they are
+*certifiable*, and a corpus of expensive-but-correct rules that a checker can be
+pointed at is worth having on its own account.
 
-They are stated over the **subtree structure of a depth-first traversal**: which
-subtree was visited before which, and the lowpoint of a node's first child. Our
-encoding knows nothing about that. `pos` is a *tour-order* labelling, not a DFS
-one, and it is pinned at exactly one place, `pos[anchor] = 0`.
+### Why the encoding takes them at all
 
-That sounds like an obstacle and mostly is not, because the DFS tree turns out to
-be how the propagator *finds* these inferences rather than why they hold. Working
-each clause back to what makes it true:
+F&S state the rules over the **subtree structure of a depth-first traversal**: which
+subtree was visited before which, and the lowpoint of a node's first child. This
+encoding knows nothing about that. `pos` is a *tour-order* labelling, not a DFS one,
+and it is pinned at exactly one place, `pos[anchor] = 0`.
 
-**Rules 1 and 5, and the conflict cases of 3 and 4, are already ours.** Rule 1 is
-a strongly connected sub-component `S` with an evidence node `a ∈ S`. Given an
-anchor there are only two cases and the walks cover both: if the anchor is in `S`
-then nothing outside `S` is forward-reachable from it, and if it is not, then `a`
-cannot reach the anchor. Rule 5 (an edge skipping subtrees) is the same argument
-over the partition its reason describes — with no `A → B ∪ C` and no `B → C`
-edges, whichever of the three sets holds the anchor leaves one of the other two
-unreachable in one direction or the other. The general shape is a **cut**: if
-`A` and `V \ A` both contain an evidence node and no edge crosses `A → V \ A`,
-then whichever side the anchor is on, the other side is stranded, so one of the
-two walks fires. That cut fact is what all of 2, 3, 4 and 5 rest on.
+That looked like the obstacle and mostly is not, because the DFS tree turns out to be
+how the propagator *finds* these inferences rather than why they hold. Working each of
+§5.3.2's seven explanation clauses back to what makes it true:
 
-**Prune root (rule 6) and prune within (rule 7) are strictly stronger than what we
-do, and both are the existing induction run under one assumed edge.** Prune root:
-assume `succ[anchor] = e`; if the last subtree is only reachable through the
-anchor, it is now unreachable, so its evidence node is forced off the tour, which
-contradicts the evidence literal. Prune within: assume `succ[p] = c`; the subtree
-at `c` then has no way back out, so the backward walk strands it, and `succ[p] = c`
-with `c` a self loop takes value `c` twice. Neither fires on the live domains,
-which is precisely why they add strength.
+**Rules 1 and 5, and the conflict cases of 3 and 4, were already ours.** They all rest
+on one cut fact: if both sides of a cut hold a node that must be on the tour and no
+edge crosses it, then whichever side the anchor is on, the other side is stranded ---
+and stranding is exactly what the two plain walks derive. Rule 1's component `S`
+either contains the anchor, in which case nothing outside it is forward-reachable, or
+does not, in which case its evidence node cannot reach the anchor.
 
-So, in this encoding, **prune root and prune within are singleton arc consistency
-(shaving) on the successor variables**, over the candidates a DFS pass identifies
-cheaply.
+**Prune root (rule 6) and prune within (rule 7) are strictly stronger, and both are
+the existing induction run under one assumed edge.** Assume `succ[p] = c`, run the
+reachability rules against the domains that leaves, and if a node that must be on the
+tour would be stranded in either direction, `c` is not a value `succ[p]` can take.
+Neither fires on the live domains --- while a successor is still free the anchor
+reaches everything any of its values reaches --- which is precisely why they add
+strength and why they cost a walk per candidate.
 
-### This was probed rather than argued
+So in this encoding **the two rules are singleton arc consistency (shaving) on the
+successor variables**, and both are one function, `shave_by_reachability`, with the two
+flags selecting which nodes it runs over: prune root the anchor, prune within
+everything else. Splitting them at the anchor keeps them non-overlapping.
 
-`~/claude/tmp/788-subcircuit-step0/prune_root_probe.cc`: six nodes, anchor 0 with
-candidates `{1, 4}`, a strongly connected `{1,2,3}` with no edge to `{4,5}`, and
-node 4 required on the tour and reachable only through `0 -> 4`. Every successor in
-`{1,2,3}` keeps two values under the hypothesis, so all-different fixes nothing and
-no cycle closes, which is what stops `check` and `prevent` getting there first.
+### What the certificates needed: nothing new
 
-* Free, it is satisfiable and `scc` infers enough to find the solution without
-  search (1 recursion, against `prevent`'s 5).
-* With `succ[0] = 1` posted after the constraint — so the declared domain, and
-  hence the encoding, is untouched — `scc` reaches the contradiction at the root
-  (1 recursion; `prevent` needs 3), and the proof **verifies**:
-  `s VERIFIED UNSATISFIABLE`.
-* Swapping `derive_unreachable` for a plain `JustifyUsingRUP` makes VeriPB
-  **reject** it, at `.pbp:95`. So the induction is doing the work, not unit
-  propagation.
+No new row family, no new proof-only variable, and no new cutting-planes step. Three
+small pieces of mechanism:
 
-**The existing certificate therefore survives being run under a hypothesis, with
-no new row family, no new proof-only variable and no new cutting-planes step.**
-That is the substantive finding: for these two rules the proof-logging question is
-already answered, and the work is propagator work.
+* **`AssumedEdge`**, and walks that take one. Carried as data rather than read back out
+  of the `State`, because the walk's result and the justification that reproduces it
+  must be over the same edge set --- and a justification may read only the reason and
+  the model, never the live state, which by then has moved on.
+* **The hypothesis as a guard.** Every row the induction emits picks up
+  `succ[from] != to` as an extra disjunct, so it says "*if* that edge is taken, then x
+  at position t is off the tour", and the conclusion drawn from such a chain is not "x
+  is off the tour" but "that edge is not taken". One extra literal per row. The
+  alternative --- emitting the chain at a proof level deleted once the conclusion is
+  drawn --- saves those literals and costs the level discipline; the guard was chosen
+  because it cannot be got subtly wrong.
+* **Candidates snapshotted** before the loop infers anything. Judging each against the
+  domains the pass started from is sound and not merely convenient: a walk only ever
+  uses the *absence* of a value to rule a neighbour out, so a domain that has since
+  lost more values makes the reason a stronger premise, not a weaker one.
 
-### The four things that would actually be hard
+Both mutation probes are caught by `subcircuit_prune_root_test`: dropping the guard,
+and replacing the induction with a plain `JustifyUsingRUP`.
 
-1. **Proof size, which is the binding constraint.** The induction emits one row
-   per (layer, unreached node), `O(n²)` rows per inference. Once per candidate
-   value of a successor makes it `O(n³)` rows per propagator call. The real
-   15-house instance already writes a 186 MB `.pbp` with the walks firing once;
-   measure before building.
-2. **Forced edges: shave, do not derive the cut row.** Rules 2 and 3 conclude
-   `succ[c] = b`. Two routes. Shaving gives it as a by-product — remove every
-   other candidate, and the variable's own at-least-one row unit-propagates the
-   survivor — at one induction per candidate, each carrying **one** extra guard
-   literal, so `O(n³)` literals to shave a variable. Deriving the cut row
-   `Σ_{i∈A, j∉A} [succ[i] = j] ≥ 1` instead needs one induction, but every row of
-   it carries the whole crossing set as guards: `O(n²)` guards on `O(n²)` rows,
-   `O(n⁴)` literals. Fine at `n = 15`, hopeless at competitive `n`. The cheaper
-   route is the one that looks more wasteful.
-3. **Where the hypothesis lives.** The `E(t, x)` rows are derived under an assumed
-   edge, so either they carry that literal as a guard (sound, one literal longer
-   per row) or they are emitted at a level deleted once the conclusion is drawn
-   (shorter, needs the level discipline to be right). Worth deciding before
-   writing any of it.
-4. **The one case genuinely out of reach: rule 1 with no anchor.** F&S guard it
-   with `in(a)` alone and need no root. Our induction has to start somewhere, and
-   `pos` is pinned only at the anchor; for an arbitrary component the layers would
-   have to be indexed relative to `pos[a]`, which is unknown. This is the one
-   place the "arbitrary root" position-offset problem --- argued on
-   [#788](https://github.com/ciaranm/glasgow-constraint-solver/issues/788) to be no
-   blocker, correctly, for the arm as it stands --- is real — and it is unreachable for us anyway, since the arm does nothing without
-   an anchor.
+### The cost, measured
+
+One random instance per `n` (the same one across configs), complete enumeration with
+proofs on, VeriPB 3.0.2. Harness `costcurve.cc` + `curve.sh` in
+`~/claude/tmp/788-subcircuit-step0/`.
+
+| n | recursions (scc / +root / +within) | `.pbp` scc | +prune_root | +prune_within | verify scc → +within |
+|---|---|---|---|---|---|
+| 6 | 16 / 16 / 17 | 11 KB | 1.0x | **13.1x** | 0.10 → 0.11 s |
+| 7 | 119 / 119 / 117 | 139 KB | 1.5x | **15.4x** | 0.11 → 0.10 s |
+| 8 | 492 / 492 / 478 | 212 KB | 1.0x | **51.6x** | 0.11 → 0.51 s |
+| 9 | 1281 / 1281 / 1199 | 586 KB | 1.6x | **72.2x** | 0.21 → 2.11 s |
+| 10 | 8057 / 8057 / 7461 | 4.3 MB | 1.0x | **94.9x** | 1.71 → 24.3 s |
+| 11 | 25469 / 25420 / 22846 | 72.9 MB | 1.7x | **25.5x** | 12.8 → 108 s |
+| 12 | 104134 / 104044 / — | 73.0 MB | 3.7x | *abandoned* | 93.1 s → — |
+
+**Every proof verified**, up to and including the 1.86 GB one at `n = 11`. That is the
+result worth having: the rules are checkable, at every size the checking is affordable
+at all.
+
+Read the multiplier column carefully. It is not monotone --- 95x at `n = 10` and 25x at
+`n = 11` --- because the denominator moves too: `scc`'s own proof jumps 17x between
+those sizes as its search grows. The absolute figures are the honest ones.
+
+At `n = 12` prune within passed **10.8 GB** of `.pbp` before being abandoned, which on
+this machine means it does not fit: the scratchpad is a 16 GB tmpfs and therefore
+*shares the guest's RAM*. Complete enumeration with prune within has a practical
+ceiling somewhere around `n = 11`.
+
+And what it buys: **at most ten per cent fewer search nodes** (8057 → 7461, 25469 →
+22846, 1281 → 1199), and for prune root essentially nothing at all (104134 → 104044).
+Which is consistent with everything else measured on this arm --- the node reduction
+where it is measurable at all is 1.09x to 1.38x --- and is the argument for treating
+the proof-size constant as the thing to attack rather than the propagator.
+
+### What is still hard, and what is not
+
+1. **Proof size is the whole problem.** `O(n²)` rows per inference, `O(n³)` per call
+   for prune root and `O(n^4)` for prune within. The table above is that constant.
+2. **Forced edges come out of shaving**, which is the cheap route even though it looks
+   the wasteful one. Rules 2 and 3 conclude `succ[c] = b`; shaving yields it as a
+   by-product once every other candidate is gone, at one induction per candidate each
+   carrying **one** guard literal. Deriving the cut row
+   `Σ_{i∈A, j∉A} [succ[i] = j] ≥ 1` instead needs one induction, but every row of it
+   carries the whole crossing set as guards: `O(n²)` guards on `O(n²)` rows against
+   `O(n³)` literals for the shave. Nothing here derives a cut row.
+3. **Rule 1 with no anchor is still out of reach.** F&S guard it with `in(a)` alone and
+   need no root; this induction has to start somewhere, and `pos` is pinned only at the
+   anchor, so an arbitrary component would need layers indexed relative to the unknown
+   `pos[a]`. It is the one place the "arbitrary root" position-offset problem is real
+   --- and unreachable for us anyway, since the arm does nothing without an anchor.
+4. **A constant in the successor array breaks the certificate**, which is
+   [issue #812](https://github.com/ciaranm/glasgow-constraint-solver/issues/812) and
+   not these rules' fault: the pigeonhole sums "this variable takes at least one value"
+   over every successor and that is `UnimplementedException` for a constant. Every
+   `mario` instance has one, because its `succ[LuigiHouse] = MarioHouse` pin folds into
+   the array as a literal --- so the one thing that gives the arm an anchor is the one
+   thing that stops it writing a proof, and the cost table above is measured on
+   constant-free instances for that reason.
 
 ### A sign error in the paper, for whoever implements from it
 

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -783,6 +783,10 @@ if(GCS_BUILD_TESTS)
     target_link_libraries(subcircuit_prune_root_test PRIVATE glasgow_constraint_solver)
     add_test(NAME subcircuit_prune_root COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:subcircuit_prune_root_test>)
 
+    add_executable(subcircuit_prune_within_test constraints/circuit/subcircuit_prune_within_test.cc)
+    target_link_libraries(subcircuit_prune_within_test PRIVATE glasgow_constraint_solver)
+    add_test(NAME subcircuit_prune_within COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:subcircuit_prune_within_test>)
+
     add_executable(subcircuit_scc_reaches_anchor_test constraints/circuit/subcircuit_scc_reaches_anchor_test.cc)
     target_link_libraries(subcircuit_scc_reaches_anchor_test PRIVATE glasgow_constraint_solver)
     add_test(NAME subcircuit_scc_reaches_anchor COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:subcircuit_scc_reaches_anchor_test>)

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -779,6 +779,10 @@ if(GCS_BUILD_TESTS)
     add_test(NAME subcircuit_scc COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:subcircuit_scc_test>)
     add_view_tests(subcircuit_scc subcircuit_scc_test 12)
 
+    add_executable(subcircuit_prune_root_test constraints/circuit/subcircuit_prune_root_test.cc)
+    target_link_libraries(subcircuit_prune_root_test PRIVATE glasgow_constraint_solver)
+    add_test(NAME subcircuit_prune_root COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:subcircuit_prune_root_test>)
+
     add_executable(subcircuit_scc_reaches_anchor_test constraints/circuit/subcircuit_scc_reaches_anchor_test.cc)
     target_link_libraries(subcircuit_scc_reaches_anchor_test PRIVATE glasgow_constraint_solver)
     add_test(NAME subcircuit_scc_reaches_anchor COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:subcircuit_scc_reaches_anchor_test>)

--- a/gcs/constraints/circuit/subcircuit.cc
+++ b/gcs/constraints/circuit/subcircuit.cc
@@ -290,6 +290,37 @@ namespace
             force_undecided(true);
     }
 
+    // An edge assumed present, for a walk that is asking "what would follow if this were
+    // the edge taken?" rather than "what follows from the domains as they are". Francis and
+    // Stuckey's prune root and prune within are both that question, and answering it is the
+    // whole of what those rules need beyond the two plain walks: neither fires on the live
+    // domains, which is exactly why they add strength.
+    //
+    // Carried as data rather than being read back out of the State, because the walk's
+    // result and the justification that reproduces it have to be over the *same* edge set,
+    // and a justification may only read the reason and the model -- never the live state,
+    // which by the time it runs has moved on.
+    struct AssumedEdge final
+    {
+        size_t from;
+        long long to;
+    };
+
+    // The values `succ[i]` may take for the purposes of a walk: its domain, or just the
+    // assumed value where the assumption is about `i`.
+    auto walkable_values(const vector<IntegerVariableID> & succ, const State & state, const optional<AssumedEdge> & assumed, const size_t i)
+        -> vector<long long>
+    {
+        vector<long long> values;
+        if (assumed && assumed->from == i) {
+            values.emplace_back(assumed->to);
+            return values;
+        }
+        for (const auto & v : state.each_value_immutable(succ[i]))
+            values.emplace_back(v.raw_value);
+        return values;
+    }
+
     // Everything on the tour is reachable from the anchor, because the tour is one cycle
     // through it. So anything the anchor cannot reach has to opt out. This is the
     // connectivity core of Francis and Stuckey's `scc`, and their observation that this
@@ -299,7 +330,8 @@ namespace
     // Self loops are not tour edges -- a node pointing at itself is off the tour -- so they
     // are not followed, which is the same care F&S call for: "self-cycle edges must be
     // handled carefully... ignored when finding the children of a node".
-    auto reachable_layers(const vector<IntegerVariableID> & succ, const long anchor, const State & state) -> vector<vector<bool>>
+    auto reachable_layers(const vector<IntegerVariableID> & succ, const long anchor, const State & state,
+        const optional<AssumedEdge> & assumed = nullopt) -> vector<vector<bool>>
     {
         auto n = succ.size();
         // layers[t][x]: x is reachable from the anchor in at most t steps. The certificate
@@ -311,8 +343,8 @@ namespace
             for (size_t i = 0; i < n; ++i) {
                 if (! layers[t - 1][i])
                     continue;
-                for (const auto & v : state.each_value_immutable(succ[i])) {
-                    auto j = static_cast<size_t>(v.raw_value);
+                for (const auto & v : walkable_values(succ, state, assumed, i)) {
+                    auto j = static_cast<size_t>(v);
                     if (cmp_not_equal(j, i))
                         layers[t][j] = true;
                 }
@@ -330,7 +362,8 @@ namespace
     //
     // Self loops are not followed here either, and for the same reason: a node pointing at
     // itself is off the tour, so that is not a tour edge to travel along.
-    auto reaches_anchor(const vector<IntegerVariableID> & succ, const long anchor, const State & state) -> vector<bool>
+    auto reaches_anchor(const vector<IntegerVariableID> & succ, const long anchor, const State & state,
+        const optional<AssumedEdge> & assumed = nullopt) -> vector<bool>
     {
         auto n = succ.size();
 
@@ -339,8 +372,8 @@ namespace
         // walk them once per layer.
         auto backwards = vector<vector<size_t>>(n);
         for (size_t i = 0; i < n; ++i)
-            for (const auto & v : state.each_value_immutable(succ[i])) {
-                auto j = static_cast<size_t>(v.raw_value);
+            for (const auto & v : walkable_values(succ, state, assumed, i)) {
+                auto j = static_cast<size_t>(v);
                 if (cmp_not_equal(j, i))
                     backwards[j].emplace_back(i);
             }
@@ -458,11 +491,30 @@ namespace
     // while a plain JustifyUsingRUP in place of this function still gets rejected, so it is
     // these lemmas and not the arithmetic that is load-bearing. Dropping the pigeonhole
     // does make VeriPB reject.
+    //
+    // With an `assumed` edge the whole chain is conditional on it: every row picks up
+    // `succ[from] != to` as an extra disjunct, so it says "*if* that edge is taken, then x
+    // at position t is off the tour". The conclusion drawn from such a chain is therefore
+    // not "x is off the tour" but "that edge is not taken" -- which is what prune root and
+    // prune within conclude, and why they need no other machinery. One extra literal per
+    // row is the whole price; the alternative, emitting the chain at a proof level deleted
+    // once the conclusion is drawn, saves those literals and costs the level discipline.
     auto derive_unreachable(ProofLogger & logger, const vector<IntegerVariableID> & succ, const SubCircuitPosData & pos_data, SCCProofCache & cache,
-        const vector<vector<bool>> & reached_within, const ReasonLiterals & reason) -> void
+        const vector<vector<bool>> & reached_within, const ReasonLiterals & reason, const optional<AssumedEdge> & assumed = nullopt) -> void
     {
         auto n = succ.size();
-        logger.emit_proof_comment("everything on the tour is reachable from the anchor, one layer at a time");
+        if (assumed)
+            logger.emit_proof_comment("if this edge were taken, the anchor could not reach everything on the tour");
+        else
+            logger.emit_proof_comment("everything on the tour is reachable from the anchor, one layer at a time");
+
+        // The guard, or nothing. Written once rather than at each of the O(n^2) emission
+        // sites below.
+        auto guarded = [&](WPBSum sum) {
+            if (assumed)
+                sum += 1_i * ! (succ[assumed->from] == Integer{assumed->to});
+            return sum;
+        };
 
         for (size_t t = 0; t < n; ++t)
             for (size_t x = 0; x < n; ++x) {
@@ -493,14 +545,14 @@ namespace
                     if (cmp_equal(q, *pos_data.anchor))
                         continue;
 
-                    logger.emit_rup_proof_line_under_reason(
-                        reason, WPBSum{} + 1_i * ! at_t + 1_i * ! (succ[q] == Integer(static_cast<long long>(x))) >= 1_i, ProofLevel::Temporary);
+                    logger.emit_rup_proof_line_under_reason(reason,
+                        guarded(WPBSum{} + 1_i * ! at_t + 1_i * ! (succ[q] == Integer(static_cast<long long>(x)))) >= 1_i, ProofLevel::Temporary);
                 }
 
                 // E(t, x) itself, at ProofLevel::Current so that the next layer still has it:
                 // that is how the layers chain, and why nothing has to restate a layer.
                 logger.emit_rup_proof_line_under_reason(
-                    reason, WPBSum{} + 1_i * ! at_t + 1_i * (succ[x] == Integer(static_cast<long long>(x))) >= 1_i, ProofLevel::Current);
+                    reason, guarded(WPBSum{} + 1_i * ! at_t + 1_i * (succ[x] == Integer(static_cast<long long>(x)))) >= 1_i, ProofLevel::Current);
             }
     }
 
@@ -529,10 +581,19 @@ namespace
     // at-most-one of those is written down. So on an instance where both fire, this half is
     // very nearly free.
     auto derive_cannot_reach_anchor(ProofLogger & logger, const vector<IntegerVariableID> & succ, const SubCircuitPosData & pos_data,
-        const vector<bool> & reaches, const ReasonLiterals & reason) -> void
+        const vector<bool> & reaches, const ReasonLiterals & reason, const optional<AssumedEdge> & assumed = nullopt) -> void
     {
         auto n = static_cast<long long>(succ.size());
-        logger.emit_proof_comment("everything on the tour reaches the anchor, working down from the last position");
+        if (assumed)
+            logger.emit_proof_comment("if this edge were taken, something on the tour could not reach the anchor back");
+        else
+            logger.emit_proof_comment("everything on the tour reaches the anchor, working down from the last position");
+
+        auto guarded = [&](WPBSum sum) {
+            if (assumed)
+                sum += 1_i * ! (succ[assumed->from] == Integer{assumed->to});
+            return sum;
+        };
 
         for (auto t = n - 1; t >= 0; --t)
             for (long long x = 0; x < n; ++x) {
@@ -549,18 +610,82 @@ namespace
                     if (y == x || reaches[static_cast<size_t>(y)])
                         continue;
 
-                    logger.emit_rup_proof_line_under_reason(
-                        reason, WPBSum{} + 1_i * ! at_t + 1_i * ! (succ[static_cast<size_t>(x)] == Integer{y}) >= 1_i, ProofLevel::Temporary);
+                    logger.emit_rup_proof_line_under_reason(reason,
+                        guarded(WPBSum{} + 1_i * ! at_t + 1_i * ! (succ[static_cast<size_t>(x)] == Integer{y})) >= 1_i, ProofLevel::Temporary);
                 }
 
                 // G(t, x) itself, at ProofLevel::Current so the layer below still has it.
                 logger.emit_rup_proof_line_under_reason(
-                    reason, WPBSum{} + 1_i * ! at_t + 1_i * (succ[static_cast<size_t>(x)] == Integer{x}) >= 1_i, ProofLevel::Current);
+                    reason, guarded(WPBSum{} + 1_i * ! at_t + 1_i * (succ[static_cast<size_t>(x)] == Integer{x})) >= 1_i, ProofLevel::Current);
             }
     }
 
+    // Prune root. For each value the anchor's successor could still take, ask what the
+    // reachability rule would say if it took that one; if the answer is that some node
+    // which must be on the tour could not be reached, the value goes.
+    //
+    // The evidence node is F&S's: a node whose own index has been removed from its
+    // successor's domain must be on the tour, so it cannot be one of the nodes the walk
+    // has just declared unreachable. Any such node will do and the lowest-numbered one is
+    // taken, matching how the anchor itself is chosen; F&S report a slightly better rule
+    // ("fixed highest in the search tree") which is a knob for once something measures it.
+    auto prune_anchor_successor(const vector<IntegerVariableID> & succ, const ConstraintID & owner, const SubCircuitPosData & pos_data,
+        const long anchor, SCCProofCache & cache, const State & state, auto & inference, ProofLogger * const logger) -> void
+    {
+        auto n = succ.size();
+        auto anchor_index = static_cast<size_t>(anchor);
+
+        // Snapshot the candidates before inferring anything, since the loop narrows this
+        // very domain as it goes. Judging each candidate against the domains the pass
+        // started from is sound and not merely convenient: the walk only ever uses
+        // *absence* of values to rule a predecessor out, so a domain that has since lost
+        // more values makes the reason a stronger premise, not a weaker one, and every row
+        // the certificate emits stays derivable from it.
+        vector<long long> candidates;
+        for (const auto & v : state.each_value_immutable(succ[anchor_index]))
+            candidates.emplace_back(v.raw_value);
+
+        for (const auto & v : candidates) {
+            // The anchor is on the tour, so its own index is not a value it can take, and
+            // a walk assuming otherwise would be assuming a contradiction. The declared
+            // domain has ruled it out already -- that is what made this node the anchor --
+            // but a caller-named one need not have, so check rather than assume.
+            if (v == anchor)
+                continue;
+
+            auto assumed = AssumedEdge{anchor_index, v};
+            auto layers = reachable_layers(succ, anchor, state, assumed);
+
+            // The evidence node: unreachable under the assumption, and required on the
+            // tour, so the assumption cannot hold.
+            optional<size_t> evidence;
+            for (size_t m = 0; m < n; ++m) {
+                if (layers.back()[m])
+                    continue;
+                auto here = Integer(static_cast<long long>(m));
+                if (! state.in_domain(succ[m], here)) {
+                    evidence = m;
+                    break;
+                }
+            }
+
+            if (! evidence)
+                continue;
+
+            auto justf = [&](const ReasonLiterals & reason) {
+                logger->emit_proof_comment("prune root: the anchor cannot take this successor");
+                derive_unreachable(*logger, succ, pos_data, cache, layers, reason, assumed);
+            };
+            // The throwing path: there is no _or_stop taking an explicit justification, and
+            // a contradiction here -- the anchor left with no successor at all -- ends the
+            // pass by unwinding, which is what most of this file already does.
+            inference.infer(
+                logger, succ[anchor_index] != Integer{v}, JustifyExplicitly{justf, ThenRUP::Yes, hints::SubCircuit{owner}}, generic_reason(succ));
+        }
+    }
+
     auto propagate_subcircuit(const vector<IntegerVariableID> & succ, const ConstraintID & owner, const SubCircuitPosData & pos_data,
-        const ConstraintStateHandle & unassigned_handle, const bool prevent, const optional<long> & scc_anchor,
+        const ConstraintStateHandle & unassigned_handle, const bool prevent, const optional<long> & scc_anchor, const bool prune_root,
         const std::shared_ptr<SCCProofCache> & cache, const State & state, auto & inference, ProofLogger * const logger) -> void
     {
         if (! propagate_non_gac_alldifferent(unassigned_handle, state, inference, logger, owner))
@@ -633,6 +758,21 @@ namespace
                 auto justf = [&](const ReasonLiterals & reason) { derive_cannot_reach_anchor(*logger, succ, pos_data, reaches, reason); };
                 inference.infer_all(logger, stranded, JustifyExplicitly{justf, ThenRUP::Yes, hints::SubCircuit{owner}}, generic_reason(succ));
             }
+
+            // Francis and Stuckey's prune root (their rule 3, explanation clause 6): the
+            // anchor has one successor, and if taking a particular one would leave a node
+            // that must be on the tour unreachable, it is not the one. Their version reads
+            // the condition off the depth-first traversal -- an edge into any subtree but
+            // the last -- which is a cheap sufficient condition for the same thing; this
+            // asks the question directly of every candidate value, so it prunes at least as
+            // much, and needs no traversal.
+            //
+            // The plain walk above cannot find any of this. With the anchor's successor
+            // still free the anchor reaches everything any of its candidates reaches, so
+            // there is nothing unreachable to report. That is the whole reason this rule
+            // adds strength, and the whole reason it costs a walk per candidate.
+            if (prune_root)
+                prune_anchor_successor(succ, owner, pos_data, *scc_anchor, *cache, state, inference, logger);
         }
 
         if (! prevent)
@@ -696,6 +836,12 @@ auto SubCircuit::with_required_node(long node) -> SubCircuit &
     if (node < 0 || cmp_greater_equal(node, _succ.size()))
         throw InvalidProblemDefinitionException{"SubCircuit: with_required_node() names a node outside the successor array"};
     _required_node = node;
+    return *this;
+}
+
+auto SubCircuit::with_prune_root(optional<bool> enable) -> SubCircuit &
+{
+    _prune_root = enable.value_or(true);
     return *this;
 }
 
@@ -927,8 +1073,8 @@ auto SubCircuit::install_propagators(Propagators & propagators) -> void
     propagators.install(
         constraint_id(),
         [succ = _succ, owner = constraint_id(), pos_data = std::move(_pos_data), unassigned_handle = _state_handles.unassigned, prevent, scc_anchor,
-            cache](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
-            propagate_subcircuit(succ, owner, pos_data, unassigned_handle, prevent, scc_anchor, cache, state, inference, logger);
+            prune_root = _prune_root, cache](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+            propagate_subcircuit(succ, owner, pos_data, unassigned_handle, prevent, scc_anchor, prune_root, cache, state, inference, logger);
             // Deliberately not claiming idempotence, unlike circuit::Prevent: forcing a
             // node to be a self loop fixes a successor, which changes the chain structure
             // this pass walked, and one pass makes no attempt to reach the fixpoint of
@@ -946,6 +1092,8 @@ auto SubCircuit::clone() const -> unique_ptr<Constraint>
     cloned->with_gac_all_different(_gac_all_different);
     if (_tour_size)
         cloned->with_tour_size(*_tour_size);
+    if (_prune_root)
+        cloned->with_prune_root();
     if (_required_node)
         cloned->with_required_node(*_required_node);
     return cloned;

--- a/gcs/constraints/circuit/subcircuit.cc
+++ b/gcs/constraints/circuit/subcircuit.cc
@@ -620,73 +620,97 @@ namespace
             }
     }
 
-    // Prune root. For each value the anchor's successor could still take, ask what the
-    // reachability rule would say if it took that one; if the answer is that some node
-    // which must be on the tour could not be reached, the value goes.
+    // The shave behind both of Francis and Stuckey's remaining pruning rules. For a node
+    // and a value it could still take, ask what the reachability rules would say if it took
+    // that one; if the answer is that some node which must be on the tour could not be
+    // reached from the anchor, or could not reach it back, then that is not the value.
+    //
+    // Prune root is this over the anchor alone (F&S rule 3, explanation 6) and prune within
+    // is it over every other node (rule 4, explanation 7). Their versions read the
+    // condition off the depth-first traversal they are already doing --- an edge into any
+    // subtree but the last; a first child whose exploration never gets above its parent ---
+    // which are cheap sufficient conditions for the same thing. Asking the question
+    // directly of each value prunes at least as much and needs no traversal, at the cost of
+    // a walk per candidate.
+    //
+    // Neither rule can be found by the plain walks, which is the whole point of having
+    // them: while a successor is still free, the anchor reaches everything any of that
+    // successor's values reaches, so there is nothing to report.
     //
     // The evidence node is F&S's: a node whose own index has been removed from its
-    // successor's domain must be on the tour, so it cannot be one of the nodes the walk
-    // has just declared unreachable. Any such node will do and the lowest-numbered one is
-    // taken, matching how the anchor itself is chosen; F&S report a slightly better rule
-    // ("fixed highest in the search tree") which is a knob for once something measures it.
-    auto prune_anchor_successor(const vector<IntegerVariableID> & succ, const ConstraintID & owner, const SubCircuitPosData & pos_data,
-        const long anchor, SCCProofCache & cache, const State & state, auto & inference, ProofLogger * const logger) -> void
+    // successor's domain must be on the tour, so it cannot be one of the nodes a walk has
+    // just declared stranded. Any such node will do, and the lowest-numbered one is taken,
+    // matching how the anchor itself is chosen; F&S report a slightly better rule ("fixed
+    // highest in the search tree") which is a knob for once something measures it here.
+    auto shave_by_reachability(const vector<IntegerVariableID> & succ, const ConstraintID & owner, const SubCircuitPosData & pos_data,
+        const long anchor, SCCProofCache & cache, const State & state, auto & inference, ProofLogger * const logger, const size_t node) -> void
     {
         auto n = succ.size();
-        auto anchor_index = static_cast<size_t>(anchor);
 
         // Snapshot the candidates before inferring anything, since the loop narrows this
         // very domain as it goes. Judging each candidate against the domains the pass
-        // started from is sound and not merely convenient: the walk only ever uses
-        // *absence* of values to rule a predecessor out, so a domain that has since lost
+        // started from is sound and not merely convenient: a walk only ever uses the
+        // *absence* of a value to rule a neighbour out, so a domain that has since lost
         // more values makes the reason a stronger premise, not a weaker one, and every row
         // the certificate emits stays derivable from it.
         vector<long long> candidates;
-        for (const auto & v : state.each_value_immutable(succ[anchor_index]))
+        for (const auto & v : state.each_value_immutable(succ[node]))
             candidates.emplace_back(v.raw_value);
 
+        // The lowest-numbered node that must be on the tour and is not in `may_be_on_tour`,
+        // or nothing.
+        auto stranded_evidence = [&](const vector<bool> & may_be_on_tour) -> optional<size_t> {
+            for (size_t m = 0; m < n; ++m) {
+                if (may_be_on_tour[m])
+                    continue;
+                if (! state.in_domain(succ[m], Integer(static_cast<long long>(m))))
+                    return m;
+            }
+            return nullopt;
+        };
+
         for (const auto & v : candidates) {
-            // The anchor is on the tour, so its own index is not a value it can take, and
-            // a walk assuming otherwise would be assuming a contradiction. The declared
-            // domain has ruled it out already -- that is what made this node the anchor --
-            // but a caller-named one need not have, so check rather than assume.
-            if (v == anchor)
+            // A node pointing at itself is off the tour, which is not an edge into anything
+            // and not what either rule is about. The anchor cannot take its own index at
+            // all --- that is what made it the anchor --- but a caller-named one need not
+            // have had it removed, so this is a check and not an assumption.
+            if (cmp_equal(v, node))
                 continue;
 
-            auto assumed = AssumedEdge{anchor_index, v};
-            auto layers = reachable_layers(succ, anchor, state, assumed);
+            auto assumed = AssumedEdge{node, v};
 
-            // The evidence node: unreachable under the assumption, and required on the
-            // tour, so the assumption cannot hold.
-            optional<size_t> evidence;
-            for (size_t m = 0; m < n; ++m) {
-                if (layers.back()[m])
-                    continue;
-                auto here = Integer(static_cast<long long>(m));
-                if (! state.in_domain(succ[m], here)) {
-                    evidence = m;
-                    break;
-                }
+            // Forward first, since it is the cheaper certificate to be wrong about: if the
+            // assumed edge strands something the anchor must reach, say so and stop.
+            auto layers = reachable_layers(succ, anchor, state, assumed);
+            if (auto evidence = stranded_evidence(layers.back())) {
+                auto justf = [&](const ReasonLiterals & reason) {
+                    logger->emit_proof_comment("this edge would leave a node that must be on the tour unreachable");
+                    derive_unreachable(*logger, succ, pos_data, cache, layers, reason, assumed);
+                };
+                // The throwing path: there is no _or_stop taking an explicit justification,
+                // and a contradiction here --- this node left with no successor at all ---
+                // ends the pass by unwinding, as most of this file already does.
+                inference.infer(
+                    logger, succ[node] != Integer{v}, JustifyExplicitly{justf, ThenRUP::Yes, hints::SubCircuit{owner}}, generic_reason(succ));
+                continue;
             }
 
-            if (! evidence)
-                continue;
-
-            auto justf = [&](const ReasonLiterals & reason) {
-                logger->emit_proof_comment("prune root: the anchor cannot take this successor");
-                derive_unreachable(*logger, succ, pos_data, cache, layers, reason, assumed);
-            };
-            // The throwing path: there is no _or_stop taking an explicit justification, and
-            // a contradiction here -- the anchor left with no successor at all -- ends the
-            // pass by unwinding, which is what most of this file already does.
-            inference.infer(
-                logger, succ[anchor_index] != Integer{v}, JustifyExplicitly{justf, ThenRUP::Yes, hints::SubCircuit{owner}}, generic_reason(succ));
+            auto reaches = reaches_anchor(succ, anchor, state, assumed);
+            if (auto evidence = stranded_evidence(reaches)) {
+                auto justf = [&](const ReasonLiterals & reason) {
+                    logger->emit_proof_comment("this edge would leave a node that must be on the tour unable to reach the anchor");
+                    derive_cannot_reach_anchor(*logger, succ, pos_data, reaches, reason, assumed);
+                };
+                inference.infer(
+                    logger, succ[node] != Integer{v}, JustifyExplicitly{justf, ThenRUP::Yes, hints::SubCircuit{owner}}, generic_reason(succ));
+            }
         }
     }
 
     auto propagate_subcircuit(const vector<IntegerVariableID> & succ, const ConstraintID & owner, const SubCircuitPosData & pos_data,
         const ConstraintStateHandle & unassigned_handle, const bool prevent, const optional<long> & scc_anchor, const bool prune_root,
-        const std::shared_ptr<SCCProofCache> & cache, const State & state, auto & inference, ProofLogger * const logger) -> void
+        const bool prune_within, const std::shared_ptr<SCCProofCache> & cache, const State & state, auto & inference, ProofLogger * const logger)
+        -> void
     {
         if (! propagate_non_gac_alldifferent(unassigned_handle, state, inference, logger, owner))
             return;
@@ -772,7 +796,15 @@ namespace
             // there is nothing unreachable to report. That is the whole reason this rule
             // adds strength, and the whole reason it costs a walk per candidate.
             if (prune_root)
-                prune_anchor_successor(succ, owner, pos_data, *scc_anchor, *cache, state, inference, logger);
+                shave_by_reachability(succ, owner, pos_data, *scc_anchor, *cache, state, inference, logger, static_cast<size_t>(*scc_anchor));
+
+            // Prune within: the same question of every *other* node. Splitting the two
+            // rules at the anchor keeps them non-overlapping, so having both on does no
+            // work twice, and each flag maps to one of F&S's rules.
+            if (prune_within)
+                for (size_t node = 0; node < n; ++node)
+                    if (cmp_not_equal(node, *scc_anchor))
+                        shave_by_reachability(succ, owner, pos_data, *scc_anchor, *cache, state, inference, logger, node);
         }
 
         if (! prevent)
@@ -842,6 +874,12 @@ auto SubCircuit::with_required_node(long node) -> SubCircuit &
 auto SubCircuit::with_prune_root(optional<bool> enable) -> SubCircuit &
 {
     _prune_root = enable.value_or(true);
+    return *this;
+}
+
+auto SubCircuit::with_prune_within(optional<bool> enable) -> SubCircuit &
+{
+    _prune_within = enable.value_or(true);
     return *this;
 }
 
@@ -1073,8 +1111,10 @@ auto SubCircuit::install_propagators(Propagators & propagators) -> void
     propagators.install(
         constraint_id(),
         [succ = _succ, owner = constraint_id(), pos_data = std::move(_pos_data), unassigned_handle = _state_handles.unassigned, prevent, scc_anchor,
-            prune_root = _prune_root, cache](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
-            propagate_subcircuit(succ, owner, pos_data, unassigned_handle, prevent, scc_anchor, prune_root, cache, state, inference, logger);
+            prune_root = _prune_root, prune_within = _prune_within,
+            cache](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+            propagate_subcircuit(
+                succ, owner, pos_data, unassigned_handle, prevent, scc_anchor, prune_root, prune_within, cache, state, inference, logger);
             // Deliberately not claiming idempotence, unlike circuit::Prevent: forcing a
             // node to be a self loop fixes a successor, which changes the chain structure
             // this pass walked, and one pass makes no attempt to reach the fixpoint of
@@ -1094,6 +1134,8 @@ auto SubCircuit::clone() const -> unique_ptr<Constraint>
         cloned->with_tour_size(*_tour_size);
     if (_prune_root)
         cloned->with_prune_root();
+    if (_prune_within)
+        cloned->with_prune_within();
     if (_required_node)
         cloned->with_required_node(*_required_node);
     return cloned;

--- a/gcs/constraints/circuit/subcircuit.cc
+++ b/gcs/constraints/circuit/subcircuit.cc
@@ -306,19 +306,26 @@ namespace
         long long to;
     };
 
-    // The values `succ[i]` may take for the purposes of a walk: its domain, or just the
-    // assumed value where the assumption is about `i`.
-    auto walkable_values(const vector<IntegerVariableID> & succ, const State & state, const optional<AssumedEdge> & assumed, const size_t i)
-        -> vector<long long>
+    // Visit the values `succ[i]` may take for the purposes of a walk: its live domain, or
+    // just the assumed value where the assumption is about `i`.
+    //
+    // A visitor rather than a returned vector, and that is measured rather than taste. This
+    // is called from inside reachable_layers' `t` by `i` double loop, so materialising a
+    // vector is `O(n^2)` heap allocations per walk --- on the *plain* SCC path, whether or
+    // not either pruning rule is switched on. The vector version cost **1.15x** on an
+    // n = 18 enumeration (2423-2434 ms against 2110-2126) with `recursions` and
+    // `propagations` identical in both arms, so it was pure per-call overhead for a feature
+    // the run was not using. A template parameter and not a std::function: the whole point
+    // is to keep an indirect call out of this loop.
+    template <typename Visit_>
+    auto for_each_walkable_value(
+        const vector<IntegerVariableID> & succ, const State & state, const optional<AssumedEdge> & assumed, const size_t i, Visit_ && visit) -> void
     {
-        vector<long long> values;
-        if (assumed && assumed->from == i) {
-            values.emplace_back(assumed->to);
-            return values;
-        }
-        for (const auto & v : state.each_value_immutable(succ[i]))
-            values.emplace_back(v.raw_value);
-        return values;
+        if (assumed && assumed->from == i)
+            visit(assumed->to);
+        else
+            for (const auto & v : state.each_value_immutable(succ[i]))
+                visit(v.raw_value);
     }
 
     // Everything on the tour is reachable from the anchor, because the tour is one cycle
@@ -343,11 +350,11 @@ namespace
             for (size_t i = 0; i < n; ++i) {
                 if (! layers[t - 1][i])
                     continue;
-                for (const auto & v : walkable_values(succ, state, assumed, i)) {
+                for_each_walkable_value(succ, state, assumed, i, [&](long long v) {
                     auto j = static_cast<size_t>(v);
                     if (cmp_not_equal(j, i))
                         layers[t][j] = true;
-                }
+                });
             }
         }
         return layers;
@@ -372,11 +379,11 @@ namespace
         // walk them once per layer.
         auto backwards = vector<vector<size_t>>(n);
         for (size_t i = 0; i < n; ++i)
-            for (const auto & v : walkable_values(succ, state, assumed, i)) {
+            for_each_walkable_value(succ, state, assumed, i, [&](long long v) {
                 auto j = static_cast<size_t>(v);
                 if (cmp_not_equal(j, i))
                     backwards[j].emplace_back(i);
-            }
+            });
 
         auto reaches = vector<bool>(n, false);
         reaches[static_cast<size_t>(anchor)] = true;

--- a/gcs/constraints/circuit/subcircuit.hh
+++ b/gcs/constraints/circuit/subcircuit.hh
@@ -119,6 +119,7 @@ namespace gcs
         std::optional<IntegerVariableID> _tour_size;
         std::optional<long> _required_node;
         bool _prune_root = false;
+        bool _prune_within = false;
 
         // The node the position encoding is anchored on, settled by prepare(): what
         // with_required_node() named, or the lowest-numbered node whose declared domain
@@ -194,6 +195,22 @@ namespace gcs
         /// is not switched on in the hope of going faster. It is here because the rule is
         /// certifiable and worth having implemented and checkable.
         auto with_prune_root(std::optional<bool> enable = true) -> SubCircuit &;
+
+        /// Add Francis and Stuckey's *prune within* rule to subcircuit::SCC: ask the same
+        /// question with_prune_root() asks of the anchor's successor, of every other node's.
+        /// Off by default, and ignored without subcircuit::SCC.
+        ///
+        /// The two rules are split at the anchor so that they do not overlap: with both on,
+        /// every successor is shaved exactly once, and each flag maps to one of F&S's rules
+        /// (theirs is stated over a first child whose exploration never reaches above its
+        /// parent, which is a cheap sufficient condition for the assumed edge stranding
+        /// something).
+        ///
+        /// **This is the expensive one.** A reachability walk per node per candidate value
+        /// is `O(n^4)` work per propagator call, and each pruning writes another
+        /// `O(n^2)`-row induction. It is here to be correct and checkable, not to be fast;
+        /// see with_prune_root() for what the measurements say about that.
+        auto with_prune_within(std::optional<bool> enable = true) -> SubCircuit &;
 
         /// Constrain how many nodes are on the tour: `size` is the number that do not
         /// point at themselves. This is XCSP3's `size` argument, for which MiniZinc's

--- a/gcs/constraints/circuit/subcircuit.hh
+++ b/gcs/constraints/circuit/subcircuit.hh
@@ -118,6 +118,7 @@ namespace gcs
         bool _gac_all_different = false;
         std::optional<IntegerVariableID> _tour_size;
         std::optional<long> _required_node;
+        bool _prune_root = false;
 
         // The node the position encoding is anchored on, settled by prepare(): what
         // with_required_node() named, or the lowest-numbered node whose declared domain
@@ -173,6 +174,26 @@ namespace gcs
         /// is what the SCC propagation needs, which cannot infer anything at all until some
         /// node is known to be on the tour.
         auto with_required_node(long node) -> SubCircuit &;
+
+        /// Add Francis and Stuckey's *prune root* rule to subcircuit::SCC: try each value
+        /// the anchor's successor could take, and remove any that would leave a node which
+        /// must be on the tour unreachable from the anchor. Off by default, and ignored
+        /// without subcircuit::SCC, which it strengthens rather than replaces.
+        ///
+        /// This is singleton arc consistency on the anchor's successor with respect to the
+        /// reachability rule, which is at least what F&S's rule prunes: their condition ---
+        /// that the edge leads to a subtree earlier than the last --- is a sufficient
+        /// condition for the assumed edge stranding something, found cheaply from the
+        /// depth-first traversal they already have, where this tries every value.
+        ///
+        /// **It is expensive, and deliberately so.** One reachability walk per candidate
+        /// value, so `O(n^3)` work per propagator call against the plain rule's `O(n^2)`,
+        /// and the certificate is a fresh `O(n^2)`-row induction per pruning. Measured on
+        /// the MiniZinc Challenge `subcircuit` families the walk alone is already 87--98%
+        /// of all propagation time and the node reduction it buys is 1.09--1.38x, so this
+        /// is not switched on in the hope of going faster. It is here because the rule is
+        /// certifiable and worth having implemented and checkable.
+        auto with_prune_root(std::optional<bool> enable = true) -> SubCircuit &;
 
         /// Constrain how many nodes are on the tour: `size` is the number that do not
         /// point at themselves. This is XCSP3's `size` argument, for which MiniZinc's

--- a/gcs/constraints/circuit/subcircuit_prune_root_test.cc
+++ b/gcs/constraints/circuit/subcircuit_prune_root_test.cc
@@ -1,0 +1,147 @@
+#include <gcs/constraints/circuit.hh>
+#include <gcs/constraints/innards/constraints_test_utils.hh>
+#include <gcs/problem.hh>
+#include <gcs/solve.hh>
+
+#include <cstdlib>
+#include <iostream>
+#include <optional>
+#include <string>
+#include <vector>
+
+using namespace gcs;
+using namespace gcs::test_innards;
+
+using std::cout;
+using std::endl;
+using std::make_optional;
+using std::nullopt;
+using std::vector;
+
+// Francis and Stuckey's prune root, isolated. The scenario has to make the rule the *only*
+// route to its own conclusion, which rules out most of the obvious constructions:
+//
+//   * the plain forward walk must not get there, and that part is automatic. With the
+//     anchor's successor still free the anchor reaches everything any of its candidates
+//     reaches, so there is nothing unreachable to report --- which is exactly why the rule
+//     exists, and why it costs a walk per candidate.
+//   * the plain *backward* walk must not get there either, and that is the part needing
+//     care. An earlier version of this scenario gave a component just one edge back to the
+//     anchor, and all-different went on to remove that value; the backward walk then
+//     stranded the whole component by itself and reached the same conclusion for free. So
+//     every component here has two edges back to the anchor.
+//   * `check` and `prevent` must not get there, which means nothing may become fixed: one
+//     fixed successor cascades through all-different, a cycle closes, and a closed cycle
+//     forces everyone outside it off the tour. So no domain here is a singleton.
+//
+// Seven nodes. The anchor is node 0, its own index left out of its domain, so it is
+// declared on the tour; its two candidate values are the two components it could enter.
+// Neither component has an edge to the other, and both have two edges back to node 0.
+// Node 4's own index is left out too, so node 4 must be on the tour as well --- and its
+// component is reachable only through the edge 0 -> 4.
+//
+// So assuming 0 -> 1 leaves node 4 unreachable, and the value 1 has to go. Nothing else in
+// the model can tell the two candidates apart, which is what the root-state check below
+// pins down.
+//
+// The four subcircuits are 0 -> 4 -> 5 -> 0, 0 -> 4 -> 6 -> 0, 0 -> 4 -> 5 -> 6 -> 0 and
+// 0 -> 4 -> 6 -> 5 -> 0, with 1, 2 and 3 opting out of each.
+
+// The witness is not part of the scenario: it exists so that the root is a search node
+// rather than a solution, since the trace callback --- which is where the root state is
+// read --- fires only at nodes that are not already solutions. Two values, so the eight
+// solutions are the four subcircuits twice.
+auto build(Problem & p, IntegerVariableID & witness) -> vector<IntegerVariableID>
+{
+    witness = p.create_integer_variable(0_i, 1_i, "witness");
+
+    vector<IntegerVariableID> succ;
+    // Node 0: the anchor. 0 is not in its own domain, which is what declares it on the tour.
+    succ.push_back(p.create_integer_variable(vector<Integer>{1_i, 4_i}, "succ0"));
+    // {1,2,3}: no edge to the other component, and two edges back to the anchor (2 -> 0 and
+    // 3 -> 0) so that losing one does not strand the component.
+    succ.push_back(p.create_integer_variable(vector<Integer>{1_i, 2_i, 3_i}, "succ1"));
+    succ.push_back(p.create_integer_variable(vector<Integer>{0_i, 1_i, 2_i, 3_i}, "succ2"));
+    succ.push_back(p.create_integer_variable(vector<Integer>{0_i, 1_i, 2_i, 3_i}, "succ3"));
+    // {4,5,6}: likewise, and node 4 must be on the tour, its own index being left out. The
+    // component is reachable from the anchor only through 0 -> 4.
+    succ.push_back(p.create_integer_variable(vector<Integer>{5_i, 6_i}, "succ4"));
+    succ.push_back(p.create_integer_variable(vector<Integer>{0_i, 4_i, 5_i, 6_i}, "succ5"));
+    succ.push_back(p.create_integer_variable(vector<Integer>{0_i, 4_i, 5_i, 6_i}, "succ6"));
+    return succ;
+}
+
+// Returns the number of solutions, and reports through `anchor_values_at_root` how many
+// values the anchor's successor still had after the root propagation. That is where the two
+// configurations differ crisply, and asserting on it rather than on a recursion count is
+// what stops a rule that infers nothing from passing.
+auto run(bool prune_root, const std::string & label, long & anchor_values_at_root) -> long
+{
+    Problem p;
+    IntegerVariableID witness{ConstantIntegerVariableID{0_i}};
+    auto succ = build(p, witness);
+    auto constraint = SubCircuit{succ}.with_algorithm(subcircuit::SCC{});
+    if (prune_root)
+        constraint.with_prune_root();
+    p.post(std::move(constraint));
+
+    auto proofs = can_run_veripb();
+    auto proof_name = proofs ? make_optional("subcircuit_prune_root_test_" + label) : nullopt;
+
+    long found = 0;
+    auto seen_root = false;
+    anchor_values_at_root = 0;
+    auto stats = solve_with(p, //
+        SolveCallbacks{        //
+            .solution = [&](const CurrentState &) -> bool {
+                ++found;
+                return true;
+            },
+            .trace = [&](const CurrentState & s) -> bool {
+                if (! seen_root) {
+                    seen_root = true;
+                    anchor_values_at_root = s.domain_size(succ[0]).raw_value;
+                }
+                return true;
+            }},
+        proof_name ? make_optional<ProofOptions>(*proof_name) : nullopt);
+
+    cout << label << ": " << found << " solutions, " << stats.recursions << " recursions, anchor successor had " << anchor_values_at_root
+         << " values at the root" << endl;
+
+    if (proof_name && ! verify_proof_and_dispose(*proof_name))
+        return -1;
+
+    return found;
+}
+
+auto main(int argc, char * argv[]) -> int
+{
+    establish_and_announce_seed(argc, argv);
+
+    long plain_at_root = 0, pruned_at_root = 0;
+    auto plain = run(false, "scc", plain_at_root);
+    auto pruned = run(true, "scc_prune_root", pruned_at_root);
+
+    // Same solution set: the rule strengthens an inference, not the constraint. Eight,
+    // being the four subcircuits times the witness's two values.
+    if (plain != 8 || pruned != 8) {
+        cout << "expected eight solutions from each, got " << plain << " and " << pruned << endl;
+        return EXIT_FAILURE;
+    }
+
+    // And it did something. Without the rule the anchor keeps both candidates at the root,
+    // because nothing else in the model can tell them apart; with it, the one that strands
+    // node 4 is gone and the successor is fixed.
+    if (plain_at_root != 2) {
+        cout << "expected the plain walk to leave the anchor both candidates at the root, got " << plain_at_root << endl;
+        return EXIT_FAILURE;
+    }
+
+    if (pruned_at_root != 1) {
+        cout << "expected prune root to fix the anchor's successor at the root, got " << pruned_at_root << " values" << endl;
+        return EXIT_FAILURE;
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/gcs/constraints/circuit/subcircuit_prune_within_test.cc
+++ b/gcs/constraints/circuit/subcircuit_prune_within_test.cc
@@ -1,0 +1,137 @@
+#include <gcs/constraints/circuit.hh>
+#include <gcs/constraints/innards/constraints_test_utils.hh>
+#include <gcs/problem.hh>
+#include <gcs/solve.hh>
+
+#include <cstdlib>
+#include <iostream>
+#include <optional>
+#include <string>
+#include <vector>
+
+using namespace gcs;
+using namespace gcs::test_innards;
+
+using std::cout;
+using std::endl;
+using std::make_optional;
+using std::nullopt;
+using std::vector;
+
+// Francis and Stuckey's prune within, isolated: the same shave prune root does, over a node
+// that is not the anchor.
+//
+// Unlike the prune root scenario, this instance was *found* rather than built. Hand-building
+// one kept producing structures that were unsatisfiable instead: the rule wants a component
+// whose only way back to the anchor is through the node being shaved, and saying that in a
+// domain tends to say at the same time that no tour exists at all. So a generator drew
+// random domains over seven nodes and kept the first one where prune within shrinks a root
+// domain, the plain walks and prune root do not, and there is a real solution set --- which
+// is also why nothing here is symmetric or tidy.
+//
+// Nodes 0 and 1 have their own indices left out, so both must be on the tour and node 0 is
+// the anchor. What prune within finds is that two of the seven values node 2's successor
+// could take would strand something: it goes from seven values to five at the root, and
+// neither the plain walk nor prune root touches it.
+//
+// Both certificate directions fire here, which the prune root scenario did not exercise:
+// ten of the prunings come from the forward walk and six from the backward one.
+auto build(Problem & p, IntegerVariableID & witness) -> vector<IntegerVariableID>
+{
+    // As in the prune root test, the witness only exists so that the root is a search node
+    // rather than a solution, since that is where the trace callback reads the root state.
+    witness = p.create_integer_variable(0_i, 1_i, "witness");
+
+    vector<IntegerVariableID> succ;
+    succ.push_back(p.create_integer_variable(vector<Integer>{2_i, 3_i, 6_i}, "succ0"));
+    succ.push_back(p.create_integer_variable(vector<Integer>{2_i, 4_i}, "succ1"));
+    succ.push_back(p.create_integer_variable(vector<Integer>{0_i, 1_i, 2_i, 3_i, 4_i, 5_i, 6_i}, "succ2"));
+    succ.push_back(p.create_integer_variable(vector<Integer>{0_i, 4_i, 5_i}, "succ3"));
+    succ.push_back(p.create_integer_variable(vector<Integer>{2_i, 4_i}, "succ4"));
+    succ.push_back(p.create_integer_variable(vector<Integer>{0_i, 1_i, 3_i, 6_i}, "succ5"));
+    succ.push_back(p.create_integer_variable(vector<Integer>{0_i, 1_i, 3_i, 4_i}, "succ6"));
+    return succ;
+}
+
+// The node whose successor prune within shaves, and how many values it has at the root.
+constexpr std::size_t shaved_node = 2;
+
+auto run(bool prune_root, bool prune_within, const std::string & label, long & values_at_root) -> long
+{
+    Problem p;
+    IntegerVariableID witness{ConstantIntegerVariableID{0_i}};
+    auto succ = build(p, witness);
+    auto constraint = SubCircuit{succ}.with_algorithm(subcircuit::SCC{});
+    if (prune_root)
+        constraint.with_prune_root();
+    if (prune_within)
+        constraint.with_prune_within();
+    p.post(std::move(constraint));
+
+    auto proofs = can_run_veripb();
+    auto proof_name = proofs ? make_optional("subcircuit_prune_within_test_" + label) : nullopt;
+
+    long found = 0;
+    auto seen_root = false;
+    values_at_root = 0;
+    auto stats = solve_with(p, //
+        SolveCallbacks{        //
+            .solution = [&](const CurrentState &) -> bool {
+                ++found;
+                return true;
+            },
+            .trace = [&](const CurrentState & s) -> bool {
+                if (! seen_root) {
+                    seen_root = true;
+                    values_at_root = s.domain_size(succ[shaved_node]).raw_value;
+                }
+                return true;
+            }},
+        proof_name ? make_optional<ProofOptions>(*proof_name) : nullopt);
+
+    cout << label << ": " << found << " solutions, " << stats.recursions << " recursions, succ[" << shaved_node << "] had " << values_at_root
+         << " values at the root" << endl;
+
+    if (proof_name && ! verify_proof_and_dispose(*proof_name))
+        return -1;
+
+    return found;
+}
+
+auto main(int argc, char * argv[]) -> int
+{
+    establish_and_announce_seed(argc, argv);
+
+    long plain_at_root = 0, root_at_root = 0, within_at_root = 0;
+    auto plain = run(false, false, "scc", plain_at_root);
+    auto with_root = run(true, false, "scc_prune_root", root_at_root);
+    auto with_within = run(false, true, "scc_prune_within", within_at_root);
+
+    // The rules strengthen an inference, not the constraint, so all three enumerate the
+    // same set. Twenty, being the ten subcircuits times the witness's two values.
+    constexpr long expected = 20;
+    if (plain != expected || with_root != expected || with_within != expected) {
+        cout << "expected " << expected << " solutions from each, got " << plain << ", " << with_root << " and " << with_within << endl;
+        return EXIT_FAILURE;
+    }
+
+    if (plain_at_root != 7) {
+        cout << "expected the plain walk to leave succ[" << shaved_node << "] all seven values at the root, got " << plain_at_root << endl;
+        return EXIT_FAILURE;
+    }
+
+    // Prune root is over the anchor's successor only, and this is not the anchor, so it must
+    // leave this domain exactly as the plain walk did. That is what makes this test about
+    // prune within rather than about the shave in general.
+    if (root_at_root != plain_at_root) {
+        cout << "expected prune root to leave succ[" << shaved_node << "] alone, got " << root_at_root << " against " << plain_at_root << endl;
+        return EXIT_FAILURE;
+    }
+
+    if (within_at_root != 5) {
+        cout << "expected prune within to take succ[" << shaved_node << "] to five values at the root, got " << within_at_root << endl;
+        return EXIT_FAILURE;
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/gcs/constraints/circuit/subcircuit_test.cc
+++ b/gcs/constraints/circuit/subcircuit_test.cc
@@ -183,7 +183,8 @@ auto run_tour_size_test(bool proofs, int n, int size_lower, int size_upper) -> v
 // certificate instead of one per node of the cycle. Enumerated against the same reference
 // check, restricted to the solutions where the named node is on the tour, since that is the
 // precondition the caller has to have declared.
-auto run_anchored_test(bool proofs, int n, int anchor, SubCircuitAlgorithm algorithm, const std::string & label, bool name_the_anchor = true) -> void
+auto run_anchored_test(bool proofs, int n, int anchor, SubCircuitAlgorithm algorithm, const std::string & label, bool name_the_anchor = true,
+    bool prune_root = false) -> void
 {
     println(cerr, "subcircuit/anchored/{}{} n={} anchor={}{}", label, name_the_anchor ? "" : "/found", n, anchor, proofs ? " with proofs:" : ":");
 
@@ -211,6 +212,8 @@ auto run_anchored_test(bool proofs, int n, int anchor, SubCircuitAlgorithm algor
     auto constraint = SubCircuit{succ}.with_algorithm(algorithm);
     if (name_the_anchor)
         constraint.with_required_node(anchor);
+    if (prune_root)
+        constraint.with_prune_root();
     p.post(std::move(constraint));
 
     auto proof_name = proofs ? make_optional("subcircuit_test_anchored_" + label + (name_the_anchor ? "" : "_found")) : nullopt;
@@ -298,6 +301,13 @@ auto main(int argc, char * argv[]) -> int
                     // certified at every size too, not only asserted on at the root of one
                     // twelve-node instance.
                     run_anchored_test(proofs, n, anchor, subcircuit::SCC{}, "scc", false);
+                    // And with prune root on. It cannot change the solution set --- it is a
+                    // strengthening of an inference, not of the constraint --- so the same
+                    // expected set is the assertion, and its own certificate is verified
+                    // over the whole enumeration rather than only on the scenario that was
+                    // built to make it fire. A rule that inferred nothing would pass this,
+                    // which is what subcircuit_prune_root_test is for.
+                    run_anchored_test(proofs, n, anchor, subcircuit::SCC{}, "scc-prune-root", true, true);
                 }
             for (int n : {3, 4}) {
                 run_tour_size_test(proofs, n, 0, n);

--- a/gcs/constraints/circuit/subcircuit_test.cc
+++ b/gcs/constraints/circuit/subcircuit_test.cc
@@ -184,7 +184,7 @@ auto run_tour_size_test(bool proofs, int n, int size_lower, int size_upper) -> v
 // check, restricted to the solutions where the named node is on the tour, since that is the
 // precondition the caller has to have declared.
 auto run_anchored_test(bool proofs, int n, int anchor, SubCircuitAlgorithm algorithm, const std::string & label, bool name_the_anchor = true,
-    bool prune_root = false) -> void
+    bool prune_root = false, bool prune_within = false) -> void
 {
     println(cerr, "subcircuit/anchored/{}{} n={} anchor={}{}", label, name_the_anchor ? "" : "/found", n, anchor, proofs ? " with proofs:" : ":");
 
@@ -214,6 +214,8 @@ auto run_anchored_test(bool proofs, int n, int anchor, SubCircuitAlgorithm algor
         constraint.with_required_node(anchor);
     if (prune_root)
         constraint.with_prune_root();
+    if (prune_within)
+        constraint.with_prune_within();
     p.post(std::move(constraint));
 
     auto proof_name = proofs ? make_optional("subcircuit_test_anchored_" + label + (name_the_anchor ? "" : "_found")) : nullopt;
@@ -308,6 +310,12 @@ auto main(int argc, char * argv[]) -> int
                     // built to make it fire. A rule that inferred nothing would pass this,
                     // which is what subcircuit_prune_root_test is for.
                     run_anchored_test(proofs, n, anchor, subcircuit::SCC{}, "scc-prune-root", true, true);
+                    // And both rules together, which is the shave over every successor.
+                    // Expensive --- a walk per node per value, and an induction per
+                    // pruning --- but these are the sizes where that is affordable, and
+                    // running it over a full enumeration with proofs on is the only thing
+                    // that checks the two rules do not interfere with each other.
+                    run_anchored_test(proofs, n, anchor, subcircuit::SCC{}, "scc-pruning-rules", true, true, true);
                 }
             for (int n : {3, 4}) {
                 run_tour_size_test(proofs, n, 0, n);


### PR DESCRIPTION
Stacked on #811, which is the analysis this implements. For #788.

`with_prune_root()` and `with_prune_within()`, both off by default. They cost between 1x and 95x the proof for at most a ten per cent reduction in search, and that is the point: they are *certifiable*, and a corpus of expensive-but-correct rules a checker can be pointed at is worth having on its own account.

## The rules are one operation

Assume an edge, run the reachability rules against the domains that leaves, and drop the value if a node that must be on the tour would be stranded in either direction. Prune root is that over the anchor's successor (F&S rule 3 / explanation 6), prune within over every other node's (rule 4 / explanation 7); they are split at the anchor so they do not overlap, and both are one function, `shave_by_reachability`. In this encoding the pair is **singleton arc consistency on the successor variables**.

Neither fires on the live domains — while a successor is free the anchor reaches everything any of its values reaches — which is exactly why they add strength and why they cost a walk per candidate. F&S read the condition off the depth-first traversal they already have, which is a cheap *sufficient* condition for the same thing, so asking the question directly of each value prunes at least as much and needs no traversal.

## The certificates needed nothing new

No new row family, no new proof-only variable, no new cutting-planes step — as #811 predicted and probed. Three small pieces of mechanism:

- **`AssumedEdge`**, and walks that take one, carried as data rather than read back out of the `State`: the walk's result and the justification that reproduces it must be over the same edge set, and a justification may read only the reason and the model.
- **The hypothesis as a guard** on every emitted row, so each says "*if* that edge is taken, then x at position t is off the tour" and the conclusion is "that edge is not taken". One extra literal per row. The alternative — a proof level deleted once the conclusion is drawn — saves those literals and costs the level discipline.
- **Candidates snapshotted** before the loop infers anything. Sound, not just convenient: a walk only ever uses the *absence* of a value to rule a neighbour out, so a domain that has since lost more values makes the reason a stronger premise.

## The cost, measured

One random instance per `n`, the same one across configs, complete enumeration with proofs on.

| n | recursions (scc / +root / +within) | `.pbp` scc | +prune_root | +prune_within | verify scc → +within |
|---|---|---|---|---|---|
| 6 | 16 / 16 / 17 | 11 KB | 1.0x | **13.1x** | 0.10 → 0.11 s |
| 7 | 119 / 119 / 117 | 139 KB | 1.5x | **15.4x** | 0.11 → 0.10 s |
| 8 | 492 / 492 / 478 | 212 KB | 1.0x | **51.6x** | 0.11 → 0.51 s |
| 9 | 1281 / 1281 / 1199 | 586 KB | 1.6x | **72.2x** | 0.21 → 2.11 s |
| 10 | 8057 / 8057 / 7461 | 4.3 MB | 1.0x | **94.9x** | 1.71 → 24.3 s |
| 11 | 25469 / 25420 / 22846 | 72.9 MB | 1.7x | **25.5x** | 12.8 → 108 s |
| 12 | 104134 / 104044 / — | 73.0 MB | 3.7x | *abandoned at 10.8 GB* | 93.1 s → — |

**Every proof verified**, including the 1.86 GB one at n=11. The multiplier is not monotone (95x then 25x) because the denominator moves too — `scc`'s own proof jumps 17x between those sizes — so the absolute figures are the honest ones.

Measured on constant-free instances, because the `mario` family cannot be used: **#812**, a constant in the successor array makes the certificate throw, predating this work (plain `scc` hits it at k≥10 on cut-down mario).

## Tests

- The anchored enumeration sweep runs prune root, and both rules together, at every size and anchor with proofs on — pinning that they cannot change the solution set and verifying their certificates over a whole enumeration. A rule that inferred nothing would pass that, so:
- `subcircuit_prune_root_test` and `subcircuit_prune_within_test` assert the **root state**. Building scenarios where the rule is the only route to its conclusion took several attempts: the plain backward walk gets there free if a component has one edge back to the anchor and all-different removes it, and `check` gets there free if any domain is a singleton, since one fixed successor cascades into a closed cycle. The prune-within instance was ultimately *generated* rather than built — hand-building kept producing unsatisfiable structures — so that fixture is deliberately asymmetric and untidy.
- Mutation probes caught by the tests: dropping the hypothesis guard, and replacing the induction with a plain `JustifyUsingRUP`.

790/790 tests pass, warning-free under GCC with `GCS_WERROR=ON`, clean under clang + sanitizers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)