### PR TITLE
Stop, rather than throw, in Count and in the And/Or clause conflict

### DIFF
--- a/dev_docs/propagator-performance.md
+++ b/dev_docs/propagator-performance.md
@@ -279,6 +279,57 @@ table on one in twenty-five. `Element` is not a candidate either — 2.2% on `qa
 and 1.5% on `tsp`, despite `tsp` failing 4.3 million times, because most of
 those failures already report through the non-throwing `infer_*_or_stop` path.
 
+### The throw survey, and what it found
+
+Rather than guess at the remaining candidates, all 285 MiniZinc Challenge models
+(2008-2025, one instance each, capped at twenty seconds) were run with a counter
+on each of the two ways a propagator reports failure by unwinding. The raw
+material is in `tmp/throw-survey/`. Two things came out of it, and both are worth
+knowing before doing this kind of work again.
+
+**`contradiction()` is a solved problem: there are no more candidates.** Across
+all 285 models it threw **219 918** times in total, and exactly one model
+(`2019_kidney-exchange`) reaches even 1% of its runtime that way. The table
+propagator was the outlier, not the first of many.
+
+**The volume is all on the other path — an `infer*` that empties a domain —
+which threw 19 457 165 times, eighty-eight times as often.** That is worth
+10-22% of the run on six models, and it concentrates in a handful of
+propagators. Counting throws by constraint type over the thirty worst models:
+
+| propagator | throws | models |
+|---|---|---|
+| `count` | 5 954 685 | 7 |
+| `or` | 5 629 563 | **19** |
+| `disjunctive2d_strict` | 2 435 425 | 4 |
+| `all_different_except` | 766 548 | 2 |
+| `disjunctive_strict` | 348 160 | 1 |
+| `equals` | 266 738 | 13 |
+| `element` | 199 096 | 6 |
+| `multiply` | 135 549 | 3 |
+
+`count` and `or` are converted (`infer_*_or_stop` throughout `Count`; the clause
+conflict in the shared `And`/`Or` propagator is a contradiction spelled as
+`infer(FalseLiteral{})` and became `contradiction_or_stop`). On identical trees
+that is **1.53x** on a completed `2015/grid-colouring`, and 1.17-2.65x of extra
+throughput on the capped models. `libgcc_s` goes to 0.00% on all of them.
+
+The rest are named above and left: `disjunctive2d_strict`'s two prunings sit
+inside a lambda in a doubly-nested loop, so stopping has to be threaded out by
+hand, and `all_different_except`'s failure is
+`gac_all_different.cc`'s matching-too-small `infer(logger, FalseLiteral{}, ...)`,
+which would need `propagate_gac_all_different` to return a verdict to its five
+callers. Both are mechanical; neither is one line.
+
+**Per-throw cost, measured on an identical completed search** (`gc_4_8`, 322 378
+clause conflicts): 5.65G instructions and 1.85G cycles, i.e. **17 500
+instructions and about 2.4 us** each. That is the number to multiply a
+contradiction count by when deciding whether a conversion is worth it. One model
+(`2011/roster`'s larger instance) came out far above that, at 2.65x throughput
+for only 5% of cycles in `libgcc_s`, because there the throwing build also takes
+**five page faults per node** that the non-throwing one does not; that mechanism
+is not understood and is not the general case.
+
 ### Reuse data structures to avoid per-wake allocation
 
 The same principle applies to scratch state generally: a propagator that

--- a/gcs/constraints/count/count.cc
+++ b/gcs/constraints/count/count.cc
@@ -121,7 +121,16 @@ auto Count::install_propagators(Propagators & propagators) -> void
                     }
                 }
             };
-            inference.infer(logger, how_many < how_many_is_less_than, JustifyExplicitly{justf, ThenRUP::Yes, hints::Count{owner}}, reason);
+            // The _or_stop family throughout this propagator, rather than the
+            // throwing infer: Count is the failure detector at a large share of
+            // the nodes of the rostering and puzzle models that use it -- 6.0M
+            // unwinds over seven MiniZinc Challenge models in the throw survey,
+            // where the unwinder is 11-15% of the run. Same inference, same
+            // proof step, same reason; only the way out of the propagator
+            // differs, and [[nodiscard]] makes forgetting to take it an error.
+            if (! inference.infer_less_than_or_stop(
+                    logger, how_many, how_many_is_less_than, JustifyExplicitly{justf, ThenRUP::Yes, hints::Count{owner}}, reason))
+                return PropagatorState::DisableUntilBacktrack;
 
             // must have at least this many occurrences of the value of interest
             int how_many_must = 0;
@@ -131,11 +140,17 @@ auto Count::install_propagators(Propagators & propagators) -> void
                     if (state.optional_single_value(v) == voi)
                         ++how_many_must;
             }
-            inference.infer(logger, how_many >= Integer(how_many_must), JustifyUsingRUP{hints::Count{owner}}, reason);
+            if (! inference.infer_greater_than_or_equal_or_stop(
+                    logger, how_many, Integer(how_many_must), JustifyUsingRUP{hints::Count{owner}}, reason))
+                return PropagatorState::DisableUntilBacktrack;
 
             // is each value of interest supported? also track how_many bounds supports
             // whilst we're here
             optional<Integer> lowest_how_many_must, highest_how_many_might;
+            // Set when a pruning below empties value_of_interest's domain, so the
+            // loop leaves and the propagator returns rather than carrying on
+            // reading a state that has already failed.
+            bool stop = false;
             for (const auto & voi : state.each_value_mutable(value_of_interest)) {
                 Integer how_many_must = 0_i, how_many_might = 0_i;
                 for (const auto & var : vars) {
@@ -162,12 +177,19 @@ auto Count::install_propagators(Propagators & propagators) -> void
                             }
                         }
                     };
-                    inference.infer(logger, value_of_interest != voi, JustifyExplicitly{justf, ThenRUP::Yes, hints::Count{owner}}, reason);
+                    if (! inference.infer_not_equal_or_stop(
+                            logger, value_of_interest, voi, JustifyExplicitly{justf, ThenRUP::Yes, hints::Count{owner}}, reason)) {
+                        stop = true;
+                        break;
+                    }
                 }
                 else if (how_many_must > state.upper_bound(how_many)) {
                     // unlike above, we don't need to help, because the equality flag will propagate
                     // from the fixed assignment
-                    inference.infer(logger, value_of_interest != voi, JustifyUsingRUP{hints::Count{owner}}, reason);
+                    if (! inference.infer_not_equal_or_stop(logger, value_of_interest, voi, JustifyUsingRUP{hints::Count{owner}}, reason)) {
+                        stop = true;
+                        break;
+                    }
                 }
                 else {
                     // [how_many_must, how_many_might] is the range of counts
@@ -213,7 +235,11 @@ auto Count::install_propagators(Propagators & propagators) -> void
                             logger->emit_rup_proof_line_under_reason(reason,
                                 WPBSum{} + 1_i * (value_of_interest != voi) + 1_i * (how_many >= how_many_must) >= 1_i, ProofLevel::Temporary);
                         };
-                        inference.infer(logger, value_of_interest != voi, JustifyExplicitly{justf, ThenRUP::Yes, hints::Count{owner}}, reason);
+                        if (! inference.infer_not_equal_or_stop(
+                                logger, value_of_interest, voi, JustifyExplicitly{justf, ThenRUP::Yes, hints::Count{owner}}, reason)) {
+                            stop = true;
+                            break;
+                        }
                     }
                     else {
                         if ((! lowest_how_many_must) || (how_many_must < *lowest_how_many_must))
@@ -224,6 +250,9 @@ auto Count::install_propagators(Propagators & propagators) -> void
                 }
             }
 
+            if (stop)
+                return PropagatorState::DisableUntilBacktrack;
+
             // what are the supports on possible values we've seen?
             if (lowest_how_many_must) {
                 auto emit = [&](const ReasonLiterals & reason) -> void {
@@ -232,7 +261,8 @@ auto Count::install_propagators(Propagators & propagators) -> void
                             WPBSum{} + 1_i * (value_of_interest != voi) + 1_i * (how_many >= *lowest_how_many_must) >= 1_i, ProofLevel::Temporary);
                 };
                 auto just = JustifyExplicitly{emit, ThenRUP::Yes, hints::Count{owner}};
-                inference.infer(logger, how_many >= *lowest_how_many_must, just, reason);
+                if (! inference.infer_greater_than_or_equal_or_stop(logger, how_many, *lowest_how_many_must, just, reason))
+                    return PropagatorState::DisableUntilBacktrack;
             }
 
             if (highest_how_many_might) {
@@ -264,7 +294,8 @@ auto Count::install_propagators(Propagators & propagators) -> void
                             ProofLevel::Temporary);
                 };
                 auto just = JustifyExplicitly{emit, ThenRUP::Yes, hints::Count{owner}};
-                inference.infer(logger, how_many < *highest_how_many_might + 1_i, just, reason);
+                if (! inference.infer_less_than_or_stop(logger, how_many, *highest_how_many_might + 1_i, just, reason))
+                    return PropagatorState::DisableUntilBacktrack;
             }
 
             return PropagatorState::Enable;

--- a/gcs/constraints/logical/logical.cc
+++ b/gcs/constraints/logical/logical.cc
@@ -118,13 +118,20 @@ namespace
                     if (any_false)
                         return PropagatorState::DisableUntilBacktrack;
                     else if (! undecided1) {
-                        // literals are all true, but reif is false
+                        // literals are all true, but reif is false. Stop rather
+                        // than throw: for Or -- which is this propagator over
+                        // negated literals -- this is the clause conflict, and a
+                        // clause is the failure detector at a large share of the
+                        // nodes of the models that have any. It is 1.2M unwinds
+                        // in twenty seconds of `2014_train`, where the unwinder
+                        // is 22% of the run. Inferring FalseLiteral{} and
+                        // contradicting are the same proof step and the same
+                        // reason; only the way out of the propagator differs.
                         ReasonLiterals why;
                         for (auto & lit : lits)
                             why.push_back(lit);
                         why.push_back(! full_reif);
-                        inference.infer(logger, FalseLiteral{}, JustifyUsingRUP{Hint_{owner}}, ExplicitReason{why});
-                        return PropagatorState::Enable;
+                        return inference.contradiction_or_stop(logger, JustifyUsingRUP{Hint_{owner}}, ExplicitReason{why});
                     }
                     else {
                         ReasonLiterals why;

--- a/gcs/innards/inference_tracker.hh
+++ b/gcs/innards/inference_tracker.hh
@@ -414,11 +414,24 @@ namespace gcs::innards
             track_explicit(logger, _state.infer_greater_than_or_equal(var, value), var >= value, why, snapshotted, fallback);
         }
 
-        // Non-throwing counterparts of the JustifyExplicitly infer_less_than /
-        // infer_greater_than_or_equal: on contradiction they set _contradicted and
-        // return false instead of throwing, so the caller bails up its own control
-        // flow. [[nodiscard]] makes ignoring the verdict a compile error -- the
-        // caller must stop (it cannot safely keep reading state after a failure).
+        // Non-throwing counterparts of the JustifyExplicitly infer_not_equal /
+        // infer_less_than / infer_greater_than_or_equal: on contradiction they set
+        // _contradicted and return false instead of throwing, so the caller bails
+        // up its own control flow. [[nodiscard]] makes ignoring the verdict a
+        // compile error -- the caller must stop (it cannot safely keep reading
+        // state after a failure).
+        template <IntegerVariableIDLike VarType_, typename Emit_, typename Hint_>
+        [[nodiscard]] auto infer_not_equal_or_stop(ProofLogger * const logger, const VarType_ & var, Integer value,
+            const JustifyExplicitly<Emit_, Hint_> & why, const Reason & reason, const std::optional<AssertionAnnotation> & fallback = std::nullopt)
+            -> bool
+        {
+            if (_contradicted) [[unlikely]]
+                return false;
+            auto snapshotted = snapshot_reason(logger, reason, _state);
+            track_explicit(logger, _state.infer_not_equal(var, value), var != value, why, snapshotted, fallback, false);
+            return ! _contradicted;
+        }
+
         template <IntegerVariableIDLike VarType_, typename Emit_, typename Hint_>
         [[nodiscard]] auto infer_less_than_or_stop(ProofLogger * const logger, const VarType_ & var, Integer value,
             const JustifyExplicitly<Emit_, Hint_> & why, const Reason & reason, const std::optional<AssertionAnnotation> & fallback = std::nullopt)


### PR DESCRIPTION
#823 asked for the next `contradiction_or_stop` candidates to be picked off the
`_contradictions` column rather than by eye, and #832 did the table propagator.
This is the survey that answers "what else", and the two conversions it names.

## The survey

All 285 MiniZinc Challenge models (2008-2025, one instance each, capped at
twenty seconds), with a counter on each of the two ways a propagator reports
failure by unwinding. Harness and raw results in `tmp/throw-survey`, which is
outside the repository; the conclusion is written up in
`dev_docs/propagator-performance.md`.

**`contradiction()` is a solved problem: there are no more candidates.** It
threw **219 918** times across all 285 models put together, and exactly one
model reaches 1% of its runtime that way. The table propagator was the outlier,
not the first of many.

**The volume is all on the other path -- an `infer*` that empties a domain --
which threw 19 457 165 times, eighty-eight times as often**, and is worth
10-22% of the run on six models. By constraint type over the thirty worst:

| propagator | throws | models |
|---|---|---|
| `count` | 5 954 685 | 7 |
| `or` | 5 629 563 | **19** |
| `disjunctive2d_strict` | 2 435 425 | 4 |
| `all_different_except` | 766 548 | 2 |
| `disjunctive_strict` | 348 160 | 1 |
| `equals` | 266 738 | 13 |
| `element` | 199 096 | 6 |
| `multiply` | 135 549 | 3 |

## What this converts

**`Or`**, which is the shared `And`/`Or` propagator over negated literals: its
"literals all true, reif false" case is the clause conflict, and it was spelled
`infer(logger, FalseLiteral{}, ...)` -- a contradiction wearing an inference's
clothes. One line, now `contradiction_or_stop`. It is in 19 of the 30 worst
models because every FlatZinc clause is one.

**`Count`**, on the `infer_*_or_stop` family throughout: two `how_many` bounds,
three `value_of_interest != voi` prunings inside the support loop (which now
breaks out), and the two bounds derived from the supports. Six sites.

One API addition it needed: `infer_not_equal_or_stop` on the
`JustifyExplicitly` path, which is what #823's "the JustifyExplicitly overload
can be added when a caller wants it" was waiting for. It mirrors the
`infer_less_than_or_stop` beside it exactly.

## Measured

fataepyc-10 pinned, boost off, identical nodes, failures and propagations on
every row.

**Completed searches**, `2015/grid-colouring` (the model is `or`-heavy; both
instances run to optimality):

| instance | before | after | |
|---|---|---|---|
| `4_8` | 2.321 s | 1.518 s | **1.53x** |
| `10_5` | 101.4 s | 73.5 s | **1.38x** |

**Capped models**, where nodes explored in a fixed twenty seconds is the fair
comparison, the tree being deterministic and both builds exploring the same
prefix of it:

| model | nodes before | nodes after | |
|---|---|---|---|
| `2011/roster` (larger instance) | 571 925 | 1 518 089 | **2.65x** |
| `2014/train` | 2 539 087 | 3 771 359 | **1.49x** |
| `2015/grid-colouring` | 2 204 060 | 3 079 961 | **1.40x** |
| `2011/roster` | 1 000 920 | 1 171 553 | 1.17x |
| `2012/amaze` | 1 725 333 | 2 015 894 | 1.17x |
| `2013/filters` (`disjunctive2d_strict`) | 1 407 855 | 1 404 947 | 1.00x |
| `2018/concert-hall-cap` (`all_different_except`) | 1 909 494 | 1 923 803 | 1.01x |

The last two rows are the control: the survey named those propagators and this
does not convert them, and they do not move. `libgcc_s.so.1` reads **0.00%** on
every converted model. In the curated set, `magic_series --size=300` -- the one
that leans on `Count` -- is 1.11x; the rest are unchanged.

**Per-throw cost**, from the completed `gc_4_8` (322 378 clause conflicts):
5.65G instructions and 1.85G cycles, i.e. **17 500 instructions and about
2.4 us** each. That is the figure to multiply a contradiction count by when
judging whether a conversion is worth doing.

One instance is well above that and I cannot fully explain it: `2011/roster`'s
larger instance gets 2.65x for only 5% of cycles in `libgcc_s`, because the
throwing build also takes five page faults per node that the non-throwing one
does not. Recorded rather than smoothed over.

## Nothing else changes

Both conversions keep the same inference, the same proof step and the same
reason; only the way out of the propagator differs, and `[[nodiscard]]` makes
forgetting to take it a compile error. Proofs are byte-identical to the previous
build on `seat_moving` (99 KB), `hitori` (1.4 MB) and `2015/grid-colouring`
`4_8` through `fzn-glasgow` (**528 MB**, 322 378 clause conflicts), and VeriPB
verifies the first two. ctest 799/799. ASan + UBSan clean on `count_test`,
`logical_test`, `all_different_except_test`, `inverse_test` and `arg_sort_test`.

## Left for later, deliberately

`disjunctive2d_strict`'s two prunings sit inside a lambda in a doubly-nested
loop, so stopping has to be threaded out by hand; `all_different_except`'s
failure is `gac_all_different.cc`'s matching-too-small
`infer(logger, FalseLiteral{}, ...)`, which needs `propagate_gac_all_different`
to return a verdict to its five callers. Both are mechanical, neither is one
line, and both are named with their line numbers in the dev_docs section.

---

Follows #832 and #823. Written with the assistance of Claude Opus 5.
