### PR TITLE
Sharpen the six audit probes that were passing without reaching their hazard (#833)

### DIFF
--- a/dev_docs/large-domains.md
+++ b/dev_docs/large-domains.md
@@ -115,17 +115,16 @@ is the part worth reading carefully:
 | `Clean` | has a position where a wide domain is meaningful, and survives one |
 | `KnownTrip` | likewise, and does not. This is the work #833 is about |
 | `NoWidePosition` | no variable it takes can meaningfully be wide — successors index an array, Booleans are `{0,1}`. Structural immunity, not a working fallback |
-| `HazardNotReached` | the source has a per-value site, but this probe does not reach it. **Not** a clean bill of health: a gap in the probe, tracked below |
+| `HazardNotReached` | the source has a per-value site, but this probe does not reach it. **Not** a clean bill of health: a gap in the probe. No row uses this today — every gap has been closed — but the outcome stays, because it is what to reach for rather than guessing when a probe cannot get at a site |
 
 ### Where we stand
 
-67 probes, run on `7d014207`. The trips:
+68 probes, run on `7d014207`.
 
 | | constraints |
 |---|---|
-| **KnownTrip** (21) | `Power`, `PowerTable`, `AllDifferent`, `AllDifferentExcept`, `Among`, `Count`, `NValue`, `AtMostOne`, `AtMostOneSmartTable`, `In`, `ArrayMinMax`, `LexSmartTable`, `Table`, `SmartTable`, `Regular`, `RegularLegacy`, `RegularBacchus`, `MDD`, `Cumulative`, `Disjunctive`, `Knapsack` |
-| **HazardNotReached** (5) | `GlobalCardinality`, `Element`, `NegativeTable`, `Disjunctive2D`, `MinDistance` |
-| **Clean** (27) | the arithmetic family, comparison, equality, linear, `AllDifferent` under `VC`, `Element` under `BC`, `AllEqual`, `ValuePrecede`, `SeqPrecedeChain`, `IncreasingChain`, `Lex`, `Sort`, `ArgSort`, `BinPacking`, `DifferenceConstraints`, `Nogoods` |
+| **KnownTrip** (24) | `Power`, `PowerTable`, `AllDifferent`, `AllDifferentExcept`, `AllEqual/holes`, `Among`, `Count`, `NValue`, `AtMostOne`, `AtMostOneSmartTable`, `GlobalCardinality`, `In`, `ArrayMinMax`, `Element`, `LexSmartTable`, `Table`, `SmartTable`, `Regular`, `RegularLegacy`, `RegularBacchus`, `MDD`, `Cumulative`, `Disjunctive`, `Knapsack` |
+| **Clean** (30) | the arithmetic family, comparison, equality, linear, `AllDifferent` under `VC`, `Element` under `BC`, `AllEqual` without holes, `ValuePrecede`, `SeqPrecedeChain`, `IncreasingChain`, `Lex`, `Sort`, `ArgSort`, `NegativeTable`, `Disjunctive2D`, `BinPacking`, `MinDistance`, `DifferenceConstraints`, `Nogoods` |
 | **NoWidePosition** (14) | the graph and permutation family, and the Boolean constraints |
 
 Three things in that table were not what #833 predicted, and are worth
@@ -142,22 +141,50 @@ recording because they change what the later stages have to do:
    the probe passes without touching the hazard. A probe that does not reach a
    path proves nothing about it, which is what `HazardNotReached` exists to say.
 
-### Known gaps in the lane
+### What the sharpening pass found
 
-Each of these is a probe that needs sharpening rather than a constraint that is
-known good:
+Six probes originally passed without touching the site they were meant to test.
+Chasing each one down split them three ways, and the split is the useful part:
+"survives" meant three different things.
 
-* `GlobalCardinality` — `propagate_bounds_global_cardinality` enumerates values,
-  but not on a probe of this shape.
-* `Element` — the per-value support remainder is not reached from a narrow index
-  at the root.
-* `NegativeTable` — does not take the residue path the positive table dies in.
-* `Disjunctive2D` — the time-table pass is not reached at the root.
-* `MinDistance` — its per-value sites need more sites than this probe has.
-* `AllEqual` — the probe has no holes, so `all_equal.cc`'s hole path never runs.
-* The lane runs without proof logging. H2′ (`NValue`) is caught anyway, because
-  the per-value work is in `prepare()`, but a constraint whose *encoding* alone
-  is per-value would not be. A proofs axis is the obvious next addition.
+**Three were real hazards behind a condition the probe did not meet.** Each is
+now a `KnownTrip`:
+
+* `GlobalCardinality` needs the *just-met-demand* branch
+  (`bounds_global_cardinality.cc:127`), where the number of variables that can
+  take a cover value equals that value's count lower bound, so each is forced to
+  it by removing every other value one at a time. Three variables, one cover
+  value, a count pinned at three.
+* `Element` needs the array entries to be **narrow**. The GAC sweep erases each
+  entry's domain from the result's still-unsupported set, so a *wide* entry
+  erases everything in one `erase_range` and leaves no remainder — the original
+  probe made the hazard disappear by being too wide.
+* `AllEqual` needs holes *and* a large difference. Bounds propagation runs first
+  (`all_equal.cc:95`) and collapses a merely narrow partner, so the hole has to
+  be spread across the full width: a two-value domain at the extremes leaves the
+  whole middle of the other variable to be removed one value at a time.
+
+**Three were not hazards at all**, and the entry in #833's source list was about
+a sibling rather than the constraint itself. Each is now `Clean`:
+
+* `NegativeTable` is watched-literal over tuples and never iterates a domain, so
+  it takes none of the residue path the positive `Table` dies in.
+* `Disjunctive2D` is pairwise, with no value loop and no span-indexed array, and
+  installs no 1D `Disjunctive` child that would have one.
+* `MinDistance`'s per-value loops are all over its *position* variables, and
+  `prepare()` `define_bound()`s those to `0..n-1` of the distance matrix
+  (`min_distance.cc:92-93`), so they cannot be wide. Its wide position is the
+  objective, which it reasons about by bounds.
+
+The moral for anyone adding a row: **a probe that survives has proved nothing
+until you have checked it reached the code you meant to test.** Two of the three
+real hazards above were hidden by the probe being *more* extreme than necessary,
+which is not the direction one expects to have to correct.
+
+One deliberate non-axis: the lane runs **without proof logging**. `NValue`'s
+H2′ is caught anyway, because its per-value work is in `prepare()`, but a
+constraint whose *encoding* alone were per-value would not be. That is by
+design — see below.
 
 ## Proofs
 

--- a/gcs/large_domain_audit_test.cc
+++ b/gcs/large_domain_audit_test.cc
@@ -288,6 +288,19 @@ namespace
         add("AllDifferentExcept", Expect::KnownTrip, [](Problem & p) { p.post(AllDifferentExcept{wide(p, 4), {0_i}}); });
         add("SymmetricAllDifferent", Expect::NoWidePosition, [](Problem & p) { p.post(SymmetricAllDifferent{narrow(p, 4, 0_i, 3_i)}); });
         add("AllEqual", Expect::Clean, [](Problem & p) { p.post(AllEqual{wide(p, 3)}); });
+        add("AllEqual/holes", Expect::KnownTrip, [](Problem & p) {
+            // all_equal.cc:114 prunes every variable to the intersection of all
+            // the domains once any of them has holes. It takes the difference as
+            // intervals (each_interval_minus) but then walks each interval a
+            // value at a time, so it needs a *large* difference as well as a
+            // hole. Bounds propagation runs first and would collapse a merely
+            // narrow partner, so the hole has to be spread across the full width:
+            // a two-value domain at the extremes leaves the whole middle of the
+            // other variable to remove.
+            auto holey = p.create_integer_variable(vector<Integer>{wide_lo, probe_width});
+            auto full = wide_var(p);
+            p.post(AllEqual{vector<IntegerVariableID>{holey, full}});
+        });
 
         // --- Counting family.
         add("Among", Expect::KnownTrip, [](Problem & p) {
@@ -319,13 +332,17 @@ namespace
             auto v = wide(p, 3);
             p.post(AtMostOneSmartTable{v, wide_var(p)});
         });
-        add("GlobalCardinality", Expect::HazardNotReached, // propagate_bounds_global_cardinality enumerates values, but not on a probe this shape
-            [](Problem & p) {
-                // The counterexample to "just default to BC": this already defaults
-                // to consistency::BC and still enumerates values.
-                auto v = wide(p, 3);
-                p.post(GlobalCardinality{v, {1_i, 2_i}, narrow(p, 2, 0_i, 3_i)});
-            });
+        add("GlobalCardinality", Expect::KnownTrip, [](Problem & p) {
+            // The counterexample to "just default to BC": this already defaults
+            // to consistency::BC and still enumerates values. Reaching that needs
+            // the just-met-demand branch (bounds_global_cardinality.cc:127), where
+            // the number of variables that *can* take a cover value equals that
+            // value's count lower bound -- so each is forced to it by removing
+            // every other value one at a time. Three variables, one cover value,
+            // and a count pinned at three does it.
+            auto v = wide(p, 3);
+            p.post(GlobalCardinality{v, {1_i}, {p.create_integer_variable(3_i, 3_i)}});
+        });
         add("In", Expect::KnownTrip, [](Problem & p) {
             auto v = wide(p, 1);
             p.post(In{v[0], vector<Integer>{1_i, 2_i, 3_i}});
@@ -339,15 +356,22 @@ namespace
             auto v = wide(p, 4);
             p.post(ArrayMax{vector<IntegerVariableID>{v[0], v[1], v[2]}, v[3]});
         });
-        add("Element", Expect::HazardNotReached, // element.cc's per-value support remainder is not reached from a narrow index at the root
-            [](Problem & p) {
-                auto v = wide(p, 4);
-                p.post(Element{v[3], p.create_integer_variable(0_i, 2_i), vector<IntegerVariableID>{v[0], v[1], v[2]}});
-            });
+        add("Element", Expect::KnownTrip, [](Problem & p) {
+            // The array entries have to be *narrow* for this to bite. The GAC
+            // sweep erases each entry's domain from the result's still-unsupported
+            // set (element.cc:583), so a wide entry erases the lot in one
+            // erase_range and leaves nothing, while a narrow one leaves the rest
+            // of the result's domain to be walked a value at a time
+            // (element.cc:621).
+            auto result = wide_var(p);
+            p.post(Element{result, p.create_integer_variable(0_i, 2_i), narrow(p, 3, 1_i, 3_i)});
+        });
         add("Element/BC", Expect::Clean, [](Problem & p) {
-            auto v = wide(p, 4);
-            p.post(
-                Element{v[3], p.create_integer_variable(0_i, 2_i), vector<IntegerVariableID>{v[0], v[1], v[2]}}.with_consistency(consistency::BC{}));
+            // The same instance as the GAC probe above, so the pair is
+            // comparable: the weaker arm is what makes it clean, not an easier
+            // instance.
+            auto result = wide_var(p);
+            p.post(Element{result, p.create_integer_variable(0_i, 2_i), narrow(p, 3, 1_i, 3_i)}.with_consistency(consistency::BC{}));
         });
 
         // --- Ordering.
@@ -377,12 +401,14 @@ namespace
             SimpleTuples tuples{{1_i, 2_i, 3_i}, {4_i, 5_i, 6_i}};
             p.post(Table{v, tuples});
         });
