### PR TITLE
Find In's forbidden runs by merge, not by walking the domain (#833)

### DIFF
--- a/dev_docs/large-domains.md
+++ b/dev_docs/large-domains.md
@@ -61,6 +61,17 @@ Neither the audit lane nor the test suite can tell these two apart — both are
 the loop for its exit condition before reaching for an interval rewrite, and put
 any rewrite of a hot query through a before/after benchmark.
 
+**The cheapest H1a of all is where the conclusions are already intervals and only
+the search for them is per-value.** `In`'s constant-set filter emitted one
+`infer_not_in_range` per maximal run of forbidden values, and found those runs by
+walking the domain and grouping consecutive ones. A merge against the permitted
+set yields the same runs — a run breaks exactly where the domain has a hole or a
+permitted value intervenes, which is where `each_interval_minus` ends one too — so
+the rewrite changes nothing at all in the proof. Verified rather than argued: at a
+fixed seed the OPB, the proof, and the test output are byte-identical before and
+after, and a differential check computing both algorithms in one binary reports
+zero disagreements over ten seeds. Look for this shape first; it is free.
+
 H1a is the one worth looking for first, because it is not a trade-off at all.
 The tree already has the machinery: `IntervalSet::each_interval_minus()`,
 `InferenceTracker::infer_not_in_range()`, and
@@ -228,13 +239,20 @@ Two kinds of check, and the difference matters:
   one value from it, which is fine. An early version of this guard checked the
   width and condemned `Plus`, `Abs`, `LessThan` and `LinearEquality` for it.
 
-  `State`'s iterators are not the only way a propagator walks a domain: it can
-  also build an `IntervalSet` of its own and walk that, which `State` never sees.
-  Such a loop needs its own counter, declared at the loop. `Element`'s sweep over
-  the result values the array does not support (`element.cc`) is the one such site
-  outside proof logging, and it is instrumented. The counter does not belong in
-  `IntervalSet::each()` itself, which is a general container used for deliberate
-  enumeration — tabulation, and the tests.
+  `State`'s iterators are not the only way a propagator walks a domain. It can
+  build an `IntervalSet` of its own and walk that, or take an interval and expand
+  it with a plain `for (Integer v = lo; v <= hi; ++v)`. `State` sees neither, so
+  each such loop needs its own counter declared at the loop. Two sites carry one:
+  `element.cc`'s sweep over unsupported result values (now only on its per-value
+  view path) and `all_equal.cc`'s expansion of the intersection difference. The
+  counter does not belong in `IntervalSet::each()` itself, which is a general
+  container used for deliberate enumeration — tabulation, and the tests.
+
+  Both were found the same way, and it is worth naming the smell: **a row that
+  starts passing when you did not fix it.** Neither site allocated a suspicious
+  amount or crashed; each simply ran for a minute or two and finished, so the row
+  came out `Clean` on a machine with 16 GB free and `KnownTrip` on a smaller one.
+  If a probe stops tripping, measure what it costs before believing it.
 * **`GCS_CHECK_LARGE_DOMAIN`** checks a size up front, for the H3 sites that
   commit to a whole array at once.
 
@@ -278,12 +296,19 @@ table, which is a snapshot for orientation.
 
 | | constraints |
 |---|---|
