### PR TITLE
Recover x = y and x != y from the two-term linear form MiniZinc gives us

### DIFF
--- a/minizinc/CMakeLists.txt
+++ b/minizinc/CMakeLists.txt
@@ -4,6 +4,23 @@ target_link_libraries(fzn-glasgow PRIVATE glasgow_constraint_solver cxxopts gcs_
 add_test(NAME minizinc-abs COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ abs true true)
 set_tests_properties(minizinc-abs PROPERTIES SKIP_RETURN_CODE 66)
 
+# MiniZinc rewrites `x = y` and `x != y` between two variables into a two-term
+# int_lin_eq / int_lin_ne rather than emitting int_eq / int_ne, and the FlatZinc
+# reader recovers the shape so the specialised propagators are reached at all.
+# Both guards are load-bearing: --fzn-pattern pins that MiniZinc really does hand
+# us the linear form (if a future version emits int_eq instead, the recovery is
+# dead code and this says so), and the required output pattern pins that the
+# recovery actually fired, counting the four sign patterns and *not* the
+# variable-right-hand-side constraint, which is three terms and must fall through
+# to LinearEquality. Without the second guard the test passes against a binary
+# that does no recovery at all; without the enumeration diff a sign error in the
+# normalisation passes too.
+add_test(NAME minizinc-two-term-lin-eq COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash --fzn-pattern int_lin_eq $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ twotermlineq true true "-s" "propagatorCallsEqualsConstraints=4")
+set_tests_properties(minizinc-two-term-lin-eq PROPERTIES SKIP_RETURN_CODE 66 ENVIRONMENT "GCS_PROPAGATOR_STATS=calls")
+
+add_test(NAME minizinc-two-term-lin-ne COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash --fzn-pattern int_lin_ne $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ twotermlinne true true "-s" "propagatorCallsNotEqualsConstraints=4")
+set_tests_properties(minizinc-two-term-lin-ne PROPERTIES SKIP_RETURN_CODE 66 ENVIRONMENT "GCS_PROPAGATOR_STATS=calls")
+
 add_test(NAME minizinc-alldifferentexcept COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ alldifferentexcept true true)
 set_tests_properties(minizinc-alldifferentexcept PROPERTIES SKIP_RETURN_CODE 66)
 

--- a/minizinc/fzn_glasgow.cc
+++ b/minizinc/fzn_glasgow.cc
@@ -613,10 +613,47 @@ auto main(int argc, char * argv[]) -> int
                 else
                     terms += -1_i * arg_as_var(data, args, 2);
 
-                if (id.ends_with("_eq"))
-                    problem.post(LinearEquality{terms, total});
-                else if (id.ends_with("_ne"))
-                    problem.post(LinearNotEquals{terms, total});
+                // MiniZinc rewrites `x = y` and `x != y` between two variables into a
+                // two-term int_lin_eq / int_lin_ne rather than int_eq / int_ne --- it emits
+                // those only for the reified forms --- so from this frontend the
+                // specialised propagators would otherwise never be reached at all. Across
+                // 75 sampled challenge instances: 13,605 two-term unit-coefficient
+                // int_lin_eq in 37 of them and 24,636 int_lin_ne in 6, against zero int_eq
+                // and 125 int_ne. So recover the shape here. Any two unit coefficients
+                // work, not just [1, -1]: dividing through by the first and moving the
+                // second across gives a +-var + constant view of the second variable, which
+                // is exactly what an IntegerVariableID can already express.
+                //
+                // This is the frontend deciding what to post, not a rewrite of a posted
+                // model, so the OPB simply describes the constraint that was posted and
+                // there is no proof gap to bridge (contrast issue #649).
+                auto recover_two_variable_form = [&]() -> optional<pair<IntegerVariableID, IntegerVariableID>> {
+                    if (terms.terms.size() != 2)
+                        return nullopt;
+                    const auto [a, v0] = terms.terms[0];
+                    const auto [b, v1] = terms.terms[1];
+                    if ((a != 1_i && a != -1_i) || (b != 1_i && b != -1_i))
+                        return nullopt;
+                    return pair{v0, (a * b == -1_i ? v1 : -v1) + (a == 1_i ? total : -total)};
+                };
+
+                if (id.ends_with("_eq")) {
+                    // Equals intersects the two domains; the generic linear equality is
+                    // bounds(Z), so it cannot carry a hole across. A strength gain as well
+                    // as a cheaper propagator.
+                    if (auto two = recover_two_variable_form())
+                        problem.post(Equals{two->first, two->second});
+                    else
+                        problem.post(LinearEquality{terms, total});
+                }
+                else if (id.ends_with("_ne")) {
+                    // Same strength either way (a two-term not-equals is GAC both ways),
+                    // so this one is purely the cheaper propagator.
+                    if (auto two = recover_two_variable_form())
+                        problem.post(NotEquals{two->first, two->second});
+                    else
+                        problem.post(LinearNotEquals{terms, total});
+                }
                 else
                     problem.post(terms <= total);
             }

