### PR TITLE
Ask domains_intersect the question, not a generator per variable

### DIFF
--- a/gcs/constraints/min_max/min_max.cc
+++ b/gcs/constraints/min_max/min_max.cc
@@ -27,7 +27,6 @@ using std::string;
 using std::stringstream;
 using std::unique_ptr;
 using std::vector;
-using std::ranges::any_of;
 
 ArrayMinMax::ArrayMinMax(vector<IntegerVariableID> vars, const IntegerVariableID result, bool min) : _vars(move(vars)), _result(result), _min(min)
 {
@@ -134,7 +133,7 @@ auto ArrayMinMax::install_propagators(Propagators & propagators) -> void
             // is there more than one variable that can support the values in result?
             optional<IntegerVariableID> support_1, support_2;
             for (auto & var : vars) {
-                if (any_of(state.each_value_immutable(result), [&](const Integer & val) { return state.in_domain(var, val); })) {
+                if (state.domains_intersect(var, result)) {
                     if (! support_1)
                         support_1 = var;
                     else {


### PR DESCRIPTION
One line in `ArrayMinMax`'s propagator. The "is there more than one variable that can support the values in result" scan asked, once per variable per wake,

```cpp
any_of(state.each_value_immutable(result), [&](const Integer & val) { return state.in_domain(var, val); })
```

which is verbatim the expression `dev_docs/constraints.md` says to replace with `state.domains_intersect` — each range form allocates a `std::generator` frame and routes every value through a `std::function`, and this one sits inside a loop over the whole array, so a 60-variable `ArrayMax` paid sixty frames per call.

Found while measuring #819: `colour`'s single `ArrayMax{vertices, colours}` is **82% of its propagation time** — 1,009,581 calls at ~14.5 us each, against 111M essentially free `not_equals` wakes. This one line is not all of that 14.5 us (the propagator does ~900 state operations per call, and making it incremental is the real fix), but it is the part the docs already tell you not to write.

`colour --file g_60_40_2.col`, min-of-3, solo:

| | min | mid | max |
|---|---|---|---|
| before | 17.73 | 17.86 | 17.93 |
| after | 17.26 | 17.34 | 17.34 |

**2.6% end-to-end**, non-overlapping, with every count identical: 399,729 recursions, 399,639 failures, 111,996,471 propagations, 13,203,207 effectful, 202,988 contradictions, 3 solutions. `ctest -R "min_max|max|min"` is 116/116; the full suite is green on the branch this was measured against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)