### PR TITLE
Guard the one domain walk State's iterators cannot see (#833)

### DIFF
--- a/dev_docs/large-domains.md
+++ b/dev_docs/large-domains.md
@@ -103,7 +103,7 @@ you `f_i` — so the lemmas above do not apply and it needs `pol` over OPB line
 numbers `define_proof_model` does not keep. The interval rewrite above makes it
 unnecessary for the case that motivated it.
 
-H3 has two precedents in the tree for what a good cap looks like:H3 has two precedents in the tree for what a good cap looks like:
+H3 has two precedents in the tree for what a good cap looks like:
 `ExtensionalDomainBitmaps::max_words` and `cumulative.cc`'s
 `max_knapsack_capacity`. Both are far above anything a real model asks for, both
 degrade to a named weaker rung rather than silently doing less, and the comment
@@ -132,6 +132,14 @@ Two kinds of check, and the difference matters:
   branching heuristic asks for a generator over a billion-value domain and reads
   one value from it, which is fine. An early version of this guard checked the
   width and condemned `Plus`, `Abs`, `LessThan` and `LinearEquality` for it.
+
+  `State`'s iterators are not the only way a propagator walks a domain: it can
+  also build an `IntervalSet` of its own and walk that, which `State` never sees.
+  Such a loop needs its own counter, declared at the loop. `Element`'s sweep over
+  the result values the array does not support (`element.cc`) is the one such site
+  outside proof logging, and it is instrumented. The counter does not belong in
+  `IntervalSet::each()` itself, which is a general container used for deliberate
+  enumeration — tabulation, and the tests.
 * **`GCS_CHECK_LARGE_DOMAIN`** checks a size up front, for the H3 sites that
   commit to a whole array at once.
 

--- a/gcs/constraints/element/element.cc
+++ b/gcs/constraints/element/element.cc
@@ -4,6 +4,7 @@
 #include <gcs/constraints/equals.hh>
 #include <gcs/exception.hh>
 #include <gcs/innards/inference_tracker.hh>
+#include <gcs/innards/large_domain_guard.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/proofs/proof_model.hh>
@@ -619,7 +620,19 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators_impl(Prop
                 };
                 collect_supported_values(collect_supported_values, 0);
 
+                // The set left over is the result's domain minus what the array
+                // covers, so a narrow array over a wide result leaves nearly the
+                // whole domain to walk a value at a time. The guard belongs here
+                // rather than only on State's iterators: this walks an IntervalSet
+                // the propagator built for itself, which those never see, and a
+                // walk of that shape is the same #833 hazard however the values
+                // were obtained. Without it the probe's outcome is decided by how
+                // much memory the machine happens to have -- 16 GB and 81 s here,
+                // a bad_alloc somewhere smaller -- which is not a test result.
+                LargeDomainIterationCounter unsupported_guard{"the number of unsupported result values one Element propagation has walked"};
+
                 for (auto value : still_to_find_support_for.each()) {
+                    unsupported_guard.step();
                     // index_vars stay a declarative generic_reason, concatenated with
                     // the per-considered-var literals; assembled only when a reason
                     // will be read.


### PR DESCRIPTION
Part of #833, stacked on #854.

The audit lane's `Element` row is pinned `KnownTrip` and had started surviving. The
both-ways pinning caught it, and nothing had been fixed: the probe still walks a billion
values, it just does not always die of it. Standalone it takes **81 seconds and 16 GB of
resident memory** and then finishes, so whether the row trips is decided by how much memory
the machine happens to have — a `bad_alloc` on a smaller one, a pass here.

That is a hole in the lane's central claim, which is that a wedged core or a `bad_alloc`
becomes a deterministic test result.

The gap is that the guard only instruments `State`'s iterators. `Element` does not use one
here: it builds its own `IntervalSet` of result values the array does not support and walks
that, which `State` never sees. Same hazard, invisible to the guard.

So the counter goes at the loop. Deliberately *not* into `IntervalSet::each()`, which is a
general container that tabulation and the tests iterate on purpose. A sweep of the tree
finds exactly two propagator loops of this shape; the other (`count.cc`) is inside a
proof-emit lambda, so it cannot run in the lane's no-proof pass and is covered by its own
row already.

The row goes back to tripping for the reason it is meant to: `Element`'s GAC sweep is an
H1a site and stage 4 has yet to reach it.

**Guard off, this is absent rather than merely cheap.** All 1265 executable sections of
`element.cc.o` are unchanged in size and the disassembly is byte-identical to the parent
commit's; the object differs only in line-table debug info.

Also fixes a sentence duplicated in the H3 paragraph of `dev_docs/large-domains.md`.

802/802, and the audit lane is green again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EdcpzKhRabS67Kcfq3eq9e