--- a/minizinc/tests/twotermlineq.mzn
+++ b/minizinc/tests/twotermlineq.mzn
@@ -1,0 +1,26 @@
+% MiniZinc rewrites `x = y` between two variables into a two-term int_lin_eq
+% rather than emitting int_eq, so the FlatZinc reader recovers the shape and
+% posts Equals (which intersects domains, where the generic linear equality is
+% bounds(Z) only). Every unit-coefficient sign pattern the rewrite has to
+% normalise appears here, plus a variable right-hand side, which is three terms
+% after it is moved across and so must fall through to LinearEquality.
+var -4..4: a;
+var -4..4: b;
+var -4..4: c;
+var -4..4: d;
+var -4..4: e;
+var -4..4: f;
+var -4..4: g;
+var -4..4: h;
+var -4..4: s;
+
+constraint a - b = 2;   % coefficients [1, -1]
+constraint c + d = -1;  % coefficients [1, 1]
+constraint -e + f = 3;  % coefficients [-1, 1]
+constraint -g - h = 0;  % coefficients [-1, -1]
+constraint a + e = s;   % variable right-hand side: not two terms
+
+solve satisfy;
+
+output ["ENUMSOL: " ++ show(a) ++ " " ++ show(b) ++ " " ++ show(c) ++ " " ++ show(d) ++ " " ++
+    show(e) ++ " " ++ show(f) ++ " " ++ show(g) ++ " " ++ show(h) ++ " " ++ show(s)];

--- a/minizinc/tests/twotermlinne.mzn
+++ b/minizinc/tests/twotermlinne.mzn
@@ -1,0 +1,18 @@
+% As twotermlineq, for `x != y`: MiniZinc gives us a two-term int_lin_ne, and
+% the reader recovers NotEquals. Domains are kept small because these
+% constraints are loose, so the enumeration stays a few hundred solutions.
+var -2..2: a;
+var -2..2: b;
+var -2..2: c;
+var -2..2: d;
+var -2..2: s;
+
+constraint a - b != 1;   % coefficients [1, -1]
+constraint a + b != 0;   % coefficients [1, 1]
+constraint -c + d != 2;  % coefficients [-1, 1]
+constraint -c - d != -1; % coefficients [-1, -1]
+constraint a + c != s;   % variable right-hand side: not two terms
+
+solve satisfy;
+
+output ["ENUMSOL: " ++ show(a) ++ " " ++ show(b) ++ " " ++ show(c) ++ " " ++ show(d) ++ " " ++ show(s)];


### PR DESCRIPTION
Yes, it was worth it — for `!=` clearly, for `=` as tidiness rather than as a win. Both are the same three lines, so both are here, with the numbers to judge each on.

## The gap

MiniZinc emits `int_eq` / `int_ne` **only for the reified forms**. A non-reified `x = y` or `x != y` between two variables comes out as a two-term `int_lin_eq` / `int_lin_ne` with coefficients `[1, -1]`, so from this frontend `Equals` and `NotEquals` were never reached at all. One instance per model directory across the 2012/2016/2019/2022 challenge sets, 75 instances flattened and counted:

| shape | constraints | instances |
|---|---|---|
| `int_lin_eq`, two terms, unit coefficients | 13,605 | **37 of 75** |
| `int_eq` | 0 | 0 |
| `int_lin_ne`, two terms, unit coefficients | 24,636 | 6 |
| `int_ne` | 125 | 6 |

Any two unit coefficients are recoverable, not just `[1, -1]`: dividing through by the first and moving the second across gives a ±variable + constant view of the second variable, which an `IntegerVariableID` already expresses. A variable right-hand side has been moved onto the left as a third term before this runs, so those fall through to the linear propagator, as does any coefficient other than ±1.

