### PR TITLE
Teach find_makespan_links the comparison family

### DIFF
--- a/gcs/constraints/cumulative/derived_cumulative_test.cc
+++ b/gcs/constraints/cumulative/derived_cumulative_test.cc
@@ -1,3 +1,4 @@
+#include <gcs/constraints/comparison.hh>
 #include <gcs/constraints/cumulative.hh>
 #include <gcs/constraints/cumulative/derived_cumulative.hh>
 #include <gcs/constraints/innards/constraints_test_utils.hh>
@@ -359,6 +360,24 @@ namespace
         }
     };
 
+    /// How a model spells the rows that say every task finishes by the makespan.
+    /// find_makespan_links has to recognise all three, and the energy
+    /// derivation cites whichever row it found --- which for the two comparison
+    /// spellings is stated over an offset view, whose BinEnc the confine `pol`
+    /// deviews before it can cancel. So each spelling is its own path through
+    /// the proof, not a restatement of the same one.
+    enum class MakespanRows
+    {
+        /// `LinearGreaterThanEqual{makespan - start, length}`, which is what a
+        /// scheduling model writes and what MiniZinc's int_lin_le flattens to.
+        Linear,
+        /// `LessThanEqual{start + length, makespan}`: the view is over the start.
+        OffsetOnStart,
+        /// `LessThanEqual{start, makespan - length}`: the view is over the
+        /// makespan. This is the shape the FlatZinc reader recovers.
+        OffsetOnMakespan
+    };
+
     struct Instance
     {
         vector<pair<int, int>> start_ranges;
@@ -370,6 +389,8 @@ namespace
         /// --- which is the entailment the makespan bound's derivation rests
         /// on, and the only thing that makes those demos legal.
         optional<int> makespan_horizon = nullopt;
+        /// Which spelling those rows get. Ignored without a horizon.
+        MakespanRows makespan_rows = MakespanRows::Linear;
         /// When non-empty, one per task: the domain that task's presence
         /// variable is declared over, and the constraint is posted with the
         /// optional-task constructor. A solution then carries every presence
@@ -438,7 +459,12 @@ namespace
         if (inst.makespan_horizon) {
             makespan = p.create_integer_variable(0_i, Integer{*inst.makespan_horizon}, "makespan");
             for (size_t i = 0; i < starts.size(); ++i)
-                p.post(LinearGreaterThanEqual{WeightedSum{} + 1_i * *makespan + -1_i * starts[i], lengths[i]});
+                switch (inst.makespan_rows) {
+                    using enum MakespanRows;
+                case Linear: p.post(LinearGreaterThanEqual{WeightedSum{} + 1_i * *makespan + -1_i * starts[i], lengths[i]}); break;
+                case OffsetOnStart: p.post(LessThanEqual{starts[i] + lengths[i], *makespan}); break;
+                case OffsetOnMakespan: p.post(LessThanEqual{starts[i], *makespan - lengths[i]}); break;
+                }
         }
 
         vector<IntegerVariableID> presences;
@@ -651,6 +677,39 @@ auto main(int argc, char * argv[]) -> int
         auto unproved = solve_it(makespan_instance, make_optional(Demo::Makespan), nullopt);
         if (unproved.makespan_bound != with_bound.makespan_bound)
             fail("makespan demo: the bound differs with proofs off");
+    }
+
+    // The same bound, from a model that spells its makespan rows as comparisons
+    // over an offset view rather than as two-term linear rows. Two things have
+    // to work that the linear spelling does not exercise: find_makespan_links
+    // recognising the shape at all --- miss it and there is no link, so the
+    // task's energy is not counted and the bound is not reached --- and the
+    // confine `pol` deviewing the row it cites, since the row is stated in
+    // BinEnc(V) and has to cancel against the start's and the makespan's own
+    // order literals. The first failure shows up as a wrong bound here, the
+    // second as a proof VeriPB rejects.
+    for (const auto & [spelling, tag] :
+        {pair{MakespanRows::OffsetOnStart, string{"offset_on_start"}}, pair{MakespanRows::OffsetOnMakespan, string{"offset_on_makespan"}}}) {
+        auto comparison_makespan = makespan_instance;
+        comparison_makespan.makespan_rows = spelling;
+
+        auto with_bound =
+            solve_it(comparison_makespan, make_optional(Demo::Makespan), proofs ? make_optional("derived_cumulative_makespan_" + tag) : nullopt);
+
+        if (with_bound.makespan_bound != make_optional(6_i))
+            fail("makespan demo, " + tag + ": the derived constraint inferred " +
+                (with_bound.makespan_bound ? std::to_string(with_bound.makespan_bound->raw_value) : string{"nothing"}) +
+                ", not the six its tasks' energy supports --- the model's rows were not recognised as makespan links");
+
+        set<vector<int>> expected;
+        build_expected(
+            expected, [&](const vector<int> & a) { return is_satisfying(comparison_makespan, a); }, assignment_ranges(comparison_makespan));
+        if (expected != with_bound.solutions)
+            fail("makespan demo, " + tag + ": solutions do not match brute force");
+
+        auto unproved = solve_it(comparison_makespan, make_optional(Demo::Makespan), nullopt);
+        if (unproved.makespan_bound != with_bound.makespan_bound)
+            fail("makespan demo, " + tag + ": the bound differs with proofs off");
     }
 
     // The same three tasks, made optional. What a derived constraint over an

