### PR TITLE
Extensional GAC: share compact-table support masks across a tupleset

### DIFF
--- a/dev_docs/propagator-performance.md
+++ b/dev_docs/propagator-performance.md
@@ -426,6 +426,58 @@ is never executed, and the cost does not show up where you would look for it. An
 such change needs the *old* path measured against the *unmodified* build, not
 just the new path measured against the old one.
 
+### Data derived from a shared input belongs to the input, not to the constraint
+
+A propagator that precomputes something from bulk input holds one copy per
+constraint by default, and where the input is shared that is *n* copies of the
+same bytes. It is not the memory that costs — it is that the copies compete for
+cache that one copy would have kept.
+
+The table propagator's compact algorithm keeps a support mask per (position,
+value): one bitset over the tuple indices, saying which tuples use that value
+there. Those masks are a pure function of the tuples — the value ranges they are
+indexed by are read off the table, never off a variable's domain — so every
+`Table` over one tupleset builds identical ones. A crossword posts twenty tables
+over one 4 591-word dictionary: 146 KB each, **2.9 MB of the same thing**, in a
+512 KB L2.
+
+The numbers, on `Crossword-words-vg-10-10-relaxed`, single core, boost off,
+identical trees (9 927 nodes, 317 193 propagations) before and after:
+
+| | before | after |
+|---|---|---|
+| L2 data-read misses (`l2_cache_req_stat.ls_rd_blk_c`) | 183.6M | **14.6M** |
+| instructions | 10.461G | 10.442G |
+| cycles | 7.24G | 6.47G |
+| solve time | 3.169 s | **2.834 s** (1.12x) |
+| peak RSS | 9.5 MB | 6.4 MB |
+
+The instruction count is flat to 0.2%: it is the same algorithm doing the same
+work, and all of the gain is the working set fitting. `perf record` on the L2
+miss event said so in advance — 65% of the program's L2 misses were in
+`propagate_compact_table`, and half of *those* were on the one line that reads a
+mask word in the filter pass — which is why it was worth doing before it was
+worth building.
+
+`Propagators::shared_derived_data()` is where such a thing goes: keyed on the
+address of the input it came from, and living exactly as long as the
+`Propagators`, i.e. one solve, so the key cannot outlive the data it names.
+Three things to get right when using it:
+
+- **Derive it from the input alone, or not at all.** If the answer depends on
+  the constraint's scope or its variables' domains, it is not shareable, and the
+  shape of the bug you get is silent misreading rather than a crash. Check the
+  derivation's inputs, and check the shared object still agrees with the sharer
+  at the point of adoption.
+- **Share the verdict as well as the answer.** The mask build declines a table it
+  cannot rasterise; that verdict belongs to the tuples, so the second constraint
+  must find it recorded rather than rediscover it.
+- **Keep the hot path's loads where they were.** The masks moved behind a
+  `shared_ptr`, but the propagator holds a raw pointer to them and its own copy
+  of the small per-position layout, so the innermost test is the same loads it
+  was before. Reaching through the `shared_ptr` in the loop would have given some
+  of the win straight back.
+
 ## Is it the propagator, the strength, or the search?
 
 When a model is slow, "the propagator is slow" is only one of three

--- a/gcs/constraints/extensional_utils.cc
+++ b/gcs/constraints/extensional_utils.cc
@@ -47,10 +47,14 @@ auto gcs::innards::ExtensionalLiveTuples::create(State & initial_state, size_t n
     return result;
 }
 
