### PR TITLE
Prune AllEqual to the common domain by range (#833)

### DIFF
--- a/dev_docs/large-domains.md
+++ b/dev_docs/large-domains.md
@@ -439,7 +439,7 @@ previous version of it went stale, see below.
 | **Both** grow | 10x / 10x | `Power`, `PowerTable`, `NValue`, `Regular`, `RegularLegacy`, `RegularBacchus`, `MDD` |
 | **OPB only** | 10x / 1.0x | `Cumulative` (19046 → 190046 rows; one capacity line per time point, so it is H3 on the encoding side) |
 | **Steps only** | 1.0x / 10x | `GlobalCardinality/hall` (34-row OPB fixed, 33984 → 339984 steps) |
-| neither | 1.0x / 1.0x | everything else, 60 of 70 |
+| neither | 1.0x / 1.0x | everything else, 61 of 70 |
 
 `Multiply`, `Divide` and `Modulus` sit in the last row but are not flat: their OPB
 grows 1.8x for a 10x width, which is the bit-width of the product, not a per-value

--- a/dev_docs/large-domains.md
+++ b/dev_docs/large-domains.md
@@ -124,6 +124,25 @@ Views keep the per-value path: a view's atoms are spelled through the view and
 the lemmas have not been shown to bridge that. Same restriction, and same reason,
 as the single-support range path in the same file.
 
+**Two things that make an interval rewrite pay, learned on `AllEqual`.**
+
+*Keep the per-value spelling for a width-1 interval.* A range literal of one value
+*is* the eq atom — the proof machinery never makes an interval of one — so saying
+it as `infer_not_equal` is the identical inference, and finding its reason costs
+no set construction. Over holey domains most removed intervals are single values,
+and routing them through the interval path instead cost 2% on a search.
+
+*Do not pay for machinery the common case does not need.* Where the reason names a
+witness that can vary within an interval, the general answer is to split the
+interval by which variable accounts for which part. But almost always one variable
+explains the whole of it, and a scan for a single covering witness is a few
+allocation-free merge-walks, where building a leftover set to subtract from costs
+an allocation whatever happens. Check for the easy case first and only then split.
+
+Together these take a rewrite that was 2.5% slower on holey-domain search back to
+level, while keeping the wide case (200 ms of work, and 131 seconds in the audit
+probe) at nothing.
+
 **Where the equality is guarded by a conjunction, the same lemmas take a longer
 guard.** `Element`'s model is `result - array[i] == 0` half-reified on the
 conjunction of index conditions, so it is `ArrayMinMax`'s shape with the selector
@@ -296,13 +315,13 @@ table, which is a snapshot for orientation.
 
 | | constraints |
 |---|---|
-| **KnownTrip** (20) | `Power`, `PowerTable`, `AllDifferent`, `AllDifferentExcept`, `AllEqual/holes`, `Count`, `NValue`, `AtMostOne`, `AtMostOneSmartTable`, `GlobalCardinality/hall`, `ArrayMinMax`, `LexSmartTable`, `SmartTable`, `Regular`, `RegularLegacy`, `RegularBacchus`, `MDD`, `Cumulative`, `Disjunctive`, `Knapsack` |
-| **Clean** (36) | the arithmetic family, comparison, equality, linear, `AllDifferent` under `VC`, `Element` in both arms, `AllEqual` without holes, `Among`, `In`, `GlobalCardinality`, `Table` (both shapes), `ValuePrecede`, `SeqPrecedeChain`, `IncreasingChain`, `Lex`, `Sort`, `ArgSort`, `NegativeTable`, `Disjunctive2D`, `BinPacking`, `MinDistance`, `DifferenceConstraints`, `Nogoods` |
+| **KnownTrip** (19) | `Power`, `PowerTable`, `AllDifferent`, `AllDifferentExcept`, `Count`, `NValue`, `AtMostOne`, `AtMostOneSmartTable`, `GlobalCardinality/hall`, `ArrayMinMax`, `LexSmartTable`, `SmartTable`, `Regular`, `RegularLegacy`, `RegularBacchus`, `MDD`, `Cumulative`, `Disjunctive`, `Knapsack` |
+| **Clean** (37) | the arithmetic family, comparison, equality, linear, `AllDifferent` under `VC`, `Element` in both arms, `AllEqual` with holes and without, `Among`, `In`, `GlobalCardinality`, `Table` (both shapes), `ValuePrecede`, `SeqPrecedeChain`, `IncreasingChain`, `Lex`, `Sort`, `ArgSort`, `NegativeTable`, `Disjunctive2D`, `BinPacking`, `MinDistance`, `DifferenceConstraints`, `Nogoods` |
 | **NoWidePosition** (14) | the graph and permutation family, and the Boolean constraints |
 
-`Among`, `In`, `GlobalCardinality`, `Table` and `Element` started as `KnownTrip`
-and are now `Clean`, by the interval rewrites rather than by a weaker arm: all of
-them still propagate at their original strength.
+`Among`, `In`, `AllEqual/holes`, `GlobalCardinality`, `Table` and `Element` started
+as `KnownTrip` and are now `Clean`, by the interval rewrites rather than by a
+weaker arm: all of them still propagate at their original strength.
 
 `GlobalCardinality` mattered most of the five, because it was the rule's own
 counterexample: already the bounds arm, and still enumerating, so it had nothing
@@ -419,8 +438,8 @@ previous version of it went stale, see below.
 |---|---|---|
 | **Both** grow | 10x / 10x | `Power`, `PowerTable`, `NValue`, `Regular`, `RegularLegacy`, `RegularBacchus`, `MDD` |
 | **OPB only** | 10x / 1.0x | `Cumulative` (19046 → 190046 rows; one capacity line per time point, so it is H3 on the encoding side) |
-| **Steps only** | 1.0x / 10x | `AllEqual/holes` (22-row OPB fixed, 16987 → 169987 steps), `GlobalCardinality/hall` (34-row, 33984 → 339984) |
-| neither | 1.0x / 1.0x | everything else, 59 of 70 |
+| **Steps only** | 1.0x / 10x | `GlobalCardinality/hall` (34-row OPB fixed, 33984 → 339984 steps) |
+| neither | 1.0x / 1.0x | everything else, 60 of 70 |
 
 `Multiply`, `Divide` and `Modulus` sit in the last row but are not flat: their OPB
 grows 1.8x for a 10x width, which is the bit-width of the product, not a per-value
@@ -445,14 +464,15 @@ and a checker feature is the only way out.
 H1a sites — a propagator expanding an interval by hand — and all three are stage 4
 work rather than evidence:
 
-* `AllEqual/holes` is the starkest. `all_equal.cc` already computes the values to
-  remove with `each_interval_minus`, and then expands each interval one value at a
-  time. The interval is literally in hand when the per-value loop starts. The only
-  real obstacle is that the reason names a *witness* — some variable whose domain
-  lacks that value — which can differ across one interval, because the difference
-  is taken against the intersection of every domain. Differencing against each
-  variable separately gives ranges with a constant witness, at the cost of
-  overlapping removals, which are idempotent.
+* `AllEqual/holes` was the starkest: `all_equal.cc` already computed the values to
+  remove with `each_interval_minus` and then expanded each interval one value at a
+  time, so the interval was literally in hand when the per-value loop started. The
+  obstacle was that the reason names a *witness* — some variable whose domain lacks
+  that value — which can differ across one interval, because the difference is
+  taken against the intersection of every domain. **Done**: 16987 → 169987 steps
+  became a flat 37. The witness is resolved by splitting the interval by which
+  variable accounts for which part, and striking off what is accounted for, so each
+  part is still removed exactly once.
 * `GlobalCardinality`'s just-met-demand branch
   (`bounds_global_cardinality.cc`) removed every value of a variable *except*
   one, which is two range removals — and its reason was already hoisted out of the

--- a/gcs/constraints/all_equal/all_equal.cc
+++ b/gcs/constraints/all_equal/all_equal.cc
@@ -1,5 +1,6 @@
 #include <gcs/constraints/all_equal/all_equal.hh>
 #include <gcs/constraints/all_equal/hints.hh>
+#include <gcs/constraints/innards/justify_not_in_range.hh>
 #include <gcs/innards/inference_tracker.hh>
 #include <gcs/innards/large_domain_guard.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
@@ -24,13 +25,16 @@
 using namespace gcs;
 using namespace gcs::innards;
 
+using std::holds_alternative;
 using std::make_unique;
 using std::move;
+using std::pair;
 using std::string;
 using std::stringstream;
 using std::to_string;
 using std::unique_ptr;
 using std::vector;
+using std::ranges::all_of;
 
 #if defined(__cpp_lib_print) && defined(__cpp_lib_format)
 using std::print;
@@ -113,38 +117,150 @@ auto AllEqual::install_propagators(Propagators & propagators) -> void
                 }
 
             if (any_holes) {
-                auto common = state.copy_of_values(vars[0]);
+                // Snapshot every domain up front. The old code took `common` from
+                // the state at the top of this block and then pruned against it, so
+                // the removal set is the one the domains had on entry; recomputing
+                // a domain mid-loop would use one this block has already shrunk and
+                // could remove more. Snapshots keep the removals exactly what they
+                // were.
+                vector<IntervalSet<Integer>> domains;
+                domains.reserve(n);
+                for (const auto & v : vars)
+                    domains.push_back(state.copy_of_values(v));
+
+                auto common = domains[0];
                 for (size_t i = 1; i < n; ++i)
-                    common.intersect_with(state.copy_of_values(vars[i]));
+                    common.intersect_with(domains[i]);
 
-                // The interval is already in hand and is then written out one value
-                // at a time, so this is an H1a site with nothing standing in its way
-                // except the witness: which variable is missing a value can change
-                // within one interval, because the difference is taken against the
-                // intersection of every domain. Differencing per variable instead
-                // would give constant-witness ranges (#833).
+                // The values to remove were already computed as intervals and then
+                // written out one at a time. What stopped that being a one-line
+                // change is the *witness*: the reason names some variable whose
+                // domain lacks the value, and because the difference is taken
+                // against the intersection of every domain, which variable that is
+                // can change part-way through an interval.
                 //
-                // Until then the guard has to see it, and it cannot otherwise: this
-                // is a plain integer loop over an interval, not one of State's
-                // iterators and not IntervalSet::each(). Without the counter the probe
-                // takes 131 seconds and 16 GB and then *passes*, so whether the row
-                // trips is decided by how much memory the machine has -- the same
-                // defect the Element sweep had, in a different place.
-                LargeDomainIterationCounter expansion_guard{"the number of values one AllEqual intersection pruning has walked"};
+                // So the difference is taken against one variable at a time
+                // instead. Every range that yields against `vars[j]` has `vars[j]`
+                // as a witness for the whole of it, by construction. Ranges already
+                // accounted for are struck off as we go, so each is removed once
+                // rather than once per variable that happens to witness it --- which
+                // matters, since every emission carries two lemmas.
+                //
+                // The union over j of (D_i minus D_j) is D_i minus the intersection
+                // of the others, and that is D_i minus `common`, so the removal set
+                // is exactly what it was.
+                auto all_simple = all_of(vars, [](const IntegerVariableID & v) { return holds_alternative<SimpleIntegerVariableID>(v); });
 
-                for (size_t i = 0; i < n; ++i) {
-                    auto vi_set = state.copy_of_values(vars[i]);
-                    for (auto [l, u] : vi_set.each_interval_minus(common)) {
-                        for (Integer val = l; val <= u; ++val) {
-                            expansion_guard.step();
-                            IntegerVariableID witness = vars[0];
+                // A range asserts order atoms and never bits, so it cannot cross
+                // the model's bit-sum equality on its own; the two ge-layer bound
+                // lemmas carry the bounds over to vars[j] first, and then the
+                // reason's range literal is a clause with every literal falsified.
+                // Same helper, and same argument, as equals.cc --- the model here is
+                // a chain of consecutive-pair equalities, so for non-adjacent i and
+                // j unit propagation walks the chain between them.
+                auto prune_range = [&](size_t i, size_t j, Integer l, Integer u) {
+                    inference.infer_not_in_range(logger, vars[i], l, u,
+                        JustifyExplicitly{[logger, &vars, i, j, l, u](const ReasonLiterals & r) {
+                                              justify_not_in_range_across_equality(
+                                                  *logger, r, std::get<SimpleIntegerVariableID>(vars[i]), l, u, vars[j], l, u);
+                                          },
+                            ThenRUP::Yes, hints::AllEqual{owner}},
+                        ExplicitReason{ReasonLiterals{{not_in_range(vars[j], l, u)}}});
+                };
+
+                if (all_simple) {
+                    for (size_t i = 0; i < n; ++i) {
+                        for (auto [l, u] : domains[i].each_interval_minus(common)) {
+                            if (l == u) {
+                                // A width-1 range literal *is* the eq atom -- the proof
+                                // machinery never makes an interval of one -- so saying
+                                // it that way is the same inference, and finding its
+                                // witness is n in_domain checks against no set at all.
+                                // Worth the branch: over holey domains most removed
+                                // intervals are single values, and routing them through
+                                // the interval path instead cost 2%.
+                                IntegerVariableID witness = vars[0];
+                                for (size_t j = 0; j < n; ++j)
+                                    if (! state.in_domain(vars[j], l)) {
+                                        witness = vars[j];
+                                        break;
+                                    }
+                                inference.infer_not_equal(
+                                    logger, vars[i], l, JustifyUsingRUP{hints::AllEqual{owner}}, ExplicitReason{ReasonLiterals{{witness != l}}});
+                                continue;
+                            }
+
+                            // Almost always one variable's hole explains the whole
+                            // of a removed interval, and then there is nothing to
+                            // split: a scan for a single covering witness is n
+                            // merge-walks with no allocation, where building the
+                            // leftover set to subtract from costs one whatever
+                            // happens. Measured: with the splitting machinery run
+                            // unconditionally this was 2% slower on a search over
+                            // holey domains, and the fast path takes that back.
+                            IntervalSet<Integer> range{l, u};
+                            auto witness = n;
                             for (size_t j = 0; j < n; ++j)
-                                if (! state.in_domain(vars[j], val)) {
-                                    witness = vars[j];
+                                if (j != i && ! domains[j].contains_any_of(range)) {
+                                    witness = j;
                                     break;
                                 }
-                            inference.infer_not_equal(
-                                logger, vars[i], val, JustifyUsingRUP{hints::AllEqual{owner}}, ExplicitReason{ReasonLiterals{{witness != val}}});
+
+                            if (witness != n) {
+                                prune_range(i, witness, l, u);
+                                continue;
+                            }
+
+                            // Mixed: different parts of this interval are missing
+                            // from different variables, which is the whole reason
+                            // the per-value form needed a witness lookup per value.
+                            // Take the difference against one variable at a time and
+                            // strike off what it accounts for, so each part is
+                            // removed once rather than once per variable that
+                            // witnesses it --- every emission carries two lemmas.
+                            IntervalSet<Integer> todo{l, u};
+                            for (size_t j = 0; j < n && ! todo.empty(); ++j) {
+                                if (j == i)
+                                    continue;
+
+                                // Collected before erasing: each_interval_minus()
+                                // borrows `todo`, which must not be modified while
+                                // the generator is live.
+                                vector<pair<Integer, Integer>> witnessed;
+                                for (auto [wl, wu] : todo.each_interval_minus(domains[j]))
+                                    witnessed.emplace_back(wl, wu);
+
+                                for (auto [wl, wu] : witnessed) {
+                                    todo.erase_range(wl, wu);
+                                    prune_range(i, j, wl, wu);
+                                }
+                            }
+                        }
+                    }
+                }
+                else {
+                    // A view keeps the per-value walk, since the bound lemmas have
+                    // not been shown to bridge a view's atoms --- the same
+                    // restriction, and the same reason, as equals.cc's range path.
+                    // It keeps the guard with it: this is a plain integer loop over
+                    // an interval, which neither State's iterators nor
+                    // IntervalSet::each() covers, so without a counter the probe
+                    // takes 131 seconds and 16 GB and then *passes*.
+                    LargeDomainIterationCounter expansion_guard{"the number of values one AllEqual intersection pruning has walked"};
+
+                    for (size_t i = 0; i < n; ++i) {
+                        for (auto [l, u] : domains[i].each_interval_minus(common)) {
+                            for (Integer val = l; val <= u; ++val) {
+                                expansion_guard.step();
+                                IntegerVariableID witness = vars[0];
+                                for (size_t j = 0; j < n; ++j)
+                                    if (! state.in_domain(vars[j], val)) {
+                                        witness = vars[j];
+                                        break;
+                                    }
+                                inference.infer_not_equal(
+                                    logger, vars[i], val, JustifyUsingRUP{hints::AllEqual{owner}}, ExplicitReason{ReasonLiterals{{witness != val}}});
+                            }
                         }
                     }
                 }

--- a/gcs/constraints/all_equal/all_equal_test.cc
+++ b/gcs/constraints/all_equal/all_equal_test.cc
@@ -154,6 +154,62 @@ auto run_holes_test(bool proofs) -> void
     check_results(proof_name, expected, actual);
 }
 
+// A removed interval whose parts are missing from *different* variables.
+//
+// The intersection pruning takes each variable's domain minus the intersection of
+// all of them, so a single contiguous run of that difference can be explained by
+// one variable at its start and another at its end. That is the case the reason
+// has to split by witness, and nothing else in this file reaches it: everywhere
+// else, one variable's hole happens to cover the whole run.
+//
+// x is the full range; y is missing the lower half of the middle band and z the
+// upper half, so the band leaves x as one interval that neither alone witnesses.
+auto run_mixed_witness_test(bool proofs) -> void
+{
+    print(cerr, "all_equal mixed witness{}", proofs ? " with proofs:" : ":");
+    cerr << flush;
+
+    const int hi = 20;
+    auto without = [](int lo, int upper, int gap_lo, int gap_hi) {
+        vector<int> vs;
+        for (int v = lo; v <= upper; ++v)
+            if (v < gap_lo || v > gap_hi)
+                vs.push_back(v);
+        return vs;
+    };
+    auto dy = without(0, hi, 5, 9);
+    auto dz = without(0, hi, 10, 14);
+
+    auto in = [](int v, const vector<int> & sv) {
+        for (auto u : sv)
+            if (u == v)
+                return true;
+        return false;
+    };
+
+    set<tuple<int, int, int>> expected, actual;
+    build_expected(
+        expected, [&](int x, int y, int z) -> bool { return x == y && y == z && in(y, dy) && in(z, dz); }, pair{0, hi}, pair{0, hi}, pair{0, hi});
+    println(cerr, " expecting {} solutions", expected.size());
+
+    auto to_integers = [](const vector<int> & vs) {
+        vector<Integer> out;
+        for (auto v : vs)
+            out.emplace_back(v);
+        return out;
+    };
+
+    Problem p;
+    auto x = p.create_integer_variable(0_i, Integer{hi});
+    auto y = p.create_integer_variable(to_integers(dy));
+    auto z = p.create_integer_variable(to_integers(dz));
+    p.post(AllEqual{vector<IntegerVariableID>{x, y, z}});
+
+    auto proof_name = proofs ? make_optional("all_equal_test_mixed_witness") : nullopt;
+    solve_for_tests_checking_gac(p, proof_name, expected, actual, tuple{x, y, z});
+    check_results(proof_name, expected, actual);
+}
+
 // Dup-variable test: AllEqual with the same handle in several positions.
 // Duplicates are idempotent (x = x is vacuous); the constraint reduces to
 // AllEqual over the unique vars. Consistency isn't checked on dup runs;
@@ -250,6 +306,7 @@ auto main(int argc, char * argv[]) -> int
             run_test(proofs, view_cfg, doms);
         if (run_holes)
             run_holes_test(proofs);
+        run_mixed_witness_test(proofs);
         if (view_wrap_config_is_effectively_bare(view_cfg, n_positions)) {
             // Degenerate collections with genuine constants (issue #254).
             run_all_equal_collection_test(proofs, "empty", {});

--- a/gcs/constraints/all_equal/all_equal_test.cc
+++ b/gcs/constraints/all_equal/all_equal_test.cc
@@ -164,6 +164,13 @@ auto run_holes_test(bool proofs) -> void
 //
 // x is the full range; y is missing the lower half of the middle band and z the
 // upper half, so the band leaves x as one interval that neither alone witnesses.
+//
+// Bare variables only, like run_holes_test above, and gated the same way. The view
+// lanes would add nothing here -- nothing is wrapped -- but they would share this
+// fixed proof basename with the plain lane, and the two lanes share a working
+// directory and delete their proofs once veripb has run. Under `ctest -j` that
+// races: 5 rounds in 6 of `ctest -R all_equal -j 8` failed before the gate, either
+// losing the file outright or parsing one still being written.
 auto run_mixed_witness_test(bool proofs) -> void
 {
     print(cerr, "all_equal mixed witness{}", proofs ? " with proofs:" : ":");
@@ -304,9 +311,10 @@ auto main(int argc, char * argv[]) -> int
             continue;
         for (const auto & doms : data)
             run_test(proofs, view_cfg, doms);
-        if (run_holes)
+        if (run_holes) {
             run_holes_test(proofs);
-        run_mixed_witness_test(proofs);
+            run_mixed_witness_test(proofs);
+        }
         if (view_wrap_config_is_effectively_bare(view_cfg, n_positions)) {
             // Degenerate collections with genuine constants (issue #254).
             run_all_equal_collection_test(proofs, "empty", {});

--- a/gcs/large_domain_audit_test.cc
+++ b/gcs/large_domain_audit_test.cc
@@ -288,7 +288,7 @@ namespace
         add("AllDifferentExcept", Expect::KnownTrip, [](Problem & p) { p.post(AllDifferentExcept{wide(p, 4), {0_i}}); });
         add("SymmetricAllDifferent", Expect::NoWidePosition, [](Problem & p) { p.post(SymmetricAllDifferent{narrow(p, 4, 0_i, 3_i)}); });
         add("AllEqual", Expect::Clean, [](Problem & p) { p.post(AllEqual{wide(p, 3)}); });
-        add("AllEqual/holes", Expect::KnownTrip, [](Problem & p) {
+        add("AllEqual/holes", Expect::Clean, [](Problem & p) {
             // all_equal.cc:114 prunes every variable to the intersection of all
             // the domains once any of them has holes. It takes the difference as
             // intervals (each_interval_minus) but then walks each interval a
@@ -296,7 +296,7 @@ namespace
             // hole. Bounds propagation runs first and would collapse a merely
             // narrow partner, so the hole has to be spread across the full width:
             // a two-value domain at the extremes leaves the whole middle of the
-            // other variable to remove.
+            // other variable to remove -- which is now one range removal.
             //
             // Note this row used to trip on the `In` that create_integer_variable
             // posts to carve the hole, rather than on AllEqual at all. With that


### PR DESCRIPTION
Part of #833 (stage 4), stacked on #860.

The values to remove were **already computed as intervals** with `each_interval_minus` and
then written out one at a time, so the interval was in hand when the per-value loop
started. What stopped that being a one-line change is the *witness*: the reason names some
variable whose domain lacks the value, and because the difference is taken against the
intersection of *every* domain, which variable that is can change part-way through an
interval.

So the difference is taken against one variable at a time instead. Every range that yields
against `vars[j]` has `vars[j]` as a witness for the whole of it, by construction, and
ranges already accounted for are struck off as we go, so each is removed once rather than
once per variable that happens to witness it. The union over `j` of `D_i \ D_j` is `D_i`
minus the intersection of the others, which is `D_i \ common` — so the removal set is
exactly what it was, confirmed by identical node counts on every benchmark shape.

Domains are snapshotted up front: the old code took `common` from the state on entry to the
block, so recomputing a domain mid-loop would use one this block had already shrunk, and
could remove more.

## The proof

`equals.cc`'s, generalised from two variables to n:
`justify_not_in_range_across_equality` carries the bounds across to `vars[j]`, and then the
reason's range literal is a clause with every literal falsified.

The model here is a **chain** of consecutive-pair equalities, so for non-adjacent `i` and
`j` unit propagation has to walk the chain between them. That verifies — and it is checked
where the two interesting axes meet rather than where the suite happens to go: the suite
reaches witness gaps of 1–3 but only ranges of **width 1**, so the wide case is checked
separately, at widths up to **4999** with gaps up to **5**. A negative control confirms the
lemmas are load-bearing: suppress them and VeriPB rejects.

## Two performance findings, both from the benchmark rather than the tests

- **A width-1 range literal *is* the eq atom** — the proof machinery never makes an interval
  of one — so saying it as `infer_not_equal` is the identical inference at no
  set-construction cost. Over holey domains most removed intervals are single values, and
  routing them through the interval path cost 2%.
- **The witness-splitting machinery almost never has anything to split.** A scan for a
  single covering witness is a few allocation-free merge-walks, where building a leftover
  set to subtract from allocates whatever happens. Checking the easy case first takes most
  of the rest back.

Together those bring a rewrite that was 2.5% slower on holey-domain search back to level on
two-interval domains, the common shape. **On four-interval domains it is still about 1.7%
behind**, which is the honest cost of width-independence here.

## A branch with no coverage at all

The splitting branch was reached by nothing — not the suite, not the probes — because
everywhere they go, one variable's hole happens to cover the whole run. `all_equal_test`
gains a case that forces it: `x` full, `y` missing the lower half of the middle band and `z`
the upper half, so the band leaves `x` as one interval that neither alone witnesses. It
reaches the branch, and verifies at widths up to 1000.

## Measurements

Pinned, three repeats, node counts identical throughout:

| | before | after |
|---|---|---|
| wide (5 wide vars vs a two-value partner) | 198 ms | **0 ms** |
| narrow2 (two-interval holey domains) | 355 ms | **352 ms** |
| narrow (four-interval holey domains) | 365 ms | 371 ms |
| audit probe at `0..10^9` | 131 s, 16 GB | **6 ms, 4.7 MB** |
| proof survey | 16987 → 169987 steps | **flat 37** |

## Testing

804/804. `all_equal_test` uncapped on GCC and clang, plain and view-wrapped. Audit lane
green, and the row flips to `Clean`.

That leaves **`GlobalCardinality/hall` as the only row in the survey whose steps still
grow** — see #857.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EdcpzKhRabS67Kcfq3eq9e
