### PR TITLE
Force GlobalCardinality's variables by range, not value by value (#833)

### DIFF
--- a/dev_docs/large-domains.md
+++ b/dev_docs/large-domains.md
@@ -291,17 +291,26 @@ is the part worth reading carefully:
 
 ### Where we stand
 
-69 probes. The lane itself is the authority — run it rather than trusting this
+70 probes. The lane itself is the authority — run it rather than trusting this
 table, which is a snapshot for orientation.
 
 | | constraints |
 |---|---|
-| **KnownTrip** (20) | `Power`, `PowerTable`, `AllDifferent`, `AllDifferentExcept`, `AllEqual/holes`, `Count`, `NValue`, `AtMostOne`, `AtMostOneSmartTable`, `GlobalCardinality`, `ArrayMinMax`, `LexSmartTable`, `SmartTable`, `Regular`, `RegularLegacy`, `RegularBacchus`, `MDD`, `Cumulative`, `Disjunctive`, `Knapsack` |
-| **Clean** (35) | the arithmetic family, comparison, equality, linear, `AllDifferent` under `VC`, `Element` in both arms, `AllEqual` without holes, `Among`, `In`, `Table` (both shapes), `ValuePrecede`, `SeqPrecedeChain`, `IncreasingChain`, `Lex`, `Sort`, `ArgSort`, `NegativeTable`, `Disjunctive2D`, `BinPacking`, `MinDistance`, `DifferenceConstraints`, `Nogoods` |
+| **KnownTrip** (20) | `Power`, `PowerTable`, `AllDifferent`, `AllDifferentExcept`, `AllEqual/holes`, `Count`, `NValue`, `AtMostOne`, `AtMostOneSmartTable`, `GlobalCardinality/hall`, `ArrayMinMax`, `LexSmartTable`, `SmartTable`, `Regular`, `RegularLegacy`, `RegularBacchus`, `MDD`, `Cumulative`, `Disjunctive`, `Knapsack` |
+| **Clean** (36) | the arithmetic family, comparison, equality, linear, `AllDifferent` under `VC`, `Element` in both arms, `AllEqual` without holes, `Among`, `In`, `GlobalCardinality`, `Table` (both shapes), `ValuePrecede`, `SeqPrecedeChain`, `IncreasingChain`, `Lex`, `Sort`, `ArgSort`, `NegativeTable`, `Disjunctive2D`, `BinPacking`, `MinDistance`, `DifferenceConstraints`, `Nogoods` |
 | **NoWidePosition** (14) | the graph and permutation family, and the Boolean constraints |
 
-`Among`, `In`, `Table` and `Element` started as `KnownTrip` and are now `Clean`, by
-the interval rewrites rather than by a weaker arm: all four still propagate GAC.
+`Among`, `In`, `GlobalCardinality`, `Table` and `Element` started as `KnownTrip`
+and are now `Clean`, by the interval rewrites rather than by a weaker arm: all of
+them still propagate at their original strength.
+
+`GlobalCardinality` mattered most of the five, because it was the rule's own
+counterexample: already the bounds arm, and still enumerating, so it had nothing
+weaker to fall back to. Its just-met-demand branch forces a variable to a value,
+which is two range removals however wide the domain is. **A second per-value site
+remains** in its Hall reasoning, which the original probe could not reach — one
+cover value means there is no multi-value hall — so it now has a row of its own
+rather than being covered by association.
 
 **`In` is worth more than its own row.** `create_integer_variable` over a vector
 posts an `In` to carve the holes, so any probe that builds a sparse variable that
@@ -410,8 +419,8 @@ previous version of it went stale, see below.
 |---|---|---|
 | **Both** grow | 10x / 10x | `Power`, `PowerTable`, `NValue`, `Regular`, `RegularLegacy`, `RegularBacchus`, `MDD` |
 | **OPB only** | 10x / 1.0x | `Cumulative` (19046 → 190046 rows; one capacity line per time point, so it is H3 on the encoding side) |
-| **Steps only** | 1.0x / 10x | `AllEqual/holes` (22-row OPB fixed, 16987 → 169987 steps), `GlobalCardinality` (30-row, 18024 → 180024) |
-| neither | 1.0x / 1.0x | everything else, 59 of 69 |
+| **Steps only** | 1.0x / 10x | `AllEqual/holes` (22-row OPB fixed, 16987 → 169987 steps), `GlobalCardinality/hall` (34-row, 33984 → 339984) |
+| neither | 1.0x / 1.0x | everything else, 59 of 70 |
 
 `Multiply`, `Divide` and `Modulus` sit in the last row but are not flat: their OPB
 grows 1.8x for a 10x width, which is the bit-width of the product, not a per-value
