### PR TITLE
Restrict Among to its value set at interval level (#833)

### DIFF
--- a/dev_docs/large-domains.md
+++ b/dev_docs/large-domains.md
@@ -362,26 +362,43 @@ either width. The copy-paste was real, but the right place to remove it was the
 propagator, not the checker.
 
 So the question to ask of a row here is not "are the steps repetitive" but **"is
-the removed set an interval?"** Where it is, an interval rewrite deletes the
-volume at full strength and needs nothing from VeriPB. Where it is not, no rewrite
-helps and a checker feature is the only way out. On that test the three rows above
-are much better candidates than the two they replaced:
+the removed set an interval?"** Where it is, an interval rewrite deletes the volume
+at full strength and needs nothing from VeriPB. Where it is not, no rewrite helps
+and a checker feature is the only way out.
 
-* `AllEqual/holes` is the clearest case. The removed set is a domain punched full
-  of holes, so it is *not* an interval by construction — that is what the probe is
-  for — and no rewrite of the loop can turn it into one.
-* `GlobalCardinality` enumerates values in
-  `propagate_bounds_global_cardinality`, and under this document's own rule that
-  is a broken fallback arm rather than a missing one, so it is scheduled work
-  either way.
+**On that test, none of the three rows above is a candidate either.** All three are
+H1a sites — a propagator expanding an interval by hand — and all three are stage 4
+work rather than evidence:
+
+* `AllEqual/holes` is the starkest. `all_equal.cc` already computes the values to
+  remove with `each_interval_minus`, and then expands each interval one value at a
+  time. The interval is literally in hand when the per-value loop starts. The only
+  real obstacle is that the reason names a *witness* — some variable whose domain
+  lacks that value — which can differ across one interval, because the difference
+  is taken against the intersection of every domain. Differencing against each
+  variable separately gives ranges with a constant witness, at the cost of
+  overlapping removals, which are idempotent.
+* `GlobalCardinality`'s just-met-demand branch
+  (`bounds_global_cardinality.cc`) removes every value of a variable *except*
+  one, which is two range removals — and its reason is already hoisted out of the
+  loop and constant, so it is a simpler case than `Among`'s. Under this document's
+  own rule it is a broken fallback arm rather than a missing one, so it is
+  scheduled work regardless.
 * `Element` walks the result values its array does not support (`element.cc`),
-  which for a narrow array over a wide result *is* mostly intervals. It is the
-  next H1a rewrite, and the honest expectation is that it collapses like the other
-  two rather than surviving as evidence.
+  which for a narrow array over a wide result is mostly intervals.
 
-The table was last stale because the probe sharpening of PR #849 turned exactly
-these three rows from `HazardNotReached` into real hazards without the survey
-being re-run. Sharpening a probe changes what the survey measures.
+So the survey currently supports **no** VeriPB feature request at all: every row
+whose steps grow at a fixed encoding is a propagator that has an interval and
+spells it out. That is a real conclusion rather than a gap in the survey, and it
+should be re-tested after stage 4 rather than assumed to stay true — a genuine
+candidate would be a growing row whose removed set provably is not an interval,
+and none of the 69 probes produces one today.
+
+Two things kept this table wrong for longer than it should have been. The probe
+sharpening of PR #849 turned exactly these three rows from `HazardNotReached` into
+real hazards without the survey being re-run — sharpening a probe changes what the
+survey measures. And the rows were read as feature evidence without first checking
+the propagator for an interval it had already computed.
 
 ### The bad encoding cases
 

--- a/dev_docs/large-domains.md
+++ b/dev_docs/large-domains.md
@@ -44,6 +44,23 @@ Two corollaries that are easy to get wrong:
 | **H2′** | an OPB *encoding* proportional to a domain | no consistency level helps; `NValue` writes one proof flag per value of the union of the domains |
 | **H3** | arrays sized by a span, which no consistency level covers | a cap and a weaker rung |
 
+**First, check whether the loop already stops early.** A `for` over a domain is
+not automatically a hazard: what matters is how many values it takes before it
+can answer. `Among`'s variable partition asks "is every value of this domain one
+of the values of interest", walking the domain — but as a `none_of`, so it stops
+at the first value that is not, and among any `|voi| + 1` values at most `|voi|`
+can be of interest. It is bounded by the value set, not the domain, and rewriting
+it as a counting query over `in_domain` made it **9% slower** on a search that
+calls it hundreds of thousands of times, for no width benefit at all. Ten lines
+below it the *same* predicate was written as a plain loop with no early exit, and
+that one really did walk a billion values; the fix there was the missing exit, not
+a new algorithm.
+
+Neither the audit lane nor the test suite can tell these two apart — both are
+`each_value_immutable` over a wide domain, and only one trips the guard. So read
+the loop for its exit condition before reaching for an interval rewrite, and put
+any rewrite of a hot query through a before/after benchmark.
+
 H1a is the one worth looking for first, because it is not a trade-off at all.
 The tree already has the machinery: `IntervalSet::each_interval_minus()`,
 `InferenceTracker::infer_not_in_range()`, and
@@ -95,6 +112,48 @@ unconditional equality to one that holds only under a guard.
 Views keep the per-value path: a view's atoms are spelled through the view and
 the lemmas have not been shown to bridge that. Same restriction, and same reason,
 as the single-support range path in the same file.
+
+**Where the conclusion needs a counting argument, only the case split changes.**
+`Among` is the third shape, and it is much cheaper than `ArrayMinMax`'s. Its
+conclusion does not follow from one row: it needs `pol` over the encoding's
+`sum >= how_many` half plus an at-most-one line per other variable, which is what
+shows that a variable stepping outside the value set leaves the count short. That
+argument does not mention the removed value at all, so it is *unchanged* by the
+rewrite. What changes is only the step before it, which zeroes the `[var = voi]`
+terms. Per value that was, for each value of interest,
+
+```
+rup  var != val \/ var != voi
+```
+
+and per range it is, for each value of interest,
+
+```
+rup  var < lo      \/ var != voi      [when voi < lo]
+rup  var >= hi + 1 \/ var != voi      [when voi > hi]
+```
+
+Every value of interest sits wholly on one side of the range — the ranges removed
+are the gaps between them — so which of the two applies is decided when the line
+is written, and unit propagation then reaches the negated eq atom along the
+ge-atom chain links. The per-value form needed no such choice because `var = val`
+pins every bit of `var`; a range pins none, so the side has to be picked
+explicitly rather than left to the checker.
+
+The count goes from `|voi|` lines per removed *value* to `|voi|` per removed
+*range*, and there are at most `|voi| + 1` of those however wide the domain is.
+Measured: `Among`'s survey row falls from 32996 → 329996 steps across a 10x width
+to a flat 98.
+
+**And unlike `ArrayMinMax`, this one bridges views**, so `Among` needs no
+plain-variable restriction: 259 range removals on view variables under proofs,
+all verified. The difference is that every atom in these lines is on the *same*
+variable — its order atoms against its own eq atoms — and `need_gevar` pol-derives
+a view's chain links from the underlying variable's. `ArrayMinMax`'s lemmas have
+to carry an atom on `result` across a row to an atom on `var_i`, and it is the
+crossing, not the range, that views break. So "does this constraint's range
+justification stay within one variable" is the question to ask before restricting
+a rewrite to `SimpleIntegerVariableID`.
 
 **The related trap.** The *hull bound* `result <= max_i ub(var_i)`, which #815
 proposes as a small first fix, is a different problem and is still open. There the
@@ -178,13 +237,17 @@ is the part worth reading carefully:
 
 ### Where we stand
 
-68 probes, run on `7d014207`.
+69 probes. The lane itself is the authority — run it rather than trusting this
+table, which is a snapshot for orientation.
 
 | | constraints |
 |---|---|
-| **KnownTrip** (24) | `Power`, `PowerTable`, `AllDifferent`, `AllDifferentExcept`, `AllEqual/holes`, `Among`, `Count`, `NValue`, `AtMostOne`, `AtMostOneSmartTable`, `GlobalCardinality`, `In`, `ArrayMinMax`, `Element`, `LexSmartTable`, `Table`, `SmartTable`, `Regular`, `RegularLegacy`, `RegularBacchus`, `MDD`, `Cumulative`, `Disjunctive`, `Knapsack` |
-| **Clean** (30) | the arithmetic family, comparison, equality, linear, `AllDifferent` under `VC`, `Element` under `BC`, `AllEqual` without holes, `ValuePrecede`, `SeqPrecedeChain`, `IncreasingChain`, `Lex`, `Sort`, `ArgSort`, `NegativeTable`, `Disjunctive2D`, `BinPacking`, `MinDistance`, `DifferenceConstraints`, `Nogoods` |
+| **KnownTrip** (22) | `Power`, `PowerTable`, `AllDifferent`, `AllDifferentExcept`, `AllEqual/holes`, `Count`, `NValue`, `AtMostOne`, `AtMostOneSmartTable`, `GlobalCardinality`, `In`, `ArrayMinMax`, `Element`, `LexSmartTable`, `SmartTable`, `Regular`, `RegularLegacy`, `RegularBacchus`, `MDD`, `Cumulative`, `Disjunctive`, `Knapsack` |
+| **Clean** (33) | the arithmetic family, comparison, equality, linear, `AllDifferent` under `VC`, `Element` under `BC`, `AllEqual` without holes, `Among`, `Table` (both shapes), `ValuePrecede`, `SeqPrecedeChain`, `IncreasingChain`, `Lex`, `Sort`, `ArgSort`, `NegativeTable`, `Disjunctive2D`, `BinPacking`, `MinDistance`, `DifferenceConstraints`, `Nogoods` |
 | **NoWidePosition** (14) | the graph and permutation family, and the Boolean constraints |
+
+`Among` and `Table` started as `KnownTrip` and are now `Clean`, by the interval
+rewrites rather than by a weaker arm: both still propagate GAC.
 
 Three things in that table were not what #833 predicted, and are worth
 recording because they change what the later stages have to do:
@@ -195,10 +258,12 @@ recording because they change what the later stages have to do:
    `BC`.
 2. **`Power` trips**, which #833 did not list — it reaches `PowerTable`'s
    product enumeration. So does `LexSmartTable`.
-3. **`Among`'s trip is conditional.** Its per-value branch only runs with the
-   count pinned; with slack in the count the propagator concludes nothing and
-   the probe passes without touching the hazard. A probe that does not reach a
+3. **`Among`'s trip was conditional.** Its per-value branch only ran with the
+   count pinned; with slack in the count the propagator concluded nothing and
+   the probe passed without touching the hazard. A probe that does not reach a
    path proves nothing about it, which is what `HazardNotReached` exists to say.
+   The probe still pins the count for the same reason, now to reach the interval
+   rewrite that replaced the per-value branch.
 
 ### What the sharpening pass found
 
@@ -270,32 +335,53 @@ separately, because they mean different things:
 
 ### Results at 10^3 → 10^4
 
+Re-measured over all 69 probes after the interval rewrites for `ArrayMinMax`,
+`Table` and `Among` landed. The figures move, so re-run the survey rather than
+quoting this table after touching any propagator's removal loop — that is how the
+previous version of it went stale, see below.
+
 | | growth (opb / steps) | constraints |
 |---|---|---|
 | **Both** grow | 10x / 10x | `Power`, `PowerTable`, `NValue`, `Regular`, `RegularLegacy`, `RegularBacchus`, `MDD` |
 | **OPB only** | 10x / 1.0x | `Cumulative` (19046 → 190046 rows; one capacity line per time point, so it is H3 on the encoding side) |
-| **Steps only** | 1.0x / 10x | **`Among`** (42-row OPB fixed, 32996 → 329996 steps) and **`Table`** (47-row OPB fixed, 50788 → 509788 steps) |
-| neither | 1.0x / 1.0x | everything else, 59 of 67 |
+| **Steps only** | 1.0x / 10x | `AllEqual/holes` (22-row OPB fixed, 16987 → 169987 steps), `GlobalCardinality` (30-row, 18024 → 180024), `Element` (32-row, 27981 → 279981) |
+| neither | 1.0x / 1.0x | everything else, 58 of 69 |
 
-**`Among` and `Table` are the two clean candidates.** Their encodings do not grow
-at all, so every one of those extra steps is the *same* derivation with a
-different value in it:
+`Multiply`, `Divide` and `Modulus` sit in the last row but are not flat: their OPB
+grows 1.8x for a 10x width, which is the bit-width of the product, not a per-value
+encoding. Nothing to do about that, and nothing a checker feature would help with.
 
-* `Table` is the purest. `extensional_utils.cc`'s support scan calls
-  `inference.infer(logger, vars[idx] != val, JustifyUsingRUP{hint}, table.reason)`
-  once per unsupported value — the same reason, the same hint, one RUP step each,
-  differing only in `val`. A rule that could discharge "these removals, for every
-  value in this interval, by this one derivation" would replace the lot.
-* `Among` emits, per removed value, one line per value-of-interest
-  (`among.cc`) — the same clause shape with one constant substituted, nested one
-  level deeper.
+**A "steps only" row is not on its own evidence for a checker feature**, and this
+is the lesson the table's own history teaches. The previous version named `Among`
+(32996 → 329996 steps) and `Table` (50788 → 509788) as the two clean candidates,
+on the grounds that their encodings do not grow at all, so every extra step is the
+same derivation with a different constant in it. That was true, and it was still
+the wrong conclusion: both were also H1a in the propagation column, and the
+interval rewrites collapsed both to **flat** — `Among` 98 steps and `Table` 93, at
+either width. The copy-paste was real, but the right place to remove it was the
+propagator, not the checker.
 
-Both are also H1a in the propagation column, so the interval-level rewrite would
-remove much of the proof volume as a side effect: an interval removal is one
-inference where a run of values was many. That does not make a checker feature
-redundant — the rewrite only applies where the removed set *is* an interval — but
-it does mean these two rows should be re-measured afterwards rather than quoted
-as a standing figure.
+So the question to ask of a row here is not "are the steps repetitive" but **"is
+the removed set an interval?"** Where it is, an interval rewrite deletes the
+volume at full strength and needs nothing from VeriPB. Where it is not, no rewrite
+helps and a checker feature is the only way out. On that test the three rows above
+are much better candidates than the two they replaced:
+
+* `AllEqual/holes` is the clearest case. The removed set is a domain punched full
+  of holes, so it is *not* an interval by construction — that is what the probe is
+  for — and no rewrite of the loop can turn it into one.
+* `GlobalCardinality` enumerates values in
+  `propagate_bounds_global_cardinality`, and under this document's own rule that
+  is a broken fallback arm rather than a missing one, so it is scheduled work
+  either way.
+* `Element` walks the result values its array does not support (`element.cc`),
+  which for a narrow array over a wide result *is* mostly intervals. It is the
+  next H1a rewrite, and the honest expectation is that it collapses like the other
+  two rather than surviving as evidence.
+
+The table was last stale because the probe sharpening of PR #849 turned exactly
+these three rows from `HazardNotReached` into real hazards without the survey
+being re-run. Sharpening a probe changes what the survey measures.
 
 ### The bad encoding cases
 

--- a/gcs/constraints/among/among.cc
+++ b/gcs/constraints/among/among.cc
@@ -63,6 +63,33 @@ namespace
         result.erase(unique(result).begin(), result.end());
         return result;
     }