-auto gcs::innards::ExtensionalCompactTable::create(State & initial_state, bool forced) -> shared_ptr<ExtensionalCompactTable>
+auto gcs::innards::ExtensionalCompactTable::create(State & initial_state, bool forced, shared_ptr<ExtensionalSupportMasks> supports)
+    -> shared_ptr<ExtensionalCompactTable>
 {
     auto result = make_shared<ExtensionalCompactTable>();
     result->forced = forced;
+    // A caller with nothing to share with gets a set of its own, so that the
+    // rest of the code never has to ask whether it is sharing.
+    result->supports = supports ? move(supports) : make_shared<ExtensionalSupportMasks>();
     // One plain integer, which std::any holds without allocating. Everything
     // else the compact table owns is restored by unwinding the trail down to
     // it: the words, the previous domains, and the limit.
@@ -58,9 +62,10 @@ auto gcs::innards::ExtensionalCompactTable::create(State & initial_state, bool f
     return result;
 }
 
-auto gcs::innards::ExtensionalCompactTable::create_for_auto(State & initial_state, size_t n_tuples) -> shared_ptr<ExtensionalCompactTable>
+auto gcs::innards::ExtensionalCompactTable::create_for_auto(State & initial_state, size_t n_tuples, shared_ptr<ExtensionalSupportMasks> supports)
+    -> shared_ptr<ExtensionalCompactTable>
 {
-    return n_tuples >= min_tuples ? create(initial_state, false) : shared_ptr<ExtensionalCompactTable>{};
+    return n_tuples >= min_tuples ? create(initial_state, false, move(supports)) : shared_ptr<ExtensionalCompactTable>{};
 }
 
 gcs::innards::ExtensionalData::ExtensionalData(
@@ -178,25 +183,28 @@ namespace
     /**
      * Lay out and fill the support masks: one bitset of n_words per (position,
      * value), holding the tuples whose entry at that position is that value.
-     * Returns false, leaving the compact table unusable, if any position could
-     * not be rasterised (a wildcard, or a value range too wide) or if the masks
-     * would be larger than the cap -- in either case the live-set algorithm
-     * runs instead.
+     * Returns false, leaving the masks unusable, if any position could not be
+     * rasterised (a wildcard, or a value range too wide) or if they would be
+     * larger than the cap -- in either case the live-set algorithm runs instead.
+     *
+     * Writes into the shared object rather than the constraint, since which
+     * masks a table has and whether it can have them at all follow from the
+     * tuples alone. \see ExtensionalSupportMasks
      */
-    auto build_compact_table(
-        ExtensionalCompactTable & ct, const ExtensionalDomainBitmaps & bitmaps, const ExtensionalData & table, const std::size_t n_tuples) -> bool
+    auto build_support_masks(ExtensionalSupportMasks & supports, const ExtensionalDomainBitmaps & bitmaps, const ExtensionalData & table,
+        const std::size_t n_tuples) -> bool
     {
         auto n_vars = table.vars.size();
         for (unsigned idx = 0; idx < n_vars; ++idx)
             if (! bitmaps.positions[idx].usable)
                 return false;
 
-        ct.n_words = extensional_words_for(n_tuples);
-        ct.mask_at.assign(n_vars, 0);
+        supports.n_words = extensional_words_for(n_tuples);
+        supports.mask_at.assign(n_vars, 0);
         std::size_t total = 0;
         for (unsigned idx = 0; idx < n_vars; ++idx) {
-            ct.mask_at[idx] = total;
-            auto here = bitmaps.positions[idx].n_values * ct.n_words;
+            supports.mask_at[idx] = total;
+            auto here = bitmaps.positions[idx].n_values * supports.n_words;
             if (here > ExtensionalCompactTable::max_mask_words - total)
                 return false;
             total += here;
@@ -204,11 +212,7 @@ namespace
         if (total > ExtensionalCompactTable::max_mask_words)
             return false;
 
-        ct.masks.assign(total, ExtensionalWord{});
-        ct.index.resize(ct.n_words);
-        ct.scratch.assign(ct.n_words, ExtensionalWord{});
-        ct.words.assign(ct.n_words, ExtensionalWord{});
-        ct.previous_domain.assign(bitmaps.words.size(), ExtensionalWord{});
+        supports.masks.assign(total, ExtensionalWord{});
         visit(
             [&](const auto & tuples) {
                 const auto & rows = *tuples;
@@ -219,12 +223,50 @@ namespace
                     for (unsigned idx = 0; idx < n_vars; ++idx) {
                         const auto & p = bitmaps.positions[idx];
                         auto off = static_cast<std::size_t>(compact_value(row[idx]) - p.base);
-                        ct.masks[ct.mask_at[idx] + off * ct.n_words + word] |= bit;
+                        supports.masks[supports.mask_at[idx] + off * supports.n_words + word] |= bit;
                     }
                 }
             },
             table.tuples);
 
+        supports.positions = bitmaps.positions;
+        return true;
+    }
+
+    /**
+     * Point this constraint at the shared masks and give it the per-constraint
+     * arrays that go with them, building the masks first if this is the
+     * constraint that got here first. False means the live-set algorithm runs
+     * instead, which is what a table the masks cannot describe falls back to --
+     * for every constraint over those tuples, not just the one that found out.
+     */
+    auto adopt_compact_table(
+        ExtensionalCompactTable & ct, const ExtensionalDomainBitmaps & bitmaps, const ExtensionalData & table, const std::size_t n_tuples) -> bool
+    {
+        auto & supports = *ct.supports;
+        if (ExtensionalSupportMasks::Status::Unbuilt == supports.status)
+            supports.status = build_support_masks(supports, bitmaps, table, n_tuples) ? ExtensionalSupportMasks::Status::Built
+                                                                                      : ExtensionalSupportMasks::Status::Declined;
+
+        if (ExtensionalSupportMasks::Status::Built != supports.status)
+            return false;
+
+        // Cannot fail: both rasterisations are computed from the same tuples by
+        // the same code, and the store these came from is keyed on the address
+        // of those tuples. Checked anyway because the masks are *indexed* by
+        // this, so a key that named the wrong data would otherwise read the
+        // wrong words and prune soundly-looking nonsense rather than complain.
+        if (supports.positions != bitmaps.positions || supports.n_words != extensional_words_for(n_tuples))
+            throw UnexpectedException{"shared table support masks do not match the table sharing them"};
+
+        ct.masks = supports.masks.data();
+        ct.mask_at = supports.mask_at;
+        ct.n_words = supports.n_words;
+
+        ct.index.resize(ct.n_words);
+        ct.scratch.assign(ct.n_words, ExtensionalWord{});
+        ct.words.assign(ct.n_words, ExtensionalWord{});
+        ct.previous_domain.assign(bitmaps.words.size(), ExtensionalWord{});
         return true;
     }
 
@@ -380,7 +422,7 @@ namespace
                 continue;
 
             const bool by_removals = n_removed <= n_kept;
-            const auto * const masks_here = ct.masks.data() + ct.mask_at[idx];
+            const auto * const masks_here = ct.masks + ct.mask_at[idx];
             bool any = false;
             for (std::size_t k = 0; k < domain_words; ++k) {
                 auto bits = by_removals ? (prev[k] & ~cur[k]) : cur[k];
@@ -446,7 +488,7 @@ namespace
         // would have made.
         for (unsigned idx = 0; idx < n_vars; ++idx) {
             const auto & p = bitmaps.positions[idx];
-            const auto * const masks_here = ct.masks.data() + ct.mask_at[idx];
+            const auto * const masks_here = ct.masks + ct.mask_at[idx];
             state.for_each_value_mutable(table.vars[idx], [&](Integer val) {
                 auto off = static_cast<unsigned long long>(val.raw_value - p.base);
                 bool supported = false;
@@ -562,7 +604,7 @@ auto gcs::innards::propagate_extensional(
             auto n_tuples = live.dense.size();
             auto mean_live = static_cast<std::size_t>(ct.total_live / ct.wakes);
             bool worth_it = forced || (mean_live >= ExtensionalCompactTable::min_mean_live && extensional_word_bits * mean_live >= n_tuples);
-            if (worth_it && build_compact_table(ct, bitmaps, table, n_tuples)) {
+            if (worth_it && adopt_compact_table(ct, bitmaps, table, n_tuples)) {
                 ct.built = true;
                 just_built = true;
             }

--- a/gcs/constraints/extensional_utils.hh
+++ b/gcs/constraints/extensional_utils.hh
@@ -136,11 +136,75 @@ namespace gcs::innards
             std::size_t n_values = 0;
             std::size_t offset = 0;
             bool usable = false;
+
+            /// So that a constraint adopting another's support masks can check
+            /// the layout they were built against is the one it computed for
+            /// itself, rather than assume it. \see ExtensionalSupportMasks
+            [[nodiscard]] auto operator==(const Position &) const -> bool = default;
         };
 
         std::vector<Position> positions;
         std::vector<ExtensionalWord> words;
         bool initialised = false;
+    };
+
+    /**
+     * \brief The support masks a compact table filters with: one bitset of
+     * \c n_words per (position, value), holding the tuples whose entry at that
+     * position is that value.
+     *
+     * A separate object from the rest of ExtensionalCompactTable because it is
+     * the only part that several constraints can share, and it is by far the
+     * largest. It is a pure function of the tuples alone: every position's value
+     * range is read off the table (see ExtensionalDomainBitmaps), never off a
+     * variable's domain, so two constraints over the same tupleset lay out
+     * byte-identical masks however different their scopes are. Everything else
+     * the compact table owns -- the live words, the index over them, the
+     * previous domains, the trail -- is per constraint and stays there.
+     *
+     * Crossword is why: twenty Table constraints over one 4 591-word dictionary,
+     * which unshared is twenty copies of the same 146 KB. 2.9 MB does not fit in
+     * a 512 KB L2 and one copy does, and mask loads in the filter pass are half
+     * of that propagator's L2 misses and a third of the whole program's.
+     *
+     * Shared through Propagators::shared_derived_data(), keyed on the tuples'
+     * address, which is what makes the sharing last exactly one solve. Built
+     * lazily, by whichever of the sharers first decides it wants masks, and
+     * read-only from then on -- so the only thing sharing it needs is that the
+     * build happens once, and it is guarded by \c status rather than by a lock,
+     * on the same single-threaded-per-solve footing as the rest of the
+     * propagator's mutable scratch.
+     *
+     * \sa ExtensionalCompactTable
+     * \ingroup Innards
+     */
+    struct ExtensionalSupportMasks
+    {
+        /**
+         * Whether the masks have been built, and if so whether they can be used.
+         * The build declines a table it cannot rasterise or that wants more
+         * memory than the cap allows, and that verdict belongs to the tuples
+         * rather than to the constraint that happened to ask first -- so it is
+         * recorded here and the next sharer does not try again.
+         */
+        enum class Status
+        {
+            Unbuilt,
+            Built,
+            Declined
+        };
+
+        Status status = Status::Unbuilt;
+
+        std::vector<ExtensionalWord> masks;
+        std::vector<std::size_t> mask_at;
+        std::size_t n_words = 0;
+
+        /// The rasterisation the masks are indexed by. Kept so an adopting
+        /// constraint can check it against its own: they must agree, since both
+        /// come from the same tuples, and a mismatch would otherwise be a silent
+        /// misread rather than a loud one.
+        std::vector<ExtensionalDomainBitmaps::Position> positions;
     };
 
     /**
@@ -164,7 +228,7 @@ namespace gcs::innards
      */
     struct ExtensionalCompactTable
     {
-        /// Do not build masks larger than this, in words, per constraint.
+        /// Do not build masks larger than this, in words, per tupleset.
         /// The suite's largest is Renault-big at 755 623 words over 332 tables;
         /// a single table wanting more than this is better served by the
         /// live-set algorithm than by the memory.
@@ -209,13 +273,19 @@ namespace gcs::innards
         static constexpr std::size_t min_tuples = extensional_word_bits;
 
         /**
-         * Supports: one bitset of \c n_words per (position, value), holding the
-         * tuples whose entry at that position is that value. Values are indexed
-         * from the position's ExtensionalDomainBitmaps::Position, so a value the
-         * table never uses at that position is outside the range and is
-         * unsupported without a lookup.
+         * The support masks, and the layout they are indexed by, copied out of
+         * \c supports once it has been built. Values are indexed from the
+         * position's ExtensionalDomainBitmaps::Position, so a value the table
+         * never uses at that position is outside the range and is unsupported
+         * without a lookup.
+         *
+         * A raw pointer plus its own copy of the small layout, rather than
+         * reaching through \c supports, because both are read in the filter
+         * loop's innermost test: that keeps it exactly the loads it was before
+         * the masks moved out of here. \c supports below owns the storage the
+         * pointer names, so it is valid for as long as this object is.
          */
-        std::vector<ExtensionalWord> masks;
+        const ExtensionalWord * masks = nullptr;
         std::vector<std::size_t> mask_at;
         std::size_t n_words = 0;
 
@@ -278,6 +348,16 @@ namespace gcs::innards
         /// which std::any holds without allocating.
         ConstraintStateHandle trail_mark_handle{0};
 
+        /**
+         * The masks, shared with every other constraint over the same tuples,
+         * or private to this one where there is nothing to share with. Whoever
+         * decides to build first builds; the rest adopt what is there.
+         *
+         * Down here with the cold fields on purpose: it is read once, when the
+         * decision is made, and never again during propagation.
+         */
+        std::shared_ptr<ExtensionalSupportMasks> supports;
+
         /// table::Auto watches this many wakes before deciding; table::CompactTable
         /// builds at the first one. Once \c decided is set the answer never changes.
         bool forced = true;
@@ -286,7 +366,13 @@ namespace gcs::innards
         bool decided = false;
         bool built = false;
 
-        [[nodiscard]] static auto create(State & initial_state, bool forced) -> std::shared_ptr<ExtensionalCompactTable>;
+        /**
+         * \param supports the masks to share, from
+         * Propagators::shared_derived_data(); null for a caller with no other
+         * constraint to share them with, which gets a private set.
+         */
+        [[nodiscard]] static auto create(State & initial_state, bool forced, std::shared_ptr<ExtensionalSupportMasks> supports = {})
+            -> std::shared_ptr<ExtensionalCompactTable>;
 
         /**
          * \brief create() for a caller with no user-facing algorithm choice:
@@ -299,7 +385,8 @@ namespace gcs::innards
          * for the bookkeeping, and every constraint state is deep-copied into
          * every search node whether the propagator uses it or not.
          */
-        [[nodiscard]] static auto create_for_auto(State & initial_state, std::size_t n_tuples) -> std::shared_ptr<ExtensionalCompactTable>;
+        [[nodiscard]] static auto create_for_auto(State & initial_state, std::size_t n_tuples, std::shared_ptr<ExtensionalSupportMasks> supports = {})
+            -> std::shared_ptr<ExtensionalCompactTable>;
     };
 
     /**

--- a/gcs/constraints/table/shared_tuples_test.cc
+++ b/gcs/constraints/table/shared_tuples_test.cc
@@ -1,10 +1,18 @@
+#include <gcs/constraints/extensional_utils.hh>
 #include <gcs/constraints/table.hh>
+#include <gcs/current_state.hh>
 #include <gcs/extensional.hh>
+#include <gcs/innards/propagators.hh>
 #include <gcs/problem.hh>
+#include <gcs/solve.hh>
+#include <gcs/stats.hh>
 
 #include <catch2/catch_test_macros.hpp>
 
 #include <memory>
+#include <set>
+#include <tuple>
+#include <utility>
 
 using namespace gcs;
 
@@ -47,4 +55,81 @@ TEST_CASE("NegativeTable shares tuple storage rather than copying it")
 
     auto cloned = table.clone();
     CHECK(tuples.use_count() == 3);
+}
+
+// Issue #508: sharing the tuples means sharing what a propagator derives from
+// them. The compact table's support masks are the biggest thing it holds and a
+// pure function of the tuples, so every Table over one tupleset uses one copy:
+// a crossword posts twenty tables over one dictionary, and twenty copies of the
+// same 146 KB does not fit in cache where one copy does.
+
+namespace
+{
+    // Two positions, values 0..7, a tuple wherever the two values differ. Big
+    // enough to be a table worth a mask (see ExtensionalCompactTable::min_tuples)
+    // and small enough to enumerate by hand below.
+    auto not_equals_tuples() -> std::shared_ptr<const SimpleTuples>
+    {
+        SimpleTuples tuples;
+        for (Integer a = 0_i; a < 8_i; ++a)
+            for (Integer b = 0_i; b < 8_i; ++b)
+                if (a != b)
+                    tuples.push_back({a, b});
+        return make_shared<const SimpleTuples>(std::move(tuples));
+    }
+}
+
+TEST_CASE("Tables over one tupleset share one set of support masks")
+{
+    Problem problem;
+    auto x = problem.create_integer_variable(0_i, 7_i);
+    auto y = problem.create_integer_variable(0_i, 7_i);
+    auto z = problem.create_integer_variable(0_i, 7_i);
+
+    auto tuples = not_equals_tuples();
+    for (auto [a, b] : {std::pair{x, y}, std::pair{y, z}, std::pair{x, z}})
+        problem.post(Table{{a, b}, ExtensionalTuples{ArrayParam<SimpleTuples>{tuples}}}.with_algorithm(table::CompactTable{}));
+
+    Stats stats;
+    auto state = problem.create_state_for_new_search(nullptr);
+    auto propagators = problem.create_propagators(state, stats, nullptr);
+
+    // Same pin as the tuple-storage tests above: asking the store for the masks
+    // hands back what the three constraints are holding, so a use count above
+    // two says they found each other's rather than each making its own. (One
+    // for the store, one for the local here, one per constraint.)
+    auto masks = propagators.shared_derived_data<innards::ExtensionalSupportMasks>(&*tuples);
+    CHECK(masks.use_count() == 5);
+}
+
+TEST_CASE("Tables sharing support masks solve the same as tables that do not")
+{
+    auto tuples = not_equals_tuples();
+
+    auto enumerate = [&](bool share) {
+        Problem problem;
+        auto x = problem.create_integer_variable(0_i, 7_i);
+        auto y = problem.create_integer_variable(0_i, 7_i);
+        auto z = problem.create_integer_variable(0_i, 7_i);
+
+        // Unshared posts a copy of the same tuples per constraint, which is the
+        // same constraint over the same values and so must have the same
+        // solutions -- only the first constraint to want masks builds any.
+        for (auto [a, b] : {std::pair{x, y}, std::pair{y, z}, std::pair{x, z}})
+            problem.post(Table{{a, b},
+                share ? ExtensionalTuples{ArrayParam<SimpleTuples>{tuples}} : ExtensionalTuples{ArrayParam<SimpleTuples>{SimpleTuples{*tuples}}}}
+                    .with_algorithm(table::CompactTable{}));
+
+        std::set<std::tuple<long long, long long, long long>> solutions;
+        solve_with(problem, SolveCallbacks{.solution = [&](const CurrentState & s) -> bool {
+            solutions.emplace(s(x).raw_value, s(y).raw_value, s(z).raw_value);
+            return true;
+        }});
+        return solutions;
+    };
+
+    auto shared = enumerate(true);
+    // 8 * 7 * 6 all-different triples over 0..7.
+    CHECK(shared.size() == 336);
+    CHECK(shared == enumerate(false));
 }

--- a/gcs/constraints/table/table.cc
+++ b/gcs/constraints/table/table.cc
@@ -117,7 +117,7 @@ namespace
     }
 }
 
-auto Table::prepare(Propagators &, State & initial_state, ProofModel * const) -> bool
+auto Table::prepare(Propagators & propagators, State & initial_state, ProofModel * const) -> bool
 {
     visit(
         [&](auto & tuples) {
@@ -135,13 +135,22 @@ auto Table::prepare(Propagators &, State & initial_state, ProofModel * const) ->
                 if (tuple.size() != _vars.size())
                     throw InvalidProblemDefinitionException{"table size mismatch"};
             _live = ExtensionalLiveTuples::create(initial_state, depointinate(tuples).size());
-            // create_for_auto applies the min_tuples test and documents why;
-            // an explicit table::CompactTable overrides it, which is the only
-            // way to get the compact algorithm on a table that small.
-            if (holds_alternative<table::CompactTable>(_algorithm))
-                _compact = ExtensionalCompactTable::create(initial_state, true);
-            else if (! holds_alternative<table::LiveSet>(_algorithm))
-                _compact = ExtensionalCompactTable::create_for_auto(initial_state, depointinate(tuples).size());
+            if (! holds_alternative<table::LiveSet>(_algorithm)) {
+                // The support masks follow from the tuples alone, so every Table
+                // over this tupleset would build byte-identical ones: ask for a
+                // shared set instead, keyed on the tuples. A crossword posts
+                // twenty tables over one dictionary, and twenty copies of the
+                // same 146 KB is 2.9 MB that does not fit in cache where one copy
+                // does. Whether this constraint ever builds them is decided
+                // during search and separately for each; sharing is not.
+                auto supports = propagators.shared_derived_data<ExtensionalSupportMasks>(&depointinate(tuples));
+                // create_for_auto applies the min_tuples test and documents why;
+                // an explicit table::CompactTable overrides it, which is the only
+                // way to get the compact algorithm on a table that small.
+                _compact = holds_alternative<table::CompactTable>(_algorithm)
+                    ? ExtensionalCompactTable::create(initial_state, true, std::move(supports))
+                    : ExtensionalCompactTable::create_for_auto(initial_state, depointinate(tuples).size(), std::move(supports));
+            }
         },
         _tuples);
 

--- a/gcs/innards/propagators.cc
+++ b/gcs/innards/propagators.cc
@@ -11,6 +11,7 @@
 #include <util/overloaded.hh>
 
 #include <algorithm>
+#include <any>
 #include <array>
 #include <chrono>
 #include <cstddef>
@@ -18,10 +19,12 @@
 #include <cstdlib>
 #include <functional>
 #include <iostream>
+#include <map>
 #include <optional>
 #include <set>
 #include <span>
 #include <string>
+#include <typeindex>
 #include <unordered_map>
 #include <utility>
 
@@ -300,6 +303,11 @@ struct Propagators::Imp : RefinedWatchSink
     // stays movable, which create_propagators returning one by value needs.
     Stats * stats = nullptr;
 
+    // See Propagators::shared_derived_data. A std::map rather than a hash: it is
+    // touched once per constraint at install time and never during search, so
+    // the only thing worth having is not needing a hash for the key.
+    std::map<std::pair<const void *, std::type_index>, std::any> shared_derived_data;
+
     vector<PropagationFunction> propagation_functions;
     std::array<vector<InitialisationFunction>, number_of_initialiser_priorities> initialisation_functions_by_priority;
     // How many of each bucket initialise() has already run. A presolver can
@@ -553,6 +561,11 @@ auto Propagators::define_bound(const State & state, ProofModel * const optional_
         });
         return;
     }
+}
+
+auto Propagators::shared_derived_data_slot(const void * const key, const std::type_index type) -> std::any &
+{
+    return _imp->shared_derived_data[std::pair{key, type}];
 }
 
 auto Propagators::install(const ConstraintID & constraint_id, PropagationFunction && f, const Triggers & triggers) -> void

--- a/gcs/innards/propagators.hh
+++ b/gcs/innards/propagators.hh
@@ -15,6 +15,7 @@
 #include <gcs/problem.hh>
 #include <gcs/stats.hh>
 
+#include <any>
 #include <atomic>
 #include <cstddef>
 #include <cstdint>
@@ -22,6 +23,7 @@
 #include <memory>
 #include <span>
 #include <type_traits>
+#include <typeindex>
 #include <utility>
 #include <vector>
 
@@ -411,6 +413,8 @@ namespace gcs::innards
         struct Imp;
         std::unique_ptr<Imp> _imp;
 
+        auto shared_derived_data_slot(const void * key, std::type_index type) -> std::any &;
+
         auto trigger_on_change(IntegerVariableID, int id) -> void;
         auto trigger_on_bounds(IntegerVariableID, int id) -> void;
         auto trigger_on_instantiated(IntegerVariableID, int id) -> void;
@@ -483,6 +487,42 @@ namespace gcs::innards
          * state so it cannot be mis-sequenced.
          */
         auto install(const ConstraintID & constraint_id, PropagationFunction &&, const Triggers & trigger_vars) -> void;
+
+        /**
+         * Fetch, creating it empty on the first ask, the object that every
+         * constraint deriving data from the same shared input is to share.
+         *
+         * Constraints share bulk input by sharing an ArrayParam, which is a
+         * shared_ptr: the twenty Table constraints of a crossword all read one
+         * dictionary. Anything derived from that input *alone* is then the same
+         * for all of them, so deriving it per constraint buys nothing and costs
+         * twenty copies of a structure that would otherwise stay in cache. This
+         * is where such a thing goes.
+         *
+         * The key is the address of the input it is derived from, which is what
+         * "the same input" means for an ArrayParam. That is safe because the
+         * store lives exactly as long as this Propagators, i.e. one solve, and
+         * the propagator that put an address here holds a handle to that input
+         * for the same span: an owned or shared ArrayParam keeps the data
+         * alive, and a borrowed one is required to be backed by storage
+         * outliving every copy of the handle. Either way the address cannot be
+         * recycled underneath the entry naming it. The type is part of the key
+         * too, so two constraints deriving different things from one input get
+         * a slot each.
+         *
+         * Deliberately hands back an empty object rather than taking a factory:
+         * whether the data is worth deriving at all, and when, is the caller's
+         * business --- the compact table decides that some way into the search,
+         * and only for some of the constraints that share the slot.
+         */
+        template <typename Data_>
+        [[nodiscard]] auto shared_derived_data(const void * key) -> std::shared_ptr<Data_>
+        {
+            auto & slot = shared_derived_data_slot(key, std::type_index{typeid(Data_)});
+            if (! slot.has_value())
+                slot = std::make_shared<Data_>();
+            return std::any_cast<std::shared_ptr<Data_>>(slot);
+        }
 
         /**
          * Retire every propagator belonging to any of the given constraints for

--- a/gcs/innards/propagators_test.cc
+++ b/gcs/innards/propagators_test.cc
@@ -273,3 +273,68 @@ TEST_CASE("A view of a distinct variable does not downgrade the claim")
     CHECK(state.upper_bound(x) == 5_i);
     CHECK(runs == 1);
 }
+
+// Propagators::shared_derived_data: the store that lets several constraints
+// over one shared input derive something from it once between them. Keyed by
+// (input address, type), created empty on the first ask, and the same object
+// thereafter --- which is the whole of what a caller relies on, since it then
+// fills the object in itself.
+
+namespace
+{
+    struct Derived
+    {
+        int filled_in = 0;
+    };
+
+    struct OtherwiseDerived
+    {
+        int filled_in = 0;
+    };
+}
+
+TEST_CASE("Shared derived data is shared between asks with the same key")
+{
+    Stats stats;
+    Propagators propagators{stats};
+    int input = 0;
+
+    auto first = propagators.shared_derived_data<Derived>(&input);
+    REQUIRE(first);
+    CHECK(0 == first->filled_in);
+    first->filled_in = 42;
+
+    // The second constraint over the same input sees what the first left there,
+    // rather than an empty one of its own.
+    auto second = propagators.shared_derived_data<Derived>(&input);
+    CHECK(second == first);
+    CHECK(42 == second->filled_in);
+}
+
+TEST_CASE("Shared derived data is not shared between different inputs")
+{
+    Stats stats;
+    Propagators propagators{stats};
+    int input = 0, other_input = 0;
+
+    auto first = propagators.shared_derived_data<Derived>(&input);
+    auto second = propagators.shared_derived_data<Derived>(&other_input);
+    CHECK(second != first);
+    CHECK(0 == second->filled_in);
+}
+
+TEST_CASE("Shared derived data is not shared between different types")
+{
+    Stats stats;
+    Propagators propagators{stats};
+    int input = 0;
+
+    // Two constraints deriving different things from one input get a slot each,
+    // rather than the second one finding the first one's object under its own
+    // type and failing the cast.
+    auto first = propagators.shared_derived_data<Derived>(&input);
+    first->filled_in = 42;
+    auto second = propagators.shared_derived_data<OtherwiseDerived>(&input);
+    CHECK(0 == second->filled_in);
+    CHECK(42 == first->filled_in);
+}


### PR DESCRIPTION
The compact table's support masks -- one bitset over the tuple indices per
(position, value) -- are a pure function of the tuples. Every position's value
range is read off the *table*, never off a variable's domain, so two `Table`
constraints over one tupleset build byte-identical masks however different their
scopes are. They were built once per constraint anyway.

A crossword posts twenty tables over one 4 591-word dictionary. That is twenty
copies of the same 146 KB: **2.9 MB competing for a 512 KB L2**, where one copy
would have stayed in it.

So the masks move out of `ExtensionalCompactTable` into a new
`ExtensionalSupportMasks`, and `Table::prepare` asks for a shared one keyed on
the tuples. Everything else the compact table owns -- the live words, the index
over them, the previous domains, the trail -- is genuinely per constraint and
stays where it was. Which constraints build masks, and when, is unchanged:
`table::Auto` still decides per propagator some way into the search, and the
first of the sharers to decide yes is the one that builds. The verdict is shared
as well as the answer, since a table the masks cannot describe (a wildcard, a
range too wide, over the memory cap) is one for every constraint over those
tuples, not just the one that found out.

### Where the shared object lives

New `Propagators::shared_derived_data<T>(key)`: fetch, creating it empty on the
first ask, the object every constraint deriving something from the same shared
input is to share. Keyed on (input address, type), and living exactly as long as
the `Propagators`, i.e. one solve -- which is the whole soundness argument for
keying on an address. The propagator that put an address there holds a handle to
that input for the same span: an owned or shared `ArrayParam` keeps the data
alive, and a borrowed one is required to be backed by storage outliving every
copy of the handle. So the address cannot be recycled underneath the entry
naming it.

It hands back an empty object rather than taking a factory, because whether the
data is worth deriving at all, and when, is the caller's business.

### Measured

`Crossword-words-vg-10-10-relaxed`, fataepyc-10 pinned, boost off, hyperfine 5
runs. Identical tree (9 927 nodes, 317 193 propagations) before and after:

| | before | after | |
|---|---|---|---|
| L2 data-read misses (`ls_rd_blk_c`) | 183.6M | **14.6M** | 12.6x fewer |
| instructions | 10.461G | 10.442G | -0.2% |
| cycles | 7.24G | 6.47G | |
| solve time | 3.169 s | **2.834 s** | **1.12x** |
| peak RSS | 9.5 MB | 6.4 MB | |

**12.6x fewer L2 misses for 0.2% fewer instructions**: it is the same algorithm
doing the same work, and all of the gain is the working set fitting.

Predicted before it was built, by `perf record` on the L2 miss event -- 65% of
the program's L2 misses were in `propagate_compact_table`, and `perf annotate
-l` put half of those on the single line that reads a mask word in the filter
pass.

The other two crosswords are 1.10x. Renault-big loses the same 3.1 MB of masks
(41.6 -> 38.5 MB peak RSS) but is 47 nodes, so it cannot show a time. **Nothing
else in the suite moves**: all 18 matrix instances and all 26 real instances are
1.0x, both at the default and with `--table compact` forced, with identical
nodes, solutions and propagations on every row. The one row that looked like a
regression (`enum_bin_d2_n14` at 0.83x, forced compact) is an 18 ms instance and
is 1.03x *faster* over 20 runs.

### Gates

- ctest **797/797**.
- ASan + UBSan clean on `table_test`, `tabulation_test`, `negative_table_test`,
  `table_shared_tuples_test` and `propagators_test` -- the raw pointer into the
  shared storage is the thing worth sanitising.
- The 16 validation instances of the table benchmark suite still agree with
  Gecode on solutions and nodes.
- Proofs unchanged: the `.opb` and `.pbp` of a ten-table model over one shared
  tupleset (1 920 solutions, 807 KB proof) are byte-identical to the previous
  build's, for all three of `--table auto|live|compact`, and VeriPB verifies.

### Tests

`propagators_test` gets the store's semantics: same key and type gives the same
object back, a different input or a different type does not.

`table_shared_tuples_test` gets two. One pins the sharing itself, with the same
`use_count()` trick the file already uses for the tuple storage: asking the
store for the masks hands back what the three constraints are holding, so a use
count of five says they found each other's rather than each making its own.
Passing `{}` instead of the shared object in `Table::prepare` takes it to two.
The other enumerates the same model shared and unshared and checks the solution
sets agree, which is what pins the adopt path -- and, being a behaviour test,
deliberately cannot tell sharing from not sharing, which is why the first one
exists.

### Documentation

`dev_docs/propagator-performance.md` gains "Data derived from a shared input
belongs to the input, not to the constraint", with the numbers above and the
three things to get right when using the new store.

---

Part of #508. Written with the assistance of Claude Opus 5.