-        add("NegativeTable", Expect::HazardNotReached, // does not take the residue path the positive table dies in
-            [](Problem & p) {
-                auto v = wide(p, 3);
-                SimpleTuples tuples{{1_i, 2_i, 3_i}, {4_i, 5_i, 6_i}};
-                p.post(NegativeTable{v, tuples});
-            });
+        add("NegativeTable", Expect::Clean, [](Problem & p) {
+            // Genuinely clean rather than merely unreached: it is watched-literal
+            // over tuples and never iterates a domain, so it takes none of the
+            // residue path the positive table dies in.
+            auto v = wide(p, 3);
+            SimpleTuples tuples{{1_i, 2_i, 3_i}, {4_i, 5_i, 6_i}};
+            p.post(NegativeTable{v, tuples});
+        });
         add("SmartTable", Expect::KnownTrip, [](Problem & p) {
             auto v = wide(p, 2);
             // Built a step at a time rather than from a nested braced list. GCC
@@ -427,11 +453,13 @@ namespace
             auto starts = wide(p, 3);
             p.post(Disjunctive{starts, vector<Integer>{2_i, 2_i, 2_i}});
         });
-        add("Disjunctive2D", Expect::HazardNotReached, // the time-table pass is not reached at the root here
-            [](Problem & p) {
-                auto xs = wide(p, 2), ys = wide(p, 2);
-                p.post(Disjunctive2D{xs, ys, narrow(p, 2, 1_i, 1_i), narrow(p, 2, 1_i, 1_i)});
-            });
+        add("Disjunctive2D", Expect::Clean, [](Problem & p) {
+            // Clean rather than unreached: it is pairwise, with no value loop and
+            // no span-indexed array anywhere, and it installs no 1D Disjunctive
+            // child that would have one.
+            auto xs = wide(p, 2), ys = wide(p, 2);
+            p.post(Disjunctive2D{xs, ys, narrow(p, 2, 1_i, 1_i), narrow(p, 2, 1_i, 1_i)});
+        });
 
         // --- Packing and knapsack.
         add("BinPacking", Expect::Clean, [](Problem & p) {
@@ -494,12 +522,15 @@ namespace
             p.post(Nogoods{vector<Nogood>{{v[0] == 0_i, v[1] == 0_i}}});
         });
 
