### PR TITLE
The three hand-rolled clique folds, and the guard the third needed

### DIFF
--- a/gcs/constraints/all_different/justify.cc
+++ b/gcs/constraints/all_different/justify.cc
@@ -1,4 +1,5 @@
 #include <gcs/constraints/all_different/justify.hh>
+#include <gcs/innards/proofs/am1_from_pairs.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
 #include <gcs/innards/proofs/pol_builder.hh>
 
@@ -19,24 +20,20 @@ auto gcs::innards::justify_all_different_hall_set_or_violator(ProofLogger & logg
         if (value_am1_constraint_numbers.contains(val))
             continue;
 
-        // at most one variable can take this value
-        PolBuilder am1;
-        int layer = 0;
-        for (unsigned i = 1; i < all_variables.size(); ++i) {
-            if (++layer >= 2)
-                am1.multiply_by(Integer{layer});
-
-            for (unsigned j = 0; j < i; ++j) {
-                auto ne = logger.emit_rup_proof_line(
-                    WPBSum{} + 1_i * ! (all_variables[i] == val) + 1_i * ! (all_variables[j] == val) >= 1_i, ProofLevel::Temporary);
-                am1.add(ne);
-            }
-
-            am1.divide_by(Integer{layer + 1});
+        // At most one variable can take this value: the pairwise clauses, and
+        // then the shared fold of them into the clique inequality. Emitted at
+        // Top and cached here, because the Hall set argument below is replayed
+        // for every violator that mentions this value.
+        vector<ProofLiteralOrFlag> members;
+        vector<vector<ProofLine>> at_most_ones(all_variables.size());
+        for (unsigned i = 0; i < all_variables.size(); ++i) {
+            members.push_back(ProofLiteral{all_variables[i] == val});
+            for (unsigned j = 0; j < i; ++j)
+                at_most_ones[i].push_back(logger.emit_rup_proof_line(
+                    WPBSum{} + 1_i * ! (all_variables[i] == val) + 1_i * ! (all_variables[j] == val) >= 1_i, ProofLevel::Temporary));
         }
 
-        if (! am1.empty())
-            value_am1_constraint_numbers.emplace(val, am1.emit(logger, ProofLevel::Top));
+        value_am1_constraint_numbers.emplace(val, recover_am1_from_pairs(logger, members, at_most_ones, ProofLevel::Top));
     }
 
     // we are going to need the at least one value variables

--- a/gcs/constraints/min_distance/min_distance.cc
+++ b/gcs/constraints/min_distance/min_distance.cc
@@ -1,6 +1,7 @@
 #include <gcs/constraints/min_distance/min_distance.hh>
 #include <gcs/exception.hh>
 #include <gcs/innards/inference_tracker.hh>
+#include <gcs/innards/proofs/am1_from_pairs.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
 #include <gcs/innards/proofs/pol_builder.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
@@ -697,33 +698,32 @@ auto MinDistance::install_matching_propagator(Propagators & propagators) -> void
                 // Per unordered pair emit ~l_r \/ ~l_s \/ g by RUP (cross-site via
                 // the pair clause + z order; same-site via the per-site count
                 // constraint + z order; same-position via the variable's at-most-one),
-                // then combine with the all_different PolBuilder layer recurrence, so
-                // g rides through the ceil-divisions with an exact coefficient:
-                // Sum_{l in L} ~l + (|L|-1) g >= |L|-1.
+                // then hand them to the shared clique fold, which carries g through
+                // the ceil-divisions with its coefficient tracking the degree:
+                // Sum_{l in L} ~l + (|L|-1) g >= |L|-1. That (|L|-1) is what sum_c
+                // above counts, and what the final division cancels.
                 auto emit_am1 = [&](const vector<pair<std::size_t, Integer>> & lits) -> optional<ProofLine> {
                     if (lits.size() < 2) {
                         // A single-literal site contributes nothing to the counting
                         // beyond cancelling its own at-least-one term; the trivially
-                        // true ~[x_pos = site] >= 0 does exactly that.
+                        // true ~[x_pos = site] >= 0 does exactly that. Below the two
+                        // members the fold needs, so it is handled here rather than
+                        // there.
                         if (lits.size() == 1)
                             return logger->emit_rup_proof_line(WPBSum{} + 1_i * (x[lits[0].first] != lits[0].second) >= 0_i, ProofLevel::Temporary);
                         return std::nullopt;
                     }
-                    PolBuilder am1;
-                    int layer = 0;
-                    for (std::size_t i = 1; i < lits.size(); ++i) {
-                        if (++layer >= 2)
-                            am1.multiply_by(Integer{layer});
-                        for (std::size_t j = 0; j < i; ++j) {
-                            auto ne = logger->emit_rup_proof_line(
+                    vector<ProofLiteralOrFlag> members;
+                    vector<vector<ProofLine>> at_most_ones(lits.size());
+                    for (std::size_t i = 0; i < lits.size(); ++i) {
+                        members.push_back(ProofLiteral{x[lits[i].first] == lits[i].second});
+                        for (std::size_t j = 0; j < i; ++j)
+                            at_most_ones[i].push_back(logger->emit_rup_proof_line(
                                 WPBSum{} + 1_i * (x[lits[i].first] != lits[i].second) + 1_i * (x[lits[j].first] != lits[j].second) + 1_i * guard >=
                                     1_i,
-                                ProofLevel::Temporary);
-                            am1.add(ne);
-                        }
-                        am1.divide_by(Integer{layer + 1});
+                                ProofLevel::Temporary));
                     }
-                    return am1.emit(*logger, ProofLevel::Temporary);
+                    return recover_am1_from_pairs(*logger, members, at_most_ones, ProofLevel::Temporary, ProofLiteralOrFlag{ProofLiteral{guard}});
                 };
 
                 PolBuilder final_pol;

--- a/gcs/constraints/sort/sort.cc
+++ b/gcs/constraints/sort/sort.cc
@@ -2,6 +2,7 @@
 #include <gcs/constraints/sort/sort.hh>
 #include <gcs/exception.hh>
 #include <gcs/innards/inference_tracker.hh>
+#include <gcs/innards/proofs/am1_from_pairs.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
 #include <gcs/innards/proofs/pol_builder.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
@@ -1063,30 +1064,25 @@ auto gcs::innards::install_sortedness_propagator(Propagators & propagators, cons
             }
 
             // Per-rank injectivity: at most one position has rank k, i.e.
-            // sum_i [pos[i] = k] <= 1. This is recover_am1's pairwise->global
-            // fold (the layer/multiply/divide pol from all_different's
-            // justify.cc), done inline because pos is proof-only and so the
-            // shared recover_am1 template isn't instantiated for its condition
-            // type. Each pairwise distinctness clause
+            // sum_i [pos[i] = k] <= 1, by the shared clique fold. Each pairwise
+            // distinctness clause
             //   !(pos[i]=k) + !(pos[i']=k) >= 1
             // is RUP from the two GAP lines and the antisymmetry clause: if both
             // had rank k, the GAPs force both directed before-flags, which
-            // antisymmetry forbids.
+            // antisymmetry forbids. pos is proof-only, but a condition on a
+            // ProofOnlySimpleIntegerVariableID is a ProofLiteral like any other,
+            // so recover_am1_from_pairs takes it unchanged.
             inj_lines->clear();
             for (size_t k = 0; n >= 2 && k < n; ++k) {
-                PolBuilder am1;
-                long long layer = 0;
-                for (size_t i = 1; i < n; ++i) {
-                    if (++layer >= 2)
-                        am1.multiply_by(Integer{layer});
-                    for (size_t ip = 0; ip < i; ++ip) {
-                        auto ne = logger->emit_rup_proof_line(
-                            WPBSum{} + 1_i * (pos[i] != Integer(k)) + 1_i * (pos[ip] != Integer(k)) >= 1_i, ProofLevel::Temporary);
-                        am1.add(ne);
-                    }
-                    am1.divide_by(Integer{layer + 1});
+                vector<ProofLiteralOrFlag> members;
+                vector<vector<ProofLine>> at_most_ones(n);
+                for (size_t i = 0; i < n; ++i) {
+                    members.push_back(ProofLiteral{pos[i] == Integer(k)});
+                    for (size_t ip = 0; ip < i; ++ip)
+                        at_most_ones[i].push_back(logger->emit_rup_proof_line(
+                            WPBSum{} + 1_i * (pos[i] != Integer(k)) + 1_i * (pos[ip] != Integer(k)) >= 1_i, ProofLevel::Temporary));
                 }
-                inj_lines->push_back(am1.emit(*logger, ProofLevel::Top));
+                inj_lines->push_back(recover_am1_from_pairs(*logger, members, at_most_ones, ProofLevel::Top));
             }
         },
         InitialiserPriority::Expensive);

--- a/gcs/innards/proofs/am1_from_pairs.cc
+++ b/gcs/innards/proofs/am1_from_pairs.cc
@@ -6,6 +6,7 @@
 #include <gcs/innards/proofs/pseudo_boolean.hh>
 
 #include <cstddef>
+#include <optional>
 #include <string>
 #include <utility>
 #include <variant>
@@ -20,7 +21,8 @@ using std::to_string;
 using std::vector;
 
 auto gcs::innards::recover_am1_from_pairs(ProofLogger & logger, const vector<ProofLiteralOrFlag> & members,
-    const vector<vector<ProofLine>> & at_most_ones, ProofLevel level, Am1FromPairsMutation mutation) -> ProofLine
+    const vector<vector<ProofLine>> & at_most_ones, ProofLevel level, const std::optional<ProofLiteralOrFlag> & guard, Am1FromPairsMutation mutation)
+    -> ProofLine
 {
     auto k = members.size();
     if (k < 2)
@@ -38,7 +40,7 @@ auto gcs::innards::recover_am1_from_pairs(ProofLogger & logger, const vector<Pro
     if ((drop_one || skip_final_division) && k < 3)
         throw ProofError{"clique derivation: this mutation needs a merge to corrupt, so at least three members"};
 
-    logger.emit_proof_comment("clique at-most-one over " + to_string(k) + " members");
+    logger.emit_proof_comment("clique at-most-one over " + to_string(k) + " members" + (guard ? ", or the guard" : ""));
 
     // Only the pin below is ever cited again: every line the induction emits
     // between here and it exists to reach it. See ProofScaffoldingScope.
@@ -101,9 +103,19 @@ auto gcs::innards::recover_am1_from_pairs(ProofLogger & logger, const vector<Pro
     WPBSum clique;
     for (const auto & member : members)
         add_term_to(clique, 1_i, member);
+    auto bound = claim_one_more ? 0_i : 1_i;
+
+    // A guarded fold concludes `sum a_p <= 1 + (k-1) g`, the guard's
+    // coefficient having tracked the degree the whole way up. Stated over `~g`
+    // so that the pin has no negative coefficient in it: `(k-1) ~g = (k-1) -
+    // (k-1) g`, which is the same constraint with `k - 1` added to both sides.
+    if (guard) {
+        add_term_to(clique, Integer{static_cast<long long>(k) - 1}, ! *guard);
+        bound += Integer{static_cast<long long>(k) - 1};
+    }
 
     // Back at the caller's level to pin, while the induction is still alive for
     // VeriPB to resolve the reference against, and only then drop it.
     scaffolding.restore();
-    return logger.emit(ImpliesProofRule{current}, move(clique) <= (claim_one_more ? 0_i : 1_i), level);
+    return logger.emit(ImpliesProofRule{current}, move(clique) <= bound, level);
 }

--- a/gcs/innards/proofs/am1_from_pairs.hh
+++ b/gcs/innards/proofs/am1_from_pairs.hh
@@ -34,7 +34,9 @@ namespace gcs::innards
 
         /// Claim the members are all inactive rather than at most one active
         /// --- the "bound + 1 must fail" check for a rule whose content is a
-        /// number.
+        /// number. The only one of these that is purely about the pin: it
+        /// leaves the derivation alone, so there is nothing for a downstream
+        /// consumer to reject.
         struct ClaimOneMore
         {
         };
@@ -100,19 +102,28 @@ namespace gcs::innards
      * that VeriPB is right to accept, so nothing *here* catches it and the
      * caller has no guarantee that what it got says what it wanted.
      *
-     * Whether anything catches it *later* is the caller's to know, and the
-     * answer is not always no. Where the consumer is coefficient-sensitive ---
-     * a pigeonhole `pol` that adds this line into a count and needs an exact
-     * cancellation --- a corrupted merge is rejected downstream with or without
-     * the pin. That was measured rather than assumed, at `subcircuit.cc`'s call
-     * site and again at `all_different/justify.cc`'s (#805): with the pin taken
-     * off, every one of these mutations was still rejected. Where the consumer
-     * only needs the line to be sound, the pin is the only thing between a
-     * quietly weakened derivation and a proof that verifies. Both kinds of
-     * caller live here, so the pin stays --- it is one line, and a caller
-     * should not have to know which kind it is --- but do not read a passing
-     * mutation test at your own call site as evidence that the pin is what
-     * caught it.
+     * Whether anything catches it *later* is the caller's to know, and so far
+     * the answer has always been yes. Every call site here consumes the clique
+     * line coefficient by coefficient --- a counting `pol` that needs an exact
+     * cancellation, and whose RUP then fails when it does not get one --- so a
+     * weakened merge is rejected downstream whether or not it was pinned. That
+     * was measured rather than assumed. With the pin replaced by an unpinned
+     * copy of whatever the induction landed on, the `DropAnAtMostOne`,
+     * `NaiveOneShot` and `SkipFinalDivision` mutations were each still
+     * rejected: at `subcircuit.cc` (#797), and at all three of
+     * `all_different/justify.cc`, `sort/sort.cc` and
+     * `min_distance/min_distance.cc` (#805).
+     *
+     * What that leaves the pin doing here is saying so locally, where it can
+     * name the line that is wrong, instead of as a RUP failure a few hundred
+     * lines further on --- and covering a caller who is *not*
+     * coefficient-sensitive, for whom it would be the only thing between a
+     * quietly weakened derivation and a proof that verifies. So the pin stays;
+     * it is one line, and a caller should not have to know which kind it is.
+     * But do not read a mutation rejected at your own call site as evidence
+     * that the pin is what rejected it: run the experiment. `ClaimOneMore`
+     * cannot answer it for you, since it corrupts nothing but the pin's target
+     * and so has nothing left to catch once the pin is gone.
      *
      * The pin is also stricter than "weaker fails". An implication check is
      * syntactic, so it rejects a line that is *equivalent* to the target but

--- a/gcs/innards/proofs/am1_from_pairs.hh
+++ b/gcs/innards/proofs/am1_from_pairs.hh
@@ -5,6 +5,7 @@
 #include <gcs/innards/proofs/proof_logger-fwd.hh>
 #include <gcs/innards/proofs/proof_only_variables.hh>
 
+#include <optional>
 #include <variant>
 #include <vector>
 
@@ -96,9 +97,22 @@ namespace gcs::innards
      * The returned line is pinned to `sum a_p <= 1` with an `ia` step before it
      * comes back, and that step is not decoration. Dropping an input, or
      * mis-scaling a merge, leaves the `pol` on a weaker but still sound line
-     * that VeriPB is right to accept --- so without the pin there is no
-     * mutation of this derivation that can be caught, and the caller has no
-     * guarantee that what it got says what it wanted.
+     * that VeriPB is right to accept, so nothing *here* catches it and the
+     * caller has no guarantee that what it got says what it wanted.
+     *
+     * Whether anything catches it *later* is the caller's to know, and the
+     * answer is not always no. Where the consumer is coefficient-sensitive ---
+     * a pigeonhole `pol` that adds this line into a count and needs an exact
+     * cancellation --- a corrupted merge is rejected downstream with or without
+     * the pin. That was measured rather than assumed, at `subcircuit.cc`'s call
+     * site and again at `all_different/justify.cc`'s (#805): with the pin taken
+     * off, every one of these mutations was still rejected. Where the consumer
+     * only needs the line to be sound, the pin is the only thing between a
+     * quietly weakened derivation and a proof that verifies. Both kinds of
+     * caller live here, so the pin stays --- it is one line, and a caller
+     * should not have to know which kind it is --- but do not read a passing
+     * mutation test at your own call site as evidence that the pin is what
+     * caught it.
      *
      * The pin is also stricter than "weaker fails". An implication check is
      * syntactic, so it rejects a line that is *equivalent* to the target but
@@ -118,6 +132,20 @@ namespace gcs::innards
      * at-most-one for its pair rather than some other line that happens to
      * carry the arithmetic.
      *
+     * `guard`, if given, is a literal every input at-most-one carries as an
+     * extra disjunct --- `~a_p + ~a_q + g >= 1` --- so that what is being
+     * derived is "at most one of these, *or* the guard". None of the arithmetic
+     * changes: the guard rides through the induction, and its coefficient stays
+     * equal to the degree at every step, because a merge takes `m` copies of it
+     * from the pairs and `m - 1` from the copies of `current`, and that same
+     * `m(m-1) + 1` divides by `m` to the same `m`. So the pin at `k` members is
+     * `sum a_p <= 1 + (k-1) g`, written with the guard negated to keep every
+     * coefficient positive, and it is as strict as the unguarded one. What the
+     * caller has to remember is that the coefficient grows with the clique: a
+     * sum of folds over cliques of different sizes carries `sum (k_f - 1)` of
+     * the guard, and getting back to a coefficient of one means dividing by
+     * exactly that.
+     *
      * Every intermediate is emitted at `level`. Only the returned line needs to
      * outlive the call, so a caller replaying this across a scheduling horizon
      * should think about deriving the intermediates at `ProofLevel::Temporary`
@@ -130,8 +158,8 @@ namespace gcs::innards
      * \ingroup Innards
      */
     [[nodiscard]] auto recover_am1_from_pairs(ProofLogger &, const std::vector<ProofLiteralOrFlag> & members,
-        const std::vector<std::vector<ProofLine>> & at_most_ones, ProofLevel, Am1FromPairsMutation mutation = am1_from_pairs_mutation::None{})
-        -> ProofLine;
+        const std::vector<std::vector<ProofLine>> & at_most_ones, ProofLevel, const std::optional<ProofLiteralOrFlag> & guard = std::nullopt,
+        Am1FromPairsMutation mutation = am1_from_pairs_mutation::None{}) -> ProofLine;
 }
 
 #endif

--- a/gcs/innards/proofs/am1_from_pairs_test.cc
+++ b/gcs/innards/proofs/am1_from_pairs_test.cc
@@ -7,14 +7,19 @@
  * against an unsatisfiable one every RUP step is vacuously valid and a
  * corrupted derivation would sail through, which is the trap #656 walked into.
  *
- * The three claims made here are separate:
+ * The four claims made here are separate:
  *
  *   1. the derivation follows, for cliques of two to twelve;
  *   2. the line that comes back is the clique inequality and not something
- *      weaker --- which nothing but the `ia` pin can say, because every step of
- *      a corrupted merge is still individually sound;
+ *      weaker --- which nothing but the `ia` pin can say *here*, because every
+ *      step of a corrupted merge is still individually sound, and this model
+ *      has no consumer to reject it downstream;
  *   3. the induction is necessary, which the NaiveOneShot mutation shows by
- *      being accepted for two and three members and rejected from four on.
+ *      being accepted for two and three members and rejected from four on;
+ *   4. a guard rides through unchanged and comes out with coefficient exactly
+ *      `k - 1`, which the guarded contradiction pins down from both sides: too
+ *      few copies of the guard-is-false axiom and the pol does not close, too
+ *      many and it is not a contradiction the checker will take.
  */
 
 #include <gcs/constraints/innards/constraints_test_utils.hh>
@@ -76,7 +81,17 @@ namespace
         WithTwoActive
     };
 
-    auto check(size_t k, Am1FromPairsMutation mutation, Model model_kind, const string & tag, bool expect_veripb_to_accept) -> void
+    enum class Guard
+    {
+        /// The plain fold: every at-most-one is unconditional.
+        None,
+        /// Every at-most-one carries an extra disjunct, so the clique
+        /// inequality holds only where the guard is false --- min_distance's
+        /// shape.
+        Present
+    };
+
+    auto check(size_t k, Am1FromPairsMutation mutation, Model model_kind, Guard guard_kind, const string & tag, bool expect_veripb_to_accept) -> void
     {
         auto proof_name = "am1_from_pairs_" + to_string(k) + "_" + tag;
         ProofOptions proof_options{proof_name};
@@ -91,23 +106,36 @@ namespace
             members.push_back(flag);
         }
 
+        std::optional<ProofFlag> guard;
+        if (guard_kind == Guard::Present)
+            guard = model.create_proof_flag("guard");
+
         // The lower triangle, in the order the induction consumes it. Labelled,
-        // because a pol step may only reference an OPB row by name.
+        // because a pol step may only reference an OPB row by name. A guarded
+        // pair is `~a_i + ~a_j + g >= 1`, written here as `a_i + a_j + ~g <= 2`.
         vector<vector<ProofLine>> at_most_ones(k);
         for (size_t j = 1; j < k; ++j)
             for (size_t i = 0; i < j; ++i) {
                 WPBSum pair;
                 pair += 1_i * flags[i];
                 pair += 1_i * flags[j];
-                at_most_ones[j].push_back(model.add_labelled_constraint("amo" + to_string(i) + "x" + to_string(j), move(pair) <= 1_i));
+                if (guard)
+                    pair += 1_i * ! *guard;
+                auto bound = guard ? 2_i : 1_i;
+                at_most_ones[j].push_back(model.add_labelled_constraint("amo" + to_string(i) + "x" + to_string(j), move(pair) <= bound));
             }
 
-        std::optional<ProofLine> two_active;
+        std::optional<ProofLine> two_active, guard_false;
         if (model_kind == Model::WithTwoActive) {
             WPBSum both;
             both += 1_i * flags[0];
             both += 1_i * flags[1];
             two_active = model.add_labelled_constraint("bothactive", move(both) >= 2_i);
+            // A guarded clique inequality says nothing at all where the guard
+            // holds, so two active members only contradict it once the guard is
+            // ruled out.
+            if (guard)
+                guard_false = model.add_labelled_constraint("guardfalse", WPBSum{} + 1_i * ! *guard >= 1_i);
         }
         model.finalise();
 
@@ -116,15 +144,20 @@ namespace
         logger.start_proof(model);
         tracker.emit_delayed_proof_steps();
 
-        auto clique = recover_am1_from_pairs(logger, members, at_most_ones, ProofLevel::Top, mutation);
+        auto clique = recover_am1_from_pairs(
+            logger, members, at_most_ones, ProofLevel::Top, guard ? std::optional<ProofLiteralOrFlag>{*guard} : std::nullopt, mutation);
 
         if (two_active) {
             // The clique inequality says at most one is active and the axiom
             // says two are, so one pol closes it --- and `ia` against the
             // result insists that it really is a contradiction rather than
-            // something the checker refuted by other means.
+            // something the checker refuted by other means. The guarded fold
+            // carries `k - 1` of the guard, so it takes that many copies of the
+            // axiom ruling it out to cancel them.
             PolBuilder contradiction;
             contradiction.add(clique).add(*two_active);
+            if (guard_false)
+                contradiction.add(*guard_false, Integer{static_cast<long long>(k) - 1});
             auto combined = contradiction.emit(logger, ProofLevel::Top);
             logger.emit(ImpliesProofRule{combined}, WPBSum{} >= 1_i, ProofLevel::Top);
             logger.conclude_unsatisfiable(false);
@@ -160,12 +193,12 @@ auto main(int argc, char * argv[]) -> int
     // is where #548 expects to stop caring: the merge is O(k^2) additions per
     // time point, so a clique is not something to be casual about.
     for (size_t k = 2; k <= 12; ++k)
-        check(k, am1_from_pairs_mutation::None{}, Model::Plain, "honest", true);
+        check(k, am1_from_pairs_mutation::None{}, Model::Plain, Guard::None, "honest", true);
     println(cerr, "cliques of 2 to 12 members: derived and verified");
 
     // And it means what it says: two members active contradicts it.
     for (size_t k : {2, 3, 5, 8})
-        check(k, am1_from_pairs_mutation::None{}, Model::WithTwoActive, "contradiction", true);
+        check(k, am1_from_pairs_mutation::None{}, Model::WithTwoActive, Guard::None, "contradiction", true);
     println(cerr, "the clique inequality contradicts two active members");
 
     // Dropping an input from the last merge. Worth being clear about what this
@@ -173,12 +206,12 @@ auto main(int argc, char * argv[]) -> int
     // VeriPB would be right to accept. It is the `ia` pin that rejects, which
     // is the only reason this mutation is a test at all.
     for (size_t k : {3, 4, 7})
-        check(k, am1_from_pairs_mutation::DropAnAtMostOne{}, Model::Plain, "dropped", false);
+        check(k, am1_from_pairs_mutation::DropAnAtMostOne{}, Model::Plain, Guard::None, "dropped", false);
     println(cerr, "veripb rejected a merge missing an at-most-one, as expected");
 
     // Claiming no member may be active at all.
     for (size_t k : {2, 3, 6})
-        check(k, am1_from_pairs_mutation::ClaimOneMore{}, Model::Plain, "onemore", false);
+        check(k, am1_from_pairs_mutation::ClaimOneMore{}, Model::Plain, Guard::None, "onemore", false);
     println(cerr, "veripb rejected the one-stronger claim, as expected");
 
     // The induction is necessary, and here is where. Summing every at-most-one
@@ -187,9 +220,9 @@ auto main(int argc, char * argv[]) -> int
     // and rejected from four on --- if this boundary ever moves, the argument
     // for the induction has changed and the comment explaining it is wrong.
     for (size_t k : {2, 3})
-        check(k, am1_from_pairs_mutation::NaiveOneShot{}, Model::Plain, "naive", true);
+        check(k, am1_from_pairs_mutation::NaiveOneShot{}, Model::Plain, Guard::None, "naive", true);
     for (size_t k : {4, 5, 9})
-        check(k, am1_from_pairs_mutation::NaiveOneShot{}, Model::Plain, "naive", false);
+        check(k, am1_from_pairs_mutation::NaiveOneShot{}, Model::Plain, Guard::None, "naive", false);
     println(cerr, "the one-shot merge works to three members and fails from four, as the induction's premise says");
 
     // Leaving the division off the last merge gives a line that is *stronger*
@@ -199,8 +232,36 @@ auto main(int argc, char * argv[]) -> int
     // it says the final division is load-bearing for the pin and not only for
     // the induction.
     for (size_t k : {3, 5})
-        check(k, am1_from_pairs_mutation::SkipFinalDivision{}, Model::Plain, "nodivide", false);
+        check(k, am1_from_pairs_mutation::SkipFinalDivision{}, Model::Plain, Guard::None, "nodivide", false);
     println(cerr, "veripb rejected an undivided --- and strictly stronger --- last merge, as expected");
+
+    // And the same again with a guard riding through the induction, which is
+    // min_distance's shape. The claim being tested is the one the header makes
+    // about the coefficient: the guard comes out at exactly `k - 1`, so the pin
+    // states it, and the contradiction below cancels it with exactly that many
+    // copies of the axiom ruling the guard out. Either number being wrong is a
+    // rejection, which is why the contradiction model is the interesting one
+    // here rather than an extra.
+    for (size_t k = 2; k <= 12; ++k)
+        check(k, am1_from_pairs_mutation::None{}, Model::Plain, Guard::Present, "ghonest", true);
+    for (size_t k : {2, 3, 5, 8})
+        check(k, am1_from_pairs_mutation::None{}, Model::WithTwoActive, Guard::Present, "gcontradiction", true);
+    println(cerr, "the guarded fold derives, and carries the guard at k-1 exactly");
+
+    // A guard does not soften the pin: every mutation is still caught, and the
+    // one-shot merge still turns from right to wrong between three members and
+    // four.
+    for (size_t k : {3, 4, 7})
+        check(k, am1_from_pairs_mutation::DropAnAtMostOne{}, Model::Plain, Guard::Present, "gdropped", false);
+    for (size_t k : {2, 3, 6})
+        check(k, am1_from_pairs_mutation::ClaimOneMore{}, Model::Plain, Guard::Present, "gonemore", false);
+    for (size_t k : {2, 3})
+        check(k, am1_from_pairs_mutation::NaiveOneShot{}, Model::Plain, Guard::Present, "gnaive", true);
+    for (size_t k : {4, 5, 9})
+        check(k, am1_from_pairs_mutation::NaiveOneShot{}, Model::Plain, Guard::Present, "gnaive", false);
+    for (size_t k : {3, 5})
+        check(k, am1_from_pairs_mutation::SkipFinalDivision{}, Model::Plain, Guard::Present, "gnodivide", false);
+    println(cerr, "the guarded fold rejects every mutation the plain one does");
 
     return EXIT_SUCCESS;
 }

--- a/gcs/presolvers/inferred_disjunctive/inferred_disjunctive.cc
+++ b/gcs/presolvers/inferred_disjunctive/inferred_disjunctive.cc
@@ -714,7 +714,7 @@ auto InferredDisjunctive::run(Problem & problem, Propagators & propagators, Stat
                         at_most_ones[b].push_back(pair_amo.emit(recipe_logger, ProofLevel::Temporary));
                     }
 
-                return recover_am1_from_pairs(recipe_logger, flags, at_most_ones, ProofLevel::Top,
+                return recover_am1_from_pairs(recipe_logger, flags, at_most_ones, ProofLevel::Top, std::nullopt,
                     claim_rhs_zero ? Am1FromPairsMutation{am1_from_pairs_mutation::ClaimOneMore{}}
                                    : Am1FromPairsMutation{am1_from_pairs_mutation::None{}});
             },


### PR DESCRIPTION
Closes #805.

`all_different/justify.cc`, `sort/sort.cc` and `min_distance/min_distance.cc` each kept their own copy of the pairwise-to-clique staircase, all three predating `recover_am1_from_pairs`. They now use it.

## The decision #805 asked for first

`min_distance` was the one that needed one: its pairwise clauses each carry an extra `guard` literal, so what it folds is "at most one of these, **or** the guard", and the helper's unconditional pin would have been false.

The helper grows an optional guard rather than `min_distance` keeping its own fold. Nothing in the arithmetic changes — the guard rides through the induction with its coefficient tracking the degree at every step, because a merge takes `m` copies of it from the pairs and `m-1` from the copies of the running line, and that same `m(m-1)+1` divides by `m` to the same `m`. So at `k` members the pin is

    sum a_p <= 1 + (k-1) g

written over `~g` to keep every coefficient positive. That `(k-1)` is exactly what `min_distance`'s `sum_c` already counts and its final division cancels, so the certificate it emits is the same one — with the induction's working `del range`d behind it instead of left live.

The test grows a guarded half: the fold derives for two to twelve members, still rejects all four mutations, and the guarded contradiction pins the coefficient down from both sides, since it takes exactly `k-1` copies of the guard-is-false axiom to cancel it.

## The catchability claim, measured

#805 asks whoever does this to check which case each site is in rather than assuming. Replacing the pin with an unpinned copy of whatever the induction landed on, and running each mutation:

| mutation | all_different | sort | min_distance |
|---|---|---|---|
| `DropAnAtMostOne` | rejected | rejected | rejected |
| `NaiveOneShot` | rejected | rejected | rejected |
| `SkipFinalDivision` | rejected | rejected | rejected |
| `ClaimOneMore` | **accepted** | **accepted** | **accepted** |

All three consumers are coefficient-sensitive, like subcircuit's: each takes the clique line into a counting `pol` that needs an exact cancellation, and the RUP that follows fails when it does not get one. The rejections are downstream RUP failures, not `pol` failures. `ClaimOneMore` is not a counterexample — it corrupts nothing but the pin's target, so with no pin there is nothing left of it to catch, which the header now says.

The second commit rewrites the header paragraph that claimed the pin was the only thing that could catch any of this. What it does buy, on the evidence: a local rejection naming the wrong line rather than one a few hundred lines later, and cover for a caller that is not coefficient-sensitive — of which there is currently none. One line, so it stays.

## Cost

`.pbp` bytes over each test's whole proof set, seed pinned (unseeded runs move by several percent in both directions and say nothing):

| | before | after | |
|---|---|---|---|
| `all_different_test` | 29,130,197 | 29,137,219 | +0.02% |
| `sort_test` | 5,336,189 | 5,347,181 | +0.21% |
| `min_distance_test` | 2,698,422 | 2,719,220 | +0.77% |

## Checks

* full `ctest`: 799/799.
* `run_test_and_verify.bash` on every binary that reaches a changed fold or the changed signature — `all_different`, `all_different_except`, `symmetric_all_different`, `arg_sort`, `inverse`, `circuit`, `sort`, `min_distance`, `min_distance_matching`, `disjunctive`, `disjunctive_overload`, `subcircuit_scc`, `inferred_disjunctive_presolver`: every proof verified, no checking errors beyond that last test's own expected must-fail lanes.
* gcc with `-DGCS_WERROR=ON`, and clang, both clean on the changed files. (clang + `GCS_WERROR` is already red on `variable_weighting.hh:134` on main, untouched here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)