### PR TITLE
Pass the bin packing and regular offsets instead of shifting the array

### DIFF
--- a/dev_docs/subcircuit-proof-logging.md
+++ b/dev_docs/subcircuit-proof-logging.md
@@ -427,9 +427,13 @@ alone recovers the search (10,021 → 3,099 on `easy_2`, 1,133,233 → 55,157 on
 equalities' consistency, not the extra variables. Views are still the right fix,
 since a view shares the domain outright and costs nothing to propagate.
 
-The same shape is in four more redefinitions — the three `bin_packing` ones and
-`fzn_regular` — and is [issue #803](https://github.com/ciaranm/glasgow-constraint-solver/issues/803).
-The graph family shifts *parameters*, which costs nothing.
+The same shape was in four more redefinitions — the three `bin_packing` ones and
+`fzn_regular` — and was
+[issue #803](https://github.com/ciaranm/glasgow-constraint-solver/issues/803).
+That is now fixed the same way: the three `bin_packing` redefinitions pass the
+offset, and `fzn_regular` needs none at all, because `Regular` takes the symbol
+values it is given rather than assuming an alphabet. The graph family shifts
+*parameters*, which costs nothing.
 
 ## The pruning rules: implemented, certified, and expensive
 

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -652,6 +652,10 @@ if(GCS_BUILD_TESTS)
     endforeach()
     add_view_tests(cumulative_constraint cumulative_test 4)
     add_view_tests(regular_constraint regular_test 4)
+    # Every MiniZinc model hands BinPacking views: glasgow_bin_packing_capa and
+    # glasgow_bin_packing_load take the bin offset and fzn_glasgow applies it with
+    # operator+, so the item scope is never a plain variable on that path.
+    add_view_tests(bin_packing_constraint bin_packing_test 4)
     add_test(NAME in_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:in_test>)
     add_test(NAME increasing_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:increasing_test>)
     add_test(NAME inverse_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:inverse_test>)

--- a/gcs/constraints/bin_packing/bin_packing_test.cc
+++ b/gcs/constraints/bin_packing/bin_packing_test.cc
@@ -42,11 +42,11 @@ using namespace gcs::test_innards;
 
 namespace
 {
-    auto run_bin_packing_capa_test(
-        bool proofs, bool upfront, const vector<pair<int, int>> & item_ranges, const vector<int> & sizes, const vector<int> & capacities) -> void
+    auto run_bin_packing_capa_test(bool proofs, bool upfront, const ViewWrapConfig & view_cfg, const vector<pair<int, int>> & item_ranges,
+        const vector<int> & sizes, const vector<int> & capacities) -> void
     {
-        print(cerr, "bin_packing capa {} sizes={} caps={}{}{}", item_ranges, sizes, capacities, upfront ? " upfront" : "",
-            proofs ? " with proofs:" : ":");
+        print(cerr, "bin_packing capa [{}] {} sizes={} caps={}{}{}", view_wrap_config_label(view_cfg), item_ranges, sizes, capacities,
+            upfront ? " upfront" : "", proofs ? " with proofs:" : ":");
         cerr << flush;
 
         auto n = item_ranges.size();
@@ -70,9 +70,15 @@ namespace
         println(cerr, " expecting {} solutions", expected.size());
 
         Problem p;
+        // The items are what every MiniZinc model now hands over as views: the
+        // redefinition passes the bin offset and fzn_glasgow applies it with
+        // operator+, so BinPacking sees `bin[i] + -offset` rather than a variable
+        // of its own. The wrap lands back on the requested visible domain, so the
+        // solution set is unchanged and only the view plumbing differs.
+        auto wraps = wraps_for_positions(view_cfg, static_cast<int>(item_ranges.size()));
         vector<IntegerVariableID> items;
-        for (auto & [lo, hi] : item_ranges)
-            items.push_back(p.create_integer_variable(Integer{lo}, Integer{hi}));
+        for (size_t i = 0; i < item_ranges.size(); ++i)
+            items.push_back(create_integer_variable_or_constant_with_view(p, item_ranges.at(i), wraps.at(i)));
 
         vector<Integer> sizes_i, caps_i;
         for (auto s : sizes)
@@ -84,7 +90,7 @@ namespace
                 .with_proof_strategy(
                     upfront ? BinPackingProofStrategy{proof_strategy::Upfront{}} : BinPackingProofStrategy{proof_strategy::PerCall{}}));
 
-        auto proof_name = proofs ? make_optional("bin_packing_test") : nullopt;
+        auto proof_name = proofs ? make_optional("bin_packing_test_" + view_wrap_config_label(view_cfg)) : nullopt;
         // Enumeration only — Stage 3 achieves per-bin GAC, not joint GAC
         // (joint GAC for BinPacking is NP-hard, classic subset-sum). For the
         // constant-cap form per-bin GAC is structurally identical to Stage
@@ -96,11 +102,11 @@ namespace
         check_results(proof_name, expected, actual);
     }
 
-    auto run_bin_packing_load_test(bool proofs, bool upfront, const vector<pair<int, int>> & item_ranges, const vector<int> & sizes,
-        const vector<pair<int, int>> & load_ranges) -> void
+    auto run_bin_packing_load_test(bool proofs, bool upfront, const ViewWrapConfig & view_cfg, const vector<pair<int, int>> & item_ranges,
+        const vector<int> & sizes, const vector<pair<int, int>> & load_ranges) -> void
     {
-        print(cerr, "bin_packing load {} sizes={} loads={}{}{}", item_ranges, sizes, load_ranges, upfront ? " upfront" : "",
-            proofs ? " with proofs:" : ":");
+        print(cerr, "bin_packing load [{}] {} sizes={} loads={}{}{}", view_wrap_config_label(view_cfg), item_ranges, sizes, load_ranges,
+            upfront ? " upfront" : "", proofs ? " with proofs:" : ":");
         cerr << flush;
 
         auto n = item_ranges.size();
@@ -124,9 +130,13 @@ namespace
         println(cerr, " expecting {} solutions", expected.size());
 
         Problem p;
+        // Only the items are wrapped; see the capa runner. glasgow_bin_packing_load
+        // shifts the bins alone, because the load array is indexed by bin rather
+        // than valued in bins, so loads stay plain variables on the MiniZinc path.
+        auto wraps = wraps_for_positions(view_cfg, static_cast<int>(item_ranges.size()));
         vector<IntegerVariableID> items, loads;
-        for (auto & [lo, hi] : item_ranges)
-            items.push_back(p.create_integer_variable(Integer{lo}, Integer{hi}));
+        for (size_t i = 0; i < item_ranges.size(); ++i)
+            items.push_back(create_integer_variable_or_constant_with_view(p, item_ranges.at(i), wraps.at(i)));
         for (auto & [lo, hi] : load_ranges)
             loads.push_back(p.create_integer_variable(Integer{lo}, Integer{hi}));
 
@@ -138,7 +148,7 @@ namespace
                 .with_proof_strategy(
                     upfront ? BinPackingProofStrategy{proof_strategy::Upfront{}} : BinPackingProofStrategy{proof_strategy::PerCall{}}));
 
-        auto proof_name = proofs ? make_optional("bin_packing_test") : nullopt;
+        auto proof_name = proofs ? make_optional("bin_packing_test_" + view_wrap_config_label(view_cfg)) : nullopt;
         // Enumeration only; see capa runner for why per-bin GAC isn't
         // checked here.
         solve_for_tests(p, proof_name, actual, tuple{items, loads});
@@ -150,6 +160,7 @@ namespace
 auto main(int argc, char * argv[]) -> int
 {
     establish_and_announce_seed(argc, argv);
+    auto view_cfg = parse_view_wrap_config_from_argv(argc, argv);
 
     // Each capa case: { item_ranges, sizes, capacities }.
     vector<tuple<vector<pair<int, int>>, vector<int>, vector<int>>> capa_data = {
@@ -220,9 +231,9 @@ auto main(int argc, char * argv[]) -> int
             if (upfront && ! proofs)
                 continue;
             for (auto & [items, sizes, caps] : capa_data)
-                run_bin_packing_capa_test(proofs, upfront, items, sizes, caps);
+                run_bin_packing_capa_test(proofs, upfront, view_cfg, items, sizes, caps);
             for (auto & [items, sizes, loads] : load_data)
-                run_bin_packing_load_test(proofs, upfront, items, sizes, loads);
+                run_bin_packing_load_test(proofs, upfront, view_cfg, items, sizes, loads);
         }
     }
 

--- a/gcs/constraints/regular/regular_test.cc
+++ b/gcs/constraints/regular/regular_test.cc
@@ -190,6 +190,24 @@ auto run_all_tests(bool proofs, const ViewWrapConfig & view_cfg, bool run_dup) -
         2, {{{0_i, 1}, {1_i, 0}}, {{0_i, 0}, {1_i, 1}}},                       //
         {0});
 
+    // The same automaton over the alphabet {1,2} rather than {0,1}. Regular takes
+    // the symbol values it is given rather than assuming a 0-based alphabet, and
+    // fzn_regular relies on exactly that: FlatZinc regular numbers its alphabet
+    // 1..S, so the transition table arrives keyed 1..S and the variables are handed
+    // over unshifted. Before that, the redefinition shifted with a comprehension and
+    // every explicit-transitions case here started its alphabet at 0, so nothing
+    // covered a table whose keys miss zero.
+    run_regular_test(proofs, view_cfg, "even ones, 1-based alphabet", {{1, 2}, {1, 2}, {1, 2}}, //
+        2, {{{1_i, 1}, {2_i, 0}}, {{1_i, 0}, {2_i, 1}}},                                        //
+        {0});
+
+    // A 1-based alphabet with a gap in the middle: symbol 2 has no transition from
+    // either state, so every solution must avoid it even though it sits inside the
+    // variables' declared range. A bounds-only reading of the table cannot do this.
+    run_regular_test(proofs, view_cfg, "1-based alphabet with a hole", {{1, 3}, {1, 3}, {1, 3}}, //
+        2, {{{1_i, 1}, {3_i, 0}}, {{1_i, 0}, {3_i, 1}}},                                         //
+        {0});
+
     // DFA: no two consecutive 0s, binary alphabet {0,1}
     // State 0 (initial, final): 0->1, 1->0
     // State 1 (final, last was 0): 0->dead (absent), 1->0

--- a/minizinc/CMakeLists.txt
+++ b/minizinc/CMakeLists.txt
@@ -34,6 +34,19 @@ set_tests_properties(minizinc-aust PROPERTIES SKIP_RETURN_CODE 66)
 add_test(NAME minizinc-binpacking COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ binpackingtest true true)
 set_tests_properties(minizinc-binpacking PROPERTIES SKIP_RETURN_CODE 66)
 
+# The bin offset the three bin_packing redefinitions pass, which fzn_glasgow
+# applies as a view. --fzn-pattern is load-bearing on both: MiniZinc's
+# bin_packing wrappers are free to rewrite into the library decomposition, which
+# agrees with the reference solver and verifies its proof just as happily, and
+# then the offset argument under test is never read. binpackingtest above is
+# 1-based, where the offset is 1; these reach offsets of 5, 3 and 0, and
+# binpackingloadtest is the only test of the variable-load form at all.
+add_test(NAME minizinc-binpacking-offset COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash --fzn-pattern glasgow_bin_packing_capa $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ binpackingoffsettest true true)
+set_tests_properties(minizinc-binpacking-offset PROPERTIES SKIP_RETURN_CODE 66)
+
+add_test(NAME minizinc-binpacking-load COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash --fzn-pattern glasgow_bin_packing_load $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ binpackingloadtest true true)
+set_tests_properties(minizinc-binpacking-load PROPERTIES SKIP_RETURN_CODE 66)
+
 add_test(NAME minizinc-boolxor COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ boolxor true true)
 set_tests_properties(minizinc-boolxor PROPERTIES SKIP_RETURN_CODE 66)
 

--- a/minizinc/fzn_glasgow.cc
+++ b/minizinc/fzn_glasgow.cc
@@ -264,25 +264,34 @@ namespace
         return Integer{static_cast<long long>(a)};
     }
 
-    // Both circuit predicates hand over the successor array unshifted, with the
-    // offset to subtract from each value, and gcs applies it as a view.
+    // Several of our predicates take an array whose values gcs numbers from zero
+    // -- circuit and subcircuit successors, bin packing's bins -- and hand it over
+    // unshifted with the offset to subtract, which gcs applies as a view.
     //
     // That is not just tidier than shifting in the redefinition, it keeps
     // information. A comprehension there introduces a fresh FlatZinc variable per
-    // node, declared over the full range before its defining constraint has
-    // propagated, so every narrowing the model had already made is invisible to the
-    // constraint. SubCircuit cares about exactly one such narrowing -- a node whose
-    // own index has left its domain is a node known to be on the tour, which is what
-    // lets it anchor the position encoding -- and `constraint succ[n] != n`, which is
-    // how the tpp challenge model says it, was being lost that way. A view keeps the
-    // domain, and n variables and n linear constraints never get written at all.
-    auto zero_based_successors(const vector<IntegerVariableID> & vars, Integer offset) -> vector<IntegerVariableID>
+    // element, declared over the full range before its defining int_lin_eq has
+    // propagated, and LinearEquality is bounds consistent by default, so every
+    // narrowing the model had already made reaches the constraint only as a bound
+    // -- and every hole the constraint punches reaches the model's array, which is
+    // what a search annotation names, only as a bound too.
+    //
+    // SubCircuit cared about exactly one such narrowing -- a node whose own index
+    // has left its domain is a node known to be on the tour, which is what lets it
+    // anchor the position encoding -- and `constraint succ[n] != n`, which is how
+    // the tpp challenge model says it, was being lost that way. For bin packing it
+    // is the per-item bin pruning that was being lost, worth better-or-equal
+    // objectives on all five steelmillslab instances and strictly better on four.
+    //
+    // A view keeps the domain, because a view is the same variable, and n variables
+    // and n linear constraints never get written at all.
+    auto zero_based(const vector<IntegerVariableID> & vars, Integer offset) -> vector<IntegerVariableID>
     {
-        vector<IntegerVariableID> succ;
-        succ.reserve(vars.size());
+        vector<IntegerVariableID> shifted;
+        shifted.reserve(vars.size());
         for (const auto & v : vars)
-            succ.push_back(v + -offset);
-        return succ;
+            shifted.push_back(v + -offset);
+        return shifted;
     }
 
     auto arg_as_var(ExtractedData & data, const auto & args, int idx) -> IntegerVariableID
@@ -815,27 +824,31 @@ auto main(int argc, char * argv[]) -> int
                 problem.post(ArgSort{x, p, 1_i});
             }
             else if (id == "glasgow_bin_packing_capa") {
+                // BinPacking numbers bins 0..num_bins-1, which the fourth argument's
+                // offset turns the model's bin variables into, as a view.
                 auto capacities = arg_as_array_of_integer(data, args, 0);
                 const auto & items = arg_as_array_of_var(data, args, 1);
                 auto sizes = arg_as_array_of_integer(data, args, 2);
-                problem.post(BinPacking{items, *sizes, *capacities});
+                problem.post(BinPacking{zero_based(items, arg_as_constant(args, 3)), *sizes, *capacities});
             }
             else if (id == "glasgow_bin_packing_load") {
+                // As glasgow_bin_packing_capa; only the bins are shifted, since the
+                // load array is indexed by bin rather than valued in bins.
                 const auto & loads = arg_as_array_of_var(data, args, 0);
                 const auto & items = arg_as_array_of_var(data, args, 1);
                 auto sizes = arg_as_array_of_integer(data, args, 2);
-                problem.post(BinPacking{items, *sizes, loads});
+                problem.post(BinPacking{zero_based(items, arg_as_constant(args, 3)), *sizes, loads});
             }
             else if (id == "glasgow_circuit") {
                 // Circuit expects a length-n array valued in 0..n-1, which the
                 // second argument's offset turns the model's successors into.
-                problem.post(Circuit{zero_based_successors(arg_as_array_of_var(data, args, 0), arg_as_constant(args, 1))});
+                problem.post(Circuit{zero_based(arg_as_array_of_var(data, args, 0), arg_as_constant(args, 1))});
             }
             else if (id == "glasgow_subcircuit") {
                 // As glasgow_circuit. SubCircuit is the opt-out sibling: a node not
                 // on the tour takes its own index, and the empty tour is a solution,
                 // so unlike Circuit this must not assume every node is visited.
-                problem.post(SubCircuit{zero_based_successors(arg_as_array_of_var(data, args, 0), arg_as_constant(args, 1))});
+                problem.post(SubCircuit{zero_based(arg_as_array_of_var(data, args, 0), arg_as_constant(args, 1))});
             }
             else if (id == "glasgow_reachable" || id == "glasgow_dreachable") {
                 // The mznlib redefinition has already shifted the endpoints and
@@ -1062,20 +1075,27 @@ auto main(int argc, char * argv[]) -> int
                 const auto & raw_transitions = arg_as_array_of_integer(data, args, 3);
                 const auto & start_state = static_cast<long long>(args.at(4));
 
-                vector<vector<long>> transitions;
+                // Keyed by the symbol values the model's own variables take, which
+                // FlatZinc regular numbers 1..S. Regular takes the symbols it is
+                // given rather than assuming an alphabet, so nothing needs shifting:
+                // the redefinition used to hand over `[x[i] - 1 | ...]`, which cost a
+                // fresh variable per position and lost every hole across the
+                // bounds-consistent int_lin_eq that defined it.
+                vector<unordered_map<Integer, long>> transitions(num_states);
                 for (int i = 0; i < num_states; i++) {
-                    transitions.emplace_back();
                     for (int j = 0; j < num_symbols; j++) {
                         // Swap 0 and start state to ensure start state is always 0 for gcs::regular
                         auto t_value = raw_transitions->at(i * num_symbols + j).raw_value;
-                        if (t_value == start_state) {
-                            transitions[i].emplace_back(0);
-                        }
-                        else if (t_value == 1) {
-                            transitions[i].emplace_back(start_state - 1);
-                        }
+                        long target;
+                        if (t_value == start_state)
+                            target = 0;
+                        else if (t_value == 1)
+                            target = start_state - 1;
                         else
-                            transitions[i].emplace_back(t_value - 1);
+                            target = t_value - 1;
+                        // A FlatZinc transition to state 0 means "no transition", which
+                        // maps to -1 above and is what Regular drops.
+                        transitions[i].emplace(Integer{j + 1}, target);
                     }
                 }
 

--- a/minizinc/mznlib/fzn_bin_packing.mzn
+++ b/minizinc/mznlib/fzn_bin_packing.mzn
@@ -1,14 +1,19 @@
 predicate glasgow_bin_packing_capa(array[int] of int: c,
-    array[int] of var int: bin, array[int] of int: w);
+    array[int] of var int: bin, array[int] of int: w, int: offset);
 
