### PR TITLE
Prune ArrayMinMax's result to the union of the array at interval level (#833, #815)

### DIFF
--- a/dev_docs/large-domains.md
+++ b/dev_docs/large-domains.md
@@ -52,31 +52,58 @@ The tree already has the machinery: `IntervalSet::each_interval_minus()`,
 that removes "everything not in this small given set" one value at a time is an
 interval operation written out longhand, and rewriting it keeps GAC.
 
-### A trap: a bound that is obvious is not necessarily RUP
+### Getting a range removal past the checker
 
-`ArrayMinMax` has no hull bound on the loose side — for a max it posts
-`result >= lb(var_i)` for every i but never `result <= max_i ub(var_i)`, so the
-per-value union sweep is what establishes it (issue #815, which proposes adding
-the bound as a small, obviously-correct first fix).
+Replacing a per-value removal with a range one is not free in the proof, and the
+reason it is not is worth understanding once, because it decides which
+interval rewrites are cheap.
 
-It is obviously correct, and it is **not a small fix**, because it does not
-verify. Negating it gives `result > max_i ub(var_i)`; each selector asserts
-`result <= var_i`, so every selector must be false and the al1 row fails. That
-argument needs to carry an order atom on `result` across the half-reified row
-relating `result` and `var_i`, which is a linear row over the *bits* — and unit
-propagation does not cross a bit sum on a wide domain, where nothing fixes an
-individual bit. Adding the bound with `JustifyUsingRUP` fails VeriPB on
-`min_max_constraint` and `min_max_constraint_view_mixed`. Making it verify needs
-an explicit `pol` per selector, over line numbers `define_proof_model` does not
-currently keep.
+The conclusion side is fine. Negating `result NOT IN [lo, hi]` gives two opposing
+bounds on `result`, and those *do* contradict through the bit rows — that is the
+configuration `justify_not_in_range_across_equality()` already relies on, and it
+holds even for a signed 63-bit variable.
 
-The interval rewrite of the union sweep is the better target anyway: it fixes the
-general case rather than only the narrow-array one, and the range-removal proof
-pattern it needs already exists and verifies fifty lines further down the same
-file (`min_max.cc:199`, `infer_not_in_range` with a value-independent
-justification emitted once per interval).
+**The blocker is the reason side.** A reason literal `var NOT IN [lo, hi]` is the
+*disjunction* `~ge_lo(var) OR ge_{hi+1}(var)`, and RUP cannot case split. Unit
+propagation can *refute* "result >= lo and var <= lo-1 and f_i", but it cannot
+*derive* "var >= lo" from "result >= lo and f_i". The per-value form never meets
+this, because `result = val` pins every bit of `result`, which pins every bit of
+`var` through the linear row, deciding both halves of the disjunction at once. A
+range pins no bit, so both halves stay open.
 
-H3 has two precedents in the tree for what a good cap looks like:
+The fix is to restate each refutation as a clause the checker can propagate — the
+two ge-layer bound lemmas — and only then draw the conclusion. For `ArrayMinMax`
+that is, per variable `i`:
+
+```
+rup  ~f_i \/ ~ge_lo(result) \/ ge_lo(var_i)             [crosses the half-reified row]
+rup  ~ge_{hi+1}(var_i) \/ ge_{hi+1}(result)             [crosses the unconditional row]
+rup  ~f_i \/ ~in(result,lo,hi) \/ in(var_i,lo,hi)
+```
+
+then RUP the conclusion. **3n+1 lines per interval, independent of the range
+width**, which is the property that matters: the point of the rewrite is to
+replace 9.2x10^18 steps with a constant number, so a procedure linear in `hi-lo`
+would be worthless.
+
+Which of the two lemmas carries the selector depends on which row it crosses. For
+`max` the model has `result >= var_i` unconditionally and `result <= var_i` under
+`f_i`, so the *lower* lemma needs the selector; for `min` it is the upper one.
+This is `justify_not_in_range_across_equality()` generalised from an
+unconditional equality to one that holds only under a guard.
+
+Views keep the per-value path: a view's atoms are spelled through the view and
+the lemmas have not been shown to bridge that. Same restriction, and same reason,
+as the single-support range path in the same file.
+
+**The related trap.** The *hull bound* `result <= max_i ub(var_i)`, which #815
+proposes as a small first fix, is a different problem and is still open. There the
+selector has to be *derived* rather than assumed — the RUP negation does not hand
+you `f_i` — so the lemmas above do not apply and it needs `pol` over OPB line
+numbers `define_proof_model` does not keep. The interval rewrite above makes it
+unnecessary for the case that motivated it.
+
+H3 has two precedents in the tree for what a good cap looks like:H3 has two precedents in the tree for what a good cap looks like:
 `ExtensionalDomainBitmaps::max_words` and `cumulative.cc`'s
 `max_knapsack_capacity`. Both are far above anything a real model asks for, both
 degrade to a named weaker rung rather than silently doing less, and the comment

