### PR TITLE
Extensional GAC: stop, rather than throw, when the table detects failure

### DIFF
--- a/dev_docs/propagator-performance.md
+++ b/dev_docs/propagator-performance.md
@@ -236,6 +236,49 @@ thousand times a search has nothing to gain, and the conversion is a control-flo
 change in the propagator (it must now return immediately, which
 `[[nodiscard]]` enforces) rather than a free win.
 
+**Measure the unwinder by DSO, not by symbol name.** `perf report | grep -i
+unwind` finds `_Unwind_Find_FDE` and `__gxx_personality_v0` and misses most of
+the cost, because the bulk of `libgcc_s.so.1`'s unwinder has no symbol names in
+the profile and appears as bare addresses. On `Dubois-017` a symbol grep says
+8.8%; `perf report --sort dso` says **30.7% in `libgcc_s.so.1`**, plus another
+10% in `libstdc++.so.6` — and that 40% is what converting the extensional
+propagator was actually worth (1.69x measured). Read that way the profile
+predicts the prize on every instance, including the ones with no prize in them:
+
+| instance | `libgcc_s` before | after | speed-up |
+|---|---|---|---|
+| `Dubois-017` | 30.7% | 0.00% | 1.69x |
+| `enum_func_k3_n20` | 11.6% | 0.00% | 1.24x |
+| `srch_bin_d12_n25_s1` | 7.5% | 0.00% | 1.09x |
+| `Crossword` | 1.3% | 0.00% | 1.00x |
+| `enum_single_k10_t200k` | 0.0% | 0.00% | 1.00x |
+
+Instruction counts say it more bluntly still: 42.6% of `Dubois-017`'s
+instructions were in `libgcc_s` plus `libstdc++` before the change and 1.9%
+after, which is 21.6G instructions down to 11.5G for the same search.
+
+Take the zero in the "after" column as well as the speed-up: it says the
+conversion caught every failure path the propagator actually uses.
+
+The second lesson from that conversion is that **a propagator can have failure
+paths it never actually takes**, and knowing which is what decides how much
+there is to do. `propagate_extensional` can fail in two places: the empty live
+set, and an `infer` that empties a domain. The second is unreachable for a table
+whose variables are distinct -- a live tuple is its own witness that every
+position still has a supported value -- so only the first was worth converting,
+and the unwinding going to exactly zero is the evidence that the second never
+fired.
+
+The counter-example, so nobody re-does it: **`NegativeTable` is not a candidate**,
+despite failing 55 497 times in a 3.5 s search of its own benchmark. `libgcc_s`
+is **3.6%** there, because its propagator is woken twenty-five times per
+contradiction and each wake does real work (`test_literal` alone is 18% of the
+profile). The ratio that matters is contradictions per *call*, not per node: the
+extensional propagator on `Dubois` contradicts on one call in six, the negative
+table on one in twenty-five. `Element` is not a candidate either — 2.2% on `qap`
+and 1.5% on `tsp`, despite `tsp` failing 4.3 million times, because most of
+those failures already report through the non-throwing `infer_*_or_stop` path.
+
 ### Reuse data structures to avoid per-wake allocation
 
 The same principle applies to scratch state generally: a propagator that

--- a/gcs/constraints/extensional_utils.cc
+++ b/gcs/constraints/extensional_utils.cc
@@ -317,7 +317,7 @@ namespace
     template <typename Hint_, typename Inference_>
     [[gnu::noinline]] auto propagate_compact_table(const ExtensionalData & table, ExtensionalCompactTable & ct, const State & state,
         Inference_ & inference, ProofLogger * const logger, const Hint_ & hint, ExtensionalDomainBitmaps & bitmaps,
-        const ExtensionalLiveTuples & live, const std::size_t live_count, const bool just_built) -> void
+        const ExtensionalLiveTuples & live, const std::size_t live_count, const bool just_built) -> PropagatorState
     {
         auto & trail_mark = any_cast<size_t &>(state.get_constraint_state(ct.trail_mark_handle));
         const auto n_vars = static_cast<unsigned>(table.vars.size());
@@ -434,10 +434,16 @@ namespace
             // The same two spellings as the live-set path below, and for the
             // same reason: the dom/wdeg conflict observer reads the reason of a
             // no-justification contradiction.
+            //
+            // Returning without publishing the trail mark is what the throw used
+            // to do, and is what the note below the filter pass asks for: this
+            // call's trail entries stay unclaimed, to be undone at the top of
+            // the next one rather than committed to an epoch that did not
+            // survive.
             if (logger && logger->get_assertion_level() != AssertionLevel::Off)
-                inference.contradiction(logger, JustifyUsingRUP{hint}, table.reason);
+                return inference.contradiction_or_stop(logger, JustifyUsingRUP{hint}, table.reason);
             else
-                inference.contradiction(logger, NoJustificationNeeded{}, NoReason{});
+                return inference.contradiction_or_stop(logger, NoJustificationNeeded{}, NoReason{});
         }
 
         // Filter: a value survives iff some live tuple supports it. Same