+% gcs's BinPacking numbers bins 0..num_bins-1 and rejects an item whose domain
+% leaves that range, so there is an offset. It is passed rather than applied
+% here: see fzn_bin_packing_capa.mzn for why a comprehension over bin is the
+% wrong way to apply it.
+%
+% Here the bins are the values bin can take, so the offset is lb_array(bin) and
+% the capacity array is built over that same range.
 predicate fzn_bin_packing(int: c, array[int] of var int: bin,
     array[int] of int: w) =
-    if length(bin) > 0 then
+    if length(bin) = 0 then true
+    else
         let {
             int: lb = lb_array(bin);
             int: ub = ub_array(bin);
-        } in glasgow_bin_packing_capa(
-            [c | b in lb..ub],
-            [bin[i] - lb | i in index_set(bin)],
-            w)
+        } in glasgow_bin_packing_capa([c | b in lb..ub], bin, w, lb)
     endif;

--- a/minizinc/mznlib/fzn_bin_packing_capa.mzn
+++ b/minizinc/mznlib/fzn_bin_packing_capa.mzn
@@ -1,11 +1,27 @@
 predicate glasgow_bin_packing_capa(array[int] of int: c,
-    array[int] of var int: bin, array[int] of int: w);
+    array[int] of var int: bin, array[int] of int: w, int: offset);
 
