### PR TITLE
A large-domain development tripwire, and a per-constraint audit lane (#833)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,17 @@ cmake -S . -B build -DGCS_ENABLE_VIEW_WRAP_SWEEP=ON
 The harness and `--view-wrap=N` / `--view-position=K` argv flags on each
 test are always built; only the ctest registrations are gated.
 
+Enable the large-domain guard, a development tripwire that turns work
+proportional to a variable's domain width into a test failure (issue #833):
+```shell
+cmake -S . -B build-guard -DGCS_LARGE_DOMAIN_GUARD=ON
+```
+Off by default, and deliberately not user-facing: what protects a user is a
+constraint having somewhere cheap to fall back to, not an exception thrown from
+the middle of propagation. Turning it on also registers `large_domain_audit_test`,
+which probes every constraint class over a `0..10^9` domain against a table of
+expected outcomes. See `dev_docs/large-domains.md`.
+
 By default the data-driven constraint tests run with generous per-solve
 solution/recursion caps (`GCS_TEST_CAP_DEFAULTS=ON`) so a pathological
 random instance can't dominate the parallel suite. A capped run checks

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,6 +122,22 @@ unset(_gcs_enable_executables_default)
 option(GCS_BUILD_TESTS "Build GCS tests" ${PROJECT_IS_TOP_LEVEL})
 option(GCS_ENABLE_VIEW_WRAP_SWEEP "Register the view-wrap proof-verification sweep (many tests, most failing today; opt in when working on view proof logging)" OFF)
 
+# The large-domain guard (issue #833). A development tripwire, not a user-facing
+# safety net: it turns work proportional to a variable's domain width -- a
+# per-value propagation loop, or an array sized by a domain's span -- into a
+# LargeDomainGuardTripped exception, so that a wedged core or a bad_alloc deep in
+# propagation becomes an attributable test failure instead. What protects a user
+# is a constraint having somewhere cheap to fall back to, which is the rest of
+# #833; this only helps us find the places that do not have one yet.
+#
+# OFF by default and never on in a release build. The checks are behind a macro
+# that expands to nothing when this is off, so a default build does not even
+# evaluate the sizes being checked.
+#
+# Turning it ON also registers the large-domain audit lane (see gcs/CMakeLists.txt),
+# which is where the per-constraint expected-outcome table lives.
+option(GCS_LARGE_DOMAIN_GUARD "Development tripwire: fail when work is proportional to a variable's domain width (issue #833)" OFF)
+
 # Runtime caps for data-driven constraint tests. When enabled, each registered
 # test gets generous per-solve solution/recursion caps in its environment so
 # that the occasional pathological random instance (huge solution count or

--- a/dev_docs/README.md
+++ b/dev_docs/README.md
@@ -46,6 +46,12 @@ library. For an introduction to *using* the solver, start with the top-level
   measuring the wall-time impact of a performance-sensitive change, the
   rationale for each pick, the harness pattern for comparing two builds,
   and what to capture. Use when quantifying a refactor's perf impact.
+- [Large domains](large-domains.md) — the policy for constraints whose work is
+  proportional to how *wide* a variable's domain is: the rule that every
+  bounds-consistency path must be width-independent, the hazard taxonomy, the
+  `GCS_LARGE_DOMAIN_GUARD` development tripwire, and the per-constraint audit
+  lane and its current table. Read before writing a loop over a variable's
+  values, or when a model with a wide declared domain wedges.
 - [Making a propagator faster](propagator-performance.md) — what to change
   once a propagator is correct: the per-constraint-type breakdown
   (`GCS_PROPAGATOR_STATS`) that says which constraint the time went to, then

--- a/dev_docs/constraints.md
+++ b/dev_docs/constraints.md
@@ -409,6 +409,15 @@ Inside the propagator body, the `State` parameter exposes:
 
 These are read-only — modifying the state goes through `inference`.
 
+Every one of the value-iterating forms above costs time proportional to how
+*wide* the domain is, and a declared domain of `0..1000000000` is an ordinary
+input rather than a mistake — so a loop over one is a hang, not a slow path. Read
+[large-domains.md](large-domains.md) before writing one: it says when the loop is
+really an interval operation written out longhand (in which case
+`IntervalSet::each_interval_minus()` and `InferenceTracker::infer_not_in_range()`
+give you the same pruning in time proportional to the number of *intervals*), and
+how to check your constraint with the `GCS_LARGE_DOMAIN_GUARD` build.
+
 ## Making inferences
 
 The `inference` parameter is templated; treat it as exposing:

--- a/dev_docs/large-domains.md
+++ b/dev_docs/large-domains.md
@@ -1,0 +1,169 @@
+# Large domains
+
+Nothing in the solver bounds the work a constraint does as a function of how
+*wide* a variable's domain is. A propagator that reasons value by value over a
+billion-value domain does a billion units of work per call; an initialiser that
+precomputes per value allocates per value; a scheduling propagator that indexes
+by time allocates over the whole horizon. None of that is a bug in any one
+constraint. It is a missing policy, and this document is where the policy and
+the machinery for finding violations of it live.
+
+The tracking issue is [#833](https://github.com/ciaranm/glasgow-constraint-solver/issues/833).
+
+## The rule
+
+> **Every bounds-consistency path must be independent of domain width.**
+
+This is the backstop the rest of the policy hangs off. A model may legitimately
+declare `var 0..1000000000`, and `fzn-glasgow` gives a domainless FlatZinc `var
+int` a domain of about 9.2×10^18 values, so a wide domain is an ordinary input
+rather than a mistake to be refused. What makes that safe is not a check that
+rejects it, but every constraint having somewhere cheap to fall back to. A
+constraint may drop to propagating almost nothing over a wide domain — that is
+allowed, and it should say so on the stats channel — but it must stay correct
+and it must stay cheap.
+
+Two corollaries that are easy to get wrong:
+
+* **"Fall back to bounds" is not the same as "pick the BC arm."** A bounds arm
+  that enumerates values is not a fallback at all. `GlobalCardinality` already
+  defaults to `consistency::BC{}` and still enumerates
+  (`bounds_global_cardinality.cc`), which is the canonical counterexample.
+* **Weakening for cost is legitimate; weakening for proof size is not.** See
+  `propagator-performance.md` — a fallback arm is justified by time and memory,
+  never by the proof being too big.
+
+## The hazards
+
+| | hazard | where it bites |
+|---|---|---|
+| **H1a** | a per-value spelling of an interval operation | fixable at full strength — see below |
+| **H1b** | a missing bounds inference, so a per-value loop is what establishes the bound | a propagator bug |
+| **H1c** | a genuine per-value support scan with no interval structure to exploit | needs a weaker arm |
+| **H2** | install-time precompute proportional to the sum of domain sizes, before search exists | needs the decision taken in `prepare()` |
+| **H2′** | an OPB *encoding* proportional to a domain | no consistency level helps; `NValue` writes one proof flag per value of the union of the domains |
+| **H3** | arrays sized by a span, which no consistency level covers | a cap and a weaker rung |
+
+H1a is the one worth looking for first, because it is not a trade-off at all.
+The tree already has the machinery: `IntervalSet::each_interval_minus()`,
+`InferenceTracker::infer_not_in_range()`, and
+`justify_not_in_range_across_equality()` for the proof side, used in
+`equals.cc`, `in.cc`, `min_max.cc` and `global_cardinality.cc` today. A loop
+that removes "everything not in this small given set" one value at a time is an
+interval operation written out longhand, and rewriting it keeps GAC.
+
+H3 has two precedents in the tree for what a good cap looks like:
+`ExtensionalDomainBitmaps::max_words` and `cumulative.cc`'s
+`max_knapsack_capacity`. Both are far above anything a real model asks for, both
+degrade to a named weaker rung rather than silently doing less, and the comment
+on the second is the model for how to write one up.
+
+## The guard
+
+`-DGCS_LARGE_DOMAIN_GUARD=ON` turns work proportional to a domain's width into a
+`LargeDomainGuardTripped`. It is **off by default and is not a user-facing
+safety net**: what protects a user is a constraint having somewhere to fall back
+to, not an exception thrown from the middle of propagation. The guard is a
+development tripwire, so that a wedged core or a `bad_alloc` deep inside
+propagation becomes an attributable test failure.
+
+```shell
+cmake -S . -B build-guard -DGCS_LARGE_DOMAIN_GUARD=ON
+cmake --build build-guard --parallel $(nproc)
+./build-guard/large_domain_audit_test
+```
+
+Two kinds of check, and the difference matters:
+
+* **`LargeDomainIterationCounter`** counts values *as an iteration hands them
+  out*, in `State::each_value_*` and `State::for_each_value_*`. Counting work
+  done is the right measure and checking the domain's width up front is not: a
+  branching heuristic asks for a generator over a billion-value domain and reads
+  one value from it, which is fine. An early version of this guard checked the
+  width and condemned `Plus`, `Abs`, `LessThan` and `LinearEquality` for it.
+* **`GCS_CHECK_LARGE_DOMAIN`** checks a size up front, for the H3 sites that
+  commit to a whole array at once.
+
+The limit is 100000, overridable with `GCS_LARGE_DOMAIN_GUARD_LIMIT`. It sits in
+the gap #833 measured between "free" (10^4) and "hundreds of megabytes" (10^6),
+and far above anything the test suite asks for. It is deliberately *not* the
+threshold the policy itself will use to choose an arm: a guard wants to be far
+enough above normal work never to fire on it, and a policy wants to be near the
+cliff.
+
+With the guard off, every check compiles to nothing — not merely to a no-op call,
+but to nothing that evaluates the size being checked.
+
+## The audit lane
+
+`gcs/large_domain_audit_test.cc` posts every constraint class once over a
+`0..10^9` domain, installs it, propagates at the root and nowhere else. It is
+built always (so it cannot rot) but registered as a ctest case only when the
+guard is on, since without the guard every probe passes trivially.
+
+Each row pins the outcome we currently expect, so the lane is green today and
+each piece of #833 flips rows rather than introducing failures. **A row that
+stops tripping is a failure too** — that is good news which needs the table
+updated, and pinning both directions is what stops the table drifting away from
+what the code does.
+
+The four outcomes say different things, and the difference between the last two
+is the part worth reading carefully:
+
+| outcome | meaning |
+|---|---|
+| `Clean` | has a position where a wide domain is meaningful, and survives one |
+| `KnownTrip` | likewise, and does not. This is the work #833 is about |
+| `NoWidePosition` | no variable it takes can meaningfully be wide — successors index an array, Booleans are `{0,1}`. Structural immunity, not a working fallback |
+| `HazardNotReached` | the source has a per-value site, but this probe does not reach it. **Not** a clean bill of health: a gap in the probe, tracked below |
+
+### Where we stand
+
+67 probes, run on `7d014207`. The trips:
+
+| | constraints |
+|---|---|
+| **KnownTrip** (21) | `Power`, `PowerTable`, `AllDifferent`, `AllDifferentExcept`, `Among`, `Count`, `NValue`, `AtMostOne`, `AtMostOneSmartTable`, `In`, `ArrayMinMax`, `LexSmartTable`, `Table`, `SmartTable`, `Regular`, `RegularLegacy`, `RegularBacchus`, `MDD`, `Cumulative`, `Disjunctive`, `Knapsack` |
+| **HazardNotReached** (5) | `GlobalCardinality`, `Element`, `NegativeTable`, `Disjunctive2D`, `MinDistance` |
+| **Clean** (27) | the arithmetic family, comparison, equality, linear, `AllDifferent` under `VC`, `Element` under `BC`, `AllEqual`, `ValuePrecede`, `SeqPrecedeChain`, `IncreasingChain`, `Lex`, `Sort`, `ArgSort`, `BinPacking`, `DifferenceConstraints`, `Nogoods` |
+| **NoWidePosition** (14) | the graph and permutation family, and the Boolean constraints |
+
+Three things in that table were not what #833 predicted, and are worth
+recording because they change what the later stages have to do:
+
+1. **`AllDifferent` under `consistency::VC{}` is clean.** The designated
+   fallback really is width-independent, so the `AllDifferent` fix is a policy
+   decision rather than new propagator work. The same holds for `Element` under
+   `BC`.
+2. **`Power` trips**, which #833 did not list — it reaches `PowerTable`'s
+   product enumeration. So does `LexSmartTable`.
+3. **`Among`'s trip is conditional.** Its per-value branch only runs with the
+   count pinned; with slack in the count the propagator concludes nothing and
+   the probe passes without touching the hazard. A probe that does not reach a
+   path proves nothing about it, which is what `HazardNotReached` exists to say.
+
+### Known gaps in the lane
+
+Each of these is a probe that needs sharpening rather than a constraint that is
+known good:
+
+* `GlobalCardinality` — `propagate_bounds_global_cardinality` enumerates values,
+  but not on a probe of this shape.
+* `Element` — the per-value support remainder is not reached from a narrow index
+  at the root.
+* `NegativeTable` — does not take the residue path the positive table dies in.
+* `Disjunctive2D` — the time-table pass is not reached at the root.
+* `MinDistance` — its per-value sites need more sites than this probe has.
+* `AllEqual` — the probe has no holes, so `all_equal.cc`'s hole path never runs.
+* The lane runs without proof logging. H2′ (`NValue`) is caught anyway, because
+  the per-value work is in `prepare()`, but a constraint whose *encoding* alone
+  is per-value would not be. A proofs axis is the obvious next addition.
+
+## See also
+
+- [constraints.md](constraints.md) — the constraint-authoring pattern; "Querying
+  state" is where the per-value APIs this document is about are introduced.
+- [propagator-performance.md](propagator-performance.md) — the strength-versus-
+  performance ground rules a fallback arm has to respect.
+- [state-and-variables.md](state-and-variables.md) — `IntervalSet`, and why a
+  wide domain is cheap to *store* and expensive only to *walk*.

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -108,6 +108,7 @@ add_library(glasgow_constraint_solver
         constraints/tree/tree.cc
         constraints/value_precede/value_precede.cc
         innards/integer_overflow.cc
+        innards/large_domain_guard.cc
         innards/literal.cc
         innards/power.cc
         innards/proofs/am1_from_pairs.cc
@@ -151,6 +152,14 @@ target_include_directories(glasgow_constraint_solver PUBLIC
 # via FetchContent or find_package.
 add_library(GlasgowConstraintSolver::glasgow_constraint_solver ALIAS glasgow_constraint_solver)
 
+# PUBLIC, not PRIVATE: the guard's checks sit in State's header-inline value
+# loops, so a test or example compiled against the library has to agree with the
+# library about whether they are there. A mismatch would be an ODR violation
+# rather than a merely surprising build.
+if(GCS_LARGE_DOMAIN_GUARD)
+    target_compile_definitions(glasgow_constraint_solver PUBLIC GCS_LARGE_DOMAIN_GUARD)
+endif()
+
 if(GCS_COMPILER_HAS_STACKTRACE AND NOT MSVC)
     # stacktrace is only used in .cc files, not public headers, so PRIVATE suffices.
     # stdc++exp is the libstdc++ support library for <stacktrace>/<print>; it is
@@ -181,6 +190,15 @@ if(GCS_BUILD_TESTS)
     add_executable(solve_test solve_test.cc)
     target_link_libraries(solve_test PRIVATE glasgow_constraint_solver Catch2::Catch2WithMain)
     add_test(NAME solve_test COMMAND $<TARGET_FILE:solve_test>)
+
+    # The large-domain audit lane (issue #833). Always built, so it cannot rot
+    # while the guard is off, but registered as a test only when the guard is on:
+    # without it every probe passes trivially and the lane would assert nothing.
+    add_executable(large_domain_audit_test large_domain_audit_test.cc)
+    target_link_libraries(large_domain_audit_test PRIVATE glasgow_constraint_solver Catch2::Catch2WithMain)
+    if(GCS_LARGE_DOMAIN_GUARD)
+        add_test(NAME large_domain_audit_test COMMAND $<TARGET_FILE:large_domain_audit_test>)
+    endif()
 
     # Checks that the GCS_VERBOSE_LOGGING proof annotation resolves gcs source
     # frames, which depends on the debug info the Release build keeps (-g1 on

--- a/gcs/constraints/cumulative/cumulative.cc
+++ b/gcs/constraints/cumulative/cumulative.cc
@@ -5,6 +5,7 @@
 #include <gcs/constraints/innards/window_energy.hh>
 #include <gcs/exception.hh>
 #include <gcs/innards/inference_tracker.hh>
+#include <gcs/innards/large_domain_guard.hh>
 #include <gcs/innards/power.hh>
 #include <gcs/innards/proofs/bits_encoding.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
@@ -331,6 +332,7 @@ auto gcs::innards::prepare_cumulative_overload_check(const vector<IntegerVariabl
     }
 
     auto range = (global_hi - global_lo + 1_i).raw_value;
+    GCS_CHECK_LARGE_DOMAIN("the horizon a cumulative overload check is being sized by", range);
     vector<long long> starting_or_ending(static_cast<size_t>(range) + 1, 0);
     for (auto i : active_tasks) {
         ++starting_or_ending[static_cast<size_t>((per_task_t_lo[i] - global_lo).raw_value)];
@@ -1321,6 +1323,7 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
         return PropagatorState::DisableUntilBacktrack;
 
     auto range = (t_hi - t_lo + 1_i).raw_value;
+    GCS_CHECK_LARGE_DOMAIN("the horizon a cumulative time-table is being sized by", range);
     vector<Integer> mand_load(range, 0_i);
 
     // Only tasks known present have a mandatory part: an undecided one might
@@ -1515,6 +1518,8 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
         constexpr auto max_knapsack_capacity = 4096;
         auto knapsack_rule = rules.knapsack_overload && capacity <= Integer{max_knapsack_capacity};
         auto knapsack_words = static_cast<size_t>(capacity.raw_value / 64 + 1);
+        if (elastic_rules)
+            GCS_CHECK_LARGE_DOMAIN("the window a cumulative elastic profile is being sized by", range);
         vector<Integer> optional_height(elastic_rules ? static_cast<size_t>(range) : 0, 0_i);
         vector<uint64_t> reachable(elastic_rules && knapsack_rule ? static_cast<size_t>(range) * knapsack_words : 0, 0);
 

--- a/gcs/constraints/disjunctive/disjunctive.cc
+++ b/gcs/constraints/disjunctive/disjunctive.cc
@@ -4,6 +4,7 @@
 #include <gcs/constraints/innards/window_energy.hh>
 #include <gcs/exception.hh>
 #include <gcs/innards/inference_tracker.hh>
+#include <gcs/innards/large_domain_guard.hh>
 #include <gcs/innards/proofs/am1_from_pairs.hh>
 #include <gcs/innards/proofs/comparator_network.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
@@ -1396,6 +1397,7 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                 };
 
                 auto range = (t_hi - t_lo + 1_i).raw_value;
+                GCS_CHECK_LARGE_DOMAIN("the horizon a disjunctive time-table is being sized by", range);
                 vector<int> mand_load(range, 0);
 
                 // Only a task known present puts a mandatory part into the

--- a/gcs/constraints/extensional_utils.cc
+++ b/gcs/constraints/extensional_utils.cc
@@ -14,6 +14,7 @@
 #include <gcs/exception.hh>
 #include <gcs/innards/inference_tracker.hh>
 #include <gcs/innards/justification.hh>
+#include <gcs/innards/large_domain_guard.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/reason.hh>
 #include <gcs/innards/state-fwd.hh>
@@ -721,6 +722,7 @@ auto gcs::innards::propagate_extensional(
         for (unsigned idx = 0; idx < table.vars.size(); ++idx) {
             auto [lo, hi] = state.bounds(table.vars[idx]);
             residues.base[idx] = lo.raw_value;
+            GCS_CHECK_LARGE_DOMAIN("the domain an extensional residue row is being sized by", (hi - lo).raw_value + 1);
             residues.support[idx].assign(static_cast<std::size_t>((hi - lo).raw_value + 1), ExtensionalResidues::none);
         }
         residues.initialised = true;

--- a/gcs/innards/large_domain_guard.cc
+++ b/gcs/innards/large_domain_guard.cc
@@ -1,0 +1,38 @@
+#include <gcs/innards/large_domain_guard.hh>
+
+#include <cstdlib>
+#include <version>
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+#include <format>
+using std::format;
+#else
+#include <fmt/core.h>
+using fmt::format;
+#endif
+
+using namespace gcs;
+using namespace gcs::innards;
+
+LargeDomainGuardTripped::LargeDomainGuardTripped(const char * what_was_too_big, long long how_big, long long limit) :
+    UnexpectedException{format("Large domain guard tripped: {} is {}, over the limit of {}. This build was configured with "
+                               "-DGCS_LARGE_DOMAIN_GUARD=ON, which turns work proportional to a domain's width into a "
+                               "diagnostic; see dev_docs/large-domains.md and issue #833",
+        what_was_too_big, how_big, limit)}
+{
+}
+
+auto gcs::innards::large_domain_guard_limit() -> long long
+{
+    static const long long limit = []() -> long long {
+        if (const char * e = std::getenv("GCS_LARGE_DOMAIN_GUARD_LIMIT"))
+            return std::strtoll(e, nullptr, 10);
+        return 100000; // see the header for why this sits where it does
+    }();
+    return limit;
+}
+
+auto gcs::innards::throw_large_domain_guard_tripped(const char * what_was_too_big, long long how_big) -> void
+{
+    throw LargeDomainGuardTripped{what_was_too_big, how_big, large_domain_guard_limit()};
+}

--- a/gcs/innards/large_domain_guard.hh
+++ b/gcs/innards/large_domain_guard.hh
@@ -1,0 +1,132 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_INNARDS_LARGE_DOMAIN_GUARD_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_INNARDS_LARGE_DOMAIN_GUARD_HH
+
+#include <gcs/exception.hh>
+
+namespace gcs::innards
+{
+    /**
+     * \brief Thrown when the large-domain guard trips: something iterated over,
+     * or allocated an array proportional to, a domain wider than the guard's
+     * limit.
+     *
+     * Only ever thrown in a build configured with `-DGCS_LARGE_DOMAIN_GUARD=ON`,
+     * which is a *development* configuration. The guard is a tripwire for finding
+     * the work issue #833 is about, not a user-facing safety net: the policy that
+     * protects a user is a constraint having somewhere cheap to fall back to, not
+     * an exception thrown from the middle of propagation. In a default build the
+     * checks compile to nothing at all and this class is never constructed.
+     *
+     * The message names what was too big and by how much; the audit lane runs one
+     * constraint at a time, so the test's name is the attribution for which
+     * constraint tripped, and the backtrace (every configuration keeps at least
+     * `-g1`) says where.
+     *
+     * \sa GCS_CHECK_LARGE_DOMAIN
+     * \ingroup Innards
+     */
+    class LargeDomainGuardTripped : public UnexpectedException
+    {
+    public:
+        LargeDomainGuardTripped(const char * what_was_too_big, long long how_big, long long limit);
+    };
+
+    /**
+     * \brief How wide is too wide, for the large-domain guard.
+     *
+     * Defaults to 100000, overridable with the `GCS_LARGE_DOMAIN_GUARD_LIMIT`
+     * environment variable in the same way as
+     * gcs::innards::default_tabulation_threshold(). The default sits in the gap
+     * measured on #833 between "free" (10^4) and "costs hundreds of megabytes"
+     * (10^6), and well above anything the test suite or a deliberate tabulation
+     * asks for.
+     *
+     * This is emphatically *not* the threshold the large-domain policy itself
+     * uses to pick a propagation arm: that one is a separate quantity with its
+     * own default, because a guard wants to be far enough above normal work to
+     * never fire on it, and a policy wants to be near the cliff.
+     *
+     * \ingroup Innards
+     */
+    [[nodiscard]] auto large_domain_guard_limit() -> long long;
+
+    [[noreturn]] auto throw_large_domain_guard_tripped(const char * what_was_too_big, long long how_big) -> void;
+
+    /**
+     * \brief The guard check itself; prefer the GCS_CHECK_LARGE_DOMAIN macro.
+     *
+     * \ingroup Innards
+     */
+    inline auto check_large_domain_guard(const char * what_was_too_big, long long how_big) -> void
+    {
+        if (how_big > large_domain_guard_limit())
+            throw_large_domain_guard_tripped(what_was_too_big, how_big);
+    }
+
+    /**
+     * \brief Counts values as an iteration hands them out, and trips the guard
+     * when one call has been handed too many.
+     *
+     * Counting the values actually visited is the right measure, and checking
+     * the domain's *width* up front is not: a branching heuristic asks for a
+     * generator over a billion-value domain and reads one value from it, which
+     * is perfectly reasonable work that an up-front width check would condemn.
+     * What #833 is about is a loop that walks the whole thing.
+     *
+     * Compiles to an empty struct with a no-op step() when the guard is off, so
+     * an iteration in a default build carries no counter and no branch.
+     *
+     * \ingroup Innards
+     */
+    class LargeDomainIterationCounter
+    {
+#if defined(GCS_LARGE_DOMAIN_GUARD)
+    private:
+        long long _count = 0;
+        const char * _what;
+
+    public:
+        explicit LargeDomainIterationCounter(const char * what) : _what(what)
+        {
+        }
+
+        auto step() -> void
+        {
+            if (++_count > large_domain_guard_limit())
+                throw_large_domain_guard_tripped(_what, _count);
+        }
+#else
+    public:
+        explicit LargeDomainIterationCounter(const char *)
+        {
+        }
+
+        auto step() -> void
+        {
+        }
+#endif
+    };
+}
+
+/**
+ * \brief Trip the large-domain guard if \p n exceeds its limit.
+ *
+ * For sites that commit to the whole size at once -- an array sized by a
+ * domain's span, which is allocated in one go -- where checking up front is
+ * exactly right. For an *iteration*, whose caller may stop after one value, use
+ * gcs::innards::LargeDomainIterationCounter instead.
+ *
+ * A macro rather than a function because \p n must not be *evaluated* when the
+ * guard is off. With the guard off this expands to nothing, so a default build
+ * is unchanged instruction for instruction.
+ *
+ * \sa gcs::innards::LargeDomainGuardTripped
+ * \ingroup Innards
+ */
+#if defined(GCS_LARGE_DOMAIN_GUARD)
+#define GCS_CHECK_LARGE_DOMAIN(what, n) ::gcs::innards::check_large_domain_guard((what), (n))
+#else
+#define GCS_CHECK_LARGE_DOMAIN(what, n) static_cast<void>(0)
+#endif
+
+#endif

--- a/gcs/innards/state.cc
+++ b/gcs/innards/state.cc
@@ -1,4 +1,5 @@
 #include <gcs/exception.hh>
+#include <gcs/innards/large_domain_guard.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/state.hh>
 #include <gcs/innards/variable_id_utils.hh>
@@ -631,8 +632,15 @@ namespace
 {
     auto each_value_generator(IntervalSet<Integer> set, std::function<auto(Integer)->Integer> apply) -> generator<Integer>
     {
-        for (auto i : set.each())
+        // Counted as the values are handed out rather than checked against the
+        // domain's width up front: a caller that reads one value from a very
+        // wide domain -- which is what a branching heuristic does -- is doing
+        // nothing wrong, and only a caller that walks the whole thing is.
+        LargeDomainIterationCounter guard{"the number of values one each_value_*() generator has yielded"};
+        for (auto i : set.each()) {
+            guard.step();
             co_yield apply(i);
+        }
     }
 
     auto each_value_constant_generator(Integer val, std::function<auto(Integer)->Integer> apply) -> generator<Integer>

--- a/gcs/innards/state.hh
+++ b/gcs/innards/state.hh
@@ -2,6 +2,7 @@
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_STATE_HH
 
 #include <gcs/current_state.hh>
+#include <gcs/innards/large_domain_guard.hh>
 #include <gcs/innards/literal.hh>
 #include <gcs/innards/state-fwd.hh>
 #include <gcs/innards/variable_id_utils.hh>
@@ -433,7 +434,11 @@ namespace gcs::innards
             state_detail::visit_actual(
                 actual_var,
                 [&, negate_first = negate_first, then_add = then_add](const SimpleIntegerVariableID & v) {
-                    state_of_for_iteration(v).for_each([&](Integer i) { return cb(state_detail::apply_view(i, negate_first, then_add)); });
+                    LargeDomainIterationCounter guard{"the number of values one for_each_value_immutable() call has visited"};
+                    state_of_for_iteration(v).for_each([&](Integer i) {
+                        guard.step();
+                        return cb(state_detail::apply_view(i, negate_first, then_add));
+                    });
                 },
                 [&, negate_first = negate_first, then_add = then_add](
                     const ConstantIntegerVariableID & v) { cb(state_detail::apply_view(v.const_value, negate_first, then_add)); });
@@ -455,7 +460,11 @@ namespace gcs::innards
                 actual_var,
                 [&, negate_first = negate_first, then_add = then_add](const SimpleIntegerVariableID & v) {
                     auto snapshot = state_of_for_iteration(v);
-                    snapshot.for_each([&](Integer i) { return cb(state_detail::apply_view(i, negate_first, then_add)); });
+                    LargeDomainIterationCounter guard{"the number of values one for_each_value_mutable() call has visited"};
+                    snapshot.for_each([&](Integer i) {
+                        guard.step();
+                        return cb(state_detail::apply_view(i, negate_first, then_add));
+                    });
                 },
                 [&, negate_first = negate_first, then_add = then_add](
                     const ConstantIntegerVariableID & v) { cb(state_detail::apply_view(v.const_value, negate_first, then_add)); });

--- a/gcs/large_domain_audit_test.cc
+++ b/gcs/large_domain_audit_test.cc
@@ -372,7 +372,16 @@ namespace
             });
         add("SmartTable", Expect::KnownTrip, [](Problem & p) {
             auto v = wide(p, 2);
-            SmartTuples tuples{{SmartTable::equals(v[0], v[1])}};
+            // Built a step at a time rather than from a nested braced list. GCC
+            // cannot see that a SmartEntry variant's inactive alternative is
+            // never destroyed, and reports a maybe-uninitialized vector<Integer>
+            // inside the variant's destructor -- which the -Werror CI lane turns
+            // into a build failure. This is the spelling the smart_table tests
+            // already use.
+            vector<SmartEntry> tuple;
+            tuple.push_back(SmartTable::equals(v[0], v[1]));
+            SmartTuples tuples;
+            tuples.push_back(move(tuple));
             p.post(SmartTable{v, tuples});
         });
 

--- a/gcs/large_domain_audit_test.cc
+++ b/gcs/large_domain_audit_test.cc
@@ -1,0 +1,522 @@
+/* The large-domain audit lane: issue #833.
+ *
+ * Every constraint class is posted once over a deliberately wide domain, then
+ * installed and propagated at the root and nowhere else. The question this asks
+ * is not "does it get the right answer" -- the other tests do that -- but "does
+ * the amount of work it does depend on how *wide* a variable's domain is". A
+ * build with -DGCS_LARGE_DOMAIN_GUARD=ON turns that dependence into a
+ * LargeDomainGuardTripped, so the answer is a deterministic pass or fail rather
+ * than a wedged core or a bad_alloc.
+ *
+ * Each row carries the outcome we currently expect, so this lane is green from
+ * the day it lands and each later piece of #833 flips rows rather than
+ * introducing failures. The three outcomes say different things:
+ *
+ *   Clean           -- the constraint has a position where a wide domain is
+ *                      meaningful, and it survives one.
+ *   KnownTrip       -- likewise, and it does not. This is the work #833 is
+ *                      about, and the comment on the row says which hazard.
+ *   HazardNotReached -- the source has a per-value site, but this probe does
+ *                      not reach it: the site is behind a condition (a fixed
+ *                      count, a domain with holes, a rule that only fires
+ *                      deeper in search) that a one-shot root probe does not
+ *                      meet. Asserted to survive, because that is what it does,
+ *                      and labelled so nobody reads it as a clean bill of
+ *                      health. Turning one of these into a Clean or a KnownTrip
+ *                      means building a sharper probe, and is tracked as a gap.
+ *   NoWidePosition  -- no variable this constraint takes can meaningfully be
+ *                      wide: successor variables index an array, Boolean
+ *                      variables are {0,1}. Probed at its widest legal domain
+ *                      and required to be clean, but a pass here is a weaker
+ *                      statement than a Clean, and the label records that so a
+ *                      reader does not mistake structural immunity for a
+ *                      fallback that works.
+ *
+ * With the guard off this file still builds and runs, and every probe passes
+ * trivially without the guard's checks -- so it also serves as a cheap "does
+ * every constraint install and propagate at the root at all" smoke test.
+ * Registered as a ctest case only when the guard is on; see gcs/CMakeLists.txt.
+ */
+
+#include <gcs/gcs.hh>
+
+#include <gcs/constraints/all_different.hh>
+#include <gcs/constraints/at_most_one.hh>
+#include <gcs/constraints/lex_smart_table.hh>
+#include <gcs/constraints/table.hh>
+
+#include <gcs/constraints/all_different/all_different_except.hh>
+#include <gcs/constraints/all_different/symmetric_all_different.hh>
+#include <gcs/constraints/circuit/subcircuit.hh>
+#include <gcs/constraints/power/power_table.hh>
+#include <gcs/constraints/regular/regular_bacchus.hh>
+#include <gcs/constraints/regular/regular_legacy.hh>
+#include <gcs/constraints/sort/arg_sort.hh>
+#include <gcs/constraints/table/negative_table.hh>
+
+#include <gcs/innards/large_domain_guard.hh>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <version>
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+#include <print>
+using std::println;
+#else
+#include <fmt/core.h>
+using fmt::println;
+#endif
+
+#include <exception>
+#include <functional>
+#include <new>
+#include <string>
+#include <vector>
+
+using namespace gcs;
+using namespace gcs::innards;
+
+using std::function;
+using std::string;
+using std::vector;
+
+namespace
+{
+    // Wide enough that any per-value work is hopeless, and the same width the
+    // issue's MiniZinc probes used, so the two sets of numbers are comparable.
+    const auto wide_lo = 0_i;
+    const auto wide_hi = 1000000000_i;
+
+    enum class Expect
+    {
+        Clean,
+        KnownTrip,
+        NoWidePosition,
+        HazardNotReached
+    };
+
+    struct Result
+    {
+        bool tripped = false;
+        bool broken = false; ///< the probe itself failed to run, so it says nothing
+        string detail = {};
+    };
+
+    /* Install and propagate at the root, and nowhere else.
+     *
+     * Both callbacks return false, which stops the search at the first node
+     * whichever way that node goes: `trace` runs once root propagation has
+     * produced something to branch on, and `solution` runs instead if root
+     * propagation happened to fix everything. Neither is reached until root
+     * propagation has finished, so a constraint that never finishes propagating
+     * is exactly what this catches. Constraints are installed lazily by
+     * Problem::create_propagators, so an install-time hazard -- which is most of
+     * them -- is inside this call too, not inside build().
+     */
+    auto probe(const function<auto(Problem &)->void> & build) -> Result
+    {
+        try {
+            Problem problem;
+            build(problem);
+            solve_with(problem,
+                SolveCallbacks{.solution = [](const CurrentState &) { return false; },
+                    .trace = [](const CurrentState &) { return false; },
+                    .stats_report = silent_stats_report()});
+            return {false, false, {}};
+        }
+        catch (const LargeDomainGuardTripped & e) {
+            return {true, false, e.what()};
+        }
+        catch (const std::bad_alloc &) {
+            // An allocation the guard does not cover. Still a trip as far as
+            // this lane is concerned, and worth a distinct message because it
+            // means there is a hazard site with no check on it yet.
+            return {true, false, "std::bad_alloc, at a site the guard does not check"};
+        }
+        catch (const std::exception & e) {
+            // A probe that cannot be posted or solved says nothing about the
+            // constraint, so it is its own outcome rather than a pass or a
+            // fail: one badly-built probe must not truncate the audit.
+            return {false, true, e.what()};
+        }
+    }
+
+    struct Probe
+    {
+        string name;
+        Expect expect;
+        function<auto(Problem &)->void> build;
+    };
+
+    auto wide(Problem & p, int n) -> vector<IntegerVariableID>
+    {
+        vector<IntegerVariableID> result;
+        for (int i = 0; i < n; ++i)
+            result.push_back(p.create_integer_variable(wide_lo, wide_hi));
+        return result;
+    }
+
+    auto narrow(Problem & p, int n, Integer lo, Integer hi) -> vector<IntegerVariableID>
+    {
+        vector<IntegerVariableID> result;
+        for (int i = 0; i < n; ++i)
+            result.push_back(p.create_integer_variable(lo, hi));
+        return result;
+    }
+
+    auto all_probes() -> vector<Probe>
+    {
+        vector<Probe> probes;
+        auto add = [&](string name, Expect expect, function<auto(Problem &)->void> build) {
+            probes.push_back(Probe{move(name), expect, move(build)});
+        };
+
+        // --- Arithmetic. These are the six that already implement the policy
+        // #833 asks for, as consistency::Auto: tabulate within a budget, else BC.
+        add("Abs", Expect::Clean, [](Problem & p) {
+            auto v = wide(p, 2);
+            p.post(Abs{v[0], v[1]});
+        });
+        add("Plus", Expect::Clean, [](Problem & p) {
+            auto v = wide(p, 3);
+            p.post(Plus{v[0], v[1], v[2]});
+        });
+        add("Minus", Expect::Clean, [](Problem & p) {
+            auto v = wide(p, 3);
+            p.post(Minus{v[0], v[1], v[2]});
+        });
+        add("Multiply", Expect::Clean, [](Problem & p) {
+            auto v = wide(p, 3);
+            p.post(Multiply{v[0], v[1], v[2]});
+        });
+        add("Divide", Expect::Clean, [](Problem & p) {
+            auto v = wide(p, 3);
+            p.post(Divide{v[0], v[1], v[2]});
+        });
+        add("Modulus", Expect::Clean, [](Problem & p) {
+            auto v = wide(p, 3);
+            p.post(Modulus{v[0], v[1], v[2]});
+        });
+        add("Power", Expect::KnownTrip, [](Problem & p) { // H2: reaches PowerTable's product enumeration
+            auto v = wide(p, 3);
+            p.post(Power{v[0], p.create_integer_variable(0_i, 3_i), v[2]});
+        });
+        add("PowerTable", Expect::KnownTrip, [](Problem & p) {
+            // H2: PowerTable::prepare enumerates the product of two domains.
+            auto v = wide(p, 3);
+            p.post(PowerTable{v[0], p.create_integer_variable(0_i, 3_i), v[2]});
+        });
+
+        // --- Comparison and equality: bounds reasoning throughout.
+        add("LessThan", Expect::Clean, [](Problem & p) {
+            auto v = wide(p, 2);
+            p.post(LessThan{v[0], v[1]});
+        });
+        add("GreaterThan", Expect::Clean, [](Problem & p) {
+            auto v = wide(p, 2);
+            p.post(GreaterThan{v[0], v[1]});
+        });
+        add("ReifiedCompareLessThanOrMaybeEqual", Expect::Clean, [](Problem & p) {
+            auto v = wide(p, 2);
+            auto r = p.create_integer_variable(0_i, 1_i);
+            p.post(LessThanIf{v[0], v[1], r == 1_i});
+        });
+        add("Equals", Expect::Clean, [](Problem & p) {
+            auto v = wide(p, 2);
+            p.post(Equals{v[0], v[1]});
+        });
+        add("NotEquals", Expect::Clean, [](Problem & p) {
+            auto v = wide(p, 2);
+            p.post(NotEquals{v[0], v[1]});
+        });
+        add("ReifiedEquals", Expect::Clean, [](Problem & p) {
+            auto v = wide(p, 2);
+            auto r = p.create_integer_variable(0_i, 1_i);
+            p.post(EqualsIff{v[0], v[1], r == 1_i});
+        });
+
+        // --- Linear.
+        add("LinearEquality", Expect::Clean, [](Problem & p) {
+            auto v = wide(p, 3);
+            p.post(LinearEquality{WeightedSum{} + 1_i * v[0] + 1_i * v[1] + -1_i * v[2], 0_i});
+        });
+        add("ReifiedLinearEquality", Expect::Clean, [](Problem & p) {
+            auto v = wide(p, 3);
+            auto r = p.create_integer_variable(0_i, 1_i);
+            p.post(LinearEqualityIff{WeightedSum{} + 1_i * v[0] + 1_i * v[1] + -1_i * v[2], 0_i, r == 1_i});
+        });
+        add("ReifiedLinearInequality", Expect::Clean, [](Problem & p) {
+            auto v = wide(p, 3);
+            p.post(LinearLessThanEqual{WeightedSum{} + 1_i * v[0] + 1_i * v[1] + -1_i * v[2], 0_i});
+        });
+
+        // --- Logical and parity: {0,1} variables only.
+        add("And", Expect::NoWidePosition, [](Problem & p) {
+            auto v = narrow(p, 3, 0_i, 1_i);
+            p.post(And{v});
+        });
+        add("Or", Expect::NoWidePosition, [](Problem & p) {
+            auto v = narrow(p, 3, 0_i, 1_i);
+            p.post(Or{v});
+        });
+        add("ParityOdd", Expect::NoWidePosition, [](Problem & p) {
+            auto v = narrow(p, 3, 0_i, 1_i);
+            p.post(ParityOdd{v});
+        });
+
+        // --- All-different family.
+        add("AllDifferent", Expect::KnownTrip, [](Problem & p) {
+            // H2: AllDifferent::prepare builds the compressed value set under
+            // GAC, with a linear find per value.
+            p.post(AllDifferent{wide(p, 4)});
+        });
+        add("AllDifferent/VC", Expect::Clean, [](Problem & p) { p.post(AllDifferent{wide(p, 4)}.with_consistency(consistency::VC{})); });
+        add("AllDifferentExcept", Expect::KnownTrip, [](Problem & p) { p.post(AllDifferentExcept{wide(p, 4), {0_i}}); });
+        add("SymmetricAllDifferent", Expect::NoWidePosition, [](Problem & p) { p.post(SymmetricAllDifferent{narrow(p, 4, 0_i, 3_i)}); });
+        add("AllEqual", Expect::Clean, [](Problem & p) { p.post(AllEqual{wide(p, 3)}); });
+
+        // --- Counting family.
+        add("Among", Expect::KnownTrip, [](Problem & p) {
+            // H1a: removes everything outside a small given value set, one value
+            // at a time. That branch needs the count pinned -- with slack in it
+            // the propagator has nothing to conclude -- so the count is fixed to
+            // the whole scope, forcing every variable into the value set.
+            auto v = wide(p, 3);
+            p.post(Among{v, {1_i, 2_i}, p.create_integer_variable(3_i, 3_i)});
+        });
+        add("Count", Expect::KnownTrip, [](Problem & p) {
+            // H1c: a genuine per-value support scan over the value variable.
+            auto v = wide(p, 3);
+            p.post(Count{v, v[0], p.create_integer_variable(0_i, 3_i)});
+        });
+        add("NValue", Expect::KnownTrip, [](Problem & p) {
+            // H2 in prepare, and H2' in the encoding: one proof flag per value
+            // of the union of the domains.
+            auto v = wide(p, 3);
+            p.post(NValue{p.create_integer_variable(1_i, 3_i), v});
+        });
+        add("AtMostOne", Expect::KnownTrip, [](Problem & p) {
+            // The value variable has to be distinct from the scope: an aliased
+            // one is rejected at post time, so it would probe nothing.
+            auto v = wide(p, 3);
+            p.post(AtMostOne{v, p.create_integer_variable(wide_lo, wide_hi)});
+        });
+        add("AtMostOneSmartTable", Expect::KnownTrip, [](Problem & p) {
+            auto v = wide(p, 3);
+            p.post(AtMostOneSmartTable{v, p.create_integer_variable(wide_lo, wide_hi)});
+        });
+        add("GlobalCardinality", Expect::HazardNotReached, // propagate_bounds_global_cardinality enumerates values, but not on a probe this shape
+            [](Problem & p) {
+                // The counterexample to "just default to BC": this already defaults
+                // to consistency::BC and still enumerates values.
+                auto v = wide(p, 3);
+                p.post(GlobalCardinality{v, {1_i, 2_i}, narrow(p, 2, 0_i, 3_i)});
+            });
+        add("In", Expect::KnownTrip, [](Problem & p) {
+            auto v = wide(p, 1);
+            p.post(In{v[0], vector<Integer>{1_i, 2_i, 3_i}});
+        });
+        add("ValuePrecede", Expect::Clean, [](Problem & p) { p.post(ValuePrecede{1_i, 2_i, wide(p, 4)}); });
+        add("SeqPrecedeChain", Expect::Clean, [](Problem & p) { p.post(SeqPrecedeChain{narrow(p, 4, 0_i, 3_i)}); });
+
+        // --- Min / max / element.
+        add("ArrayMinMax", Expect::KnownTrip, [](Problem & p) {
+            // H1b (a missing hull bound) and H1a (the union scan) at once.
+            auto v = wide(p, 4);
+            p.post(ArrayMax{vector<IntegerVariableID>{v[0], v[1], v[2]}, v[3]});
+        });
+        add("Element", Expect::HazardNotReached, // element.cc's per-value support remainder is not reached from a narrow index at the root
+            [](Problem & p) {
+                auto v = wide(p, 4);
+                p.post(Element{v[3], p.create_integer_variable(0_i, 2_i), vector<IntegerVariableID>{v[0], v[1], v[2]}});
+            });
+        add("Element/BC", Expect::Clean, [](Problem & p) {
+            auto v = wide(p, 4);
+            p.post(
+                Element{v[3], p.create_integer_variable(0_i, 2_i), vector<IntegerVariableID>{v[0], v[1], v[2]}}.with_consistency(consistency::BC{}));
+        });
+
+        // --- Ordering.
+        add("IncreasingChain", Expect::Clean, [](Problem & p) { p.post(Increasing{wide(p, 4)}); });
+        add("LexCompareGreaterThanOrMaybeEqual", Expect::Clean, [](Problem & p) {
+            auto a = wide(p, 3), b = wide(p, 3);
+            p.post(LexGreaterEqual{a, b});
+        });
+        add("LexSmartTable", Expect::KnownTrip, [](Problem & p) { // H1c: the smart-table encoding walks values
+            auto a = wide(p, 3), b = wide(p, 3);
+            p.post(LexSmartTable{a, b});
+        });
+        add("Sort", Expect::Clean, [](Problem & p) {
+            auto x = wide(p, 3), y = wide(p, 3);
+            p.post(Sort{x, y});
+        });
+        add("ArgSort", Expect::Clean, [](Problem & p) {
+            auto x = wide(p, 3);
+            p.post(ArgSort{x, narrow(p, 3, 0_i, 2_i)});
+        });
+
+        // --- Extensional.
+        add("Table", Expect::KnownTrip, [](Problem & p) {
+            // H3: the residue rows are sized by the variable's bounds rather
+            // than by the table's own value range.
+            auto v = wide(p, 3);
+            SimpleTuples tuples{{1_i, 2_i, 3_i}, {4_i, 5_i, 6_i}};
+            p.post(Table{v, tuples});
+        });
+        add("NegativeTable", Expect::HazardNotReached, // does not take the residue path the positive table dies in
+            [](Problem & p) {
+                auto v = wide(p, 3);
+                SimpleTuples tuples{{1_i, 2_i, 3_i}, {4_i, 5_i, 6_i}};
+                p.post(NegativeTable{v, tuples});
+            });
+        add("SmartTable", Expect::KnownTrip, [](Problem & p) {
+            auto v = wide(p, 2);
+            SmartTuples tuples{{SmartTable::equals(v[0], v[1])}};
+            p.post(SmartTable{v, tuples});
+        });
+
+        // --- Automata. The alphabet is given by the automaton, so the hazard is
+        // the variables' own width rather than the number of states.
+        add("Regular", Expect::KnownTrip, [](Problem & p) {
+            auto v = wide(p, 3);
+            p.post(Regular{v, 2, {{{1_i, 1L}}, {{1_i, 1L}}, {{1_i, 1L}}}, {1L}});
+        });
+        add("RegularLegacy", Expect::KnownTrip, [](Problem & p) {
+            auto v = wide(p, 3);
+            p.post(RegularLegacy{v, 2, {{{1_i, 1L}}, {{1_i, 1L}}, {{1_i, 1L}}}, {1L}});
+        });
+        add("RegularBacchus", Expect::KnownTrip, [](Problem & p) {
+            auto v = wide(p, 3);
+            p.post(RegularBacchus{v, 2, {{{1_i, 1L}}, {{1_i, 1L}}, {{1_i, 1L}}}, {1L}});
+        });
+        add("MDD", Expect::KnownTrip, [](Problem & p) {
+            auto v = wide(p, 2);
+            p.post(MDD{v, {{{{1_i, 0L}}}, {{{1_i, 0L}}}}, {1L, 1L, 1L}, {0L}});
+        });
+
+        // --- Scheduling.
+        add("Cumulative", Expect::KnownTrip, [](Problem & p) {
+            // H3: the overload check's arrays are sized by the horizon.
+            auto starts = wide(p, 3);
+            p.post(Cumulative{starts, vector<Integer>{2_i, 2_i, 2_i}, vector<Integer>{1_i, 1_i, 1_i}, 2_i});
+        });
+        add("Disjunctive", Expect::KnownTrip, [](Problem & p) {
+            auto starts = wide(p, 3);
+            p.post(Disjunctive{starts, vector<Integer>{2_i, 2_i, 2_i}});
+        });
+        add("Disjunctive2D", Expect::HazardNotReached, // the time-table pass is not reached at the root here
+            [](Problem & p) {
+                auto xs = wide(p, 2), ys = wide(p, 2);
+                p.post(Disjunctive2D{xs, ys, narrow(p, 2, 1_i, 1_i), narrow(p, 2, 1_i, 1_i)});
+            });
+
+        // --- Packing and knapsack.
+        add("BinPacking", Expect::Clean, [](Problem & p) {
+            auto items = narrow(p, 3, 0_i, 1_i);
+            p.post(BinPacking{items, vector<Integer>{1_i, 1_i, 1_i}, wide(p, 2)});
+        });
+        add("Knapsack", Expect::KnownTrip, [](Problem & p) {
+            auto v = narrow(p, 3, 0_i, 1_i);
+            auto totals = wide(p, 2);
+            p.post(Knapsack{vector<Integer>{1_i, 2_i, 3_i}, vector<Integer>{1_i, 2_i, 3_i}, v, totals[0], totals[1]});
+        });
+
+        // --- Graph and permutation constraints. Every variable indexes into an
+        // array of nodes, so none of them can meaningfully be wide.
+        add("Circuit", Expect::NoWidePosition, [](Problem & p) { p.post(Circuit{narrow(p, 4, 0_i, 3_i)}); });
+        add("SubCircuit", Expect::NoWidePosition, [](Problem & p) { p.post(SubCircuit{narrow(p, 4, 0_i, 3_i)}); });
+        add("Inverse", Expect::NoWidePosition, [](Problem & p) { p.post(Inverse{narrow(p, 3, 0_i, 2_i), narrow(p, 3, 0_i, 2_i)}); });
+        add("Subgraph", Expect::NoWidePosition, [](Problem & p) {
+            auto ns = narrow(p, 3, 0_i, 1_i), es = narrow(p, 2, 0_i, 1_i);
+            p.post(Subgraph{{{0, 1}, {1, 2}}, ns, es});
+        });
+        add("Tree", Expect::NoWidePosition, [](Problem & p) {
+            auto r = p.create_integer_variable(0_i, 2_i);
+            auto ns = narrow(p, 3, 0_i, 1_i), es = narrow(p, 2, 0_i, 1_i);
+            p.post(Tree{{{0, 1}, {1, 2}}, r, ns, es});
+        });
+        add("DTree", Expect::NoWidePosition, [](Problem & p) {
+            auto r = p.create_integer_variable(0_i, 2_i);
+            auto ns = narrow(p, 3, 0_i, 1_i), es = narrow(p, 2, 0_i, 1_i);
+            p.post(DTree{{{0, 1}, {1, 2}}, r, ns, es});
+        });
+        add("Path", Expect::NoWidePosition, [](Problem & p) {
+            auto r = p.create_integer_variable(0_i, 2_i), t = p.create_integer_variable(0_i, 2_i);
+            auto ns = narrow(p, 3, 0_i, 1_i), es = narrow(p, 2, 0_i, 1_i);
+            p.post(Path{{{0, 1}, {1, 2}}, r, t, ns, es});
+        });
+        add("DPath", Expect::NoWidePosition, [](Problem & p) {
+            auto r = p.create_integer_variable(0_i, 2_i), t = p.create_integer_variable(0_i, 2_i);
+            auto ns = narrow(p, 3, 0_i, 1_i), es = narrow(p, 2, 0_i, 1_i);
+            p.post(DPath{{{0, 1}, {1, 2}}, r, t, ns, es});
+        });
+        add("Reachable", Expect::NoWidePosition, [](Problem & p) {
+            auto r = p.create_integer_variable(0_i, 2_i);
+            auto ns = narrow(p, 3, 0_i, 1_i), es = narrow(p, 2, 0_i, 1_i);
+            p.post(Reachable{{{0, 1}, {1, 2}}, r, ns, es});
+        });
+        add("DReachable", Expect::NoWidePosition, [](Problem & p) {
+            auto r = p.create_integer_variable(0_i, 2_i);
+            auto ns = narrow(p, 3, 0_i, 1_i), es = narrow(p, 2, 0_i, 1_i);
+            p.post(DReachable{{{0, 1}, {1, 2}}, r, ns, es});
+        });
+
+        // --- The remaining two take a wide position and reason about it by bounds.
+        add("DifferenceConstraints", Expect::Clean, [](Problem & p) {
+            auto v = wide(p, 3);
+            p.post(DifferenceConstraints{vector<DifferenceEdge>{{v[0], v[1], 0_i}, {v[1], v[2], 1_i}}});
+        });
+        add("Nogoods", Expect::Clean, [](Problem & p) {
+            auto v = wide(p, 2);
+            p.post(Nogoods{vector<Nogood>{{v[0] == 0_i, v[1] == 0_i}}});
+        });
+
+        add("MinDistance", Expect::HazardNotReached, // the per-value sites need more sites than this probe has
+            [](Problem & p) {
+                auto x = narrow(p, 2, 0_i, 1_i);
+                auto z = p.create_integer_variable(wide_lo, wide_hi);
+                p.post(MinDistance{x, z, MinDistance::Matrix{{0_i, 1_i}, {1_i, 0_i}}});
+            });
+
+        return probes;
+    }
+}
+
+namespace
+{
+    auto describe(Expect e) -> string
+    {
+        switch (e) {
+            using enum Expect;
+        case Clean: return "Clean";
+        case KnownTrip: return "KnownTrip";
+        case NoWidePosition: return "NoWidePosition";
+        case HazardNotReached: return "HazardNotReached";
+        }
+        return "?";
+    }
+}
+
+TEST_CASE("Large domain audit")
+{
+    // The lane prints its table as it goes, so a run is the audit rather than
+    // just a pass or a fail: dev_docs/large-domains.md quotes this output.
+    println("{:<40} {:<16} {:<16} {}", "constraint", "expected", "actual", "");
+    for (const auto & probe_case : all_probes()) {
+        auto result = probe(probe_case.build);
+        auto actual = result.broken ? "BROKEN PROBE" : (result.tripped ? "trips" : "survives");
+        auto expected_trip = (probe_case.expect == Expect::KnownTrip);
+        auto agrees = (! result.broken) && (result.tripped == expected_trip);
+        println("{:<40} {:<16} {:<16} {}", probe_case.name, describe(probe_case.expect), actual, agrees ? "" : "<-- MISMATCH");
+
+        INFO("constraint: " << probe_case.name);
+        INFO("detail: " << result.detail);
+        CHECK_FALSE(result.broken);
+        // A KnownTrip that stops tripping is good news needing the table
+        // updated, not a regression; a Clean that starts tripping is the
+        // regression. Both are failures here on purpose: each row's outcome is
+        // pinned, so the table cannot drift away from what the code does.
+        CHECK(result.tripped == expected_trip);
+    }
+}


### PR DESCRIPTION
Nothing in the solver bounds the work a constraint does as a function of how *wide* a
variable's domain is (#833). This is the measuring device the rest of that work needs: an
opt-in build that turns work proportional to a domain's width into an attributable test
failure, and a lane that runs every constraint class against it.

**First of four.** This one is a pure addition — no behaviour changes with the option off.

## The guard is not a safety net, deliberately

`GCS_LARGE_DOMAIN_GUARD` is **OFF by default and not user-facing**. What protects a user is
a constraint having somewhere cheap to fall back to, not an exception thrown from the
middle of propagation; the guard only helps us find the places that do not have one yet.
With it off the checks compile to nothing that even evaluates the size being checked, and
the only trace left in the library is the exception class's message string, because the
type is compiled unconditionally so the lane can name it (measured: `strings` on the
guard-off `.a` finds that one and none of the per-iteration ones).

Two kinds of check, and the difference is load-bearing:

* **Iterations count values as they are handed out** (`LargeDomainIterationCounter`, in
  `State`'s four value-iterating entry points).
* **Span-sized allocations check up front** (`GCS_CHECK_LARGE_DOMAIN`, at the cumulative,
  disjunctive and extensional residue sites).

Counting work done is the right measure and checking the domain's *width* is not: a
branching heuristic legitimately asks for a generator over a billion-value domain and
reads one value from it. The first version of this checked the width and condemned `Plus`,
`Abs`, `LessThan` and `LinearEquality`, all of which are fine.

`GCS_CHECK_LARGE_DOMAIN` is a macro rather than a function on purpose: its argument must
not be *evaluated* when the guard is off. That is the only reason; the iteration side
needs no macro because an empty class does the job.

## The audit lane

`large_domain_audit_test` posts each constraint class once over `0..10^9`, installs it and
propagates at the root and nowhere else. Every row pins its expected outcome **in both
directions**, so a row that stops tripping fails too — that is good news needing the table
updated, and pinning both ways is what stops the table drifting from what the code does.
Built always so it cannot rot, registered as a ctest case only when the guard is on, since
otherwise every probe passes trivially.

67 probes: 21 `KnownTrip`, 27 `Clean`, 14 `NoWidePosition`, 5 `HazardNotReached`. (The
next PR in the stack sharpens the last group away; the counts there are 68 / 24 / 30 / 14 /
0.)

Three results were not what #833 predicted, and they change what the later stages have to
do:

1. **`AllDifferent` under `consistency::VC{}` and `Element` under `consistency::BC{}` are
   both clean.** Those fallbacks really are width-independent, so adopting them is a policy
   decision with no propagator work behind it.
2. **`Power` and `LexSmartTable` trip**, and are on neither of #833's lists — what auditing
   per constraint class rather than per MiniZinc-reachable global buys.
3. **A "survives" is only worth as much as the probe behind it**, which is what
   `HazardNotReached` exists to say, and why the 21 is a lower bound.

## Testing

802/802 with the guard off, byte-identical behaviour. Guard on: builds clean and the lane
is green with its table pinned. Also checked that no legitimate work in the suite trips
the guard.

`dev_docs/large-domains.md` carries the rule (*every bounds-consistency path must be
independent of domain width*), the hazard taxonomy, the guard's use and the audit table.

---

Written with the assistance of Claude Opus 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EdcpzKhRabS67Kcfq3eq9e