@@ -494,6 +500,7 @@ namespace
         // leaves this call's entries on the trail to be undone rather than
         // committed as if they belonged to an epoch that survived.
         trail_mark = ct.trail.size();
+        return PropagatorState::EnableButIdempotent;
     }
 }
 
@@ -594,10 +601,8 @@ auto gcs::innards::propagate_extensional(
         });
     }
 
-    if (compact) {
-        propagate_compact_table(table, *table.compact, state, inference, logger, hint, bitmaps, live, live_count, just_built);
-        return PropagatorState::EnableButIdempotent;
-    }
+    if (compact)
+        return propagate_compact_table(table, *table.compact, state, inference, logger, hint, bitmaps, live, live_count, just_built);
 
     // Pass 1: drop tuples that are no longer feasible, by swapping them past the
     // live count. Nothing here goes through State, so a dropped tuple costs two
@@ -647,10 +652,18 @@ auto gcs::innards::propagate_extensional(
         // justification and no reason, because that is what emptying the
         // selector's domain used to report -- and the conflict observer behind
         // dom/wdeg reads that reason.
+        //
+        // Stop rather than throw. An empty live set is how a table reports
+        // failure, and a table is the failure detector at a large share of the
+        // nodes of the models it appears in: Dubois-017 contradicts 393 216
+        // times, one call in six, and the unwinder was 40% of that run.
+        // Everything up to the signal, the reason and the justification
+        // included, is unchanged; see issue #820 and
+        // dev_docs/propagator-performance.md.
         if (logger && logger->get_assertion_level() != AssertionLevel::Off)
-            inference.contradiction(logger, JustifyUsingRUP{hint}, table.reason);
+            return inference.contradiction_or_stop(logger, JustifyUsingRUP{hint}, table.reason);
         else
-            inference.contradiction(logger, NoJustificationNeeded{}, NoReason{});
+            return inference.contradiction_or_stop(logger, NoJustificationNeeded{}, NoReason{});
     }
 
     // check for supports in selectable tuples, using residual supports: for each
@@ -705,6 +718,17 @@ auto gcs::innards::propagate_extensional(
                     }
 
                     if (! supported) {
+                        // Still the throwing infer, deliberately. With distinct
+                        // variables this cannot empty a domain -- a live tuple
+                        // is its own witness that every position keeps a
+                        // supported value -- so the only way here is a repeated
+                        // variable, where a removal at one occurrence can leave
+                        // the other unsupported. That is rare enough that a
+                        // per-inference branch to check for it would cost more
+                        // than the unwind it saves, and the measurement agrees:
+                        // once the contradiction above stops throwing, the
+                        // unwinder is 0.00% of the profile on every instance of
+                        // the suite.
                         inference.infer(logger, table.vars[idx] != val, JustifyUsingRUP{hint}, table.reason);
                     }
                 });


### PR DESCRIPTION
#823 gave `contradiction_or_stop` and asked for the next candidate to be picked
off the `_contradictions` column rather than by eye. The extensional propagator
is that candidate, by a distance: on `Dubois-017` it contradicts **393 216
times, once in every six calls**, and a table is the only propagator in the
model, so the throw is most of what the search does.

Both of its contradiction sites -- the live-set path's empty sparse set and the
compact path's empty bitset -- now return `contradiction_or_stop` instead. The
compact pass returns a `PropagatorState` to carry it out. Its early return also
leaves the trail mark unpublished, which is what the throw did and what the pass
already documents wanting: a failed call's trail entries stay unclaimed, to be
undone at the top of the next call rather than committed to an epoch that did
not survive.