+% gcs's BinPacking numbers bins 0..num_bins-1, so the bin variables have to be
+% shifted by min(index_set(c)). The offset is passed and gcs applies it as a
+% view, rather than being applied here.
+%
+% Applying it here -- `[bin[i] - lb | i in index_set(bin)]` -- is what this used
+% to do, and it is a worse idea than it looks. The comprehension introduces a
+% fresh FlatZinc variable per item, declared over the full range before its
+% defining int_lin_eq has propagated, and gcs's LinearEquality is bounds
+% consistent by default. So a hole punched in either copy crossed to the other
+% only as a bound: BinPacking prunes by removing individual bins from an item's
+% domain, and a search annotation names the model's own array, so both the
+% pruning and the brancher's view of the domain sizes were lost in the shift.
+%
+% A view keeps the domain, because a view is the same variable, and n variables
+% and n linear constraints never get written into the FlatZinc at all.
+%
+% Keep the min inside the call, guarded: with an empty capacity array the min
+% would be a min-of-empty-set error, and no bins is satisfiable exactly when
+% there are no items to place.
 predicate fzn_bin_packing_capa(array[int] of int: c,
     array[int] of var int: bin, array[int] of int: w) =
-    let {
-        int: lb = min(index_set(c));
-    } in glasgow_bin_packing_capa(
-        [c[b] | b in index_set(c)],
-        [bin[i] - lb | i in index_set(bin)],
-        w);
+    if length(c) = 0 then length(bin) = 0
+    else glasgow_bin_packing_capa(c, bin, w, min(index_set(c)))
+    endif;