--- a/gcs/constraints/cumulative/derived_cumulative_test.cc
+++ b/gcs/constraints/cumulative/derived_cumulative_test.cc
@@ -680,14 +680,16 @@ auto main(int argc, char * argv[]) -> int
     }
 
     // The same bound, from a model that spells its makespan rows as comparisons
-    // over an offset view rather than as two-term linear rows. Two things have
-    // to work that the linear spelling does not exercise: find_makespan_links
-    // recognising the shape at all --- miss it and there is no link, so the
-    // task's energy is not counted and the bound is not reached --- and the
-    // confine `pol` deviewing the row it cites, since the row is stated in
-    // BinEnc(V) and has to cancel against the start's and the makespan's own
-    // order literals. The first failure shows up as a wrong bound here, the
-    // second as a proof VeriPB rejects.
+    // over an offset view rather than as two-term linear rows.
+    //
+    // What these two lanes pin is find_makespan_links recognising the shape:
+    // miss it and there is no link, so the task's energy is not counted and the
+    // bound below is wrong. They do *not* pin the other thing the spelling
+    // needs, the confine `pol` deviewing the row it cites --- deleting that
+    // leaves both of these passing and both proofs verifying, because the
+    // framework's atom-level `[V >= v] <=> [X >= k]` clauses let the lemma's own
+    // RUP reach the deadline literals without the clause the `pol` builds. See
+    // makespan_energy.cc, which says the same thing at the call.
     for (const auto & [spelling, tag] :
         {pair{MakespanRows::OffsetOnStart, string{"offset_on_start"}}, pair{MakespanRows::OffsetOnMakespan, string{"offset_on_makespan"}}}) {
         auto comparison_makespan = makespan_instance;

--- a/gcs/constraints/innards/makespan_energy.cc
+++ b/gcs/constraints/innards/makespan_energy.cc
@@ -152,6 +152,29 @@ auto gcs::innards::makespan_energy::derive_makespan_bound(ProofLogger & logger, 
             if (! task.link->row)
                 throw ProofError{"makespan energy bound: a task's makespan link has no row to cite"};
             PolBuilder confine;
+            // Deview mode, because a link's row may be stated over an offset view
+            // --- a model that writes `start + length <= makespan`, or the
+            // `start <= makespan - length` the FlatZinc reader recovers from a
+            // two-term int_lin_le --- and a view has its own BinEnc in the OPB,
+            // which would not cancel against either variable's order-literal
+            // definitions below. Deview mode substitutes each BinEnc(V) term
+            // through the view's link axiom first, so the cancellation is the
+            // one this derivation describes. A row with no view terms has no
+            // deview-form registered and is pushed unchanged, so the linear
+            // family's proofs are byte-for-byte what they were.
+            //
+            // Removing this does not currently fail any fixture, and that is
+            // worth knowing rather than hiding: the framework pre-derives the
+            // atom-level `[V >= v] <=> [X >= k]` clauses for every view atom a
+            // proof uses, so the lemma's own reverse unit propagation can cross
+            // the V/X boundary in one step and reach the deadline literals
+            // without this clause. What it cannot do is *add* the row to the
+            // literal definitions, which is what this pol does --- so without
+            // deview mode the line emitted here is a valid consequence that is
+            // not the clause the comment below describes, and the first lemma
+            // that needs the clause rather than the atoms would fail somewhere
+            // far from the cause.
+            confine.enable_deview_mode(logger.names_and_ids_tracker());
             confine.add(*task.link->row);
             confine.add_for_literal(logger.names_and_ids_tracker(), task.start >= hi - task.link->bound + 1_i);
             confine.add_for_literal(logger.names_and_ids_tracker(), makespan < hi + 1_i);

--- a/gcs/presolvers/innards/makespan_links.cc
+++ b/gcs/presolvers/innards/makespan_links.cc
@@ -1,3 +1,5 @@
+#include <gcs/constraints/comparison.hh>
+#include <gcs/constraints/difference/difference_graph.hh>
 #include <gcs/constraints/linear.hh>
 #include <gcs/presolvers/innards/makespan_links.hh>
 #include <gcs/problem.hh>
@@ -58,6 +60,52 @@ auto gcs::innards::find_makespan_links(const Problem & problem, const ProofLogge
         auto existing = links.find(*start);
         if (existing == links.end())
             links.emplace(*start, makespan_energy::MakespanLink{bound, label});
+        else if (bound > existing->second.bound)
+            existing->second = makespan_energy::MakespanLink{bound, label};
+    }
+
+    // The comparison family says the same thing over an offset view: a model
+    // written `start + length <= makespan`, and the `start <= makespan - length`
+    // the FlatZinc reader recovers from a two-term int_lin_le. A view has its own
+    // BinEnc in the proof, so neither row is stated in the underlying variables'
+    // bits --- but makespan_energy cites the link's row in *deview mode*, which
+    // substitutes each BinEnc(V) term through the view's link axiom before the
+    // cancellation, so both spellings resolve against the start's and the
+    // makespan's own order-literal definitions exactly as the linear form's row
+    // does. That is the same trick the difference-logic propagator uses on its
+    // donors. A *negated* view is still not this shape at all --- `-start + c <=
+    // makespan` bounds the wrong side --- and deview_difference_operand rejects
+    // those for us.
+    for (const auto & [c, label] : problem.each_constraint_of_type_with_proof_data<ReifiedCompareLessThanOrMaybeEqual>(logger)) {
+        if (! std::holds_alternative<reif::MustHold>(c.reification_condition()))
+            continue;
+
+        auto left = deview_difference_operand(c.left_variable());
+        auto right = deview_difference_operand(c.right_variable());
+        if (! left || ! right || ! left->variable || ! right->variable)
+            continue;
+
+        // The makespan on the right, and not on both: aliasing states `0 >= bound`,
+        // which is a fact about the model rather than about any task, and is the
+        // degenerate case the linear branch above declines for the same reason.
+        if (IntegerVariableID{*right->variable} != makespan || IntegerVariableID{*left->variable} == makespan)
+            continue;
+
+        // `left <= right` states `left - right <= 0`, and the strict spelling `<=
+        // -1`. With left = start + cl and right = makespan + cr that is `start -
+        // makespan <= (or_equal ? 0 : -1) - cl + cr`, so the length the energy
+        // argument wants out of `makespan - start >= length` is its negation.
+        auto bound = left->offset - right->offset + (c.or_equal() ? 0_i : 1_i);
+        if (bound <= 0_i)
+            continue;
+
+        if (logger && ! label)
+            continue;
+
+        auto start = IntegerVariableID{*left->variable};
+        auto existing = links.find(start);
+        if (existing == links.end())
+            links.emplace(start, makespan_energy::MakespanLink{bound, label});
         else if (bound > existing->second.bound)
             existing->second = makespan_energy::MakespanLink{bound, label};
     }

--- a/gcs/presolvers/innards/makespan_links.hh
+++ b/gcs/presolvers/innards/makespan_links.hh
@@ -27,12 +27,16 @@ namespace gcs::innards
      * a variable that is not a makespan gets a task with no link, which costs
      * that task's energy, instead of a rejected proof.
      *
-     * Only the linear family, and only its two-term unconditional rows over
-     * plain variables with coefficients `+1` and `-1` --- which is what a
-     * scheduling model's makespan rows are, and what MiniZinc's `int_lin_le`
-     * flattens them to. A comparison spelling (`start + length <= makespan`)
-     * says the same thing over an offset view, whose bits would not cancel
-     * against the plain variable's in the `pol`, so it is not matched here.
+     * Both families, unconditionally-held rows only. From the linear family,
+     * two-term rows over plain variables with coefficients `+1` and `-1` ---
+     * which is what a scheduling model's makespan rows are, and what MiniZinc's
+     * `int_lin_le` flattens them to. From the comparison family, `start + length
+     * <= makespan` and `start <= makespan - length`, which say the same thing
+     * over an offset view: a view has its own `BinEnc` in the proof, so those
+     * rows are not stated in the underlying variables' bits, and
+     * makespan_energy cites the row in *deview mode* to put it back in them
+     * before the cancellation. A negated view is not this shape at all and is
+     * declined.
      *
      * The strongest row wins where a variable has several. With proofs off the
      * links are still found --- which is the point, since the bound they let


### PR DESCRIPTION
Half of #825. A makespan row can be spelled two ways and this only knew one.

`makespan - start >= length` as a two-term linear row it found. `start + length <= makespan`, and the `start <= makespan - length` the FlatZinc reader recovers from a two-term `int_lin_le` (#824), it did not — so on such a model `InferredCumulative` and `InferredDisjunctive` got **no makespan links at all**, every task's energy went uncounted, and the certified bound of #672/#673 was quietly not derivable. Nothing said so: neither presolver is installed by `fzn_glasgow.cc`, and every test that reaches this posts its donors through the C++ API, where the class is whatever the test named.

## The scan

`ReifiedCompareLessThanOrMaybeEqual` as well, `MustHold` rows only, as the linear branch does. `deview_difference_operand` — the helper the difference-logic presolver already uses on its own donors — reduces each operand to variable-plus-offset and declines a negated view, which is not this shape at all. `left <= right` states `left - right <= 0` (`<= -1` for the strict spelling), so with `left = start + cl` and `right = makespan + cr` the length wanted out of `makespan - start >= length` is `cl - cr + (or_equal ? 0 : 1)`. Degenerate and aliased rows are declined exactly as the linear branch declines them, and the strongest row still wins where a variable has several — now across both families.

## The proof side, which is why this was left undone

The header said a comparison spelling's "bits would not cancel against the plain variable's in the `pol`", and that was right. A view has its own `BinEnc` in the OPB — checked, not assumed:

```
@c[view_of_start0_plus_2][viewle] ... -1 p[0_view_of_start0_plus_2][b0] ... 1 i[start0][b0] ... >= -2;
@c[_1] -1 p[0_view_of_start0_plus_2][b0] -2 p[...][b1] -4 p[...][b2] 1 i[makespan][b0] ... >= 0;
```

so the row is over `p[0_view_of_start0_plus_2][b*]`, not `i[start0][b*]`, and the confine `pol` in `makespan_energy` adds that row to the start's and the makespan's own order-literal definitions expecting both to cancel.

The machinery for fixing that already exists: `ProofModel::add_labelled_constraint` derives a deview-form for every row with view terms, and `PolBuilder` has a deview mode that substitutes it in. One call, a no-op for rows without view terms, so the linear family's proofs are byte-for-byte what they were.

## Fixtures

The makespan demo re-run under each comparison spelling — one with the view over the start, one over the makespan. Both reach the same bound of **six**, match brute force, agree with the proofs-off run, and verify: 11 proofs VERIFIED, and the two deliberate mutations (`MakespanClaimHigher`, `MakespanOmitRow`) still rejected. Drop the comparison loop and the test fails with

```
makespan demo, offset_on_start: the derived constraint inferred nothing, not the six its
tasks' energy supports --- the model's rows were not recognised as makespan links
```

which is exactly the silent failure this is meant to prevent.

**Deleting the deview call fails nothing, and the comment now says so** rather than implying a check that does not exist. The framework pre-derives the atom-level `[V >= v] <=> [X >= k]` clauses for every view atom a proof uses, so the lemma's own RUP crosses the V/X boundary in one step and reaches the deadline literals without the confine clause; I confirmed the confine `pol` does fire on a view row in these fixtures, and that VeriPB accepts the non-cancelling line as a valid consequence that nothing then needs. The clause is what the `pol` claims to derive, and without deviewing it derives a valid line that is not that clause — so it stays, documented as correct rather than as verified. If someone wants it load-bearing, the fixture needed is one where the lemma asks for a deadline literal the atom-level links cannot reach.

Full `ctest` 794/794; GCC `-DGCS_WERROR=ON` and clang 21 clean.

Leaves the other half of #825 open: the `int_lin_le` recovery itself, which measured neutral, and a lane that posts a donor scan's donors through the FlatZinc reader so a class change fails loudly rather than silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
