### PR TITLE
Use make_unique where the constructor is actually reachable

### DIFF
--- a/gcs/constraints/element/element.cc
+++ b/gcs/constraints/element/element.cc
@@ -720,7 +720,8 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators_impl(Prop
 template <typename EntryType_, unsigned dimensions_>
 auto NDimensionalElement<EntryType_, dimensions_>::clone() const -> unique_ptr<Constraint>
 {
-    return unique_ptr<Constraint>(new NDimensionalElement{_result_var, _index_vars, _index_starts, _array, _bounds_only});
+    // The constructor is protected, so make_unique cannot reach it.
+    return unique_ptr<Constraint>(new NDimensionalElement(_result_var, _index_vars, _index_starts, _array, _bounds_only));
 }
 
 template <typename EntryType_, unsigned dimensions_>

--- a/gcs/constraints/regular/regular.cc
+++ b/gcs/constraints/regular/regular.cc
@@ -509,6 +509,7 @@ auto Regular::with_proof_strategy(RegularProofStrategy strategy) -> Regular &
 
 auto Regular::clone() const -> unique_ptr<Constraint>
 {
+    // The set-valued-transitions constructor is private, so make_unique cannot reach it.
     auto cloned = unique_ptr<Regular>(new Regular(_vars, _num_states, _transitions, _final_states, _symbols, _short_reasons, _regex));
     cloned->with_proof_strategy(_proof_strategy);
     return cloned;

--- a/gcs/constraints/regular/regular_legacy.cc
+++ b/gcs/constraints/regular/regular_legacy.cc
@@ -435,6 +435,7 @@ auto RegularLegacy::with_short_reasons(std::optional<bool> short_reasons) -> Reg
 
 auto RegularLegacy::clone() const -> unique_ptr<Constraint>
 {
+    // The set-valued-transitions constructor is private, so make_unique cannot reach it.
     return unique_ptr<Constraint>(new RegularLegacy(_vars, _num_states, _transitions, _final_states, _symbols, _short_reasons, _regex));
 }
 

--- a/gcs/innards/propagators.hh
+++ b/gcs/innards/propagators.hh
@@ -240,7 +240,7 @@ namespace gcs::innards
 
     public:
         template <typename Func_>
-        PropagationFunction(Func_ && f) : _impl(new PropagationFunctionImpl<Func_>(std::move(f)))
+        PropagationFunction(Func_ && f) : _impl(std::make_unique<PropagationFunctionImpl<Func_>>(std::move(f)))
         {
         }
 


### PR DESCRIPTION
Closes #287.

The issue is old, and its file list has mostly been fixed in passing since. All six PIMPL initialisers it names (`state.cc`, `problem.cc`, `propagators.cc`, `proof_logger.cc`, `proof_model.cc`, `names_and_ids_tracker.cc`) already say `make_unique<Imp>()`. A sweep for `new` over every source extension in the tree finds exactly four raw `new` expressions left.

**One moves.** `PropagationFunction`'s constructor in `gcs/innards/propagators.hh`. `InitialisationFunction`, forty lines below it in the same header, is the same type-erasing wrapper built the same way and already uses `make_unique`; the two are now written the same.

**Three stay**, and they're the per-site check the issue asked for:

| site | why not |
|---|---|
| `regular.cc:512` | the set-valued-transitions `Regular` constructor is **private** |
| `regular_legacy.cc:438` | same, `RegularLegacy` |
| `element.cc:723` | `NDimensionalElement`'s constructor is **protected** |

`make_unique` is a free function, so it can't reach any of them; `clone()` is a member and can. `unique_ptr(new ...)` is the right thing to write there, so each site now carries a one-line comment saying why, to stop it being re-flagged.

The issue read the brace-init at the element site as a sign that `NDimensionalElement` is an aggregate, and flagged that a rewrite might then hinge on C++23 parenthesised aggregate initialisation (P0960). It isn't an aggregate — the braces were calling that protected constructor. They're now parens, matching what the call is and how the other two clones read. No P0960 dependency anywhere in this.

## Testing

- GCC release, `-DGCS_WERROR=ON`: builds clean, no new warnings.
- `ctest -j 32`: 801/801 passed.
- clang 21.1.8 `-fsyntax-only` on each changed file, using its own `compile_commands.json` line plus the two pre-existing suppressions `main` needs (`-Wno-inconsistent-missing-override`, `-Wno-unused-lambda-capture`): clean, `-Werror` still on.
- `clang-format --dry-run -Werror` on all four files: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)