--- a/minizinc/mznlib/fzn_bin_packing_load.mzn
+++ b/minizinc/mznlib/fzn_bin_packing_load.mzn
@@ -1,11 +1,16 @@
 predicate glasgow_bin_packing_load(array[int] of var int: load,
-    array[int] of var int: bin, array[int] of int: w);
+    array[int] of var int: bin, array[int] of int: w, int: offset);
 
+% As fzn_bin_packing_capa.mzn, which carries the reasoning: the offset is
+% passed and applied as a view rather than shifting bin in a comprehension,
+% which would lose every hole the propagator punches.
+%
+% The load array needs no such care. `[load[b] | b in index_set(load)]` was
+% already free -- with no arithmetic in the comprehension the flattener reuses
+% the same variables rather than introducing new ones -- but it is dropped here
+% too, since passing load directly says so rather than relying on it.
 predicate fzn_bin_packing_load(array[int] of var int: load,
     array[int] of var int: bin, array[int] of int: w) =
-    let {
-        int: lb = min(index_set(load));
-    } in glasgow_bin_packing_load(
-        [load[b] | b in index_set(load)],
-        [bin[i] - lb | i in index_set(bin)],
-        w);
+    if length(load) = 0 then length(bin) = 0
+    else glasgow_bin_packing_load(load, bin, w, min(index_set(load)))
+    endif;