@@ -445,11 +454,18 @@ work rather than evidence:
   variable separately gives ranges with a constant witness, at the cost of
   overlapping removals, which are idempotent.
 * `GlobalCardinality`'s just-met-demand branch
-  (`bounds_global_cardinality.cc`) removes every value of a variable *except*
-  one, which is two range removals — and its reason is already hoisted out of the
-  loop and constant, so it is a simpler case than `Among`'s. Under this document's
-  own rule it is a broken fallback arm rather than a missing one, so it is
-  scheduled work regardless.
+  (`bounds_global_cardinality.cc`) removed every value of a variable *except*
+  one, which is two range removals — and its reason was already hoisted out of the
+  loop and constant, so it was a simpler case than `Among`'s. **Done**: 18024 →
+  180024 steps became a flat 63.
+
+  Its **Hall pruning** is a separate site, and it is the first one here whose
+  obstacle is not the removed set. That set is an interval complement like all the
+  others; what resists is the *justification*, whose `pol` builds an at-most-one
+  over the hall values plus the single removed value, so the removed value is
+  named in the derivation rather than merely concluded. It has its own probe and
+  its own survey row now (33984 → 339984), and it is the most interesting
+  remaining candidate for exactly that reason.
 * `Element` walked the result values its array does not support (`element.cc`),
   which for a narrow array over a wide result is mostly intervals. **Done**, and it
   collapsed as predicted: 27981 → 279981 steps became a flat 108. Two of the three

--- a/gcs/constraints/global_cardinality/bounds_global_cardinality.cc
+++ b/gcs/constraints/global_cardinality/bounds_global_cardinality.cc
@@ -124,9 +124,22 @@ auto gcs::innards::propagate_bounds_global_cardinality(const vector<IntegerVaria
 
         // Just-met demand: if only `can` variables can take value and the
         // count's lower bound needs all of them, each is forced to value.
+        //
+        // Forcing a variable to a value means removing everything else, which is
+        // at most two ranges however wide the domain is -- and this is the
+        // constraint the governing rule singles out, since it is already the
+        // bounds arm and so has nothing weaker to fall back to. Per value it took
+        // O(|D(var)|) inferences to reach a one-value domain.
+        //
+        // Plain RUP, as for the per-value form and for the same reason: the rows
+        // here are over eq atoms with an at-least-one, so asserting the negated
+        // conclusion refutes each of them through the ge-atom chain links. The
+        // reason is unchanged, and was already hoisted out of the loop and
+        // constant across the removed values, so nothing about it has to move.
         if (can == lb_j && can > 0_i) {
             ReasonLiterals force;
             bool have_force = false;
+            IntervalSet<Integer> just_value{value, value};
             for (const auto & var : vars)
                 if (state.in_domain(var, value) && ! state.has_single_value(var)) {
                     if (! have_force) {
@@ -134,9 +147,11 @@ auto gcs::innards::propagate_bounds_global_cardinality(const vector<IntegerVaria
                         gather_absent_ne(force);
                         force.emplace_back(counts[j] >= lb_j);
                     }
-                    for (const auto & w : state.each_value_mutable(var))
-                        if (w != value)
-                            inference.infer(logger, var != w, JustifyUsingRUP{hints::GlobalCardinality{owner}}, ExplicitReason{force});
+                    // Named local: each_interval_minus() borrows both sets, which
+                    // must outlive the generator (see IntervalSet's documentation).
+                    auto var_values = state.copy_of_values(var);
+                    for (auto [lo, hi] : var_values.each_interval_minus(just_value))
+                        inference.infer_not_in_range(logger, var, lo, hi, JustifyUsingRUP{hints::GlobalCardinality{owner}}, ExplicitReason{force});
                 }
         }
     }

--- a/gcs/large_domain_audit_test.cc
+++ b/gcs/large_domain_audit_test.cc
@@ -340,16 +340,32 @@ namespace
             auto v = wide(p, 3);
             p.post(AtMostOneSmartTable{v, wide_var(p)});
         });
