### PR TITLE
Survey how proofs and encodings grow with the domain (#833, #846)

### DIFF
--- a/dev_docs/large-domains.md
+++ b/dev_docs/large-domains.md
@@ -211,6 +211,122 @@ redundant — the rewrite only applies where the removed set *is* an interval �
 it does mean these two rows should be re-measured afterwards rather than quoted
 as a standing figure.
 
+### The bad encoding cases
+
+Eight constraints write an OPB whose size grows with the domain. They are not
+all the same shape, and the difference decides whether a checker feature is the
+only way out.
+
+| constraint | rows | what varies per row | re-encodable without checker help? |
+|---|---|---|---|
+| `Regular`, `RegularLegacy`, `RegularBacchus` | O(layers × states × D) | a value with **no transition** at that state | **yes**, see below |
+| `MDD` | O(layers × nodes × D) | same | **yes**, same fix |
+| `NValue` | O(D) | a value of the union of the domains | only by changing encoding family |
+| `Cumulative` | O(tasks × horizon) | a time point | no |
+| `Power`, `PowerTable` | O(D) | a row of an enumerated relation | no — it *is* a table |
+
+**`Regular` and `MDD` are the easy ones, and the fix needs no checker feature.**
+Both deliberately widen their OPB alphabet to the union of the transition keys
+*and every value of every variable's initial domain*
+(`regular.cc:581-584`, `mdd.cc:465-471`), purely so that a value with no
+transition gets an explicit `(x_i ≠ val) ∨ ¬(state_i = q)` row — the comment says
+it is "what veripb needs to verify the propagator's RUP-justified pruning of
+those values". But a value outside the transition keys entirely has no transition
+at *any* state, so the honest statement about it is not one row per state, it is
+`x_i ∈ alphabet`. The complement of a k-element key set inside a domain is at most
+k+1 intervals, so that is O(|alphabet|) range rows instead of O(states × D), with
+no dependence on the width at all. The measured 18042 → 180042 rows for a
+*two-state, one-symbol* automaton is all no-transition rows.
+
+What needs checking before believing that: whether the propagator's RUP pruning
+of an out-of-alphabet value still goes through against range rows. A range row
+asserts order atoms, and getting from there to `x_i ≠ val` is the same step
+`justify_not_in_range_across_equality()` exists for — so there is precedent, but
+it is exactly the sort of thing that has to be run past VeriPB rather than
+argued.
+
+#### Two thirds of that OPB is not the constraint
+
+Worth breaking down, because it is not where you would guess. `regular` over
+three variables of `0..100`, a two-state one-symbol automaton, 1841 rows:
+
+| rows | what |
+|---|---|
+| 612 | `@i[x][geN][r]` / `[f]` — **order-atom definitions** against the bit encoding, two per atom |
+| 606 | `@i[x][eqN][r]` / `[f]` — **equality-atom definitions**, two per atom, built from the order atoms |
+| 600 | the constraint's own `(x_i ≠ val) ∨ ¬(state_i = q)` rows |
+| 23 | everything else |
+
+So only a third of the per-value cost is `Regular`'s own rows. The other two
+thirds is the **variable's direct encoding**, written out one value at a time
+*because the constraint names those atoms* — atoms are emitted on reference, not
+wholesale (`always_use_full_encoding` is off by default; see
+[variable-encodings.md](variable-encodings.md)). The `geN` rows also carry one
+term per bit, so the character count is O(states × D × log D).
+
+Two consequences:
+
+* The `Regular`/`MDD` re-encoding is worth about **3x more** than the
+  constraint-row count suggests, because not naming those atoms stops their
+  definitions being emitted at all.
+* A parameterised-family feature has to be able to introduce **atom
+  definitions**, not merely constraint rows. On this instance a feature that
+  collapsed only the 600 constraint rows would leave 1218 behind and change the
+  asymptotics not at all. That is a sharper requirement than "a family of
+  constraints", and it is the one this measurement actually supports.
+
+**`NValue` is fixable, and the ugliness is not where I first assumed.** The
+value-indexed encoding is a fully-reified flag per value of the union
+(`n_value.cc:60-77`), `flag_v ⇔ ∃i. x_i = v`, and `n = Σ_v flag_v`. The
+position-indexed alternative is `n = Σ_i f_i` with `f_i ⇔ ∀j<i. x_i ≠ x_j` —
+"x_i is the first occurrence of its value" — which is O(n²) rows and completely
+independent of the domain.
+
+The obvious objection is that all the propagator's justifications would need
+rewriting against the new flags. **That objection is wrong**: `NValue`'s
+propagator emits no explicit steps at all, just two `JustifyUsingRUP` inferences
+(`n_value.cc:104` and `:116`). The real costs are different, and worse:
+
+1. `n_values ≤ |possible values|` is RUP under the value-indexed encoding almost
+   by construction — at most that many flags can be true. Under the
+   position-indexed one it is a counting argument over the `f_i`, and very likely
+   **not** RUP, so a currently-free inference would need a real justification.
+2. It abandons cake_pb_cp's nvalue encoding, which `n_value.cc:61` says it
+   conforms to deliberately (#354), so the workflow-2 chain breaks for nvalue.
+3. O(n²) is worse than O(D) whenever the domain is narrower than the scope, so
+   the honest version picks between the two — which means two encodings and two
+   sets of justifications to maintain.
+
+**`Cumulative` and the tabulated pair have no re-encoding.** Cumulative's
+encoding is time-indexed by construction: three fully-reified flags and a load
+line per (task, time point) (`cumulative.cc`, the `for (Integer t = t_lo; t <=
+t_hi; ++t)` loops), so a 10^9 horizon is an OPB with billions of rows and no
+change of variable avoids it. `PowerTable` *is* a table; its rows are the
+relation.
+
+### What a parameterised-family feature would buy
+
+Four of the eight — `NValue`, `Cumulative`, and `Regular`/`MDD` if they are left
+as they are — share one shape: **the same row schema with a single parameter
+ranging over a contiguous interval**. `flag_v ⇔ ∃i. x_i = v` for every v in
+[lo,hi]; `active_{i,t} ⇔ before ∧ after` for every t in a window; `(x_i ≠ val) ∨
+¬(state_i = q)` for every val in a gap. If a family like that could be *declared*
+once and instantiated by the checker on demand, all four collapse, and the two
+step-level cases from the previous section (`Among`, `Table`) collapse with them
+— they are the same construct applied to derivation steps rather than axioms.
+
+The `Regular` breakdown above says the feature has to reach one level further
+down than that, though: the majority of the rows in every one of these cases are
+the **eq/ge atom definitions of the variables the family mentions**, which are
+themselves a family over the same parameter. A construct that covers the
+constraint rows but not the atoms they name would leave two thirds of the OPB
+untouched.
+
+That is a stronger case for the feature than the step-level cases alone make,
+because `Cumulative` and `NValue` have no other way out: for them it is the
+feature or the O(n²) re-encoding with its own costs, and there is no third
+option.
+
 ## See also
 
 - [constraints.md](constraints.md) — the constraint-authoring pattern; "Querying

--- a/dev_docs/large-domains.md
+++ b/dev_docs/large-domains.md
@@ -159,6 +159,58 @@ known good:
   the per-value work is in `prepare()`, but a constraint whose *encoding* alone
   is per-value would not be. A proofs axis is the obvious next addition.
 
+## Proofs
+
+**Out of scope for fixing.** Several of these have no viable fix today, and a
+propagator is never weakened for proof size ([propagator-performance.md](propagator-performance.md)).
+The reason to measure it anyway is that the bad cases are *evidence*: where an
+inference's justification emits one near-identical step per value — the same
+derivation with a different constant substituted in — a VeriPB feature that
+could express the whole family in one step would take an O(n) or better bite out
+of it. This survey is where candidates for such a feature come from.
+
+```shell
+# from a build with the guard OFF, so the probes are not stopped before they write
+./build/large_domain_audit_test "[.proofscaling]"
+```
+
+It runs every probe at widths 10^3 and 10^4 and reports OPB rows and proof steps
+separately, because they mean different things:
+
+* **OPB rows growing with the width** is an encoding that is per-value. That is a
+  modelling problem, and no checker feature helps.
+* **Proof steps growing at a *fixed* encoding** is the copy-paste, and is what a
+  checker feature could collapse.
+
+### Results at 10^3 → 10^4
+
+| | growth (opb / steps) | constraints |
+|---|---|---|
+| **Both** grow | 10x / 10x | `Power`, `PowerTable`, `NValue`, `Regular`, `RegularLegacy`, `RegularBacchus`, `MDD` |
+| **OPB only** | 10x / 1.0x | `Cumulative` (19046 → 190046 rows; one capacity line per time point, so it is H3 on the encoding side) |
+| **Steps only** | 1.0x / 10x | **`Among`** (42-row OPB fixed, 32996 → 329996 steps) and **`Table`** (47-row OPB fixed, 50788 → 509788 steps) |
+| neither | 1.0x / 1.0x | everything else, 59 of 67 |
+
+**`Among` and `Table` are the two clean candidates.** Their encodings do not grow
+at all, so every one of those extra steps is the *same* derivation with a
+different value in it:
+
+* `Table` is the purest. `extensional_utils.cc`'s support scan calls
+  `inference.infer(logger, vars[idx] != val, JustifyUsingRUP{hint}, table.reason)`
+  once per unsupported value — the same reason, the same hint, one RUP step each,
+  differing only in `val`. A rule that could discharge "these removals, for every
+  value in this interval, by this one derivation" would replace the lot.
+* `Among` emits, per removed value, one line per value-of-interest
+  (`among.cc`) — the same clause shape with one constant substituted, nested one
+  level deeper.
+
+Both are also H1a in the propagation column, so the interval-level rewrite would
+remove much of the proof volume as a side effect: an interval removal is one
+inference where a run of values was many. That does not make a checker feature
+redundant — the rewrite only applies where the removed set *is* an interval — but
+it does mean these two rows should be re-measured afterwards rather than quoted
+as a standing figure.
+
 ## See also
 
 - [constraints.md](constraints.md) — the constraint-authoring pattern; "Querying

--- a/dev_docs/large-domains.md
+++ b/dev_docs/large-domains.md
@@ -215,15 +215,16 @@ as a standing figure.
 
 Eight constraints write an OPB whose size grows with the domain. They are not
 all the same shape, and the difference decides whether a checker feature is the
-only way out.
+only way out. All five are filed and parked under tracker **#846**; nothing here
+is scheduled before the propagation work in #833.
 
-| constraint | rows | what varies per row | re-encodable without checker help? |
-|---|---|---|---|
-| `Regular`, `RegularLegacy`, `RegularBacchus` | O(layers × states × D) | a value with **no transition** at that state | **yes**, see below |
-| `MDD` | O(layers × nodes × D) | same | **yes**, same fix |
-| `NValue` | O(D) | a value of the union of the domains | only by changing encoding family |
-| `Cumulative` | O(tasks × horizon) | a time point | no |
-| `Power`, `PowerTable` | O(D) | a row of an enumerated relation | no — it *is* a table |
+| issue | constraint | rows | what varies per row | re-encodable without checker help? |
+|---|---|---|---|---|
+| #841 | `Regular`, `RegularLegacy`, `RegularBacchus` | O(layers × states × D) | a value with **no transition** at that state | **yes**, see below |
+| #842 | `MDD` | O(layers × nodes × D) | same | **yes**, same fix |
+| #843 | `NValue` | O(D) | a value of the union of the domains | only by changing encoding family |
+| #844 | `Cumulative` | O(tasks × horizon) | a time point | no |
+| #845 | `Power`, `PowerTable` | O(D) | a row of an enumerated relation | no — it *is* a table |
 
 **`Regular` and `MDD` are the easy ones, and the fix needs no checker feature.**
 Both deliberately widen their OPB alphabet to the union of the transition keys
@@ -296,6 +297,22 @@ propagator emits no explicit steps at all, just two `JustifyUsingRUP` inferences
 3. O(n²) is worse than O(D) whenever the domain is narrower than the scope, so
    the honest version picks between the two — which means two encodings and two
    sets of justifications to maintain.
+
+The same breakdown for the other two measured cases, three variables at
+`0..100`, which is what the tracker's feature argument rests on:
+
+| constraint | total rows | variable `geN`/`eqN` atom definitions | its own rows |
+|---|---|---|---|
+| `Regular` | 1841 | 1218 (66%) | 600 |
+| `NValue` | 1431 | 1218 (85%) | 213 |
+| `Cumulative` | 1945 | **0** | 1836 |
+
+`Cumulative` is the instructive exception: it names no equality atoms at all,
+because its flags are defined against order comparisons over the bits
+(`starts[i] <= t`), so every one of its 1836 rows is its own reified flag
+halves. So the family construct needs to introduce *two* kinds of definition —
+eq/ge atoms for `Regular` and `NValue`, reified flag halves for `Cumulative` —
+not one.
 
 **`Cumulative` and the tabulated pair have no re-encoding.** Cumulative's
 encoding is time-indexed by construction: three fully-reified flags and a load

--- a/dev_docs/large-domains.md
+++ b/dev_docs/large-domains.md
@@ -223,7 +223,7 @@ is scheduled before the propagation work in #833.
 | #841 | `Regular`, `RegularLegacy`, `RegularBacchus` | O(layers × states × D) | a value with **no transition** at that state | **yes**, see below |
 | #842 | `MDD` | O(layers × nodes × D) | same | **yes**, same fix |
 | #843 | `NValue` | O(D) | a value of the union of the domains | only by changing encoding family |
-| #844 | `Cumulative` | O(tasks × horizon) | a time point | no |
+| ~~#844~~ | `Cumulative` | O(tasks × horizon) | a time point | **already fixed by #781**, opt-in |
 | #845 | `Power`, `PowerTable` | O(D) | a row of an enumerated relation | no — it *is* a table |
 
 **`Regular` and `MDD` are the easy ones, and the fix needs no checker feature.**
@@ -314,12 +314,22 @@ halves. So the family construct needs to introduce *two* kinds of definition —
 eq/ge atoms for `Regular` and `NValue`, reified flag halves for `Cumulative` —
 not one.
 
-**`Cumulative` and the tabulated pair have no re-encoding.** Cumulative's
-encoding is time-indexed by construction: three fully-reified flags and a load
-line per (task, time point) (`cumulative.cc`, the `for (Integer t = t_lo; t <=
-t_hi; ++t)` loops), so a 10^9 horizon is an OPB with billions of rows and no
-change of variable avoids it. `PowerTable` *is* a table; its rows are the
-relation.
+**`Cumulative` already has its fix, and it is the useful counterexample.** The
+figures above are the `TimeIndexed` encoding, which is still the default: three
+fully-reified flags and a load line per (task, time point). PR #781 (for #780)
+replaces it with a horizon-free start-checkpoint encoding, and on the same
+instance that is 1945 → **46** rows at `0..100` and 190045 → **46** at
+`0..10000`, flat in the horizon. It is opt-in behind
+`GCS_CUMULATIVE_ENCODING=start-checkpoint`; #781 says the default is deliberate
+pending a measurement over #777.
+
+This is worth remembering when arguing that a shape needs checker support. Before
+#781, `Cumulative` looked like the case with no way out — time-indexing was "what
+the encoding is". It was not: a change of formulation plus minting the
+per-(task, time) flags inside the proof rather than in the model removed the
+dependence entirely. Re-encoding may be available more often than it looks.
+
+`PowerTable` genuinely *is* a table; its rows are the relation.
 
 ### What a parameterised-family feature would buy
 

--- a/gcs/large_domain_audit_test.cc
+++ b/gcs/large_domain_audit_test.cc
@@ -61,14 +61,19 @@
 #include <version>
 
 #if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+#include <format>
 #include <print>
+using std::format;
 using std::println;
 #else
 #include <fmt/core.h>
+using fmt::format;
 using fmt::println;
 #endif
 
 #include <exception>
+#include <filesystem>
+#include <fstream>
 #include <functional>
 #include <new>
 #include <string>
@@ -83,10 +88,13 @@ using std::vector;
 
 namespace
 {
-    // Wide enough that any per-value work is hopeless, and the same width the
-    // issue's MiniZinc probes used, so the two sets of numbers are comparable.
+    // The probes' wide position is 0..probe_width. The audit runs at 10^9: wide
+    // enough that any per-value work is hopeless, and the width the issue's
+    // MiniZinc probes used, so the two sets of numbers are comparable. The proof
+    // survey below re-runs the same probes at two much smaller widths, because a
+    // proof can only be measured where it can actually be written.
     const auto wide_lo = 0_i;
-    const auto wide_hi = 1000000000_i;
+    auto probe_width = 1000000000_i;
 
     enum class Expect
     {
@@ -149,11 +157,16 @@ namespace
         function<auto(Problem &)->void> build;
     };
 
+    auto wide_var(Problem & p) -> IntegerVariableID
+    {
+        return p.create_integer_variable(wide_lo, probe_width);
+    }
+
     auto wide(Problem & p, int n) -> vector<IntegerVariableID>
     {
         vector<IntegerVariableID> result;
         for (int i = 0; i < n; ++i)
-            result.push_back(p.create_integer_variable(wide_lo, wide_hi));
+            result.push_back(wide_var(p));
         return result;
     }
 
@@ -300,11 +313,11 @@ namespace
             // The value variable has to be distinct from the scope: an aliased
             // one is rejected at post time, so it would probe nothing.
             auto v = wide(p, 3);
-            p.post(AtMostOne{v, p.create_integer_variable(wide_lo, wide_hi)});
+            p.post(AtMostOne{v, wide_var(p)});
         });
         add("AtMostOneSmartTable", Expect::KnownTrip, [](Problem & p) {
             auto v = wide(p, 3);
-            p.post(AtMostOneSmartTable{v, p.create_integer_variable(wide_lo, wide_hi)});
+            p.post(AtMostOneSmartTable{v, wide_var(p)});
         });
         add("GlobalCardinality", Expect::HazardNotReached, // propagate_bounds_global_cardinality enumerates values, but not on a probe this shape
             [](Problem & p) {
@@ -484,7 +497,7 @@ namespace
         add("MinDistance", Expect::HazardNotReached, // the per-value sites need more sites than this probe has
             [](Problem & p) {
                 auto x = narrow(p, 2, 0_i, 1_i);
-                auto z = p.create_integer_variable(wide_lo, wide_hi);
+                auto z = wide_var(p);
                 p.post(MinDistance{x, z, MinDistance::Matrix{{0_i, 1_i}, {1_i, 0_i}}});
             });
 
@@ -494,6 +507,85 @@ namespace
 
 namespace
 {
+    /* How does the *proof* grow with the domain's width?
+     *
+     * Out of scope for fixing: several of these have no viable fix today, and a
+     * propagator is never weakened for proof size (propagator-performance.md).
+     * The reason to measure it anyway is that the bad cases are evidence. Where
+     * an inference's justification emits one near-identical step per value --
+     * the same derivation with a different constant substituted in -- a VeriPB
+     * feature that could express the family in one step would take an O(n) or
+     * better bite out of it. This survey is where the candidates for such a
+     * feature come from, so it reports OPB rows and proof steps separately: OPB
+     * growth is an encoding that is per-value (a modelling problem, which no
+     * checker feature helps), while proof-step growth at a *fixed* encoding is
+     * the copy-paste that one might.
+     *
+     * Run it by hand, from a build with the guard OFF so that the wide probes
+     * are not stopped before they write anything:
+     *
+     *     ./build/large_domain_audit_test "[.proofscaling]"
+     */
+    struct ProofSizes
+    {
+        long long opb_rows = 0;
+        long long proof_steps = 0;
+        bool measured = false;
+        string detail = {};
+    };
+
+    auto count_lines(const std::filesystem::path & f) -> long long
+    {
+        std::ifstream in{f};
+        if (! in)
+            return 0;
+        long long n = 0;
+        for (string line; std::getline(in, line);)
+            ++n;
+        return n;
+    }
+
+    auto proof_sizes(const function<auto(Problem &)->void> & build, Integer width) -> ProofSizes
+    {
+        auto restore = probe_width;
+        probe_width = width;
+        ProofSizes result;
+        auto names = ProofFileNames{"large_domain_proof_scaling"};
+        try {
+            Problem problem;
+            build(problem);
+            solve_with(problem,
+                SolveCallbacks{.solution = [](const CurrentState &) { return false; },
+                    .trace = [](const CurrentState &) { return false; },
+                    .stats_report = silent_stats_report()},
+                ProofOptions{names});
+            result.measured = true;
+        }
+        catch (const std::exception & e) {
+            // Whatever was written before it gave up is not a measurement, so
+            // the row says so rather than reporting a truncated count.
+            result.detail = e.what();
+        }
+
+        result.opb_rows = count_lines(names.opb_file);
+        result.proof_steps = count_lines(names.proof_file);
+        for (const auto & f : {names.opb_file, names.proof_file})
+            std::filesystem::remove(f);
+        for (const auto & f : {names.variables_map_file, names.s_expr_file})
+            if (f)
+                std::filesystem::remove(*f);
+
+        probe_width = restore;
+        return result;
+    }
+
+    auto growth(long long small, long long large) -> string
+    {
+        if (small <= 0)
+            return "-";
+        return format("{:.1f}x", static_cast<double>(large) / static_cast<double>(small));
+    }
+
     auto describe(Expect e) -> string
     {
         switch (e) {
@@ -528,4 +620,29 @@ TEST_CASE("Large domain audit")
         // pinned, so the table cannot drift away from what the code does.
         CHECK(result.tripped == expected_trip);
     }
+}
+
+TEST_CASE("Large domain proof scaling", "[.proofscaling]")
+{
+    // Two widths a factor of ten apart, both small enough that every probe can
+    // actually write a proof. A row whose count grows by about ten is linear in
+    // the domain; one that barely moves does not depend on the width at all.
+    const auto narrow_width = 1000_i, wider_width = 10000_i;
+
+    println("{:<40} {:>10} {:>10} {:>8} {:>10} {:>10} {:>8}", "constraint", "opb@1e3", "opb@1e4", "growth", "pbp@1e3", "pbp@1e4", "growth");
+    for (const auto & probe_case : all_probes()) {
+        auto small = proof_sizes(probe_case.build, narrow_width);
+        auto large = proof_sizes(probe_case.build, wider_width);
+        if (! (small.measured && large.measured)) {
+            println("{:<40} {:>10} {}", probe_case.name, "unmeasured", small.measured ? large.detail : small.detail);
+            continue;
+        }
+        println("{:<40} {:>10} {:>10} {:>8} {:>10} {:>10} {:>8}", probe_case.name, small.opb_rows, large.opb_rows,
+            growth(small.opb_rows, large.opb_rows), small.proof_steps, large.proof_steps, growth(small.proof_steps, large.proof_steps));
+    }
+
+    // A survey, not a gate: it asserts only that it got all the way through, so
+    // that a constraint which cannot be proof-logged at all still shows up as a
+    // row rather than ending the run.
+    SUCCEED("proof scaling survey complete");
 }


### PR DESCRIPTION
Follows #847. **Second of four**, and the only one with no code that runs in a normal
build: a hidden test mode plus the documentation and issues it produced.

Proofs are **out of scope for fixing** — several of these have no viable fix today, and a
propagator is never weakened for proof size. The reason to measure is that the bad cases
are *evidence*: where a justification emits one near-identical step per value, a checker
feature that could express the family in one step would take an O(n) or better bite out of
it. This is where candidates for such a feature come from.

## The survey

`./build/large_domain_audit_test "[.proofscaling]"` (guard-off build) reuses #847's probes
at widths 10^3 and 10^4, reporting **OPB rows** and **proof steps** separately, because
they mean different things: OPB growth is a per-value *encoding*, a modelling problem no
checker feature helps; step growth at a *fixed* encoding is the copy-paste one might.

Of 67 probes, 59 are flat in both.

| | opb / steps | constraints |
|---|---|---|
| both grow | 10x / 10x | `Power`, `PowerTable`, `NValue`, the three `Regular`s, `MDD` |
| **OPB only** | 10x / 1.0x | `Cumulative` |
| **steps only** | 1.0x / 10x | **`Among`**, **`Table`** |

`Among` and `Table` are the clean step-level candidates: their encodings are flat (42 and
47 rows at both widths), so every extra step is the same derivation with a different
constant. `Table` is purest — one RUP step per unsupported value, same reason, same hint,
only the value differs.

## The encoding side, and what breaking the OPB down changed

Filed as tracker #846 with children #841 `Regular`, #842 `MDD`, #843 `NValue`, #845
`PowerTable`. Recorded and parked; nothing is scheduled before #833's propagation work.

Counting rows was not enough — the majority of the per-value cost is usually **not** the
constraint. Three variables at `0..100`:

| | total | variable `geN`/`eqN` atom definitions | its own rows |
|---|---|---|---|
| `Regular` | 1841 | 1218 (66%) | 600 |
| `NValue` | 1431 | 1218 (85%) | 213 |
| `Cumulative` | 1945 | **0** | 1836 |

For `Regular` and `NValue` the bulk is the **variable's own direct encoding**, materialised
one value at a time because the constraint names `x != val` / `x == v` for every value —
atoms are emitted on reference. `Cumulative` is the opposite, because its flags are defined
against order comparisons over the bits rather than equality atoms. So a family construct
would have to introduce **two kinds of definition**, not just constraint rows: on `Regular`
a construct covering only the 600 constraint rows leaves 1218 behind and does not change
the asymptotics.

That also makes #841/#842 worth about **3x** more than their constraint-row counts suggest,
since not naming those atoms is what stops their definitions being written.

## One case withdrawn

I filed `Cumulative` as #844 saying a time-indexed formulation was "what this encoding
*is*". That was wrong: the re-encoding exists and is **open as #781**. Measured on that
branch, same instance: 1945 OPB rows → **46** at `0..100`, and 190045 → **46** at
`0..10000`. My 5% capacity / 94% per-(task, time) flag split also matches #781's own
diagnosis, so the two agree about where the cost was. #844 closed as superseded.

It is worth more than a retraction: `Cumulative` was the strongest leg of the argument that
this shape *needs* checker support, on the grounds that it had no other way out. It had
one. #846 now carries that caveat, because re-encoding looks more often available than it
first appeared.

## Testing

Documentation and a hidden `[.proofscaling]` test case only; nothing runs in a normal
build. 802/802 unchanged.

---

Written with the assistance of Claude Opus 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EdcpzKhRabS67Kcfq3eq9e