-        add("MinDistance", Expect::HazardNotReached, // the per-value sites need more sites than this probe has
-            [](Problem & p) {
-                auto x = narrow(p, 2, 0_i, 1_i);
-                auto z = wide_var(p);
-                p.post(MinDistance{x, z, MinDistance::Matrix{{0_i, 1_i}, {1_i, 0_i}}});
-            });
+        add("MinDistance", Expect::Clean, [](Problem & p) {
+            // Its per-value loops are all over the *position* variables, and
+            // prepare() define_bound()s those to 0..n-1 of the distance matrix
+            // (min_distance.cc:92-93), so they cannot be wide. The wide position
+            // here is the objective z, which it reasons about by bounds.
+            auto x = narrow(p, 2, 0_i, 1_i);
+            auto z = wide_var(p);
+            p.post(MinDistance{x, z, MinDistance::Matrix{{0_i, 1_i}, {1_i, 0_i}}});
+        });
 
         return probes;
     }


### PR DESCRIPTION
Follows #848. **Third of four.** Test-only.

Six rows of #847's audit lane survived without touching the site they existed to test.
Chasing each down split them three ways, and the split is the point: "survives" meant three
different things.

## Three were real hazards behind a condition the probe did not meet

Now `KnownTrip`:

* **`GlobalCardinality`** needs the just-met-demand branch
  (`bounds_global_cardinality.cc:127`), where the number of variables that *can* take a
  cover value equals that value's count lower bound, so each is forced to it by removing
  every other value one at a time. Three variables, one cover value, a count pinned at
  three.