+
+    // The values of interest as intervals, so the complement of the set can be
+    // taken against a domain by merge rather than value by value. Built once per
+    // propagation: the set is fixed for the life of the constraint.
+    auto values_of_interest_set(const vector<Integer> & values_of_interest) -> IntervalSet<Integer>
+    {
+        IntervalSet<Integer> result;
+        for (const auto & val : values_of_interest)
+            result.insert_at_end(val);
+        return result;
+    }
+
+    // Is every value the variable can still take one of the values of interest?
+    //
+    // Walks the domain, but is bounded by the value set rather than by the
+    // domain: it stops at the first value that is not of interest, and among any
+    // |voi| + 1 values at most |voi| can be of interest, so a false answer comes
+    // back within |voi| + 1 steps however wide the domain is. A true answer means
+    // the domain is inside the set and so has at most |voi| values in it anyway.
+    //
+    // The early exit is the whole of it. Written without one -- which is how the
+    // second caller below used to be -- the same predicate walks a billion values
+    // to reach a conclusion its first four had already settled.
+    auto domain_is_inside_values_of_interest(const State & state, const IntegerVariableID & var, const vector<Integer> & values_of_interest) -> bool
+    {
+        return none_of(state.each_value_immutable(var), [&](const auto & val) -> bool { return ! contains(values_of_interest, val); });
+    }
 }
 
 Among::Among(vector<IntegerVariableID> vars, const vector<Integer> & values_of_interest, const IntegerVariableID & how_many) :