-        add("GlobalCardinality", Expect::KnownTrip, [](Problem & p) {
-            // The counterexample to "just default to BC": this already defaults
-            // to consistency::BC and still enumerates values. Reaching that needs
-            // the just-met-demand branch (bounds_global_cardinality.cc:127), where
-            // the number of variables that *can* take a cover value equals that
-            // value's count lower bound -- so each is forced to it by removing
-            // every other value one at a time. Three variables, one cover value,
-            // and a count pinned at three does it.
+        add("GlobalCardinality", Expect::Clean, [](Problem & p) {
+            // Was the counterexample to "just default to BC": this already
+            // defaults to consistency::BC and still enumerated values, so under
+            // the governing rule it was a broken fallback arm rather than a
+            // missing one. Reaching it needs the just-met-demand branch, where the
+            // number of variables that *can* take a cover value equals that
+            // value's count lower bound -- so each is forced to it. Three
+            // variables, one cover value, and a count pinned at three does it.
+            // Forcing a variable to a value is now two range removals.
             auto v = wide(p, 3);
             p.post(GlobalCardinality{v, {1_i}, {p.create_integer_variable(3_i, 3_i)}});
+        });
+        add("GlobalCardinality/hall", Expect::KnownTrip, [](Problem & p) {
+            // The second per-value site, in part 2's Hall reasoning: when the
+            // variables that can meet a hall set are exactly as many as the set
+            // demands, each is pruned to the set by removing everything outside it
+            // one value at a time. The probe above cannot reach this -- one cover
+            // value means there is no multi-value hall to form -- so it needs its
+            // own row rather than being covered by association.
+            //
+            // Not fixed with the other site because its justification is not
+            // range-shaped: the pol builds an at-most-one over the hall set plus
+            // the single removed value, so the removed value is named in the
+            // derivation rather than merely concluded.
+            auto v = wide(p, 2);
+            p.post(GlobalCardinality{v, {1_i, 2_i}, {p.create_integer_variable(1_i, 1_i), p.create_integer_variable(1_i, 1_i)}});
         });
         add("In", Expect::Clean, [](Problem & p) {
             // Its conclusions were always interval-level; what was per-value was


### PR DESCRIPTION
Part of #833 (stage 4), stacked on #859.

**This is the constraint the governing rule singles out.** It already defaults to
`consistency::BC` and still enumerated values, so it was not a constraint awaiting a
fallback arm — it was *the fallback arm itself being broken*, with nothing weaker to fall
back to.

The just-met-demand branch forces a variable to a value when the number that can take it
equals the count's lower bound. Forcing means removing everything else, which is at most
two ranges however wide the domain is; it was doing that one value at a time, taking
`O(|D(var)|)` inferences to reach a one-value domain.

Nothing else about the inference moves. The reason was already hoisted out of the loop and
constant across the removed values, and the justification stays **plain RUP**: the rows
here are over eq atoms with an at-least-one, so asserting the negated conclusion refutes
each of them through the ge-atom chain links.

## Not taking the RUP claim on trust

The test suite only ever reaches ranges of width **1 to 3** — precisely the size at which
chain-link behaviour can be a coincidence. The table work (#854) found exactly that, where
two-tuple instances verified for reasons three-tuple ones did not.

So it is checked directly against VeriPB at widths **5, 50, 200 and 2000**. All verify.

## A second site, and a new row for it

A second per-value site remains, in part 2's Hall reasoning, and **no probe reached it**:
one cover value means there is no multi-value hall to form, so the existing probe could not.
It gets its own row (`GlobalCardinality/hall`) rather than being covered by association,
and the row is honest about why it is not fixed here.

Its removed set is an interval complement like all the others. What resists is the
*justification*: the `pol` builds an at-most-one over the hall values **plus the single
removed value**, so the removed value is named in the derivation rather than merely
concluded. That makes it the first site in this issue whose obstacle is the proof rather
than the propagator, and the most interesting one left — see #857.

## Deliberately not touched

`domain_subset_of_hall` walks a domain, but as a `for_each_value_immutable` that stops at
the first value outside the hall, so it is bounded by the hall set rather than by the
domain. Rewriting that shape cost 9% on `Among` (#856).

## Measurements

Pinned, three repeats, node counts identical throughout:

| | before | after |
|---|---|---|
| wide (3 vars, width 4×10^5) | 147 ms | **0 ms** |
| narrow (7 vars, 51k propagations) | 743 ms | **727 ms** |
| audit probe at `0..10^9` | wedged | **7 ms, 4.9 MB** |
| proof survey | 18024 → 180024 steps | **flat 63** |

## Testing

804/804. Both global cardinality tests uncapped on GCC and clang. Audit lane green at 70
probes, with the row flipping to `Clean` and the new Hall row tripping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EdcpzKhRabS67Kcfq3eq9e
