### PR TITLE
A test that takes AutoTable past the compact-table threshold

### DIFF
--- a/dev_docs/propagator-performance.md
+++ b/dev_docs/propagator-performance.md
@@ -567,6 +567,14 @@ Three things to get right when using it:
   of the small per-position layout, so the innermost test is the same loads it
   was before. Reaching through the `shared_ptr` in the loop would have given some
   of the win straight back.
+- **Check there is a second holder at all, and say so where there is not.** The
+  key is an address, so only a caller that can name the same address can find
+  what another one stored. `Table::prepare` shares because the tuples come from
+  the user, who can hand one buffer to twenty constraints; `AutoTable::run` and
+  `build_table_in_proof` each build a tupleset inside the call and move it into
+  the one propagator that reads it, so for them sharing would be a map lookup
+  and nothing else. That is worth a comment at the call site rather than a
+  defaulted parameter, because the two read identically (#835).
 
 ## Is it the propagator, the strength, or the search?
 

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -216,6 +216,10 @@ if(GCS_BUILD_TESTS)
     add_test(NAME difference_logic_presolver_proofs
         COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:difference_logic_presolver_test> proofs)
 
+    add_executable(auto_table_presolver_test presolvers/auto_table/auto_table_test.cc)
+    target_link_libraries(auto_table_presolver_test PRIVATE glasgow_constraint_solver Catch2::Catch2WithMain)
+    add_test(NAME auto_table_presolver_test COMMAND $<TARGET_FILE:auto_table_presolver_test>)
+
     add_executable(inferred_cumulative_presolver_test presolvers/inferred_cumulative/inferred_cumulative_test.cc)
     target_link_libraries(inferred_cumulative_presolver_test PRIVATE glasgow_constraint_solver)
     add_test(NAME inferred_cumulative_presolver

--- a/gcs/constraints/extensional_utils.hh
+++ b/gcs/constraints/extensional_utils.hh
@@ -384,6 +384,12 @@ namespace gcs::innards
          * `Table::prepare` applies it: a table that fits in one word cannot pay
          * for the bookkeeping, and every constraint state is deep-copied into
          * every search node whether the propagator uses it or not.
+         *
+         * Both of those callers leave \c supports defaulted, which is a decision
+         * and not an omission: each builds its tupleset inside the call and hands
+         * it to exactly one propagator, so there is no second holder that could
+         * name the key Propagators::shared_derived_data() is looking up. See the
+         * comments at those two call sites.
          */
         [[nodiscard]] static auto create_for_auto(State & initial_state, std::size_t n_tuples, std::shared_ptr<ExtensionalSupportMasks> supports = {})
             -> std::shared_ptr<ExtensionalCompactTable>;

--- a/gcs/constraints/innards/tabulation.cc
+++ b/gcs/constraints/innards/tabulation.cc
@@ -183,6 +183,13 @@ auto gcs::innards::build_table_in_proof(const vector<IntegerVariableID> & vars, 
     // `sel` remains a State variable because the derivation above introduced its
     // literals against that identity; the propagator no longer uses it.
     auto n_tuples = permitted.size();
+    // No shared support masks, for the same reason AutoTable::run() passes none:
+    // Propagators::shared_derived_data() keys them on the address of the tupleset
+    // they were derived from, and `permitted` was built here and is about to be
+    // moved into the single propagator that reads it. Two tabulations of the same
+    // relation produce equal tuples at different addresses, so there is nothing
+    // for a second caller to find. Table::prepare shares because its tuples come
+    // from the user, who can hand the same buffer to twenty constraints.
     return ExtensionalData{vector<IntegerVariableID>{vars}, move(permitted), ExtensionalLiveTuples::create(state, n_tuples),
         ExtensionalCompactTable::create_for_auto(state, n_tuples)};
 }

--- a/gcs/presolvers/auto_table/auto_table.cc
+++ b/gcs/presolvers/auto_table/auto_table.cc
@@ -147,8 +147,17 @@ auto AutoTable::run(Problem & problem, Propagators & propagators, State & initia
     // derivation introduces its literals lazily; the propagator itself no longer
     // sees a selector at all.
     auto n_tuples = tuples.size();
-    ExtensionalData data{_vars, move(tuples), ExtensionalLiveTuples::create(initial_state, n_tuples),
-        ExtensionalCompactTable::create_for_auto(initial_state, n_tuples)};
+    // No shared support masks, and that is a decision rather than the default it
+    // looks like: the masks Propagators::shared_derived_data() shares are keyed
+    // on the address of the tupleset they come from, and this tupleset was built
+    // a few lines above and is about to be moved into the one propagator that
+    // will ever read it. There is no second holder that could name the key, so
+    // sharing would buy a lookup and nothing else. Table::prepare is the caller
+    // that does share, because a crossword posts twenty of them over one
+    // dictionary.
+    auto compact = ExtensionalCompactTable::create_for_auto(initial_state, n_tuples);
+    _stats->compact_table = nullptr != compact;
+    ExtensionalData data{_vars, move(tuples), ExtensionalLiveTuples::create(initial_state, n_tuples), move(compact)};
 
     Triggers triggers;
     triggers.on_change = {_vars.begin(), _vars.end()};
@@ -181,11 +190,13 @@ auto AutoTableStats::summary() const -> string
     if (0 == tuples)
         return "found no satisfying assignment of " + to_string(variables) + " variables, in " + to_string(search_nodes) + " nodes";
 
-    return to_string(tuples) + " tuples over " + to_string(variables) + " variables, found in " + to_string(search_nodes) + " nodes";
+    return to_string(tuples) + " tuples over " + to_string(variables) + " variables, found in " + to_string(search_nodes) + " nodes" +
+        (compact_table ? ", large enough for the compact table" : "");
 }
 
 auto AutoTableStats::entries() const -> vector<StatsEntry>
 {
     return {StatsEntry{"ran", ran ? 1 : 0}, StatsEntry{"variables", static_cast<long long>(variables)},
-        StatsEntry{"tuples", static_cast<long long>(tuples)}, StatsEntry{"search_nodes", static_cast<long long>(search_nodes)}};
+        StatsEntry{"tuples", static_cast<long long>(tuples)}, StatsEntry{"search_nodes", static_cast<long long>(search_nodes)},
+        StatsEntry{"compact_table", compact_table ? 1 : 0}};
 }

--- a/gcs/presolvers/auto_table/auto_table.hh
+++ b/gcs/presolvers/auto_table/auto_table.hh
@@ -52,6 +52,20 @@ namespace gcs
         /// other measurement, exactly like a slow model.
         std::size_t search_nodes = 0;
 
+        /// Whether the table that was installed is large enough for the
+        /// compact-table algorithm, which since #809 this presolver's tables can
+        /// use. It follows from `tuples` --- the threshold is
+        /// innards::ExtensionalCompactTable::min_tuples --- but that threshold
+        /// is an innards constant, so a caller holding this block cannot work it
+        /// out. Whether the propagator then goes on to *use* the algorithm is a
+        /// separate question, decided during search and by measurement; this is
+        /// only whether it was offered the choice.
+        ///
+        /// Last in the block on purpose, so that it gets its own eight bytes
+        /// rather than sharing `ran`'s padding: see `field_count` in
+        /// solve_test.cc for what depends on that.
+        bool compact_table = false;
+
         [[nodiscard]] virtual auto component_name() const -> std::string override;
         [[nodiscard]] virtual auto summary() const -> std::string override;
         [[nodiscard]] virtual auto entries() const -> std::vector<StatsEntry> override;

--- a/gcs/presolvers/auto_table/auto_table_test.cc
+++ b/gcs/presolvers/auto_table/auto_table_test.cc
@@ -1,0 +1,167 @@
+/* The AutoTable presolver, and specifically the size of the table it installs.
+ *
+ * #809 gave the tabulated extensional propagators access to the compact-table
+ * arm, through ExtensionalCompactTable::create_for_auto(), which hands one back
+ * only for a table of at least ExtensionalCompactTable::min_tuples --- 64 ---
+ * entries. #835 then measured what the suite actually reaches on the AutoTable
+ * half of that: 29 tabulations across four tests, the largest 22 tuples, none
+ * of them eligible. Replacing that call site with a literal null and running
+ * the whole of ctest confirms it: all 801 other tests pass.
+ *
+ * The fixture below is the one that notices. Three variables of an AllDifferent
+ * over 0..7 tabulate to 268 tuples, comfortably the other side of the
+ * threshold, and cheaply enough that the subproblem search finding them is not
+ * worth measuring.
+ *
+ * Two things are pinned here, and they are different depths. That the table is
+ * *offered* the compact algorithm is what AutoTableStats::compact_table says,
+ * and it is what the null above breaks. That the propagator then *takes* it is
+ * decided during search --- table::Auto watches 32 wakes first --- and no
+ * figure reports it, so it was established by measurement instead: this fixture
+ * decides at wake 32 on a mean live set of 28 and adopts. Sabotaging
+ * seed_compact_table_from_live_set() to keep one tuple makes the enumeration
+ * below disagree with the plain model, which is the standing consequence: the
+ * compact filtering runs here, so breaking it fails this test.
+ */
+
+#include <gcs/constraints/all_different.hh>
+#include <gcs/constraints/comparison.hh>
+#include <gcs/constraints/extensional_utils.hh>
+#include <gcs/constraints/innards/constraints_test_utils.hh>
+#include <gcs/constraints/linear.hh>
+#include <gcs/presolvers/auto_table.hh>
+#include <gcs/problem.hh>
+#include <gcs/solve.hh>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <memory>
+#include <optional>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
+
+using namespace gcs;
+using namespace gcs::test_innards;
+
+using std::make_optional;
+using std::make_shared;
+using std::move;
+using std::nullopt;
+using std::optional;
+using std::set;
+using std::shared_ptr;
+using std::string;
+using std::vector;
+
+namespace
+{
+    /// Six variables over 0..`domain` - 1, two disjoint AllDifferents, a total,
+    /// and an ordering to break the symmetry between the two triples. The
+    /// tabulated scope is the first AllDifferent's, so the table has one entry
+    /// per ordered triple of distinct values that the rest of the model does not
+    /// rule out at the root.
+    struct Instance
+    {
+        Integer domain;
+        Integer total;
+    };
+
+    /// 268 tuples, measured: of the 336 ordered triples of distinct values over
+    /// 0..7, that is how many have a completion --- three more distinct values,
+    /// the first of them above v[0], totalling 21 with them. The tabulation is
+    /// exact here rather than a superset, which is worth knowing when reading
+    /// the number but is not what the tests below rest on: they need only that
+    /// it is the far side of 64.
+    constexpr Instance big{8_i, 21_i};
+
+    /// The same shape over half the domain, and 16 tuples of a possible 24, so
+    /// that what separates the two outcomes below is the size of the table and
+    /// nothing else about the model.
+    constexpr Instance small{4_i, 9_i};
+
+    struct Outcome
+    {
+        set<vector<long long>> solutions;
+        shared_ptr<AutoTableStats> block = make_shared<AutoTableStats>();
+    };
+
+    auto enumerate(const Instance & instance, bool presolve, const optional<string> & proof_name) -> Outcome
+    {
+        Outcome outcome;
+
+        Problem p;
+        auto v = p.create_integer_variable_vector(6, 0_i, instance.domain - 1_i, "v");
+        p.post(AllDifferent{vector<IntegerVariableID>{v[0], v[1], v[2]}});
+        p.post(AllDifferent{vector<IntegerVariableID>{v[3], v[4], v[5]}});
+        p.post(WeightedSum{} + 1_i * v[0] + 1_i * v[1] + 1_i * v[2] //
+                + 1_i * v[3] + 1_i * v[4] + 1_i * v[5] ==
+            instance.total);
+        p.post(LessThan{v[0], v[3]});
+
+        if (presolve)
+            p.add_presolver(AutoTable{vector<IntegerVariableID>{v[0], v[1], v[2]}, outcome.block});
+
+        solve(
+            p,
+            [&](const CurrentState & s) -> bool {
+                vector<long long> solution;
+                for (const auto & var : v)
+                    solution.push_back(s(var).raw_value);
+                outcome.solutions.emplace(move(solution));
+                return true;
+            },
+            proof_name ? make_optional<ProofOptions>(*proof_name) : nullopt);
+
+        return outcome;
+    }
+}
+
+TEST_CASE("AutoTable tabulates past the compact table's threshold")
+{
+    auto tabulated = enumerate(big, true, nullopt);
+
+    // The point of the fixture: below this, create_for_auto() hands back a null
+    // and the propagator has only ever had the live-set arm.
+    CHECK(tabulated.block->tuples >= innards::ExtensionalCompactTable::min_tuples);
+    CHECK(tabulated.block->compact_table);
+
+    // And the answers are the ones the model has without the presolver, which is
+    // what says taking the arm was safe: the tabulation, the compact table's
+    // support masks and its incremental live-word update all sit between this
+    // enumeration and the plain one.
+    auto plain = enumerate(big, false, nullopt);
+    CHECK(! plain.solutions.empty());
+    CHECK(tabulated.solutions == plain.solutions);
+}
+
+TEST_CASE("AutoTable below the compact table's threshold gets the live-set arm")
+{
+    // The same model over half the domain, so that the figure checked above is
+    // reporting the size of the table rather than being true of every table.
+    auto tabulated = enumerate(small, true, nullopt);
+
+    CHECK(tabulated.block->tuples > 0);
+    CHECK(tabulated.block->tuples < innards::ExtensionalCompactTable::min_tuples);
+    CHECK(! tabulated.block->compact_table);
+
+    auto plain = enumerate(small, false, nullopt);
+    CHECK(! plain.solutions.empty());
+    CHECK(tabulated.solutions == plain.solutions);
+}
+
+TEST_CASE("A proof of a tabulation past the threshold verifies")
+{
+    // The tabulation half of #809 is proof-checked through odd_even_sum, which
+    // run_test_and_verify.bash runs; this is the AutoTable half of the same
+    // thing. The presolver's own derivation is a pair of redundance lines per
+    // tuple, and the propagator it installs takes NoHint, so every inference it
+    // then makes has to be RUP against them --- including the ones the compact
+    // arm is responsible for, which is what is new here.
+    const auto proof_name = "auto_table_presolver_compact_arm_test";
+
+    auto tabulated = enumerate(big, true, proof_name);
+    REQUIRE(tabulated.block->compact_table);
+    CHECK(verify_proof_and_dispose(proof_name));
+}

--- a/gcs/solve_test.cc
+++ b/gcs/solve_test.cc
@@ -592,6 +592,10 @@ namespace
     /// and a field added without a matching `entries()` line moves one side of
     /// the comparison below and not the other. That is the rot this design can
     /// grow: a figure that exists, is filled in, and reaches nobody.
+    ///
+    /// The one way to defeat this rather than trip it: two `bool`s declared next
+    /// to each other share a slot, and then `sizeof` undercounts. Keep them
+    /// apart, as AutoTableStats does.
     template <typename Block_>
     [[nodiscard]] auto field_count() -> std::size_t
     {
@@ -732,6 +736,10 @@ TEST_CASE("AutoTable reports what it did, with no stats block asked for")
     CHECK(by_name["variables"] == 2);
     CHECK(by_name["tuples"] == 4); // a + b == 3, over 0..3
     CHECK(by_name["search_nodes"] > 0);
+    // Four tuples fit in one word, so the compact table is not on offer. The
+    // other side of that threshold is auto_table_test.cc, which is where the
+    // presolver's compact arm gets exercised at all.
+    CHECK(by_name["compact_table"] == 0);
 }
 
 TEST_CASE("A caller's AutoTable stats block is the one that gets filled in and reported")


### PR DESCRIPTION
Closes #835.

## The gap, confirmed

The issue's measurement was that `AutoTable`'s `create_for_auto` call site never
returns anything: 29 tabulations across four tests, largest 22 tuples, against a
`min_tuples` of 64. I confirmed the consequence directly rather than re-counting:
with `gcs/presolvers/auto_table/auto_table.cc:151` replaced by a literal null,
`ctest` is **801/801 green**. Nothing in the suite was holding that line.

With this branch it is 802, and the new one fails under that mutation.

## The fixture

`gcs/presolvers/auto_table/auto_table_test.cc`. Six variables, two disjoint
`AllDifferent`s, a total and an ordering; the tabulated scope is the first
triple, over 0..7, and it comes out at **268 tuples** — of the 336 ordered
triples of distinct values, the ones that have a completion. Three checks:

- the table is past the threshold, and was offered the compact algorithm;
- enumerating with the presolver gives exactly the solutions the model has
  without it;
- a proof of the run verifies. That is the AutoTable counterpart of
  `odd_even_sum`, which is how the tabulation half of #809 is proof-checked.

A companion fixture over half the domain tabulates to 16, so the figure the
first one asserts on is not one that is trivially true of every table.

## Two depths, and which is pinned by what

**Offered** the compact algorithm is now a reported figure,
`AutoTableStats::compact_table`. It does follow from `tuples`, but the threshold
it follows from is an innards constant, so a caller holding the block cannot
work it out — and it is what the null mutation above breaks.

**Taken** is decided during search: `table::Auto` watches 32 wakes and then
tests the mean live set. No figure reports that, and adding one would put a
branch in a function whose instruction footprint is documented as costing 7-14%
on instances that never execute it. So it was established by measurement
instead — this fixture decides at wake 32 on a mean live set of 28 and adopts —
and by sabotage: seeding the compact table with one tuple instead of the live
set makes the enumeration test fail. The compact filtering runs here, so
breaking it fails this test. Both are written down in the test's header comment.

(Sabotage that drops just *one* live tuple is not caught, which is what you
would expect of a GAC propagator with 28 live tuples: it removes no value's last
support. Only the strong version changes an inference.)

## The shared-masks question

#831's third parameter is left defaulted at both tabulating call sites, and it
is now a decision with a reason at each rather than an inherited default. The
masks are keyed on the address of the tupleset they were derived from;
`AutoTable::run` and `build_table_in_proof` each build a tupleset inside the
call and move it into the single propagator that reads it, so there is no second
holder that could name the key — two tabulations of the same relation produce
equal tuples at different addresses. `Table::prepare` shares because its tuples
come from the user, who can hand one buffer to twenty constraints. Recorded at
both sites, on `create_for_auto` itself, and as a fourth bullet in
`dev_docs/propagator-performance.md`'s shared-derived-data section.

## Checked

- `ctest` 802/802 on GCC Release with `-DGCS_WERROR=ON`; the new test is 0.97 s
  including veripb.
- Clang: the two touched test binaries build warning-free and pass. (`-DGCS_WERROR=ON`
  under clang 21 fails on a pre-existing `-Winconsistent-missing-override` in
  `gcs/variable_weighting.hh`, untouched here.)
- Sanitize preset: both binaries clean.
- `clang-format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