-| **KnownTrip** (21) | `Power`, `PowerTable`, `AllDifferent`, `AllDifferentExcept`, `AllEqual/holes`, `Count`, `NValue`, `AtMostOne`, `AtMostOneSmartTable`, `GlobalCardinality`, `In`, `ArrayMinMax`, `LexSmartTable`, `SmartTable`, `Regular`, `RegularLegacy`, `RegularBacchus`, `MDD`, `Cumulative`, `Disjunctive`, `Knapsack` |
-| **Clean** (34) | the arithmetic family, comparison, equality, linear, `AllDifferent` under `VC`, `Element` in both arms, `AllEqual` without holes, `Among`, `Table` (both shapes), `ValuePrecede`, `SeqPrecedeChain`, `IncreasingChain`, `Lex`, `Sort`, `ArgSort`, `NegativeTable`, `Disjunctive2D`, `BinPacking`, `MinDistance`, `DifferenceConstraints`, `Nogoods` |
+| **KnownTrip** (20) | `Power`, `PowerTable`, `AllDifferent`, `AllDifferentExcept`, `AllEqual/holes`, `Count`, `NValue`, `AtMostOne`, `AtMostOneSmartTable`, `GlobalCardinality`, `ArrayMinMax`, `LexSmartTable`, `SmartTable`, `Regular`, `RegularLegacy`, `RegularBacchus`, `MDD`, `Cumulative`, `Disjunctive`, `Knapsack` |
+| **Clean** (35) | the arithmetic family, comparison, equality, linear, `AllDifferent` under `VC`, `Element` in both arms, `AllEqual` without holes, `Among`, `In`, `Table` (both shapes), `ValuePrecede`, `SeqPrecedeChain`, `IncreasingChain`, `Lex`, `Sort`, `ArgSort`, `NegativeTable`, `Disjunctive2D`, `BinPacking`, `MinDistance`, `DifferenceConstraints`, `Nogoods` |
 | **NoWidePosition** (14) | the graph and permutation family, and the Boolean constraints |
 
-`Among`, `Table` and `Element` started as `KnownTrip` and are now `Clean`, by the
-interval rewrites rather than by a weaker arm: all three still propagate GAC.
+`Among`, `In`, `Table` and `Element` started as `KnownTrip` and are now `Clean`, by
+the interval rewrites rather than by a weaker arm: all four still propagate GAC.
+
+**`In` is worth more than its own row.** `create_integer_variable` over a vector
+posts an `In` to carve the holes, so any probe that builds a sparse variable that
+way was tripping inside `In` before it reached the constraint it meant to test.
+`AllEqual/holes` was one: its row was measuring the wrong constraint, and only
+turned into a real `AllEqual` trip once `In` was fixed. A row names the probe, not
+necessarily the culprit.
 
 `ArrayMinMax` is *not* in that list even though its union sweep was rewritten the
 same way, and that is correct: it has a second per-value sweep, the full-GAC pass

--- a/gcs/constraints/all_equal/all_equal.cc
+++ b/gcs/constraints/all_equal/all_equal.cc
@@ -1,6 +1,7 @@
 #include <gcs/constraints/all_equal/all_equal.hh>
 #include <gcs/constraints/all_equal/hints.hh>
 #include <gcs/innards/inference_tracker.hh>
+#include <gcs/innards/large_domain_guard.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/proofs/proof_model.hh>
@@ -116,10 +117,26 @@ auto AllEqual::install_propagators(Propagators & propagators) -> void
                 for (size_t i = 1; i < n; ++i)
                     common.intersect_with(state.copy_of_values(vars[i]));
 
