### PR TITLE
Cap declared domains at a quarter of the machine range, and diagnose rows that will not fit (#852)

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,6 +388,13 @@ This returns an ``IntegerVariableID``, which is a light-weight handle which you 
 value. For type-safety and avoiding overflow problems, the solver does not accept raw ``int`` and
 similar types directly, and anywhere you use a numerical value you must create an ``Integer``.
 
+For the same reason there is a limit on how wide a domain you may declare: bounds must lie within
+``Integer::min_bounded_value()`` and ``Integer::max_bounded_value()``, which is a quarter of the
+range of the underlying type in each direction, and creating a variable outside it throws an
+``InvalidProblemDefinitionException``. The headroom that leaves is what lets the solver's internal
+arithmetic, and the coefficients it writes into a proof, stay within range; arithmetic itself is
+deliberately not held to the same limit.
+
 You will also want some constraints. These can be found in the ``gcs/constraints/`` directory. Once
 you construct a constraint, you can add it to a problem instance using ``Problem::post``.
 

--- a/gcs/innards/proofs/emit_inequality_to.cc
+++ b/gcs/innards/proofs/emit_inequality_to.cc
@@ -1,5 +1,7 @@
+#include <gcs/innards/integer_overflow.hh>
 #include <gcs/innards/proofs/emit_inequality_to.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
+#include <gcs/innards/proofs/proof_error.hh>
 #include <gcs/innards/proofs/simplify_literal.hh>
 
 #include <util/overloaded.hh>
@@ -88,20 +90,42 @@ namespace
     }
 }
 