--- a/gcs/constraints/min_max/min_max.cc
+++ b/gcs/constraints/min_max/min_max.cc
@@ -27,6 +27,7 @@ using std::string;
 using std::stringstream;
 using std::unique_ptr;
 using std::vector;
+using std::ranges::all_of;
 
 ArrayMinMax::ArrayMinMax(vector<IntegerVariableID> vars, const IntegerVariableID result, bool min) : _vars(move(vars)), _result(result), _min(min)
 {
@@ -102,31 +103,107 @@ auto ArrayMinMax::install_propagators(Propagators & propagators) -> void
             }
 
             // result in union(vars)
-            for (auto value : state.each_value_mutable(result)) {
-                bool found_support = false;
-                for (auto & var : vars) {
-                    if (state.in_domain(var, value)) {
-                        found_support = true;
+            //
+            // Interval-level where the proof allows it. The values to remove are
+            // result's domain minus the union of the vars' domains, which is a
+            // handful of ranges however wide the domains are; per value it was
+            // O(|D(result)|) even when it removed nothing, and this loop is also
+            // the only thing that bounds result from the loose side, so on a
+            // domainless FlatZinc objective it had 9.2x10^18 values to get
+            // through and never returned (issue #815).
+            //
+            // The removals are identical either way -- a value survives iff some
+            // var holds it -- so the search does not change, only how many
+            // inferences it takes to get there.
+            auto all_simple = std::holds_alternative<SimpleIntegerVariableID>(IntegerVariableID{result}) &&
+                all_of(vars, [](const IntegerVariableID & v) { return std::holds_alternative<SimpleIntegerVariableID>(v); });
+
+            if (all_simple) {
+                auto unsupported = state.copy_of_values(result);
+                for (const auto & var : vars) {
+                    if (unsupported.empty())
                         break;
-                    }
+                    for (auto [lo, hi] : state.copy_of_values(var).each_interval())
+                        unsupported.erase_range(lo, hi);
                 }
 
-                if (! found_support) {
+                for (auto [lo, hi] : unsupported.each_interval()) {
                     ReasonLiterals reason;
                     for (auto & var : vars)
-                        reason.emplace_back(var != value);
+                        reason.emplace_back(not_in_range(var, lo, hi));
 
-                    inference.infer_not_equal(logger, result, value,
+                    inference.infer_not_in_range(logger, result, lo, hi,
                         JustifyExplicitly{//
-                            [logger, result, value, &selectors](const ReasonLiterals & reason) {
-                                // show that none of the selectors work, if we're taking the result to be that value and also
-                                // that the value is missing from all of the vars
-                                for (const auto & sel : selectors)
-                                    logger->emit_rup_proof_line_under_reason(
-                                        reason, WPBSum{} + (1_i * ! sel) + (1_i * (result != value)) >= 1_i, ProofLevel::Temporary);
+                            [logger, result, min, lo = lo, hi = hi, &vars, &selectors](const ReasonLiterals & reason) {
+                                // The range conclusion cannot be RUPped on its own, and
+                                // not for the reason the per-value form gets away with.
+                                // Negating the conclusion is fine: two opposing bounds on
+                                // result do contradict through the bit rows. It is the
+                                // *reason* that blocks it -- "var not in [lo, hi]" is the
+                                // disjunction ~ge(lo) \/ ge(hi+1), and RUP cannot case
+                                // split. (The per-value form never meets this, because
+                                // result = val pins every bit of result and so pins var's
+                                // too, deciding both halves at once.)
+                                //
+                                // So each half is restated as a clause the checker can
+                                // unit propagate. One of the two crosses the half-reified
+                                // row and carries the selector with it; the other crosses
+                                // the unconditional row and does not. For max the model is
+                                // result >= var_i always and result <= var_i under f_i, so
+                                // it is the lower lemma that needs f_i; for min it is the
+                                // upper one. With both in the database the selector clause
+                                // and the conclusion are plain propagation.
+                                for (const auto & [idx, var] : enumerate(vars)) {
+                                    auto lower = WPBSum{} + 1_i * (result < lo) + 1_i * (var >= lo);
+                                    auto upper = WPBSum{} + 1_i * (var < hi + 1_i) + 1_i * (result >= hi + 1_i);
+                                    if (min)
+                                        upper += 1_i * ! selectors.at(idx);
+                                    else
+                                        lower += 1_i * ! selectors.at(idx);
+
+                                    logger->emit_rup_proof_line_under_reason(reason, move(lower) >= 1_i, ProofLevel::Temporary);
+                                    logger->emit_rup_proof_line_under_reason(reason, move(upper) >= 1_i, ProofLevel::Temporary);
+                                    logger->emit_rup_proof_line_under_reason(reason,
+                                        WPBSum{} + 1_i * ! selectors.at(idx) + 1_i * not_in_range(result, lo, hi) + 1_i * in_range(var, lo, hi) >=
+                                            1_i,
+                                        ProofLevel::Temporary);
+                                }
                             },
                             ThenRUP::Yes, hints::MinMax{owner}},
                         ExplicitReason{reason});
+                }
+            }
+            else {
+                // A view's atoms are spelled through the view, and the bound
+                // lemmas above have not been shown to bridge that, so anything
+                // but a plain variable keeps the per-value path. Same restriction,
+                // and the same reason, as the single-support range path below.
+                for (auto value : state.each_value_mutable(result)) {
+                    bool found_support = false;
+                    for (auto & var : vars) {
+                        if (state.in_domain(var, value)) {
+                            found_support = true;
+                            break;
+                        }
+                    }
+
+                    if (! found_support) {
+                        ReasonLiterals reason;
+                        for (auto & var : vars)
+                            reason.emplace_back(var != value);
+
+                        inference.infer_not_equal(logger, result, value,
+                            JustifyExplicitly{//
+                                [logger, result, value, &selectors](const ReasonLiterals & reason) {
+                                    // show that none of the selectors work, if we're taking the result to be that value and also
+                                    // that the value is missing from all of the vars
+                                    for (const auto & sel : selectors)
+                                        logger->emit_rup_proof_line_under_reason(
+                                            reason, WPBSum{} + (1_i * ! sel) + (1_i * (result != value)) >= 1_i, ProofLevel::Temporary);
+                                },
+                                ThenRUP::Yes, hints::MinMax{owner}},
+                            ExplicitReason{reason});
+                    }
                 }
             }
 

--- a/gcs/constraints/min_max/min_max.cc
+++ b/gcs/constraints/min_max/min_max.cc
@@ -123,7 +123,15 @@ auto ArrayMinMax::install_propagators(Propagators & propagators) -> void
                 for (const auto & var : vars) {
                     if (unsupported.empty())
                         break;
-                    for (auto [lo, hi] : state.copy_of_values(var).each_interval())
+                    // The copy has to be a named local: each_interval() hands out
+                    // a generator that *borrows* the set, which must outlive it
+                    // (see IntervalSet's class documentation). Iterating over a
+                    // temporary's generator leaves it dangling, which reads
+                    // garbage intervals, fails to erase the values that really
+                    // are supported, and so removes supported values from the
+                    // result -- lost solutions, not merely lost pruning.
+                    auto var_values = state.copy_of_values(var);
+                    for (auto [lo, hi] : var_values.each_interval())
                         unsupported.erase_range(lo, hi);
                 }
 


### PR DESCRIPTION
Follows #850. First of the interval rewrites, and the first thing in this stack that makes
a wide-domain model actually work.

## What it does

`ArrayMinMax`'s "result in union(vars)" sweep walked result's whole domain, so it was
O(|D(result)|) **even when it removed nothing** — and it is also the only thing bounding
result from the loose side, so on a domainless FlatZinc objective it had 9.2x10^18 values
to get through and never returned (#815). Compute the unsupported set as result's domain
minus the union of the array's, and remove it a range at a time.

Same removals, so the same search; only the number of inferences changes.

On #815's shape — array `1..101`, result `-10^9..10^9` — this goes from **never
terminating** to **0.004 s and five nodes**.

## The proof, which is the interesting part

My first attempt was wrong, and the way it was wrong is worth recording because it decides
which other interval rewrites are cheap.

A range conclusion is not RUP here, but **not** because "a range atom pins no bits". The
conclusion side is fine: two opposing bounds on `result` do contradict through the bit
rows. **The reason side is the blocker.** A reason literal `var NOT IN [lo, hi]` is the
disjunction `~ge_lo(var) \/ ge_hi+1(var)`, and RUP cannot case split — propagation can
*refute* "result >= lo and var <= lo-1 and f_i" but cannot *derive* "var >= lo" from it.
The per-value form never meets this, because `result = val` pins every bit of `result` and
so pins `var`'s through the linear row, deciding both halves of the disjunction at once.

So each refutation is restated as a clause the checker can propagate — the two ge-layer
bound lemmas — and only then is the conclusion drawn. Per variable:

```
rup  ~f_i \/ ~ge_lo(result) \/ ge_lo(var_i)          [crosses the half-reified row]
rup  ~ge_hi+1(var_i) \/ ge_hi+1(result)              [crosses the unconditional row]
rup  ~f_i \/ ~in(result,lo,hi) \/ in(var_i,lo,hi)
```

then RUP the conclusion. **3n+1 lines per interval, independent of the range width** —
the property that matters, since the whole point is replacing 9.2x10^18 steps with a
constant number.

Which lemma carries the selector depends on which row it crosses: for `max` the model has
`result >= var_i` unconditionally and `result <= var_i` under `f_i`, so the *lower* lemma
needs it; for `min` it is the upper. This is `justify_not_in_range_across_equality()`
generalised from an unconditional equality to a guarded one.

The procedure was derived and verified independently against real solver OPB output before
any of it was written into the propagator — including a signed 63-bit result, a 2^40-wide
gap, and negative controls confirming that dropping either lemma, or dropping the selector
from the one that needs it, makes VeriPB reject.

## What it does not do

Views keep the per-value path: their atoms are spelled through the view and the lemmas have
not been shown to bridge that. Same restriction, and the same reason, as the single-support
range path fifty lines below in the same file.

The audit row for `ArrayMinMax` **stays `KnownTrip`**, correctly. It has a second per-value
sweep — the full-GAC pass over the array variables — which a probe with *every* variable
wide still reaches. That one spins at a flat 6 MB rather than allocating, which is how the
two are told apart.

The hull bound #815 proposes as its own first fix stays unfixed, and is now recorded as a
separate problem rather than a small one: there the selector has to be *derived* rather
than assumed, so these lemmas do not apply and it needs `pol` over OPB line numbers
`define_proof_model` does not keep. This rewrite makes it unnecessary for the case that
motivated it.

## Testing

802/802 guard off, with both `min_max` lanes verifying under VeriPB including the
view-mixed one; audit lane green guard on.

---

Written with the assistance of Claude Opus 5, and of a second model consulted specifically
on the proof procedure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EdcpzKhRabS67Kcfq3eq9e