+                // The interval is already in hand and is then written out one value
+                // at a time, so this is an H1a site with nothing standing in its way
+                // except the witness: which variable is missing a value can change
+                // within one interval, because the difference is taken against the
+                // intersection of every domain. Differencing per variable instead
+                // would give constant-witness ranges (#833).
+                //
+                // Until then the guard has to see it, and it cannot otherwise: this
+                // is a plain integer loop over an interval, not one of State's
+                // iterators and not IntervalSet::each(). Without the counter the probe
+                // takes 131 seconds and 16 GB and then *passes*, so whether the row
+                // trips is decided by how much memory the machine has -- the same
+                // defect the Element sweep had, in a different place.
+                LargeDomainIterationCounter expansion_guard{"the number of values one AllEqual intersection pruning has walked"};
+
                 for (size_t i = 0; i < n; ++i) {
                     auto vi_set = state.copy_of_values(vars[i]);
                     for (auto [l, u] : vi_set.each_interval_minus(common)) {
                         for (Integer val = l; val <= u; ++val) {
+                            expansion_guard.step();
                             IntegerVariableID witness = vars[0];
                             for (size_t j = 0; j < n; ++j)
                                 if (! state.in_domain(vars[j], val)) {

--- a/gcs/constraints/in/in.cc
+++ b/gcs/constraints/in/in.cc
@@ -35,7 +35,6 @@ using std::erase_if;
 using std::make_unique;
 using std::move;
 using std::optional;
-using std::pair;
 using std::string;
 using std::unique_ptr;
 using std::vector;
@@ -153,9 +152,18 @@ auto In::install_propagators(Propagators & propagators) -> void
     for (const auto & V : _var_vals)
         triggers.on_change.emplace_back(V);
 
+    // The permitted values as intervals, built once: the set is fixed for the
+    // life of the constraint, and step 1 below takes the domain's difference
+    // against it on every call. insert_at_end needs them ascending, which holds
+    // because prepare() sorts and uniques _val_vals (and folds in any constant
+    // members) and runs before this -- see constraint.cc.
+    IntervalSet<Integer> val_vals_set;
+    for (const auto & v : _val_vals)
+        val_vals_set.insert_at_end(v);
+
     propagators.install(
         constraint_id(),
-        [var = _var, var_vals = _var_vals, val_vals = _val_vals, selectors = _selectors, owner = constraint_id()](
+        [var = _var, var_vals = _var_vals, val_vals = _val_vals, val_vals_set = move(val_vals_set), selectors = _selectors, owner = constraint_id()](
             const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
             // Step 1: filter dom(var) — drop any value that no source supports.
             if (var_vals.empty()) {
@@ -163,18 +171,23 @@ auto In::install_propagators(Propagators & propagators) -> void
                 // over constants): each contiguous run of unsupported values is one
                 // interval conclusion, RUP with no reason since asserting var in
                 // [lo, hi] walks the order chain past every supported value into the
-                // at-least-one. Collect the runs first so the domain is not mutated
-                // mid-iteration.
-                vector<pair<Integer, Integer>> runs;
-                for (auto v : state.each_value_immutable(var)) {
-                    if (binary_search(val_vals, v))
-                        continue;
-                    if (! runs.empty() && runs.back().second + 1_i == v)
-                        runs.back().second = v;
-                    else
-                        runs.emplace_back(v, v);
-                }
-                for (const auto & [lo, hi] : runs)
+                // at-least-one.
+                //
+                // The conclusions were already interval-level; what was per-value was
+                // finding them, by walking the domain and grouping maximal runs. The
+                // runs a merge against the permitted set yields are the same
+                // intervals: a run breaks exactly where the domain has a hole or a
+                // permitted value intervenes, which is where each_interval_minus ends
+                // one too. So this emits the identical inferences and changes nothing
+                // in the proof -- it just stops taking O(|D(var)|) to find them.
+                //
+                // The copy has to be a named local, and so does the permitted set:
+                // each_interval_minus() hands out a generator borrowing both, which
+                // must outlive it (see IntervalSet's class documentation). It also
+                // means the domain may be modified as we go, which the old code
+                // needed a separate collection pass to allow.
+                auto var_values = state.copy_of_values(var);
+                for (auto [lo, hi] : var_values.each_interval_minus(val_vals_set))
                     inference.infer_not_in_range(logger, var, lo, hi, JustifyUsingRUP{hints::In{owner}}, NoReason{});
             }
             else {

--- a/gcs/large_domain_audit_test.cc
+++ b/gcs/large_domain_audit_test.cc
@@ -297,6 +297,10 @@ namespace
             // narrow partner, so the hole has to be spread across the full width:
             // a two-value domain at the extremes leaves the whole middle of the
             // other variable to remove.
+            //
+            // Note this row used to trip on the `In` that create_integer_variable
+            // posts to carve the hole, rather than on AllEqual at all. With that
+            // fixed the row still trips, but now on the site the comment describes.
             auto holey = p.create_integer_variable(vector<Integer>{wide_lo, probe_width});
             auto full = wide_var(p);
             p.post(AllEqual{vector<IntegerVariableID>{holey, full}});
@@ -347,7 +351,14 @@ namespace
             auto v = wide(p, 3);
             p.post(GlobalCardinality{v, {1_i}, {p.create_integer_variable(3_i, 3_i)}});
         });
-        add("In", Expect::KnownTrip, [](Problem & p) {
+        add("In", Expect::Clean, [](Problem & p) {
+            // Its conclusions were always interval-level; what was per-value was
+            // finding them, by walking the domain to group maximal runs. A merge
+            // against the permitted set yields the same runs without the walk.
+            //
+            // This one is load-bearing beyond its own row: create_integer_variable
+            // over a vector posts an In, so any probe that builds a holey variable
+            // that way was tripping here first, whatever else it meant to test.
             auto v = wide(p, 1);
             p.post(In{v[0], vector<Integer>{1_i, 2_i, 3_i}});
         });


### PR DESCRIPTION
Part of #833 (stage 4, interval-level rewrites), stacked on #858.

`In`'s constant-set filter **already drew interval-level conclusions**: one
`infer_not_in_range` per maximal run of forbidden values. What was per-value was *finding*
those runs, by walking the domain and grouping consecutive ones. So on a wide hull with a
handful of permitted values it took `O(|D(var)|)` to reach a conclusion the permitted set
already describes.

A merge against the permitted set yields the same runs: a run breaks exactly where the
domain has a hole or a permitted value intervenes, which is where `each_interval_minus`
ends one too.

This is the cheapest shape of H1a there is, because nothing downstream changes — not the
removals, not the inferences, **not the proof**.

## Verifying "nothing changes", and getting it wrong first

The first attempt at verifying this produced garbage. `in_test` seeds itself from
`random_device`, so comparing two separate runs compares two different instance sets — an
early "the proof differs, and so does the OPB" result was entirely that, and the OPB
differing should have been the tell, since nothing here touches `define_proof_model`.

Done properly:

- **At a fixed seed, the OPB, the proof and the test output are byte-identical** before and
  after.
- A **differential check** that computes both algorithms in the same binary on every call
  and reports disagreements finds **zero, over ten seeds**.

## A mis-attributed audit row, and a second RAM-dependent one

`create_integer_variable` over a vector posts an `In` to carve the holes. So a probe that
builds a sparse variable that way trips *inside `In`* before it ever reaches the constraint
it means to test. `AllEqual/holes` was doing exactly that: **its row was measuring `In`,
not `AllEqual`.** A row names the probe, not necessarily the culprit.

Underneath it there is a real `AllEqual` hazard, and the guard could not see that either:
`all_equal.cc` takes the interval difference with `each_interval_minus` and then expands it
with a plain `for (Integer val = l; val <= u; ++val)`, which is neither one of `State`'s
iterators nor `IntervalSet::each()`. Left alone the row would have gone quietly `Clean`
while costing **131 seconds and 16 GB** — the same defect the `Element` sweep had (#855), in
a different place, and the second time in this stack that a row started passing without
anything being fixed.

A counter at that loop puts it back to tripping honestly. The `AllEqual` fix itself is a
separate change: the obstacle there is the per-value *witness* in the reason, which
differencing per variable rather than against the intersection of every domain would make
constant.

## Measurements

Pinned, three repeats, node counts identical throughout:

| | before | after |
|---|---|---|
| wide (60 vars, width 3×10^5, `In` isolated) | 303 ms | **~1 ms** |
| narrow (sparse domains, 2.2M propagations) | 2168 ms | **2045 ms** |
| audit probe at `0..10^9` | wedged | **5 ms, 3.3 MB** |

The narrow shape is the one that matters for not regressing, and it is ~6% faster.

## Testing

804/804. `in_test` and `all_equal_test` uncapped on GCC and clang, plain and view-wrapped.
Audit lane green, with `In` flipping to `Clean` and `AllEqual/holes` still `KnownTrip` for
the right reason now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EdcpzKhRabS67Kcfq3eq9e
