### PR TITLE
Stop, rather than throw, when lin_not_equals detects failure

### DIFF
--- a/dev_docs/propagator-performance.md
+++ b/dev_docs/propagator-performance.md
@@ -189,6 +189,34 @@ If the reason is materialised eagerly against the current state
 it is per-call by nature and must not be hoisted. (`lex` is the in-tree example
 that is *not* hoisted for exactly this reason.)
 
+### Don't throw from a propagator that fails in bulk
+
+`inference.contradiction(...)` signals failure by throwing
+`TrackedPropagationFailed`, which the propagation loop catches. The throw and
+unwind cost about **1.6 us**, against ~15 ns for a propagator wake — so for a
+propagator that is the failure detector at a large fraction of nodes, the
+reporting mechanism can cost more than everything else it does. Such a
+propagator should use `contradiction_or_stop`, which does the same recording and
+logging, sets the `_contradicted` flag the `infer_*_or_stop` family sets, and
+returns the `PropagatorState` for the caller to return immediately:
+
+```cpp
+return inference.contradiction_or_stop(logger, JustifyUsingRUP{hint}, reason);
+```
+
+The loop tests `tracker.contradicted()` as soon as the propagator returns and
+does everything the catch clause does — the counters, the conflict observers —
+so nothing else changes. Converting `propagate_linear_not_equals`'s all-fixed
+check (issue #820) was worth **21% to 29%** end-to-end on three `tpp` challenge
+instances, at 1.58 us per contradiction avoided, with every count and the proof
+byte-identical.
+
+Pick the candidates off the `_contradictions` column of
+`GCS_PROPAGATOR_STATS=calls`, not by eye: a propagator that contradicts a few
+thousand times a search has nothing to gain, and the conversion is a control-flow
+change in the propagator (it must now return immediately, which
+`[[nodiscard]]` enforces) rather than a free win.
+
 ### Reuse data structures to avoid per-wake allocation
 
 The same principle applies to scratch state generally: a propagator that

--- a/gcs/constraints/linear/propagate.cc
+++ b/gcs/constraints/linear/propagate.cc
@@ -664,8 +664,11 @@ auto gcs::innards::propagate_linear_not_equals(const auto & coeff_vars, Integer 
     if (single_unset == coeff_vars.terms.end()) {
         // every variable is set, do a sanity check
         if (accum == value) {
-            // we've set every variable and have equality
-            inference.contradiction(logger, JustifyUsingRUP{hint}, generic_reason(all_vars_for_reason));
+            // We've set every variable and have equality. Stop rather than throw: this
+            // is the failure detector for half the nodes of some searches (3.75M
+            // contradictions on one tpp challenge instance), and at ~1.6 us a throw and
+            // unwind that dominated everything else the propagator did (issue #820).
+            return inference.contradiction_or_stop(logger, JustifyUsingRUP{hint}, generic_reason(all_vars_for_reason));
         }
         else
             return PropagatorState::DisableUntilBacktrack;

--- a/gcs/innards/inference_tracker.hh
+++ b/gcs/innards/inference_tracker.hh
@@ -6,6 +6,7 @@
 #include <gcs/innards/justification.hh>
 #include <gcs/innards/proofs/infer_explicitly.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
+#include <gcs/innards/propagators-fwd.hh>
 #include <gcs/innards/state.hh>
 
 #include <concepts>
@@ -381,6 +382,14 @@ namespace gcs::innards
             contradiction(logger, JustifyUsingRUP{}, reason, rup_hint_annotation(logger, why.hint, fallback));
         }
 
+        template <typename Hint_>
+            requires(! std::same_as<Hint_, NoHint>)
+        [[nodiscard]] auto contradiction_or_stop(ProofLogger * const logger, const JustifyUsingRUP<Hint_> & why, const Reason & reason,
+            const std::optional<AssertionAnnotation> & fallback = std::nullopt) -> PropagatorState
+        {
+            return contradiction_or_stop(logger, JustifyUsingRUP{}, reason, rup_hint_annotation(logger, why.hint, fallback));
+        }
+
         template <IntegerVariableIDLike VarType_, typename Hint_>
             requires(! std::same_as<Hint_, NoHint>)
         auto infer_not_in_range(ProofLogger * const logger, const VarType_ & var, Integer lo, Integer hi, const JustifyUsingRUP<Hint_> & why,
@@ -535,6 +544,42 @@ namespace gcs::innards
                 if (logger)
                     logger->infer(FalseLiteral{}, why, materialise(reason, _state), assertion_hints);
             throw TrackedPropagationFailed{};
+        }
+
+        /**
+         * \brief Non-throwing counterpart of contradiction(), for the propagators
+         * that fail often enough for the unwind to be their dominant cost.
+         *
+         * Everything up to the failure signal is identical --- the reason is
+         * stashed for the conflict observers, the justification is logged --- but
+         * instead of unwinding with TrackedPropagationFailed this sets the same
+         * _contradicted flag the infer_*_or_stop family sets and hands back the
+         * PropagatorState for the caller to return immediately:
+         *
+         *     return inference.contradiction_or_stop(logger, JustifyUsingRUP{hint}, reason);
+         *
+         * The propagation loop tests tracker.contradicted() as soon as the
+         * propagator returns and does everything the catch clause does (the
+         * counters, the conflict observers), so the two paths differ only in
+         * mechanism. The returned state is not otherwise used --- a contradicted
+         * run's PropagatorState is never examined --- so the value is
+         * DisableUntilBacktrack only because that is the honest thing to say.
+         *
+         * [[nodiscard]] because a caller that drops it carries on reading and
+         * inferring against a contradicted state. See issue #820 for what this is
+         * worth: a throw and unwind is ~1.6 us, against ~15 ns for a propagator
+         * wake, so it is only worth converting a propagator that contradicts in
+         * bulk. The JustifyExplicitly overload can be added when a caller wants it.
+         */
+        [[nodiscard]] auto contradiction_or_stop(ProofLogger * const logger, const Justification & why, const Reason & reason,
+            const std::optional<AssertionAnnotation> & assertion_hints = std::nullopt) -> PropagatorState
+        {
+            _last_contradiction_reason = reason;
+            if constexpr (Actual_::materialises_reasons)
+                if (logger)
+                    logger->infer(FalseLiteral{}, why, materialise(reason, _state), assertion_hints);
+            _contradicted = true;
+            return PropagatorState::DisableUntilBacktrack;
         }
 
         template <IntegerVariableIDLike VarType_>


### PR DESCRIPTION
Closes #820. **21-29% end-to-end on three `tpp` challenge instances, with every count and the proof byte-identical.**

`inference.contradiction()` signals failure by throwing `TrackedPropagationFailed` for the propagation loop to catch, and a throw plus unwind costs about **1.6 us**. For a propagator that is the failure detector at half the nodes of a search that is not a detail: `propagate_linear_not_equals` contradicts 3,751,288 times on `2012/tpp_3_5_20_1`, and #818 established that its 6.2 s of reported propagation time — half the model's total — survived removing 56% of its calls, because it was never the wakes.

## The API

`contradiction_or_stop`, the counterpart of the existing `infer_*_or_stop` family: same reason stashing for the conflict observers, same justification logging, then the same `_contradicted` flag those methods set, and the `PropagatorState` for the caller to return immediately.

```cpp
return inference.contradiction_or_stop(logger, JustifyUsingRUP{hint}, generic_reason(all_vars_for_reason));
```

The propagation loop already tests `tracker.contradicted()` the moment a propagator returns, and that branch does everything the `catch` clause does — `contradicting_propagations`, the per-propagator counter, `note_conflict` on every observer. So the two paths differ only in mechanism. `[[nodiscard]]`, because a caller that drops the result carries on inferring against a contradicted state.

## Measured

Uncapped complete searches, min-of-3, solo:

| instance | contradictions | before | after | |
|---|---|---|---|---|
| `2012/tpp_3_5_20_1` | 3,751,288 | 20.38 | 14.44 | **−29.1%** |
| `2016/tpp_6_3_20_1` | 2,812,771 | 18.65 | 14.29 | **−23.4%** |
| `2012/tpp_7_5_20_1` | 5,868,396 | 45.48 | 35.95 | **−21.0%** |

The first works out at **1.58 us per contradiction avoided**, which is the 1.6 us the timed rung attributed to the throw in #820 — arrived at independently.

## Why nothing else can move

This changes how a failure is reported, not when. `nodes`, `failures`, total `propagations`, `effectfulPropagations` and every per-constraint-type counter are identical on both instances measured with `GCS_PROPAGATOR_STATS=calls`. The justification is logged before the failure is signalled on either path, so the proof cannot change either: a five-variable model whose `alldifferent` fixes the last term for it — so the all-fixed check really is what fails, 120 times — writes a **byte-identical `.pbp`**, `VERIFIED UNSATISFIABLE`. Full `ctest` 794/794; GCC with `-DGCS_WERROR=ON` and clang 21 both clean.

## Scope

One call site. The other 56 throwing sites are a survey job, and `propagator-performance.md` now carries the lever plus the instruction to pick candidates off the `_contradictions` column rather than by eye: a propagator that contradicts a few thousand times a search has nothing to gain, and the conversion is a control-flow change in the propagator (it must now return immediately) rather than a free win. `extensional_utils.cc` and `negative_table.cc` look like the next places to point a measurement at.

Independent of #818 and #822, and stacks with either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