--- a/minizinc/mznlib/fzn_regular.mzn
+++ b/minizinc/mznlib/fzn_regular.mzn
@@ -1,3 +1,18 @@
 predicate glasgow_regular(array[int] of var int: x, int: Q, int: S, array[int] of int: d, int: q0, set of int: F);
+
+% FlatZinc regular numbers its alphabet 1..S, and gcs's Regular takes the symbol
+% values it is given rather than assuming an alphabet, so x is handed over
+% untouched and the transition table is keyed 1..S on the solver side.
+%
+% This used to shift instead -- `[x[i] - 1 | i in index_set(x)]` -- which is a
+% worse idea than it looks. The comprehension introduces a fresh FlatZinc
+% variable per position, declared over the full range before its defining
+% int_lin_eq has propagated, and gcs's LinearEquality is bounds consistent by
+% default, so a hole punched in either copy reaches the other only as a bound.
+% Regular prunes by removing individual values, and a search annotation names
+% the model's own array, so both the propagation and the brancher's view of the
+% domain sizes were being lost in the shift. See fzn_bin_packing_capa.mzn, whose
+% sibling problem needs an offset passed because BinPacking does fix its bin
+% numbering; here no offset is needed at all.
 predicate fzn_regular(array[int] of var int: x, int: Q, int: S, array[int,int] of int: d, int: q0, set of int: F) =