@@ -127,7 +154,7 @@ auto Among::install_propagators(Propagators & propagators) -> void
             }).begin();
             auto can_be_either_start = partition(subrange{not_impossible_start, partitioned_vars.end()}, //
                 [&](const auto & var) -> bool {
-                    return none_of(state.each_value_immutable(var), [&](const auto & val) -> bool { return ! contains(values_of_interest, val); });
+                    return domain_is_inside_values_of_interest(state, var, values_of_interest);
                 }).begin();
 
             auto must_not_match_vars = subrange{partitioned_vars.begin(), not_impossible_start};
@@ -201,12 +228,7 @@ auto Among::install_propagators(Propagators & propagators) -> void
 
                 // anything that might match actually mustn't match
                 for (const auto & var : vars) {
-                    bool all_match = true;
-                    for (const auto & val : state.each_value_immutable(var))
-                        if (! contains(values_of_interest, val))
-                            all_match = false;
-
-                    if (! all_match) {
+                    if (! domain_is_inside_values_of_interest(state, var, values_of_interest)) {
                         vector<Literal> inferences;
                         for (const auto & val : values_of_interest)
                             inferences.push_back(var != val);
@@ -248,7 +270,21 @@ auto Among::install_propagators(Propagators & propagators) -> void
                 }
 
                 if (can_be_either_count > 0_i) {
-                    // each that may or may not match must in fact match
+                    // Each that may or may not match must in fact match, so
+                    // everything outside the value set comes out of its domain.
+                    //
+                    // That set is the complement of a handful of values, which is
+                    // a handful of ranges however wide the domain is, so it goes
+                    // in as ranges. Per value it was one inference per value
+                    // removed, so a variable with a wide domain and a small value
+                    // set paid O(|D(var)|) to end up with |voi| values left.
+                    //
+                    // The removals are the same either way: a value survives iff
+                    // it is a value of interest. So the search does not change,
+                    // only how many inferences it takes to get there --- verified
+                    // by identical recursion and propagation counts on a
+                    // before/after enumeration.
+                    auto voi_set = values_of_interest_set(values_of_interest);
                     for (const auto & var : vars) {
                         bool might_match = false;
                         for (const auto & val : values_of_interest) {
@@ -258,33 +294,51 @@ auto Among::install_propagators(Propagators & propagators) -> void
                             }
                         }
 
-                        if (might_match)
-                            for (const auto & val : state.each_value_mutable(var))
-                                if (! contains(values_of_interest, val)) {
-                                    auto emit = [&](const ReasonLiterals &) {
-                                        // need to point out that if var == val then var != voi for each voi
-                                        for (const auto & voi : values_of_interest)
-                                            logger->emit(
-                                                RUPProofRule{}, WPBSum{} + 1_i * (var != val) + 1_i * (var != voi) >= 1_i, ProofLevel::Temporary);
+                        if (might_match) {
+                            // Both sets have to be named locals: each_interval_minus()
+                            // hands out a generator borrowing *both*, which must outlive
+                            // it (see IntervalSet's class documentation). Iterating a
+                            // temporary's generator reads freed intervals, and here that
+                            // would remove values the constraint supports -- lost
+                            // solutions rather than lost pruning.
+                            auto var_values = state.copy_of_values(var);
+                            for (auto [lo, hi] : var_values.each_interval_minus(voi_set)) {
+                                auto emit = [&, lo = lo, hi = hi](const ReasonLiterals &) {
+                                    // Same shape as the per-value argument, restated over
+                                    // a range: if var lies in [lo, hi] then var is not any
+                                    // value of interest. Each value of interest sits
+                                    // wholly on one side of the range -- the range is a
+                                    // gap between them -- so one order atom rules it out,
+                                    // and unit propagation gets from that atom to the
+                                    // negated eq atom along the ge-atom chain links. The
+                                    // per-value form did not need the chain, because
+                                    // var == val pins every bit of var; a range pins none,
+                                    // which is why the side has to be picked explicitly
+                                    // rather than left to the checker.
+                                    for (const auto & voi : values_of_interest) {
+                                        auto outside = voi < lo ? (var < lo) : (var >= hi + 1_i);
+                                        logger->emit(RUPProofRule{}, WPBSum{} + 1_i * outside + 1_i * (var != voi) >= 1_i, ProofLevel::Temporary);
+                                    }
 
-                                        // now every other variable that contributes to the sum is
-                                        // capped at one — must_match vars (whose AM1 lines bound their
-                                        // contribution to the at-most-must_match_count tally) AND every
-                                        // other can_be_either var.
-                                        if (sum_line.second && values_of_interest.size() > 1) {
-                                            PolBuilder b;
-                                            b.add(*sum_line.second);
-                                            for (const auto & m : must_match_vars)
-                                                b.add(am1_lines->at(m));
-                                            for (const auto & other_var : can_be_either_vars)
-                                                if (var != other_var)
-                                                    b.add(am1_lines->at(other_var));
-                                            b.emit(*logger, ProofLevel::Temporary);
-                                        }
-                                    };
-                                    inference.infer(
-                                        logger, var != val, JustifyExplicitly{emit, ThenRUP::Yes, hints::Among{owner}}, vars_and_bounds_reason);
-                                }
+                                    // now every other variable that contributes to the sum is
+                                    // capped at one — must_match vars (whose AM1 lines bound their
+                                    // contribution to the at-most-must_match_count tally) AND every
+                                    // other can_be_either var.
+                                    if (sum_line.second && values_of_interest.size() > 1) {
+                                        PolBuilder b;
+                                        b.add(*sum_line.second);
+                                        for (const auto & m : must_match_vars)
+                                            b.add(am1_lines->at(m));
+                                        for (const auto & other_var : can_be_either_vars)
+                                            if (var != other_var)
+                                                b.add(am1_lines->at(other_var));
+                                        b.emit(*logger, ProofLevel::Temporary);
+                                    }
+                                };
+                                inference.infer_not_in_range(
+                                    logger, var, lo, hi, JustifyExplicitly{emit, ThenRUP::Yes, hints::Among{owner}}, vars_and_bounds_reason);
+                            }
+                        }
                     }
 
                     // now every variable is set in a way that either must

--- a/gcs/large_domain_audit_test.cc
+++ b/gcs/large_domain_audit_test.cc
@@ -303,11 +303,15 @@ namespace
         });
 
         // --- Counting family.