+namespace
+{
+    // Writing a row folds constant terms into the right-hand side and negates
+    // every weight to convert <= into >=, so a row whose coefficients and bounds
+    // together do not fit in an Integer fails here -- part-way through building
+    // the string, with the OPB already half written and nothing in the arithmetic
+    // failure naming what was being emitted. Restate it as something a caller can
+    // act on. Variable domains are capped so the ordinary routes cannot reach
+    // this (Integer::max_bounded_value()); large coefficients, or views that
+    // offset a domain outwards, still can. See issue #852.
+    [[noreturn]] auto rethrow_as_proof_error() -> void
+    {
+        throw ProofError{"cannot write a pseudo-Boolean row whose coefficients and variable bounds together do not fit in an Integer; "
+                         "the variables involved may have domains near Integer::max_bounded_value(), or the coefficients may be too large"};
+    }
+}
+
 auto gcs::innards::emit_inequality_to(NamesAndIDsTracker & names_and_ids_tracker, const SumLessThanEqual<Weighted<PseudoBooleanTerm>> & ineq,
     string & out, EnsureNames ensure_names) -> void
 {
     // build up the inequality, adjusting as we go for constant terms,
     // and converting from <= to >=.
-    Integer rhs = -ineq.rhs;
-    for (auto & [w, v] : ineq.lhs.terms) {
-        if (0_i == w)
-            continue;
-        append_or_fold_term_to(names_and_ids_tracker, w, v, out, rhs, ensure_names);
-    }
+    try {
+        Integer rhs = -ineq.rhs;
+        for (auto & [w, v] : ineq.lhs.terms) {
+            if (0_i == w)
+                continue;
+            append_or_fold_term_to(names_and_ids_tracker, w, v, out, rhs, ensure_names);
+        }
 
-    out += ">= ";
-    append_number_to(out, rhs);
+        out += ">= ";
+        append_number_to(out, rhs);
+    }
+    catch (const IntegerOverflow &) {
+        rethrow_as_proof_error();
+    }
 }
 
 auto gcs::innards::emit_reified_inequality_to(NamesAndIDsTracker & names_and_ids_tracker, const SumLessThanEqual<Weighted<PseudoBooleanTerm>> & ineq,
@@ -113,41 +137,46 @@ auto gcs::innards::emit_reified_inequality_to(NamesAndIDsTracker & names_and_ids
     // coefficient, converted from <= to >= as usual.
     auto shape = names_and_ids_tracker.reification_shape(ineq, half_reif);
 
-    Integer rhs = -shape.effective_rhs;
-    for (auto & [w, v] : ineq.lhs.terms) {
-        if (0_i == w)
-            continue;
-        append_or_fold_term_to(names_and_ids_tracker, w, v, out, rhs, ensure_names);
-    }
-
-    // Each reifying term appears negated. A flag or bit negation is a cheap
-    // struct copy, but negating a condition literal builds a whole new
-    // variant chain just to name it -- and both polarities of a condition are
-    // always introduced together, so the negated condition's literal IS the
-    // negation of the condition's literal. Look up the condition as given and
-    // flip the XLiteral instead.
-    auto w = shape.reif_coefficient;
-    for (auto & r : half_reif)
-        overloaded{
-            [&](const ProofFlag & f) { append_or_fold_term_to(names_and_ids_tracker, w, ! f, out, rhs, ensure_names); }, //
-            [&](const ProofLiteral & lit) {
-                overloaded{
-                    [&](const TrueLiteral &) { /* negated: contributes nothing */ }, //
-                    [&](const FalseLiteral &) { rhs += w; },                         //
-                    [&]<typename T_>(const VariableConditionFrom<T_> & cond) {
-                        auto xlit = EnsureNames::Yes == ensure_names ? names_and_ids_tracker.xliteral_for_ensuring(cond)
-                                                                     : names_and_ids_tracker.xliteral_for(cond);
-                        append_term_to(out, -w, names_and_ids_tracker.pb_file_string_for(! xlit));
-                    } //
-                }
-                    .visit(simplify_literal(names_and_ids_tracker, lit));
-            },                                                                                                                     //
-            [&](const ProofBitVariable & bit) { append_or_fold_term_to(names_and_ids_tracker, w, ! bit, out, rhs, ensure_names); } //
+    try {
+        Integer rhs = -shape.effective_rhs;
+        for (auto & [w, v] : ineq.lhs.terms) {
+            if (0_i == w)
+                continue;
+            append_or_fold_term_to(names_and_ids_tracker, w, v, out, rhs, ensure_names);
         }
-            .visit(r);
 
-    out += ">= ";
-    append_number_to(out, rhs);
+        // Each reifying term appears negated. A flag or bit negation is a cheap
+        // struct copy, but negating a condition literal builds a whole new
+        // variant chain just to name it -- and both polarities of a condition are
+        // always introduced together, so the negated condition's literal IS the
+        // negation of the condition's literal. Look up the condition as given and
+        // flip the XLiteral instead.
+        auto w = shape.reif_coefficient;
+        for (auto & r : half_reif)
+            overloaded{
+                [&](const ProofFlag & f) { append_or_fold_term_to(names_and_ids_tracker, w, ! f, out, rhs, ensure_names); }, //
+                [&](const ProofLiteral & lit) {
+                    overloaded{
+                        [&](const TrueLiteral &) { /* negated: contributes nothing */ }, //
+                        [&](const FalseLiteral &) { rhs += w; },                         //
+                        [&]<typename T_>(const VariableConditionFrom<T_> & cond) {
+                            auto xlit = EnsureNames::Yes == ensure_names ? names_and_ids_tracker.xliteral_for_ensuring(cond)
+                                                                         : names_and_ids_tracker.xliteral_for(cond);
+                            append_term_to(out, -w, names_and_ids_tracker.pb_file_string_for(! xlit));
+                        } //
+                    }
+                        .visit(simplify_literal(names_and_ids_tracker, lit));
+                },                                                                                                                     //
+                [&](const ProofBitVariable & bit) { append_or_fold_term_to(names_and_ids_tracker, w, ! bit, out, rhs, ensure_names); } //
+            }
+                .visit(r);
+
+        out += ">= ";
+        append_number_to(out, rhs);
+    }
+    catch (const IntegerOverflow &) {
+        rethrow_as_proof_error();
+    }
 }
 
 auto gcs::innards::emit_inequality_to(

--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -1,4 +1,5 @@
 #include <gcs/innards/assertion_hints.hh>
+#include <gcs/innards/integer_overflow.hh>
 #include <gcs/innards/interval_tree.hh>
 #include <gcs/innards/proofs/hints.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
@@ -2294,59 +2295,76 @@ auto NamesAndIDsTracker::reification_shape(const WPBSumLE & ineq, const HalfReif
     });
 
     // work out how big the reification constant needs to be, by adding together
-    // positive terms in the inequality and negating
+    // positive terms in the inequality and negating.
+    //
+    // This is where a domain too wide for the proof model bites: the sum ranges
+    // over every term, so a row relating two wide variables needs room for both,
+    // and the constant is negated again when the row is rendered. Integer's own
+    // arithmetic catches the overflow, but reports it as a bare arithmetic
+    // failure from deep inside model writing, with the OPB already half written
+    // and nothing naming the variable at fault. Restate it as something a caller
+    // can act on. Problem and State refuse such domains up front
+    // (Integer::max_bounded_value()), so reaching this means a caller built a
+    // wide bound by some other route (issue #852).
     Integer max_contribution_from_positive_terms = 0_i;
 
-    for (auto & [w, v] : ineq.lhs.terms) {
-        overloaded{
-            [&, w = w](const ProofLiteral &) { max_contribution_from_positive_terms += max(0_i, w); }, //
-            [&, w = w](const ProofFlag &) { max_contribution_from_positive_terms += max(0_i, w); },    //
-            [&, w = w](const IntegerVariableID & var) {
-                overloaded{
-                    [&](const SimpleIntegerVariableID & var) {
-                        for (const auto & [bit_value, bit_lit] : each_bit(var))
-                            max_contribution_from_positive_terms += max(0_i, w * bit_value);
-                    }, //
-                    [&](const ViewOfIntegerVariableID & view) {
-                        // A registered view is *emitted* over its own proof-only
-                        // bit-vector (BinEnc(V) directly encodes the view value),
-                        // so the reification constant must be sized from those
-                        // bits too. Sizing it from the underlying variable's bits
-                        // + then_add (the X representation) instead gives a span
-                        // matching the view's value range but smaller than its
-                        // bit-vector's, leaving the reified line valid only modulo
-                        // V's domain bound -- which RUP can't fold in.
-                        if (auto v_proof_id = find_view(view)) {
-                            for (const auto & [bit_value, bit_lit] : each_bit(*v_proof_id))
+    try {
+        for (auto & [w, v] : ineq.lhs.terms) {
+            overloaded{
+                [&, w = w](const ProofLiteral &) { max_contribution_from_positive_terms += max(0_i, w); }, //
+                [&, w = w](const ProofFlag &) { max_contribution_from_positive_terms += max(0_i, w); },    //
+                [&, w = w](const IntegerVariableID & var) {
+                    overloaded{
+                        [&](const SimpleIntegerVariableID & var) {
+                            for (const auto & [bit_value, bit_lit] : each_bit(var))
                                 max_contribution_from_positive_terms += max(0_i, w * bit_value);
-                        }
-                        // The term is w * view = w * ((negate_first ? -actual : actual) + then_add).
-                        // The variable part w * (negate_first ? -actual : actual) has per-bit max
-                        // contribution max(0, ±w * bit_value), with the sign flip depending on
-                        // negate_first. The constant part w * then_add applies regardless and is
-                        // not affected by negate_first.
-                        else if (! view.negate_first) {
-                            for (const auto & [bit_value, bit_lit] : each_bit(view.actual_variable))
-                                max_contribution_from_positive_terms += max(0_i, w * bit_value);
-                            max_contribution_from_positive_terms += max(0_i, w * view.then_add);
-                        }
-                        else {
-                            for (const auto & [bit_value, bit_lit] : each_bit(view.actual_variable))
-                                max_contribution_from_positive_terms += max(0_i, -w * bit_value);
-                            max_contribution_from_positive_terms += max(0_i, w * view.then_add);
-                        }
-                    },                                                                                                                      //
-                    [&](const ConstantIntegerVariableID & cvar) { max_contribution_from_positive_terms += max(0_i, w * cvar.const_value); } //
-                }
-                    .visit(var);
-            }, //
-            [&, w = w](const ProofOnlySimpleIntegerVariableID & var) {
-                for (const auto & [bit_value, bit_lit] : each_bit(var))
-                    max_contribution_from_positive_terms += max(0_i, w * bit_value);
-            },                                                                                             //
-            [&, w = w](const ProofBitVariable &) { max_contribution_from_positive_terms += max(0_i, w); }, //
+                        }, //
+                        [&](const ViewOfIntegerVariableID & view) {
+                            // A registered view is *emitted* over its own proof-only
+                            // bit-vector (BinEnc(V) directly encodes the view value),
+                            // so the reification constant must be sized from those
+                            // bits too. Sizing it from the underlying variable's bits
+                            // + then_add (the X representation) instead gives a span
+                            // matching the view's value range but smaller than its
+                            // bit-vector's, leaving the reified line valid only modulo
+                            // V's domain bound -- which RUP can't fold in.
+                            if (auto v_proof_id = find_view(view)) {
+                                for (const auto & [bit_value, bit_lit] : each_bit(*v_proof_id))
+                                    max_contribution_from_positive_terms += max(0_i, w * bit_value);
+                            }
+                            // The term is w * view = w * ((negate_first ? -actual : actual) + then_add).
+                            // The variable part w * (negate_first ? -actual : actual) has per-bit max
+                            // contribution max(0, ±w * bit_value), with the sign flip depending on
+                            // negate_first. The constant part w * then_add applies regardless and is
+                            // not affected by negate_first.
+                            else if (! view.negate_first) {
+                                for (const auto & [bit_value, bit_lit] : each_bit(view.actual_variable))
+                                    max_contribution_from_positive_terms += max(0_i, w * bit_value);
+                                max_contribution_from_positive_terms += max(0_i, w * view.then_add);
+                            }
+                            else {
+                                for (const auto & [bit_value, bit_lit] : each_bit(view.actual_variable))
+                                    max_contribution_from_positive_terms += max(0_i, -w * bit_value);
+                                max_contribution_from_positive_terms += max(0_i, w * view.then_add);
+                            }
+                        },                                                                                                                      //
+                        [&](const ConstantIntegerVariableID & cvar) { max_contribution_from_positive_terms += max(0_i, w * cvar.const_value); } //
+                    }
+                        .visit(var);
+                }, //
+                [&, w = w](const ProofOnlySimpleIntegerVariableID & var) {
+                    for (const auto & [bit_value, bit_lit] : each_bit(var))
+                        max_contribution_from_positive_terms += max(0_i, w * bit_value);
+                },                                                                                             //
+                [&, w = w](const ProofBitVariable &) { max_contribution_from_positive_terms += max(0_i, w); }, //
+            }
+                .visit(v);
         }
-            .visit(v);
+    }
+    catch (const IntegerOverflow &) {
+        throw ProofError{"cannot size the reification constant for a half-reified row: the sum of its positive contributions does not fit "
+                         "in an Integer. The variables involved may have domains near Integer::max_bounded_value(), or be views offsetting "
+                         "one outwards, or the coefficients may be too large"};
     }
 
     // Usually it would be fine to say 0_i rather than -1_i here, because if a constraint
@@ -2354,6 +2372,14 @@ auto NamesAndIDsTracker::reification_shape(const WPBSumLE & ineq, const HalfReif
     // not. However, for syntactic wrangling reasons, we probably want the implication
     // to always be there.
     auto clamped_reif_const = min(-max_contribution_from_positive_terms + ineq.rhs, -1_i);
+
+    // The rendered row negates this again (emit_inequality_to.cc), and the most
+    // negative Integer has no negation, so catch it here where there is still
+    // something useful to say rather than at the negation.
+    if (clamped_reif_const == Integer::min_value())
+        throw ProofError{"the reification constant for a half-reified row is the most negative Integer, which the >= rendering cannot "
+                         "negate. The variables involved may have domains near Integer::max_bounded_value(), or be views offsetting one "
+                         "outwards, or the coefficients may be too large"};
 
     // if we have a false literal on the left hand side, adjusting the degree of falsity
     // up by the sum of positive terms is enough that it will be trivially true.

--- a/gcs/innards/state.cc
+++ b/gcs/innards/state.cc
@@ -130,6 +130,14 @@ auto State::allocate_integer_variable_with_state(Integer lower, Integer upper) -
 {
     if (lower > upper)
         throw InvalidProblemDefinitionException{"variable created with lower bound greater than upper bound"};
+    // Every route to a variable comes through here, including the auxiliaries
+    // constraints mint for themselves, so this is the one place that can stop a
+    // domain too wide for the proof model to be written (issue #852). It refuses
+    // rather than narrowing: silently shrinking a declared domain would change
+    // what the model means.
+    if (lower < Integer::min_bounded_value() || upper > Integer::max_bounded_value())
+        throw InvalidProblemDefinitionException{"variable created with a domain wider than Integer::min_bounded_value() .. "
+                                                "Integer::max_bounded_value(); the proof model cannot be written for domains this wide"};
     _imp->integer_variable_states.back().emplace_back(lower, upper);
     return SimpleIntegerVariableID{_imp->integer_variable_states.back().size() - 1};
 }

--- a/gcs/innards/state.cc
+++ b/gcs/innards/state.cc
@@ -13,6 +13,14 @@
 #include <variant>
 #include <vector>
 
+#include <version>
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+#include <format>
+#else
+#include <fmt/core.h>
+#endif
+
 using namespace gcs;
 using namespace gcs::innards;
 
@@ -29,6 +37,12 @@ using std::pair;
 using std::string;
 using std::tuple;
 using std::vector;
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+using std::format;
+#else
+using fmt::format;
+#endif
 
 namespace
 {
@@ -135,9 +149,16 @@ auto State::allocate_integer_variable_with_state(Integer lower, Integer upper) -
     // domain too wide for the proof model to be written (issue #852). It refuses
     // rather than narrowing: silently shrinking a declared domain would change
     // what the model means.
+    //
+    // The numbers are spelled out because this message can reach someone who is
+    // using the solver rather than working on it: naming only the constants
+    // would send them to the source to find out what they are.
     if (lower < Integer::min_bounded_value() || upper > Integer::max_bounded_value())
-        throw InvalidProblemDefinitionException{"variable created with a domain wider than Integer::min_bounded_value() .. "
-                                                "Integer::max_bounded_value(); the proof model cannot be written for domains this wide"};
+        throw InvalidProblemDefinitionException{format("variable created with domain {}..{}, which is outside the widest supported "
+                                                       "domain of {}..{} (Integer::min_bounded_value() .. "
+                                                       "Integer::max_bounded_value()); the proof model cannot be written for a domain "
+                                                       "this wide",
+            lower.raw_value, upper.raw_value, Integer::min_bounded_value().raw_value, Integer::max_bounded_value().raw_value)};
     _imp->integer_variable_states.back().emplace_back(lower, upper);
     return SimpleIntegerVariableID{_imp->integer_variable_states.back().size() - 1};
 }

--- a/gcs/integer.hh
+++ b/gcs/integer.hh
@@ -108,6 +108,40 @@ namespace gcs
         {
             return Integer(std::numeric_limits<decltype(raw_value)>::max());
         }
+
+        /**
+         * \name The widest bounds a variable's domain may declare.
+         *
+         * A variable's domain must lie within these, and Problem and State
+         * enforce it. They are a quarter of the machine range, which is two
+         * bits of headroom rather than the obvious one, because writing the
+         * proof model costs more than a single carry: a half-reified row's
+         * reification constant is the sum of the positive contributions of
+         * *every* term, so a row relating two variables needs room for both,
+         * and that constant is then negated when the row is rendered in `>=`
+         * form -- and the most negative machine integer has no negation.
+         *
+         * The boundary is measured, not chosen. At `+/-2^61` `LessThan`, `Plus`
+         * and `AllDifferent` all write their model; at `+/-2^62` all three
+         * abort part-way through, leaving a truncated OPB (issue #852).
+         *
+         * Arithmetic is deliberately *not* held to this: intermediate results
+         * are expected to exceed it, which is what the headroom is for. This
+         * bounds what may be *declared*, so that the ordinary routes into the
+         * solver cannot reach the cliff by accident. Nothing stops a caller
+         * computing a wider value and using it anyway.
+         */
+        ///@{
+        static inline constexpr auto min_bounded_value() -> Integer
+        {
+            return Integer(std::numeric_limits<decltype(raw_value)>::min() / 4);
+        }
+
+        static inline constexpr auto max_bounded_value() -> Integer
+        {
+            return Integer(std::numeric_limits<decltype(raw_value)>::max() / 4);
+        }
+        ///@}
     };
 
     ///@{

--- a/gcs/problem.hh
+++ b/gcs/problem.hh
@@ -136,6 +136,11 @@ namespace gcs
          *
          * The returned handle is only meaningful for as long as this Problem
          * (or a search state created from it) is alive.
+         *
+         * \throws InvalidProblemDefinitionException if the bounds fall outside
+         * Integer::min_bounded_value() .. Integer::max_bounded_value(). That cap
+         * is on what may be *declared*, not on arithmetic; see Integer for why it
+         * sits where it does.
          */
         [[nodiscard]] auto create_integer_variable(Integer lower, Integer upper, const std::optional<std::string> & name = std::nullopt)
             GCS_LIFETIME_BOUND -> SimpleIntegerVariableID;
@@ -147,6 +152,10 @@ namespace gcs
          *
          * The returned handle is only meaningful for as long as this Problem
          * (or a search state created from it) is alive.
+         *
+         * \throws InvalidProblemDefinitionException if the smallest or largest
+         * value given falls outside Integer::min_bounded_value() ..
+         * Integer::max_bounded_value(); the holes in between are unconstrained.
          */
         [[nodiscard]] auto create_integer_variable(const std::vector<Integer> & domain, const std::optional<std::string> & name = std::nullopt)
             GCS_LIFETIME_BOUND -> SimpleIntegerVariableID;
@@ -156,6 +165,9 @@ namespace gcs
          * whose domain goes from lower to upper (inclusive). The final argument
          * gives an optional name that will appear in some output; it does not
          * have to be unique.
+         *
+         * \throws InvalidProblemDefinitionException on the same bounds condition
+         * as Problem::create_integer_variable.
          */
         [[nodiscard]] auto create_integer_variable_vector(std::size_t how_many, Integer lower, Integer upper,
             const std::optional<std::string> & name = std::nullopt) GCS_LIFETIME_BOUND -> std::vector<IntegerVariableID>;
@@ -170,6 +182,9 @@ namespace gcs
          * [ a, b, c ] = create_n_integer_variables<3>(1_i, 3_i);
          * ```
          * Otherwise, use Problem::create_integer_variable_vector instead.
+         *
+         * \throws InvalidProblemDefinitionException on the same bounds condition
+         * as Problem::create_integer_variable.
          */
         template <std::size_t n_>
         [[nodiscard]] auto create_n_integer_variables(Integer lower, Integer upper, const std::optional<std::string> & name = std::nullopt)

--- a/gcs/problem_test.cc
+++ b/gcs/problem_test.cc
@@ -3,6 +3,7 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include <string>
+#include <vector>
 
 using namespace gcs;
 using namespace std::string_literals;
@@ -50,4 +51,19 @@ TEST_CASE("Problem rejects duplicate variable names")
 
     CHECK_NOTHROW(p.create_integer_variable(0_i, 1_i, "dup"s));
     CHECK_THROWS_AS(p.create_integer_variable(0_i, 1_i, "dup"s), NamingError);
+}
+
+TEST_CASE("Problem rejects a domain too wide for the proof model")
+{
+    // The boundary is measured rather than chosen: at these bounds LessThan,
+    // Plus and AllDifferent all write their model, and one bit wider all three
+    // abort part-way through emission and leave a truncated OPB (issue #852).
+    Problem p;
+    CHECK_NOTHROW(p.create_integer_variable(Integer::min_bounded_value(), Integer::max_bounded_value()));
+    CHECK_THROWS_AS(p.create_integer_variable(Integer::min_bounded_value() - 1_i, 0_i), InvalidProblemDefinitionException);
+    CHECK_THROWS_AS(p.create_integer_variable(0_i, Integer::max_bounded_value() + 1_i), InvalidProblemDefinitionException);
+    CHECK_THROWS_AS(p.create_integer_variable(Integer::min_value() / 2_i, Integer::max_value() / 2_i), InvalidProblemDefinitionException);
+
+    // The vector overload goes through the same check.
+    CHECK_THROWS_AS(p.create_integer_variable(std::vector<Integer>{0_i, Integer::max_value() / 2_i}), InvalidProblemDefinitionException);
 }

--- a/gcs/solve_test.cc
+++ b/gcs/solve_test.cc
@@ -6,11 +6,13 @@
 #include <gcs/constraints/equals.hh>
 #include <gcs/constraints/in.hh>
 #include <gcs/constraints/innards/constraints_test_utils.hh>
+#include <gcs/constraints/linear.hh>
 #include <gcs/constraints/modulus.hh>
 #include <gcs/constraints/plus.hh>
 #include <gcs/constraints/power.hh>
 #include <gcs/constraints/table.hh>
 #include <gcs/expression.hh>
+#include <gcs/innards/proofs/proof_error.hh>
 #include <gcs/presolver.hh>
 #include <gcs/presolvers/auto_table.hh>
 #include <gcs/problem.hh>
@@ -842,4 +844,28 @@ TEST_CASE("A constraint that is trivially unsatisfiable at install time says whi
         CHECK(important[0].text.ends_with(", so the model is unsatisfiable before search starts"));
         CHECK(render(important[0]).ends_with(" (_1)"));
     }
+}
+
+TEST_CASE("A row too large to render says so, rather than failing as bare arithmetic")
+{
+    // Writing a pseudo-Boolean row sums the positive contributions of every term
+    // to size a half-reified row's reification constant, negates weights to turn
+    // <= into >=, and folds constants into the right-hand side. Any of those can
+    // exceed an Integer, and used to surface as a bare "Integer overflow" from
+    // deep inside model writing --- with the OPB already half written and nothing
+    // naming what was being emitted (issue #852).
+    //
+    // Variable domains are capped at Integer::max_bounded_value() so the ordinary
+    // routes cannot get here; large coefficients still can, which is what this
+    // uses. The point is the diagnosis, not the refusal: the row genuinely does
+    // not fit, and refusing it is right.
+    Problem p;
+    auto a = p.create_integer_variable(0_i, 1024_i), b = p.create_integer_variable(0_i, 1024_i);
+    auto r = p.create_integer_variable(0_i, 1_i);
+    p.post(LinearEqualityIff{WeightedSum{} + Integer{1LL << 60} * a + Integer{1LL << 60} * b, 0_i, r == 1_i});
+
+    auto proof_name = "solve_test_row_too_large";
+    CHECK_THROWS_AS(solve_with(p, SolveCallbacks{.solution = [](const CurrentState &) { return false; }, .stats_report = silent_stats_report()},
+                        ProofOptions{proof_name}),
+        ProofError);
 }

--- a/minizinc/fzn_glasgow.cc
+++ b/minizinc/fzn_glasgow.cc
@@ -459,9 +459,13 @@ auto main(int argc, char * argv[]) -> int
             }
             else if (var_type == "int") {
                 if (! vardata.contains("domain")) {
-                    // Halve the bounds so there is headroom for sums and products of
-                    // unbounded variables to stay within Integer without overflowing.
-                    auto var = problem.create_integer_variable(Integer::min_value() / 2_i, Integer::max_value() / 2_i, name);
+                    // The widest domain the solver accepts, which leaves headroom
+                    // for sums and products of unbounded variables to stay within
+                    // Integer. Halving was one bit short: writing a half-reified
+                    // row over two such variables overflowed while emitting the OPB
+                    // (issue #852), so the bound is a named quarter now rather than
+                    // a local guess.
+                    auto var = problem.create_integer_variable(Integer::min_bounded_value(), Integer::max_bounded_value(), name);
                     data.integer_variables.emplace(name, pair{var, false});
                     if ((! vardata.contains("defined")) || (! vardata["defined"].get<bool>()))
                         data.branch_variables.push_back(var);


### PR DESCRIPTION
Fixes #852. Independent of the #833 stack — this is proof emission, not large-domain
propagation — so it is based on `main`.

## The measurement

The boundary is measured, not chosen. Same three constraints, varying only the width:

| declared domain | `LessThan` | `Plus` | `AllDifferent`/VC |
|---|---|---|---|
| `[-2^61, 2^61-1]` | writes its model | writes its model | writes its model |
| `[-2^62, 2^62-1]` | aborts mid-OPB | aborts mid-OPB | aborts mid-OPB |

`2^62` is exactly what `fzn_glasgow.cc` gave a domainless FlatZinc `var int`, so any model
with two domainless ints in one constraint could not be proof-logged, and the failure left
a **truncated OPB** rather than a diagnostic.

Two bits of headroom rather than the obvious one, because emission costs more than a
single carry: a half-reified row's reification constant is the sum of the positive
contributions of *every* term, so a row relating two variables needs room for both — and
that constant is negated again when the row is rendered in `>=` form, and the most negative
`Integer` has no negation.

## The cap

`Integer::min_bounded_value()` / `max_bounded_value()` name a quarter of the machine range.
`State::allocate_integer_variable_with_state` refuses anything wider, and `fzn-glasgow`
uses the constants.

The check is on the `State` primitive rather than on `Problem` because constraints mint
auxiliaries there directly (`power.cc:185`, `divide_modulus.cc:134`) and would otherwise
bypass it. **It refuses rather than narrowing** — silently shrinking a declared domain
would change what the model means.

`fzn_glasgow.cc`'s comment already said the bounds were halved "so there is headroom": the
intent was right and the amount was one bit short, so this makes the existing comment true
rather than contradicting it.

Arithmetic is deliberately **not** held to the cap. Intermediates are expected to exceed
it — that is what the headroom is for. This bounds what may be *declared*, so the ordinary
routes cannot reach the cliff by accident; nothing stops a caller computing a wider value
and using it anyway, which is why the emitter is hardened too rather than trusting the cap.

## The hardening

Three emission sites can overflow, and each now restates the arithmetic failure as a
`ProofError` naming what did not fit:

* sizing the reification constant (`reification_shape`);
* that constant landing on the most negative `Integer` — caught there, where something
  useful can still be said, rather than downstream at the negation in `emit_inequality_to`
  where nothing knows which variable is at fault;
* the coefficient and right-hand-side folding, in **both** row renderers. I found this one
  only by trying to reach the first two, which is why it is here and not in my first pass.

This makes the failure legible; it does not make wide rows work. With the cap in place no
ordinary route reaches it — **large coefficients still do**, which is what the regression
test uses: a reified linear with `2^60` coefficients now names the reification constant
instead of failing as bare arithmetic.

## Deliberately not fixed

A fourth overflow site turned up while testing: `tidy_up_linear` (`linear/utils.cc:38`)
overflows while normalising a linear constraint whose constant does not fit, **with proofs
off entirely**. Refusing that is correct — the constraint genuinely does not fit — and only
its message is poor, so it is a separate change.

## Worth a second opinion on review

* The cap binds **internal auxiliaries** too, not just user variables. Nothing in the suite
  trips it, but a constraint wanting a legitimately wide auxiliary is now refused rather
  than producing a broken proof. I think that is right, since it *would* be broken, but it
  is a behaviour change beyond the FlatZinc path.
* `min_bounded_value()` / `max_bounded_value()` are public API on `Integer`, since
  `fzn-glasgow` needs them and callers should be able to see the limit they are held to.

## Testing

802/802. New coverage: the cap's boundary in `problem_test.cc` (both overloads), and the
emission diagnostic in `solve_test.cc`.

---

Written with the assistance of Claude Opus 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EdcpzKhRabS67Kcfq3eq9e