* **`Element`** needs its array entries **narrow**. The GAC sweep erases each entry's
  domain from the result's still-unsupported set, so a *wide* entry erases everything in
  one `erase_range` and leaves no remainder.
* **`AllEqual`** needs holes *and* a large difference. Bounds propagation runs first
  (`all_equal.cc:95`) and collapses a merely narrow partner, so the hole has to span the
  full width — a two-value domain at the extremes leaves the whole middle to remove.

## Three were not hazards at all

#833's source list was pointing at a sibling rather than the constraint. Now `Clean`:

* **`NegativeTable`** is watched-literal over tuples and never iterates a domain, so it
  takes none of the residue path the positive `Table` dies in.
* **`Disjunctive2D`** is pairwise, with no value loop, no span-indexed array, and no 1D
  `Disjunctive` child that would have one.
* **`MinDistance`**'s per-value loops are all over its *position* variables, and `prepare()`
  `define_bound()`s those to `0..n-1` of the distance matrix (`min_distance.cc:92-93`), so
  they cannot be wide. Its wide position is the objective, handled by bounds.

## Result

68 probes: **24 `KnownTrip`, 30 `Clean`, 14 `NoWidePosition`, 0 `HazardNotReached`.** The
previous count of 21 was a lower bound, as the table said it was.

Two of the three real hazards were hidden by the probe being *more* extreme than necessary,
which is not the direction one expects to have to correct, so the doc now says plainly that
**a probe which survives has proved nothing until it has been checked to reach the code it
was meant to test**. The `HazardNotReached` outcome stays although nothing uses it: it is
what to reach for rather than guessing, when a site genuinely cannot be reached.

## Testing

802/802 guard off; audit lane green guard on.

---

Written with the assistance of Claude Opus 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EdcpzKhRabS67Kcfq3eq9e