## Measured

fataepyc-10 pinned, boost off, hyperfine 5 runs. Identical nodes, solutions and
propagations on every row of both suites, at the default and with
`--table compact` forced.

| instance | before | after | |
|---|---|---|---|
| `Dubois-015` | 0.798 | 0.462 | **1.73x** |
| `Dubois-016` | 1.639 | 0.953 | **1.72x** |
| `Dubois-017` | 3.361 | 1.984 | **1.69x** |
| `Dubois-018` | 6.896 | 4.117 | **1.67x** |
| `srch_func_k3_n24` | 0.031 | 0.021 | 1.4x |
| `enum_func_k3_n20` | 6.308 | 5.099 | 1.2x |
| the other 14 matrix instances | | | 1.0-1.1x |
| Crossword, Kakuro, Renault | | | 1.0x |
| **`enum_single_k10_t200k`**, 0 contradictions | 1.078 | 1.080 | **1.00 +- 0.02** |

That last row is the control: a table instance that never fails is unchanged, so
nothing here is paid for by instances that cannot use it.

Against Gecode on the validation set the ratios move with it -- `randbin_d60`
4.3x -> 2.9x, `randbin_d15` 6.4x -> 5.6x, `clustered_k3` 5.2x -> 4.2x -- and all
16 instances still agree on solutions and nodes.

## Three things worth recording about measuring this

**Measure the unwinder by DSO, not by symbol name.** `perf report | grep -i
unwind` says 8.8% of `Dubois-017`; `perf report --sort dso` says **30.7% in
`libgcc_s.so.1`** plus another 10% in `libstdc++.so.6`, because most of the
unwinder has no symbol names in the profile and appears as bare addresses. That
40% is what the change is worth (1.69x), and read that way the profile predicts
every row, the flat ones included: `enum_func_k3_n20` 11.6% -> 1.24x,
`srch_bin_d12_n25_s1` 7.5% -> 1.09x, `Crossword` 1.3% -> 1.00x,
`enum_single_k10_t200k` 0.0% -> 1.00x. Instruction counts agree: 42.6% of
`Dubois-017`'s instructions were in those two libraries before and 1.9% after,
21.6G down to 11.5G for the same search. I got this wrong the first time and
concluded the profile understates the prize; it does not, the symbol grep does.

**`libgcc_s` reads 0.00% afterwards on every instance**, which is also how you
learn there was nothing else to convert. `propagate_extensional` has a second
failure path -- an `infer` in the support pass emptying a domain -- but it is
unreachable for a table whose variables are distinct, since a live tuple is its
own witness that every position keeps a supported value. Only a repeated
variable can reach it, so it is left throwing and commented as such: a
per-inference branch would cost more than the unwind it saves.

**Two constraints that look like candidates and are not.** `NegativeTable`, which
#823 named: it fails 55 497 times in a 3.5 s search of its own benchmark and
`libgcc_s` is still only 3.6%, because it is woken twenty-five times per
contradiction and each wake does real work (`test_literal` alone is 18% of its
profile). And `Element`: 2.2% on `qap`, 1.5% on `tsp`, despite `tsp` failing 4.3
million times -- most of those failures already report through the non-throwing
`infer_*_or_stop` path. Contradictions per propagator *call* is the ratio to
look at, not per node: one in six here against one in twenty-five there.

## Nothing else changes

The justification is logged before the failure is signalled on either path, and
the propagation loop's `contradicted()` branch does everything the `catch` does,
so the proof cannot move. Proving `Dubois-015` -- 196 606 failures, every one of
them this propagator's -- writes a **byte-identical 96 MB `.pbp`** before and
after, `s VERIFIED UNSATISFIABLE`. Byte-identical for `--table auto`, `live` and
`compact` on two smaller models too. ctest 799/799; ASan + UBSan clean on
`table_test`, `negative_table_test`, `tabulation_test` and
`table_shared_tuples_test`.

`dev_docs/propagator-performance.md` gets all four lessons, in the section #823
started.

---

Closes part of #508, follows #823. Written with the assistance of Claude Opus 5.