-        add("Among", Expect::KnownTrip, [](Problem & p) {
-            // H1a: removes everything outside a small given value set, one value
-            // at a time. That branch needs the count pinned -- with slack in it
-            // the propagator has nothing to conclude -- so the count is fixed to
-            // the whole scope, forcing every variable into the value set.
+        add("Among", Expect::Clean, [](Problem & p) {
+            // Was H1a: it removed everything outside a small given value set one
+            // value at a time. Now the complement of the value set goes in as
+            // ranges, so a wide domain costs two removals. That branch needs the
+            // count pinned -- with slack in it the propagator has nothing to
+            // conclude -- so the count is fixed to the whole scope, forcing every
+            // variable into the value set. The two values of interest sit at the
+            // bottom, which leaves a range on each side of them and so exercises
+            // both sides of the proof's per-value-of-interest case split.
             auto v = wide(p, 3);
             p.post(Among{v, {1_i, 2_i}, p.create_integer_variable(3_i, 3_i)});
         });


### PR DESCRIPTION
Part of #833 (stage 4, interval-level rewrites), stacked on #855.

`Among`'s job, once the count is pinned, is to take every variable down to the values of
interest. It did that one value at a time, so a variable with a wide domain and a two-value
set paid a billion inferences to end up holding two values. That set's complement is a
handful of ranges however wide the domain is, so it goes in as ranges.

The removals are identical — a value survives iff it is a value of interest — and a
before/after enumeration confirms it: same solutions, same recursions, same propagations on
both shapes benchmarked.

## The proof

Smaller than `ArrayMinMax`'s. The counting argument that actually draws the conclusion
(`pol` over the encoding's `sum >= how_many` half, plus an at-most-one line per other
variable) never mentions the removed value, so it is untouched. Only the step that zeroes
the `(var == voi)` terms moves. Per value it was

```
rup  var != val \/ var != voi
```

and per range it is one of

```
rup  var < lo      \/ var != voi      when voi < lo
rup  var >= hi + 1 \/ var != voi      when voi > hi
```

Every value of interest sits wholly on one side of a removed range, because the ranges
removed are the gaps between them, so the side is decided when the line is written and unit
propagation reaches the eq atom along the ge-atom chain. The per-value form needed no such
choice: `var == val` pins every bit of `var`. That is `|voi|` lines per removed *range*
rather than per removed *value*, and there are at most `|voi| + 1` ranges.

**Unlike `ArrayMinMax`, this bridges views**, so there is no plain-variable restriction:
every atom in those lines is on the same variable, its order atoms against its own eq atoms,
and `need_gevar` pol-derives a view's chain links from the underlying variable's.
`ArrayMinMax`'s lemmas have to carry an atom across a row from `result` to `var_i`, and it
is that crossing, not the range, that views break. Checked rather than assumed: 259 range
removals on view variables under proofs, all verified.

## Measurements

The audit row flips to `Clean`, and cheaply rather than merely survivably: the `0..10^9`
probe goes from wedged to **6 ms and 4.7 MB**.

The proof survey row falls from 32996 → 329996 steps across a 10x width to a **flat 98**,
which retires `Among` as evidence for a VeriPB feature. The copy-paste was real, but the
propagator was the right place to remove it.

The survey table is re-measured throughout. It had been stale since #849 sharpened three
probes without re-running it, and both constraints it named as clean candidates are now
flat. The rows that grow instead are `AllEqual/holes`, `GlobalCardinality` and `Element` —
and checking those three against the survey's own test (is the removed set an interval?)
says none of them is feature evidence either; all three are stage 4 work. See #857 and the
third commit here.

## One fix and one near miss

The variable partition asks "is this domain inside the value set" as a `none_of`, which
stops at the first value that is not — and among any `|voi| + 1` values at most `|voi|` can
be of interest, so it is bounded by the value set already and **was never a hazard**.
Rewriting it as a counting query cost **9%** on a search that calls it hundreds of thousands
of times, with the test suite and the audit lane both green; the benchmark caught it and it
is reverted.

Ten lines below, the *same predicate* was written as a plain loop with no early exit, and
that one did walk the whole domain. The fix there is the missing exit. Both are now the one
helper, and the lesson is written up in `dev_docs/large-domains.md`: read a domain loop for
its exit condition before reaching for an interval rewrite.

## Testing

802/802. `among_test` uncapped on GCC and clang, plain and view-wrapped, with 31 and 26
VeriPB verifications each. Audit lane green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EdcpzKhRabS67Kcfq3eq9e
