### PR TITLE
Size the extensional residue rows from the table, not the variable (#833)

### DIFF
--- a/dev_docs/large-domains.md
+++ b/dev_docs/large-domains.md
@@ -52,6 +52,30 @@ The tree already has the machinery: `IntervalSet::each_interval_minus()`,
 that removes "everything not in this small given set" one value at a time is an
 interval operation written out longhand, and rewriting it keeps GAC.
 
+### A trap: a bound that is obvious is not necessarily RUP
+
+`ArrayMinMax` has no hull bound on the loose side — for a max it posts
+`result >= lb(var_i)` for every i but never `result <= max_i ub(var_i)`, so the
+per-value union sweep is what establishes it (issue #815, which proposes adding
+the bound as a small, obviously-correct first fix).
+
+It is obviously correct, and it is **not a small fix**, because it does not
+verify. Negating it gives `result > max_i ub(var_i)`; each selector asserts
+`result <= var_i`, so every selector must be false and the al1 row fails. That
+argument needs to carry an order atom on `result` across the half-reified row
+relating `result` and `var_i`, which is a linear row over the *bits* — and unit
+propagation does not cross a bit sum on a wide domain, where nothing fixes an
+individual bit. Adding the bound with `JustifyUsingRUP` fails VeriPB on
+`min_max_constraint` and `min_max_constraint_view_mixed`. Making it verify needs
+an explicit `pol` per selector, over line numbers `define_proof_model` does not
+currently keep.
+
+The interval rewrite of the union sweep is the better target anyway: it fixes the
+general case rather than only the narrow-array one, and the range-removal proof
+pattern it needs already exists and verifies fifty lines further down the same
+file (`min_max.cc:199`, `infer_not_in_range` with a value-independent
+justification emitted once per interval).
+
 H3 has two precedents in the tree for what a good cap looks like:
 `ExtensionalDomainBitmaps::max_words` and `cumulative.cc`'s
 `max_knapsack_capacity`. Both are far above anything a real model asks for, both

--- a/gcs/constraints/extensional_utils.cc
+++ b/gcs/constraints/extensional_utils.cc
@@ -720,10 +720,24 @@ auto gcs::innards::propagate_extensional(
         residues.support.resize(table.vars.size());
         residues.base.resize(table.vars.size());
         for (unsigned idx = 0; idx < table.vars.size(); ++idx) {
-            auto [lo, hi] = state.bounds(table.vars[idx]);
+            // Sized from the values the *table* holds at this position, exactly
+            // as the bitmaps above are, and for the same reason: a value outside
+            // that range appears in no tuple, so it is unsupported by
+            // construction and there is never a witness to remember for it. The
+            // variable's own bounds are the wrong measure, and on a wide domain
+            // a disastrous one -- three `var 0..10^9` positions asked for 12 GB
+            // of residue rows and died at install (issue #833).
+            //
+            // Where the bitmaps declined the position -- a wildcard, or a table
+            // range too wide to rasterise -- there is no row, and the lookups
+            // below fall back to the scan on their own: `have_row` is already a
+            // bounds check, because a value outside the row has always been
+            // possible.
+            const auto & p = bitmaps.positions[idx];
+            auto lo = p.usable ? Integer{p.base} : state.lower_bound(table.vars[idx]);
+            auto n_values = p.usable ? p.n_values : std::size_t{0};
             residues.base[idx] = lo.raw_value;
-            GCS_CHECK_LARGE_DOMAIN("the domain an extensional residue row is being sized by", (hi - lo).raw_value + 1);
-            residues.support[idx].assign(static_cast<std::size_t>((hi - lo).raw_value + 1), ExtensionalResidues::none);
+            residues.support[idx].assign(n_values, ExtensionalResidues::none);
         }
         residues.initialised = true;
     }


### PR DESCRIPTION
Follows #849. **Fourth of four**, and the only one that changes what the solver does.

## The fix

The extensional residues were sized by each position's *variable* bounds, so three
`var 0..10^9` positions asked for about 12 GB of rows and died at install with `bad_alloc`
in 0.10 s. Size them from the values the **table** holds at that position instead, which is
what the domain bitmaps in the same file have always done and for the same reason: a value
outside that range appears in no tuple, so it is unsupported by construction and there is
never a witness to remember for it. The per-position range is already computed for the
bitmaps, so this reuses it rather than recomputing.

Where the bitmaps declined a position — a wildcard, or a table range too wide to rasterise
— there is now no row, and the lookups fall back to the scan on their own, because
`have_row` was already a bounds check: a value outside the row has always been possible.

**No inference changes.** Which values are supported is unchanged, and so is the removal
set.

## What it does not do, deliberately

This does not make `Table` usable on a wide domain, and its audit row stays `KnownTrip`. On
the wide probe the install-time `bad_alloc` at 0.10 s is gone and it now runs for **10.7 s**
before dying — `gdb` puts that in `SimpleInferenceTracker::track_impl`, the per-removal
deque, from the per-value support loop at `extensional_utils.cc:740`.

That loop is interval-rewrite work, not a sizing bug. Fixing the memory death without
fixing the iteration is the intended scope here, and the row stays red for the right
reason.

## A trap this turned up, recorded rather than fixed

#815 proposes `ArrayMinMax`'s missing hull bound (`result <= max_i ub(var_i)`) as a small,
obviously-correct first fix. It is obviously correct and it **does not verify**. Negating
it means carrying an order atom on `result` across the half-reified `result <= var_i` row,
which is a linear row over the *bits*, and unit propagation does not cross a bit sum on a
wide domain where nothing fixes an individual bit. Added with `JustifyUsingRUP` it fails
VeriPB on `min_max_constraint` and `min_max_constraint_view_mixed`; reverting restores
green.

Making it verify needs an explicit `pol` per selector over line numbers
`define_proof_model` does not keep. So it belongs with the interval rewrite of the union
sweep, which subsumes it, fixes the general wide case rather than only #815's narrow-array
one, and has a working proof precedent fifty lines further down the same file
(`min_max.cc:199`). Recorded in `dev_docs/large-domains.md` so the next person does not
spend the afternoon I did.

## Testing

802/802 guard off, including the 59 extensional and automaton lanes; audit lane green guard
on. The wide-domain `bad_alloc` moves from install to propagation as described above.

---

Written with the assistance of Claude Opus 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EdcpzKhRabS67Kcfq3eq9e