-    glasgow_regular([x[i] - 1 | i in index_set(x)], Q, S, array1d(d), q0, F);
+    glasgow_regular(x, Q, S, array1d(d), q0, F);

--- a/minizinc/tests/binpackingloadtest.mzn
+++ b/minizinc/tests/binpackingloadtest.mzn
@@ -1,0 +1,18 @@
+include "globals.mzn";
+
+% fzn_bin_packing_load, which no MiniZinc test reached before: it is the form
+% that carries variable loads, and it shifts the bins while leaving the load
+% array alone, because load is indexed by bin rather than valued in bins.
+%
+% The load array is 0-based so the offset is 0 -- the one value that a shift
+% applied in the wrong direction still gets right for the capa form, and so the
+% case worth having alongside binpackingoffsettest.mzn's non-zero offsets.
+array[1..4] of int: w = [3, 2, 2, 1];
+array[0..2] of var 0..8: load;
+array[1..4] of var 0..2: bin;
+
+constraint bin_packing_load(load, bin, w);
+
+solve satisfy;
+
+output ["ENUMSOL: " ++ join(" ", [show(bin[i]) | i in 1..4]) ++ " | " ++ join(" ", [show(load[b]) | b in 0..2])];

--- a/minizinc/tests/binpackingoffsettest.mzn
+++ b/minizinc/tests/binpackingoffsettest.mzn
@@ -1,0 +1,27 @@
+include "globals.mzn";
+
+% The bin offset, which the redefinitions pass and fzn_glasgow applies as a
+% view. binpackingtest.mzn covers the ordinary 1-based case, where the offset is
+% 1 and a mistake in either direction is easy to miss; these two are the ones
+% that pin it down.
+%
+% First: bin_packing_capa with a capacity array that is neither 1-based nor
+% 0-based, so the offset is min(index_set(c)) = 5 and nothing about the model is
+% consistent with assuming 1.
+array[1..4] of int: w = [3, 2, 2, 1];
+array[5..7] of int: c = array1d(5..7, [4, 4, 4]);
+array[1..4] of var 5..7: bin;
+
+constraint bin_packing_capa(c, bin, w);
+
+% Second: the single-capacity bin_packing form, whose offset is lb_array(bin2)
+% rather than an index set at all -- a different code path in the redefinition,
+% and one no test reached before.
+array[1..3] of int: w2 = [2, 2, 1];
+array[1..3] of var 3..5: bin2;
+
+constraint bin_packing(3, bin2, w2);
+
+solve satisfy;
+
+output ["ENUMSOL: " ++ join(" ", [show(bin[i]) | i in 1..4]) ++ " | " ++ join(" ", [show(bin2[i]) | i in 1..3])];