This is the frontend choosing what to post, not a rewrite of a posted model, so the OPB describes what was posted and there is no proof gap to bridge (contrast #649).

## not-equals: identical behaviour, −31.8%

`2012/tpp_3_5_20_1`, uncapped and complete. The 20 `lin_not_equals` constraints become 20 `not_equals` with **every figure identical** — 7,503,197 nodes, 7,495,104 failures, 77,751,218 propagations, 17,784,598 calls, 1 effectful, 3,751,288 contradictions — and min-of-3 solo:

| | min-of-3 |
|---|---|
| main | 20.72 s |
| this branch | **14.13 s** (−31.8%) |
| #823 (`contradiction_or_stop`) | 14.34 s |

Same prize as #823 by another route: `NotEquals` reports failure through `infer_not_equal_or_stop`, so it never throws, and a throw is ~1.6 us. The two are independent and complementary — #823 fixes the mechanism for every `LinearNotEquals` (multi-term ones, and the C++/XCSP callers), this picks the better propagator for the shape MiniZinc actually hands us.

## equals: neutral, and the reason is the interesting part

`Equals` intersects the two domains where `propagate_linear` is bounds(Z), so this looked like a free strength gain. It is not — **MiniZinc has already done the intersection**. Given

```minizinc
var {0,2,4,...,1000}: x;  var {0,1,3,5,...,999,1000}: y;  constraint x = y;
```

the flattener unifies `y` away and declares `x` as `{0, 1000}` in the FlatZinc. Whatever intersection is available at the root, the frontend performed it before we saw the model. What is left is a hole that appears during *search*, which `Equals` can carry and bounds(Z) cannot — worth about one search node:

- 41 first-solution runs that completed under both binaries, across eight model families: answers **identical**, node counts identical on 36 and **one lower on 5** (all five `elitserien`), total time 58.91 → 58.20 s.
- Min-of-3 solo: `elitserien handball3` **−5.9%**, `nside HARD_200_50` −0.6%, `steelmillslab bench_20_15` −0.3%, `code-generator use_return_register` +0.2%.

So it lands as the cheaper and occasionally stronger propagator. Nothing measured got slower, which is the bar `propagator-performance.md` sets.

## Tests

Two new `minizinc-two-term-lin-{eq,ne}` lanes covering all four sign patterns plus a variable right-hand side that must *not* be rewritten. Both guards are load-bearing, checked by breaking them:

- `--fzn-pattern int_lin_eq` pins that MiniZinc really hands us the linear form. If a future version emits `int_eq` instead, this recovery is dead code and the test says so.
- the required output pattern `propagatorCallsEqualsConstraints=4` pins that the recovery fired, and counts the four rewritten constraints and not the fall-through. Against a binary without the rewrite the lane fails with exit 9.
- with the sign normalisation deliberately inverted, the enumeration diff against MiniZinc's own solver fails with exit 4.

2,736 and 1,228 solutions agree with the default solver, and both proofs are VeriPB-verified. A scratch sweep over all four sign patterns × {eq, ne} × {constant, variable rhs}, plus an aliased pair and a one-term-with-variable-rhs case, found no solution-set difference in any of 35 models. Across the 75-instance survey no instance behaved differently on the two binaries. Full `ctest` 796/796; GCC `-DGCS_WERROR=ON` and clang 21 clean.

## Left out

Two-term unit `int_lin_le` is **37,850 constraints in 30 of the 75** — the biggest of the three — and I first wrote here that `--difference-logic` was what stood in its way. That was wrong: `DifferenceLogic::run` already enumerates `ReifiedCompareLessThanOrMaybeEqual` donors alongside `ReifiedLinearInequality` ones and deviews both operands, so `x <= y + d` lifts to exactly the edge the linear form did — measured, 4/4 and 6/6 edges lifted with only the family classification moving.

What actually blocks it is `find_makespan_links`, which enumerates *only* `ReifiedLinearInequality` and wants precisely the shape the rewrite would consume, so `InferredCumulative` / `InferredDisjunctive` would silently lose every makespan link — and no test catches that. The rewrite measures neutral anyway: identical node counts on all eight `le`-heavy instances that found a first solution inside 45 s. Written up as #825, with the working rewrite and its tests stashed on this branch. The `_reif` forms (1,044 eq and 1,875 ne two-term unit) are the same three lines and can follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

