### PR TITLE
Wake lin_not_equals only on instantiation

### DIFF
--- a/dev_docs/propagator-performance.md
+++ b/dev_docs/propagator-performance.md
@@ -149,6 +149,25 @@ They are the one legitimate way to lower the `propagations:` count — see the
 ground rule above for what must still hold, and its caveats. Get these right
 before micro-optimising the body.
 
+**What a removed wake is worth.** A wake the propagator no longer takes costs
+tens of nanoseconds, so the payoff scales with the *scan* the wake skips, not
+with the call count on its own. Moving `lin_not_equals` from `on_change` to
+`on_instantiated` (issue #807) dropped 9.9M of 17.8M calls on the `tpp`
+challenge model, whose flattened `int_lin_ne` has two terms, and moved the wall
+clock by nothing measurable (three instances, min-of-3, −0.3% to +0.7% against
+a ~1% run-to-run spread); the same change dropped 15.6M of 41.0M calls on a
+ten-term not-equals and was a reproducible 6.9% there. Both had identical
+`nodes` *and* identical `effectfulPropagations` — which is the shape to insist
+on, and the one that says the fixpoint at every node is untouched.
+
+**A `_micros` share is not necessarily wake cost.** `GCS_PROPAGATOR_STATS=time`
+brackets the propagator call, so a contradiction's `throw
+TrackedPropagationFailed` unwinds inside the sample. `lin_not_equals` on `tpp`
+reported 6.23 s of the model's 12.41 s of propagation, and 6.03 s of that
+survived removing 56% of its calls: it was 3.75M contradictions at ~1.6 µs
+each, not 17.8M wakes. Read the `_contradictions` column before reading a large
+`_micros` share as a trigger problem.
+
 ### Reuse the reason instead of rebuilding it
 
 A propagator that reasons over a fixed variable scope should build **one**

--- a/gcs/constraints/linear/linear_equality.cc
+++ b/gcs/constraints/linear/linear_equality.cc
@@ -376,11 +376,20 @@ auto ReifiedLinearEquality::install_propagators(Propagators & propagators) -> vo
                         });
                 }
 
-                // strictly speaking, we care when we're down to only one variable left unassigned, and then there's one
-                // value it potentially mustn't have
+                // We can only act once at most one variable is left unassigned: with two or more
+                // unfixed, propagate_linear_not_equals scans the terms and returns having inferred
+                // nothing. Both branches it can act in are entered by a variable becoming fixed, and
+                // every State::change_state_for_* path that leaves a domain a singleton returns
+                // Inference::Instantiated (the start-of-search call covers a term fixed before
+                // install), so on_instantiated cannot miss a wake: each node reaches the same
+                // fixpoint, and the wakes on_change adds on top of it only ever do that work a
+                // round sooner. On the tpp challenge model they cost 17.8M calls for a single
+                // pruning (issue #807). Contrast the undecided branch below, which stays enabled with one
+                // variable left and then acts when *that* variable loses the value that would make
+                // the equality hold: that one genuinely needs on_change.
                 Triggers triggers;
                 for (auto & [_, v] : _coeff_vars.terms)
-                    triggers.on_change.push_back(v);
+                    triggers.on_instantiated.push_back(v);
 
                 visit(
                     [&, modifier = modifier](const auto & sanitised_cv) {

--- a/gcs/constraints/linear/linear_test.cc
+++ b/gcs/constraints/linear/linear_test.cc
@@ -133,10 +133,17 @@ auto run_linear_test(bool proofs, const string & mode, const ViewWrapConfig & vi
     auto proof_name =
         proofs ? make_optional("linear_equality_test_" + mode + "_" + view_wrap_config_label(view_cfg) + threshold_proof_suffix()) : nullopt;
 
+    // The inequality propagators are bounds(Z), but LinearNotEquals forbids the one value
+    // that would complete the equality as soon as a single variable is left unfixed, which
+    // for a single not-equals constraint is exactly GAC. Checking at that strength is what
+    // makes this lane a test of the propagator's triggers -- it wakes on_instantiated only
+    // (issue #807), and a missed wake leaves an unsupported *interior* value behind, which
+    // the BC check the other modes use cannot see. Deliberately registering only the first
+    // term's trigger fails this on the first data item of every view configuration.
+    constexpr auto level = is_same_v<Constraint_, LinearNotEquals> ? CheckConsistency::GAC : CheckConsistency::BC;
     if ((! is_same_v<Constraint_, LinearEquality>) && 1 == ineqs.size())
-        solve_for_tests_checking_consistency(p, proof_name, expected, actual,
-            tuple{pair{v1, CheckConsistency::BC}, pair{v2, CheckConsistency::BC}, pair{v3, CheckConsistency::BC}},
-            write_s_expr_file_for<Constraint_>());
+        solve_for_tests_checking_consistency(
+            p, proof_name, expected, actual, tuple{pair{v1, level}, pair{v2, level}, pair{v3, level}}, write_s_expr_file_for<Constraint_>());
     else
         solve_for_tests(p, proof_name, actual, tuple{v1, v2, v3}, write_s_expr_file_for<Constraint_>());
 


### PR DESCRIPTION
Closes #807. `triggers.on_change` -> `triggers.on_instantiated` on the
`MustNotHold` branch of `ReifiedLinearEquality::install_propagators`, plus the
test that makes it a checkable property and a doc note on what the change is
and is not worth.

## Why the wake cannot be missed

`propagate_linear_not_equals` acts only when at most one term is unfixed; with
two or more it scans and returns `Enable` having inferred nothing, and once it
has acted it returns `DisableUntilBacktrack`. So the only wake it needs is the
one that takes it into the "at most one unfixed" state, and that transition is
by definition a variable becoming fixed:

* all six `State::change_state_for_*` paths test `set.lower() == set.upper()`
  after the mutation and return `Inference::Instantiated` before they can return
  `BoundsChanged` / `InteriorValuesChanged`, and `record_firing_inference`
  records exactly what `State` returned, against the view's actual variable ---
  which is what `trigger_on_instantiated` registers on;
* the guess seeding in `Propagators::propagate` requeues with `Instantiated`
  whatever the guess actually did, so branch decisions still wake it;
* the first `propagate()` call --- the one with no guesses --- runs every
  propagator, which covers a term fixed before install; after that the root
  state only shrinks through inferences that fire their own triggers;
* `tidy_up_linear` only folds terms into the underlying
  `SimpleIntegerVariableID`s of `_coeff_vars`, so nothing the propagator reads
  is left untriggered;
* trigger *kind* feeds neither the scope nor the degree accounting in
  `Propagators::install`, so the branching heuristic cannot see the change
  (cf. #506, where a degree change moved a root branch and cost 280,000x).

The undecided reification branch keeps `on_change` and needs to: with one
variable left it stays `Enable` and acts when *that* variable loses the value
that would make the equality hold, which is an interior removal.

## What was measured

Five 2012/2016 `tpp` challenge instances, uncapped and complete (5.6M-27.5M
nodes) --- so these are node counts, not a 60 s prefix as in the issue:

| instance | nodes | `lin_not_equals` calls | propagations | wall (min-of-3, solo) |
|---|---|---|---|---|
| `2012/tpp_3_5_20_1` | 7,503,197 = 7,503,197 | 17,784,598 -> 7,888,363 | 77.8M -> 67.9M | 20.47 -> 20.61 s |
| `2016/tpp_6_3_20_1` | 5,627,413 = 5,627,413 | 17,849,491 -> 5,960,834 | 77.1M -> 65.2M | 18.91 -> 18.85 s |
| `2012/tpp_7_5_20_1` | 11,772,627 = 11,772,627 | 35,098,831 -> 12,082,353 | 149.9M -> 126.9M | 45.42 -> 45.28 s |
| `2012/tpp_5_3_20_1` | 7,053,969 = 7,053,969 | 17,773,455 -> 7,341,480 | 77.2M -> 66.8M | |
| `2012/tpp_5_5_20_1` | 6,447,131 = 6,447,131 | 17,240,757 -> 6,629,671 | 73.6M -> 63.0M | |

`nodes`, `failures`, `peakDepth`, the whole solution stream and the proven
optimum are identical on all five. `effectfulPropagations` moves by at most 25
in ~24M, in both directions, and the per-constraint effectful/contradiction
counts move with it: that is attribution, not strength --- an `on_change` wake
could run the propagator a round earlier, so an inference it used to make first
is now made by whoever else reaches it. A four-constraint `int_lin_ne` model
(1083 nodes, 858 solutions) writes a **byte-identical** `.pbp`, VERIFIED.

**The wall clock does not move on tpp**, against a ~1% run-to-run spread, and
#807's "half the propagation time" was never the wakes.
`GCS_PROPAGATOR_STATS=time` brackets the propagator call, so the 3.75M
contradictions' `throw TrackedPropagationFailed` unwinds inside the sample:
6.03 s of the reported 6.23 s survives removing 56% of the calls, i.e. ~1.6 us
per contradiction, not ~350 ns per wake. Where the skipped scan is longer it
does pay --- a ten-term not-equals over a permutation of 1..10, all 7,257,599
nodes, goes 41.0M -> 25.4M calls and 13.55 -> 12.62 s, a reproducible 6.9%. So
this lands as the correct trigger, under the "applied uniformly, sound as a
principle" exception in propagator-performance.md, not as a tpp speedup; the doc
now carries both figures and the warning about reading a `_micros` share off a
contradiction-heavy propagator.

## The test

`linear_test`'s `ne` lane checked `CheckConsistency::BC`, which cannot see a
missed *interior* pruning --- exactly what a missed wake would leave behind. It
now checks GAC, which for a single not-equals constraint is precisely what this
propagator achieves.

* It passes on the **old** triggers, so it asserts a property the propagator
  already had rather than one this PR adds.
* Deliberately registering only the first term's trigger fails it on the first
  data item of **every one of 385** (seed, view-wrap, view-position)
  configurations swept uncapped --- so the check has teeth.
* Full `ctest` is 794/794 before and after; clang 21 and GCC with
  `-DGCS_WERROR=ON` are both clean.

## Follow-up, not in this PR

The tail of #807 asks the same question of the other propagators that can only
act on a fixed variable. `ReifiedEquals` (`not_equals`) is the obvious next one,
but it is not a one-liner: `install_reified_dispatcher` takes one `Triggers` for
all four reification branches, and its undecided path reads `in_domain` and
`domains_intersect`, so it would need per-branch triggers. Separately, the 1.6 us
per contradiction above is a much larger prize than any trigger fix on this
model --- there is an `infer_*_or_stop` non-throwing path but no
`contradiction_or_stop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