### PR DESCRIPTION
Closes #803. Same shape as #802, which did this for the two circuit predicates.

## The bug

Four mznlib redefinitions shifted a **var** array with a comprehension:

```minizinc
[bin[i] - lb | i in index_set(bin)]   % fzn_bin_packing{,_capa,_load}
[x[i] - 1 | i in index_set(x)]        % fzn_regular
```

That introduces a fresh FlatZinc variable per element, tied to the original by an `int_lin_eq`. `LinearEquality` is bounds consistent by default, so a hole punched in either copy reaches the other only as a bound. Both propagators prune by removing individual values, and a search annotation names the *model's* array, so both the pruning and the brancher's view of the domain sizes were lost in the shift.

## The fix

The three bin packing redefinitions pass the offset and `fzn_glasgow` applies it as a view, because `BinPacking` fixes its bin numbering at `0..num_bins-1` (and `prepare` throws if an item's domain leaves that range).

`fzn_regular` needs **no offset at all**. `Regular` takes the symbol values it is given rather than assuming an alphabet, so the transition table is keyed `1..S` on the solver side and `x` is handed over untouched — no view, no offset argument, nothing to shift.

## Measured — and the two halves are not one claim

`bin_packing` has a propagation case. On `steelmillslab`, whose bin scope is 50 wide, making these equalities GAC is better-or-equal on all five instances and strictly better on four, reproduced at both a 30 s and a 60 s cap:

| instance | before | after |
|---|---|---|
| bench_13_0 | 39 | 39 |
| bench_14_1 | 58 | **53** |
| bench_15_11 | 52 | **49** |
| bench_16_10 | 50 | **48** |
| bench_19_5 | 38 | **34** |

Doubling the budget moved neither side, so this is not the baseline needing more time.

`regular` has none that I can measure. `pentominoes-int` is node-for-node identical on every instance that finishes (143/143, 3,902/3,902, 193/193), and `nonogram`'s whole family has width-2 domains, where bounds consistency and GAC provably coincide — a two-value domain has no interior value to lose. `gbac` ties on all five instances, and its bin scope is 9 wide. The effect tracks scope width: 2 nil, 9 nil, 10 nil, 50 strong.

So the `regular` change stands on writing *n* fewer variables and *n* fewer linear constraints, not on propagation. Issue #803 asked for exactly this distinction to be drawn rather than assumed.

## Test coverage for what this makes load-bearing

- `BinPacking` now receives views on every MiniZinc model, so `bin_packing_test` threads a `ViewWrapConfig` through both runners and is registered with `add_view_tests`. All 38 proof cases verify bare and mixed.
- The offset was only ever exercised at 1, where a mistake in either direction is easy to miss. `binpackingoffsettest` reaches 5 (a capacity array indexed `5..7`) and 3 (the single-capacity form, whose offset is `lb_array(bin)` rather than an index set — a different path in the redefinition that no test reached). `binpackingloadtest` reaches 0 and is the only test of the variable-load form at all. Both carry `--fzn-pattern`, without which they would pass against the library decomposition with the offset argument never read.
- Every explicit-transitions case in `regular_test` started its alphabet at 0, so nothing covered a table whose keys miss zero. Two 1-based cases added, one with a gap in the middle that a bounds-only reading cannot prune.

`zero_based_successors` becomes `zero_based`, since it now serves both families.

## Checks

All 797 tests pass. `bin_packing_test` and `regular_test` pass capped and uncapped, bare and `--view-position=mixed`, with VeriPB verifying every proof case. All 96 MiniZinc tests pass. Changed translation units are clean under clang 21 (`variable_weighting.hh`'s pre-existing `-Winconsistent-missing-override` aside, which an untouched file hits identically). Formatted with clang-format 21.

## Deliberately not done here

The ~490 shifts that MiniZinc models write themselves — feeding `array_int_maximum`, `array_int_element`, `int_div`/`mod` — are outside any redefinition, so no mznlib change reaches them. Fixing those needs a substitution inside the solver, which is the same missing mechanism as #649 and is written up there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)