### PR TITLE
Constraint family documents: the template, equals as the pilot, and its re-audit

### DIFF
--- a/dev_docs/README.md
+++ b/dev_docs/README.md
@@ -29,6 +29,14 @@ library. For an introduction to *using* the solver, start with the top-level
   building blocks, and the testing pattern. Start here when adding any new
   constraint — and for the umbrella-header directory layout, which presolvers
   under `gcs/presolvers/` share.
+- [Justification techniques](justification-techniques.md) — why our proof
+  steps are RUP, rather than merely that they are. Collects the
+  unit-propagation facts the solver leans on (Theorems 2.6–2.9 of McIlree's
+  thesis), the completeness invariant `Inv1` behind them, the published
+  justification procedures our constraints instantiate, and the preconditions
+  that say when each argument stops working. Cite it from a constraint's
+  documentation or comments instead of restating the proof; read it before
+  claiming a new inference is RUP.
 - [Template: a constraint family document](constraints/TEMPLATE.md) — the
   skeleton every per-family document under `dev_docs/constraints/` follows,
   plus the conventions and the closed vocabularies (proof technique,

--- a/dev_docs/README.md
+++ b/dev_docs/README.md
@@ -36,6 +36,12 @@ library. For an introduction to *using* the solver, start with the top-level
   documents draw on. Also carries the family list — authoritative for what
   counts as a family — and the variant template for presolvers. Read before
   writing or auditing a family document.
+- [Constraint family documents](constraints/README.md) — the per-family
+  documents (semantics, frontend coverage, OPB encoding, one entry per
+  inference rule with its proof technique and assertion hint, robustness
+  limits, measured CPU and proof performance, and what wants work). Index plus
+  the template that governs them. Read the template before writing or auditing
+  one.
 - [Reification](reification.md) — additional machinery for *reified* constraints:
   the `ReificationCondition` static and `EvaluatedReificationCondition` runtime
   types, the `install_reified_dispatcher` helper, the OPB encoding pattern,

--- a/dev_docs/README.md
+++ b/dev_docs/README.md
@@ -29,6 +29,13 @@ library. For an introduction to *using* the solver, start with the top-level
   building blocks, and the testing pattern. Start here when adding any new
   constraint — and for the umbrella-header directory layout, which presolvers
   under `gcs/presolvers/` share.
+- [Template: a constraint family document](constraints/TEMPLATE.md) — the
+  skeleton every per-family document under `dev_docs/constraints/` follows,
+  plus the conventions and the closed vocabularies (proof technique,
+  consistency level, offline-reconstructibility verdict, frontend cell) those
+  documents draw on. Also carries the family list — authoritative for what
+  counts as a family — and the variant template for presolvers. Read before
+  writing or auditing a family document.
 - [Reification](reification.md) — additional machinery for *reified* constraints:
   the `ReificationCondition` static and `EvaluatedReificationCondition` runtime
   types, the `install_reified_dispatcher` helper, the OPB encoding pattern,
@@ -70,10 +77,12 @@ library. For an introduction to *using* the solver, start with the top-level
   writing or checking, records which candidates are too large to
   proof-log at all, and lists the argument-shape traps. Use when
   changing proof logging, scaffolding, encodings or hinting.
-- [Frontend support matrix](frontend-support-matrix.md) — single source of
-  truth for which gcs propagators each frontend (MiniZinc, XCSP3, CPMpy)
-  exposes, plus where the solver-side gaps are tracked. Update when adding
-  a propagator or a frontend binding.
+- [Frontend support matrix](frontend-support-matrix.md) — which gcs
+  propagators each frontend (MiniZinc, XCSP3, CPMpy) exposes, plus where the
+  solver-side gaps are tracked. **Being retired**: its rows are migrating into
+  the per-family documents under `dev_docs/constraints/`. Update the family
+  document rather than this file, and delete this one once every family carries
+  its rows.
 - [Proof logging for `Cumulative`](cumulative-proof-logging.md) — concrete
   walk-through of the three-inference proof for the time-table propagator:
   the `pol`-over-`active=1`-flags idiom, the "extended-reason pinning"

--- a/dev_docs/constraints/README.md
+++ b/dev_docs/constraints/README.md
@@ -19,4 +19,12 @@ constraints and do not restate it.
   propagation time). The pilot for this template.
 
 Everything else is still to write; the family list in
-[`TEMPLATE.md`](TEMPLATE.md#provisional-family-list) is the work plan.
+[`TEMPLATE.md`](TEMPLATE.md#provisional-family-list) is the work plan, and #871
+is the tracker for the arc — including the method that produced the pilot, and
+the decisions already settled.
+
+The point of the arc is not a complete set of documents. It is that by the time
+the audit is done, the solver is in a good state to write the
+proof-logging-for-CP paper: each family gets read carefully, its problems get
+filed and fixed, and the document is the record of that pass. Expect the fixing
+to outweigh the writing — the pilot filed seven issues.

--- a/dev_docs/constraints/README.md
+++ b/dev_docs/constraints/README.md
@@ -1,0 +1,22 @@
+# Constraint family documents
+
+One document per constraint family, written to
+[`TEMPLATE.md`](TEMPLATE.md) — which is also where the conventions, the closed
+vocabularies, and the authoritative family list live. Read it before writing or
+auditing one of these.
+
+`dev_docs/constraints.md`, one directory up, stays the generic "how to
+implement a constraint" guide. These documents are about particular
+constraints and do not restate it.
+
+## Written so far
+
+- [`equals.md`](equals.md) — `Equals`, `NotEquals` and the four reified forms:
+  one class and one propagator behind six posted constraints, a definitional
+  bit-sum OPB encoding that stays logarithmic in domain width, nine inference
+  rules of which one is O(domain width) and blows up at 10⁹, and the busiest
+  propagator in the solver on clique-encoded models (71% of calls, 18% of
+  propagation time). The pilot for this template.
+
+Everything else is still to write; the family list in
+[`TEMPLATE.md`](TEMPLATE.md#provisional-family-list) is the work plan.

--- a/dev_docs/constraints/README.md
+++ b/dev_docs/constraints/README.md
@@ -14,9 +14,11 @@ constraints and do not restate it.
 - [`equals.md`](equals.md) — `Equals`, `NotEquals` and the four reified forms:
   one class and one propagator behind six posted constraints, a definitional
   bit-sum OPB encoding that stays logarithmic in domain width, nine inference
-  rules of which one is O(domain width) and blows up at 10⁹, and the busiest
-  propagator in the solver on clique-encoded models (71% of calls, 18% of
-  propagation time). The pilot for this template.
+  rules under three wire hints, and the busiest propagator in the solver on
+  clique-encoded models (71% of calls, 18% of propagation time). The pilot for
+  this template, and now also the first **re-audit**: it filed seven issues,
+  six are fixed, and four of the fixes changed what the document says rather
+  than only what the code does.
 
 Everything else is still to write; the family list in
 [`TEMPLATE.md`](TEMPLATE.md#provisional-family-list) is the work plan, and #871
@@ -27,4 +29,8 @@ The point of the arc is not a complete set of documents. It is that by the time
 the audit is done, the solver is in a good state to write the
 proof-logging-for-CP paper: each family gets read carefully, its problems get
 filed and fixed, and the document is the record of that pass. Expect the fixing
-to outweigh the writing — the pilot filed seven issues.
+to outweigh the writing, and expect the document to need rewriting afterwards:
+the pilot filed seven issues, six of the fixes landed, and bringing the
+document back into line with them touched the rule catalogue, the robustness
+section, both performance tables and every measured figure. A family document
+is the record of a pass, so a pass that changes the code changes the document.

--- a/dev_docs/constraints/TEMPLATE.md
+++ b/dev_docs/constraints/TEMPLATE.md
@@ -354,9 +354,13 @@ between rules stays in the entries, even when most of them agree.*
   weakened when proofs are enabled. `None.` is the expected answer.*
 - **Tightness** — *whether a mutation of **this rule's** derivation has been
   shown to be refused by VeriPB, and which corruption. `Not shown.` is an
-  acceptable answer, and marks a rule whose proof is accepted but not known to
-  be tight. Where a lane's instance took work to build, say what the slack
-  instances were: that part is reusable, and the corruption rarely is.*
+  ordinary answer, not a defect: mutation lanes are a development tool, worth
+  their cost while a derivation is being written or changed and not worth
+  adding for the sake of the tally. The field exists so that someone about to
+  change a rule can see whether a lane will catch them, which is a different
+  question from whether every rule has one. Where a lane's instance took work
+  to build, say what the slack instances were: that part is reusable, and the
+  corruption rarely is.*
 
 ## Evidence
 
@@ -371,11 +375,13 @@ between rules stays in the entries, even when most of them agree.*
 - *whether the tests are seeded (`--seed=N`) and so byte-reproducible;*
 - *whether any real instance has been ported into a data-driven test, and
   which repros have not been;*
-- *whether the derivations have been shown to be tight, and whether a
-  **control** lane checks that the same instances verify uncorrupted — without
-  one, a mutation lane can be green because its instance does not verify
-  either. The per-rule evidence goes in that rule's **Tightness** field; this
-  is the inventory and the harness.*
+- *whether any derivation has been shown to be tight, and — where lanes exist
+  — whether a **control** lane checks that the same instances verify
+  uncorrupted, without which a mutation lane can be green because its instance
+  does not verify either. The per-rule evidence goes in that rule's
+  **Tightness** field; this is the inventory and the harness. Partial coverage
+  is the expected state, so say which rules have a lane rather than treating
+  the rest as outstanding work.*
 
 *Then, as a separate list, **what the tests do not cover**. This is the half
 that makes the section worth writing: the domain widths the suite never reaches,

--- a/dev_docs/constraints/TEMPLATE.md
+++ b/dev_docs/constraints/TEMPLATE.md
@@ -104,6 +104,12 @@ measured at, the date, and anything about the machine that mattered. A figure
 without that is worse than no figure, because it will be quoted a year later.
 Cite numbers that are in a table somewhere; do not report a remembered one.
 
+A figure **measured elsewhere** — an issue's pre-merge A/B, another machine,
+an earlier toolchain — is still worth keeping, but it goes in its own labelled
+paragraph saying where it came from, never in a table beside figures from this
+audit. Say outright that the two sets should not be mixed; otherwise someone
+will put them in one table and compute a ratio across them.
+
 **Vocabularies verbatim.** Proof techniques from [Appendix
 A](#appendix-a-proof-technique-vocabulary), consistency levels from [Appendix
 B](#appendix-b-consistency-level-vocabulary), reconstructibility verdicts from
@@ -139,6 +145,10 @@ and replace the italicised instructions with content.
 
 > **Maturity** production | experimental | checker-only | decomposition-only ·
 > **Audited** *yyyy-mm-dd* at `<commit>` · **Open issues** #nnn, #nnn
+
+*When nothing is open, say so and point at [Next steps](#next-steps) for what
+this audit would file — an empty issue list and an unaudited family should not
+read the same.*
 
 *One short paragraph: what this family is for, and the single most important
 thing a reader should know before touching it.*
@@ -186,11 +196,16 @@ would be wanted.*
 
 ### Relation to other families
 
-*Four directions, because the audit needs all of them: what decomposes **into**
-this family; what this family posts as **child constraints**; which
-**presolvers** rewrite it or rewrite into it; and whether it is reachable only
-via a decomposition from a frontend, in which case nothing exercises the
-propagator directly.*
+*Five directions, because the audit needs all of them: what decomposes
+**into** this family; what this family posts as **child constraints**; what
+other families **share its code** (an exported helper called from elsewhere is
+a coupling a reader will not otherwise see, and a change to it is a change to
+them); which **presolvers** rewrite it or rewrite into it; and whether it is
+reachable only via a decomposition from a frontend, in which case nothing
+exercises the propagator directly.*
+
+*If the family list marks this family as a candidate merge with another,
+settle it here and say which way, so the next reader does not re-open it.*
 
 ## The proof model
 
@@ -285,6 +300,16 @@ buy.*
 `### Rule: <short-name>` — so that the whole corpus can be swept for rules.
 Every field appears in every entry.*
 
+*A rule is **one inference the propagator makes**, not one propagator: a single
+propagator that pushes a bound, removes a value and detects a contradiction is
+three rules. Expect this section to be the bulk of the document — the smallest
+constraint in the solver has nine rules.*
+
+*Facts that hold for **every** rule in the family — the hint type they all
+share, an invariant like "no justification reads `state`" — go in a short
+preamble here rather than being repeated in each entry. Anything that varies
+between rules stays in the entries, even when most of them agree.*
+
 ### Rule: short-name
 
 - **Infers** — *what is inferred: a bound push, a value removal, a
@@ -334,6 +359,12 @@ Every field appears in every entry.*
 - *whether the derivation has been shown to be tight — a mutation that VeriPB
   should refuse, and does.*
 
+*Then, as a separate list, **what the tests do not cover**. This is the half
+that makes the section worth writing: the domain widths the suite never reaches,
+the check that turns out to be weaker than its name suggests, the evidence that
+was never recorded. A test section that only inventories what exists has not
+audited anything.*
+
 ### Benchmarks and examples
 
 *Which in-repo examples and MiniZinc Challenge instances exercise this family.
@@ -358,6 +389,16 @@ from a different search.*
 *The proof axis, which the paper's headline table is made of: proof size, VeriPB
 verification time, the ratio of verification to solve time, and which instances
 are too large to verify at all. Same provenance requirement.*
+
+*Two things to separate out, because a raw proof size conflates them. First,
+this family's **own** contribution against what the shared layers (the
+order-literal and equality-literal definitions, the range-literal layer) emit
+around it — for a cheap constraint the shared layers dominate, and a proof-size
+figure that does not say so will be read as this family's cost. Second, the
+size and verification time at the **assertion levels** as well as fully
+justified, since that difference is what an external justifier consumes; report
+how many assertions carry this family's hint, and what share of the proof's
+assertions that is.*
 
 ## Status, gaps, and next steps
 
@@ -387,6 +428,10 @@ the reason the audit was worth writing down.*
 has certified this constraint before, if anyone, and in what proof system; and
 what is novel here. Without this the attribution has to be reconstructed for
 thirty families at writing time.*
+
+*"There is none" is a good answer when it is argued: for some families nobody
+publishes a propagation algorithm and all the interesting content is on the
+proof side, which is itself something a survey wants to say.*
 
 ## Further reading
 
@@ -529,7 +574,8 @@ this table moves to `dev_docs/constraints/README.md` once it is stable.
 | `at_most_one.md` | `at_most_one/` | |
 | `bin_packing.md` | `bin_packing/` | existing note `bin-packing.md` |
 | `circuit.md` | `circuit/` | includes subcircuit |
-| `comparison.md` | `comparison/`, `equals/` | *candidate merge*: equality and inequality primitives, including `ReifiedEquals` |
+| `comparison.md` | `comparison/` | twelve classes over `ReifiedCompareLessThanOrMaybeEqual`; **not** merged with `equals` — same reified-dispatcher pattern, no shared code, separate encodings |
+| `equals.md` | `equals/` | **written** — the pilot. `Equals`, `NotEquals` and the four reified forms |
 | `count.md` | `count/` | see `among` |
 | `cumulative.md` | `cumulative/` | the largest family; notes `cumulative-proof-logging.md`, `certified-makespan-bounds.md`, `rule-counters.md` |
 | `difference.md` | `difference/` | difference constraints; note `difference-logic.md`, whose presolver half belongs under `dev_docs/presolvers/` |

--- a/dev_docs/constraints/TEMPLATE.md
+++ b/dev_docs/constraints/TEMPLATE.md
@@ -110,6 +110,23 @@ paragraph saying where it came from, never in a table beside figures from this
 audit. Say outright that the two sets should not be mixed; otherwise someone
 will put them in one table and compute a ratio across them.
 
+**Notation.** Write the bit-sum encoding of a variable as **`BinEnc(v)`**,
+which is the thesis's own notation and so the one a reader of both will
+recognise. Do not use `⟦v⟧`: semantic brackets already mean Boolean condition
+evaluation, and they are awkward to type.
+
+**"Lemma" is ours, informally, and stays undefined on purpose.** These
+documents, ten others under `dev_docs/`, and several headers
+(`comparator_network.hh` most of all) use "lemma" for an intermediate
+constraint a justification derives and adds to the proof before asserting its
+conclusion — normally at `ProofLevel::Temporary`, so it is deleted again. It is
+**not** a VeriPB concept, and the reason it is not defined here is that the
+thing it would name — a nameable, reusable derived statement — is a feature
+VeriPB cannot soundly have. So there is nothing formal to point at, and
+inventing a local definition would only compete with the informal usage
+everywhere else. Keep using the word; if VeriPB ever grows a `lemma`, we change
+the terminology across the tree in one go rather than per document.
+
 **Vocabularies verbatim.** Proof techniques from [Appendix
 A](#appendix-a-proof-technique-vocabulary), consistency levels from [Appendix
 B](#appendix-b-consistency-level-vocabulary), reconstructibility verdicts from
@@ -334,9 +351,21 @@ between rules stays in the entries, even when most of them agree.*
   single most-often-fudged line.*
 - **Why it is true** — *the mathematical argument, stated independently of any
   proof system. Someone should be able to check the rule is sound from this
-  line without knowing what VeriPB is.*
+  line without knowing what VeriPB is. So no proof-line counts, no emission
+  costs and no VeriPB vocabulary belong here — those go in **Proof technique**
+  and **Proof size**. It is an easy field to leak into, because for a rule
+  whose argument and whose derivation have the same shape the two want to be
+  written as one table; keep them apart anyway, since the whole value of this
+  field is being readable by someone auditing soundness rather than proofs.*
 - **Proof technique** — *from [Appendix
-  A](#appendix-a-proof-technique-vocabulary), verbatim.*
+  A](#appendix-a-proof-technique-vocabulary), verbatim, **and what licenses
+  it**: the justification procedure this rule is an instance of, and the
+  theorem behind that procedure, per
+  [justification-techniques.md](../justification-techniques.md). Where there is
+  no published procedure — the rule is ours — say so outright, because that is
+  precisely what an external justifier cannot replay, and then owe the
+  argument to **Why it is true**. State the procedure's **preconditions**: they
+  are what tells a later reader whether the citation survives a change.*
 - **Reason** — *which literals go into the reason, and whether that set is
   minimal. The reason is what the external tool sees; a non-minimal one costs
   it trimming work. A justification reads the reason, never `state`.*
@@ -488,22 +517,32 @@ and have no such notes; there is no need to manufacture one.*
 Use these names verbatim in the **Proof technique** field. A rule may name more
 than one.
 
-| Name | Meaning |
-|---|---|
-| `RUP` | plain reverse unit propagation, no hints |
-| `RUP+hints` | RUP with explicit constraint-id hints |
-| `pol` | a cutting-planes derivation: linear combination, with `saturate` / division as needed |
-| `extended reason` | a hypothetical literal pinned into the reason so the inference becomes RUP-derivable |
-| `redundance` | extension-variable introduction, i.e. defining a `ProofFlag` |
-| `dominance` | a dominance-rule derivation |
-| `cases` | the VeriPB 3 `cases` rule |
-| `chain scaffolding` | root-level per-value chains that a later RUP resolves against, as the diagram-shaped constraints use |
-| `counting argument` | pigeonhole or an at-most-one recurrence carrying an exact coefficient |
-| `sorting network` | a derivation through a network's comparator rows |
-| `a` oracle | an unchecked assertion — **not** a proof, and always also a gap |
-| `not logged` | the inference is made but nothing is emitted — always also a gap |
+**A name is not an argument.** `RUP` says which VeriPB rule we emit; it does
+not say why unit propagation will succeed, which depends on the shape of the
+row and the encoding underneath it. So the field takes a name from this table
+**and** the result that licenses it — see
+[justification-techniques.md](../justification-techniques.md), which collects
+the handful of unit-propagation facts the solver leans on and maps them onto
+the published justification procedures. Cite a procedure and a theorem; do not
+paraphrase the proof.
 
-Adding a name here is fine; inventing one locally is not.
+| Name | Meaning | Where the licence comes from |
+|---|---|---|
+| `RUP` | plain reverse unit propagation, no hints | a justification procedure (JP 3.1, 3.2, 3.12, 3.15, …) resting on Thm 2.6–2.9 |
+| `RUP+hints` | RUP with explicit constraint-id hints | as `RUP`; the hint is for the reader, not the checker |
+| `pol` | a cutting-planes derivation: linear combination, with `saturate` / division as needed | the derivation itself, stated in the rule |
+| `extended reason` | a hypothetical literal pinned into the reason so the inference becomes RUP-derivable | Thm 2.6, plus whatever licenses the underlying step |
+| `redundance` | extension-variable introduction, i.e. defining a `ProofFlag` | Thm 2.4 (extension variables) |
+| `dominance` | a dominance-rule derivation | the dominance rule's own side conditions — state them |
+| `cases` | the VeriPB 3 `cases` rule | `dev_docs/`'s `cases`-rule notes |
+| `chain scaffolding` | root-level per-value chains that a later RUP resolves against, as the diagram-shaped constraints use | the family's own argument |
+| `counting argument` | pigeonhole or an at-most-one recurrence carrying an exact coefficient | the family's own argument |
+| `sorting network` | a derivation through a network's comparator rows | the network's comparator rows, per family |
+| `a` oracle | an unchecked assertion — **not** a proof, and always also a gap | nothing; that is the point |
+| `not logged` | the inference is made but nothing is emitted — always also a gap | nothing |
+
+Adding a name here is fine; inventing one locally is not. Adding one **without**
+saying what licenses it is how the table stopped being useful the first time.
 
 ## Appendix B: consistency level vocabulary
 

--- a/dev_docs/constraints/TEMPLATE.md
+++ b/dev_docs/constraints/TEMPLATE.md
@@ -144,11 +144,21 @@ and replace the italicised instructions with content.
 # `Family`: one-line statement of what it enforces
 
 > **Maturity** production | experimental | checker-only | decomposition-only ·
-> **Audited** *yyyy-mm-dd* at `<commit>` · **Open issues** #nnn, #nnn
+> **Audited** *yyyy-mm-dd* at `<commit>`; re-audited *yyyy-mm-dd* at
+> `<commit>` · **Open issues** #nnn, #nnn
 
 *When nothing is open, say so and point at [Next steps](#next-steps) for what
 this audit would file — an empty issue list and an unaudited family should not
 read the same.*
+
+*A **re-audit** is a distinct event, and the status line carries both dates,
+because a reader needs to know which commit each figure was taken at. When the
+audit's own issues get fixed the document has to be brought back into line with
+them and re-measured; fixing four issues in one family moved its rule
+catalogue, its robustness section and both performance tables. Open the
+re-audit with a short `issue → PR → what it changed here` table, so the diff
+against the first pass is legible, and say outright which figures were taken
+again.*
 
 *One short paragraph: what this family is for, and the single most important
 thing a reader should know before touching it.*
@@ -342,6 +352,11 @@ between rules stays in the entries, even when most of them agree.*
   provenance if there is one.*
 - **Gaps** — *whether this rule is logged at all, and whether the propagator is
   weakened when proofs are enabled. `None.` is the expected answer.*
+- **Tightness** — *whether a mutation of **this rule's** derivation has been
+  shown to be refused by VeriPB, and which corruption. `Not shown.` is an
+  acceptable answer, and marks a rule whose proof is accepted but not known to
+  be tight. Where a lane's instance took work to build, say what the slack
+  instances were: that part is reusable, and the corruption rarely is.*
 
 ## Evidence
 
@@ -356,8 +371,11 @@ between rules stays in the entries, even when most of them agree.*
 - *whether the tests are seeded (`--seed=N`) and so byte-reproducible;*
 - *whether any real instance has been ported into a data-driven test, and
   which repros have not been;*
-- *whether the derivation has been shown to be tight — a mutation that VeriPB
-  should refuse, and does.*
+- *whether the derivations have been shown to be tight, and whether a
+  **control** lane checks that the same instances verify uncorrupted — without
+  one, a mutation lane can be green because its instance does not verify
+  either. The per-rule evidence goes in that rule's **Tightness** field; this
+  is the inventory and the harness.*
 
 *Then, as a separate list, **what the tests do not cover**. This is the half
 that makes the section worth writing: the domain widths the suite never reaches,
@@ -384,6 +402,12 @@ from a different search.*
 
 *Caption every table with the build, commit, date and machine.*
 
+*Say what the chosen benchmark does **not** exercise. A family's natural
+benchmark often reaches a small minority of its rules — read that off the
+proof's assertions rather than guessing — and a per-inference cost quoted from
+it is an average over those. Without this line, a cross-family pivot over these
+documents will silently compare unlike things.*
+
 ### Proof performance
 
 *The proof axis, which the paper's headline table is made of: proof size, VeriPB
@@ -398,7 +422,12 @@ figure that does not say so will be read as this family's cost. Second, the
 size and verification time at the **assertion levels** as well as fully
 justified, since that difference is what an external justifier consumes; report
 how many assertions carry this family's hint, and what share of the proof's
-assertions that is.*
+assertions that is, broken down by wire form.*
+
+*The own-versus-shared split wants a **measurement**, not an estimate. Vary
+whatever the family's cost is proportional to, count the lines each layer
+emits, and give the two as functions of it. "2n against 10n + 1" is a finding;
+"the shared layers dominate" is a guess that happens to be right.*
 
 ## Status, gaps, and next steps
 

--- a/dev_docs/constraints/TEMPLATE.md
+++ b/dev_docs/constraints/TEMPLATE.md
@@ -1,0 +1,570 @@
+# Template: a constraint family document
+
+Every constraint family in `gcs/constraints/` gets one document under
+`dev_docs/constraints/`, written to the skeleton below. This file is the
+skeleton, the conventions that govern filling it in, and the controlled
+vocabularies the sections draw on.
+
+These documents are meant to serve five purposes at once, and the shape is a
+compromise between them:
+
+1. **Structure.** Give the developer documentation we already have a fixed
+   place to live, per family, instead of a pile of individually-shaped design
+   notes.
+2. **The paper.** Supply the raw material for a "VeriPB proof logging for all
+   of constraint programming" writeup — which wants a row per *inference rule*,
+   naming its proof technique, its proof size, and its provenance.
+3. **The external justification tool.** Matthew's tool takes a proof in which
+   the solver emitted only VeriPB `a` lines plus hints, trims it, and replaces
+   the remaining `a` lines with real derivations. It needs to know, per rule,
+   exactly what is asserted, exactly what the hint carries, and whether the
+   derivation can be rebuilt from those two things alone. GCS also needs a mode
+   that emits hints only; these documents are its specification.
+4. **Triage.** Flag the implementations that want more work, with enough
+   detail that the flag is actionable rather than a feeling.
+5. **Audit.** Give a one-family-at-a-time code review something to be written
+   down in, so the result is recorded rather than re-derived next time.
+
+## Why this shape
+
+The obvious organisation — one narrative per family — does not serve purposes
+2, 3 and 4, because all three of them key off individual *inference rules*, not
+families. The paper wants a table row per rule. Matthew's tool wants a record
+per rule. Triage lands on rules ("edge-finding is certified, the energetic
+variant is not"). So the repeated, uniform unit in these documents is the rule,
+under [Inference catalogue](#inference-catalogue), and the sections before it
+exist mostly to give the rules a shared context to refer back to.
+
+That is also why the vocabularies in the appendices are *closed lists* used
+verbatim. If every family names its proof techniques, consistency levels and
+reconstructibility verdicts from the same short lists, then the paper's
+headline tables and the external tool's coverage matrix are a pivot over these
+documents rather than a re-reading of thirty of them.
+
+## Where these live
+
+```
+dev_docs/constraints/README.md      index: the family list, one line each
+dev_docs/constraints/<family>.md    one per family
+dev_docs/presolvers/<name>.md       one per presolver (see the variant below)
+```
+
+The file name is the `gcs/constraints/` directory name, so the mapping is
+mechanical — with the documented exceptions in [the family
+list](#provisional-family-list), which is authoritative for what counts as a
+family. Do not derive the family list from `ls`: arithmetic is one family
+spread over several directories and loose headers, and some directories
+(`innards/`, `extensional_utils`) are not families at all.
+
+This directory sits alongside `dev_docs/constraints.md`, which stays the
+generic "how to implement a constraint" guide. These documents are about
+*particular* constraints and should not restate it — link instead.
+
+## How to fill it in
+
+**Mandatory sections must appear even when the answer is "none".** A section
+that has been considered and found empty and a section nobody looked at are
+different states, and a reader cannot tell them apart if the empty one is
+simply absent. Say `None.` and move on. The optional sections may be dropped
+entirely.
+
+| Section | |
+|---|---|
+| Status line | mandatory |
+| Semantics | mandatory |
+| Concrete constraints and frontend coverage | mandatory |
+| Options | mandatory (`None.` if there are none) |
+| Variable kinds and views | mandatory |
+| Reification | mandatory |
+| Relation to other families | mandatory |
+| OPB encoding | mandatory |
+| Labels | mandatory |
+| Cake conformity | mandatory |
+| Proof-time state | mandatory |
+| Initialisation and global data | mandatory |
+| Propagator inventory | mandatory |
+| Mutable state and incrementality | mandatory |
+| Robustness and limits | mandatory |
+| Inference catalogue | mandatory, one entry per rule |
+| Tests | mandatory |
+| Benchmarks and examples | mandatory |
+| CPU performance | mandatory (`Not measured.` is an acceptable answer) |
+| Proof performance | mandatory (likewise) |
+| Proof-logging gaps | mandatory |
+| Known limitations | mandatory |
+| Next steps | mandatory |
+| Prior art | optional |
+| Further reading | optional |
+| Developer commentary | optional |
+
+Three more rules:
+
+**Provenance on every number.** A performance figure carries the commit it was
+measured at, the date, and anything about the machine that mattered. A figure
+without that is worse than no figure, because it will be quoted a year later.
+Cite numbers that are in a table somewhere; do not report a remembered one.
+
+**Vocabularies verbatim.** Proof techniques from [Appendix
+A](#appendix-a-proof-technique-vocabulary), consistency levels from [Appendix
+B](#appendix-b-consistency-level-vocabulary), reconstructibility verdicts from
+[Appendix C](#appendix-c-reconstructibility-verdicts), frontend cells from
+[Appendix D](#appendix-d-frontend-coverage-cells). If a family needs a
+technique the list does not have, add it to the appendix in the same commit
+rather than inventing a local name.
+
+**Existing deep docs.** Where a family already has a design note in
+`dev_docs/`, short ones (roughly under 150 lines) get appended into
+[Developer commentary](#developer-commentary) and the original deleted; long
+ones stay where they are and are cross-referenced from [Further
+reading](#further-reading) with a sentence saying what is in them. Do not
+inline a thousand-line proof-logging writeup.
+
+**`frontend-support-matrix.md` is being retired.** Its rows migrate into each
+family's [Concrete constraints and frontend
+coverage](#concrete-constraints-and-frontend-coverage) table, which is why that
+table inherits the matrix's cell vocabulary and footnote style. Delete the
+matrix once every family document carries its rows; until then, do not update
+both — update the family document and let the matrix rot.
+
+---
+
+# The skeleton
+
+Everything from here down is the template. Copy it, delete these two lines,
+and replace the italicised instructions with content.
+
+---
+
+# `Family`: one-line statement of what it enforces
+
+> **Maturity** production | experimental | checker-only | decomposition-only ·
+> **Audited** *yyyy-mm-dd* at `<commit>` · **Open issues** #nnn, #nnn
+
+*One short paragraph: what this family is for, and the single most important
+thing a reader should know before touching it.*
+
+## What it is
+
+### Semantics
+
+*The precise semantics, with the signature. `Foo(X, Y, 3)` enforces that `X` is
+fooed by `Y` no more than three times. Say what happens in the degenerate cases
+— empty arrays, a single variable, a zero bound — because that is where the
+frontends and the tests disagree.*
+
+### Concrete constraints and frontend coverage
+
+*One row per posted constraint in this family. Cells use [Appendix
+D](#appendix-d-frontend-coverage-cells). Footnote anything non-obvious,
+especially a `decompose` cell: say what it decomposes into.*
+
+| C++ class | MiniZinc / FlatZinc | XCSP3 | CPMpy | SCP `s_expr` | Notes |
+|---|---|---|---|---|---|
+| `Foo` | `fzn_foo` ✓ | `foo` ✓ | ? | ✓ | |
+
+### Options
+
+*Each option: what it does, its default, and why that is the default. Then the
+question that matters most — does the option change the **OPB model**, or only
+the propagation and proof strategy? A knob should pick a strategy, not a model;
+an option that changes the model needs a reason. Note any legacy tunables kept
+as no-op dummies so that one binary can benchmark every variant.*
+
+### Variable kinds and views
+
+*Which variable kinds the constraint accepts: plain `IntegerVariableID`,
+constants, and which views. Then, separately, whether the **proof** handles
+views here, because that is where the gaps are — a propagator that accepts a
+view and a proof layer that can justify an inference about one are different
+claims.*
+
+### Reification
+
+*Whether there is a reified or half-reified form, which class provides it, and
+how it is encoded and justified. `None.` if there is not, and say whether one
+would be wanted.*
+
+### Relation to other families
+
+*Four directions, because the audit needs all of them: what decomposes **into**
+this family; what this family posts as **child constraints**; which
+**presolvers** rewrite it or rewrite into it; and whether it is reachable only
+via a decomposition from a frontend, in which case nothing exercises the
+propagator directly.*
+
+## The proof model
+
+### OPB encoding
+
+*The encoding, in the style of Matthew's thesis — no need to spell out the
+creation of integer encoding variables. Where variants of the constraint share
+an encoding, either put conditionals in the block, or use a bowtie for
+greater/less-than, or give one block per variant, whichever reads best.*
+
+*State whether the encoding is **definitional** — the rows say what the
+constraint means, and nothing more — because that is the standard here.
+Consequences of the constraint belong in the proof, not the model. If the
+encoding's size depends on domain size, say so explicitly and give the
+formula; that is what makes a family unusable at large domains.*
+
+### Labels
+
+*Only for encoding rows whose labels are actually used. Give the label, the
+rows it names, and which rule in the catalogue refers to it. A label nobody
+refers to should not be documented as if it were load-bearing.*
+
+### Cake conformity
+
+*Whether the encoding matches what `cake_pb_cp` verifies, which constraints in
+the family are covered by an SCP chain test, and where the two diverge. Name
+the divergence even when it is benign.*
+
+### Proof-time state
+
+*This section exists for the external justification tool, which has to rebuild
+derivations offline and therefore has to be able to find, by name, everything
+the assertion refers to. Cover:*
+
+- *what is emitted **at the root** as scaffolding, and what is emitted
+  **lazily** during search;*
+- *what is **deleted**, when, and whether deletion makes a later
+  reconstruction impossible;*
+- *the **naming and labelling convention** by which an external tool locates
+  that scaffolding — this is the load-bearing part;*
+- *which auxiliaries are **in the OPB** versus **introduced inside the
+  proof**, per `dev_docs/variable-encodings.md`, and whether each proof-only
+  auxiliary is determined by unit propagation on a solution (it must be, for
+  `solx`);*
+- *any proof-only vector indexed by something that dangles when proofs are
+  off.*
+
+## The implementation
+
+### Initialisation and global data
+
+*What `install_initialiser` does, what is computed once, and what that costs at
+the root. If a family has a root cost that dominates on some instance shape,
+say which shape.*
+
+### Propagator inventory
+
+*A table, because a family usually installs several propagators and the audit
+needs to see them side by side. `Rule` names the entry in the inference
+catalogue.*
+
+| Propagator | Triggers | Priority | Rule(s) | Enabled by | Idempotent? | Self-disables? |
+|---|---|---|---|---|---|---|
+| | | | | always | | |
+
+*Then a sentence per propagator on when it disables itself
+(`DisableUntilBacktrack`, or permanently), and on the idempotence claim —
+`Inference::NoChange` has to mean no change.*
+
+### Mutable state and incrementality
+
+*What state persists between calls, whether it is backtrackable
+(`add_constraint_state`) or needs no restore on backtrack, and why. What is
+recomputed per call that could in principle be maintained, and what that would
+buy.*
+
+### Robustness and limits
+
+*Mandatory, and answer every part explicitly:*
+
+- *behaviour at **large domains** — what happens at a domain of width 1e9, and
+  whether the answer is "fine", "slow", or "hangs";*
+- *behaviour at **unbounded domains**;*
+- *negative values, and zero;*
+- ***overflow** — where the arithmetic could overflow, and what guards it;*
+- *whether any cost, in the propagator or in the encoding, is proportional to
+  the **number of values** rather than the number of intervals or bits.*
+
+## Inference catalogue
+
+*One entry per inference rule, using exactly this heading form —
+`### Rule: <short-name>` — so that the whole corpus can be swept for rules.
+Every field appears in every entry.*
+
+### Rule: short-name
+
+- **Infers** — *what is inferred: a bound push, a value removal, a
+  contradiction, a flag.*
+- **Fires when** — *the trigger, and which propagator from the inventory runs
+  it.*
+- **Strength** — *from [Appendix B](#appendix-b-consistency-level-vocabulary);
+  what this rule alone achieves on its scope.*
+- **Algorithm** — *what it does, its complexity, and the literature reference.
+  Be explicit about what the complexity is in: genuinely the **number of
+  values**, or the number of **intervals**, or **bits**, or tasks. This is the
+  single most-often-fudged line.*
+- **Why it is true** — *the mathematical argument, stated independently of any
+  proof system. Someone should be able to check the rule is sound from this
+  line without knowing what VeriPB is.*
+- **Proof technique** — *from [Appendix
+  A](#appendix-a-proof-technique-vocabulary), verbatim.*
+- **Reason** — *which literals go into the reason, and whether that set is
+  minimal. The reason is what the external tool sees; a non-minimal one costs
+  it trimming work. A justification reads the reason, never `state`.*
+- **Assertion** — *the PB inequality actually emitted, as a shape in terms of
+  the rule's data. This is what an `a` line would contain in hints-only mode.*
+- **Hint** — *the `gcs::innards::hints` type, and one line per field giving its
+  type and meaning. If the hint does not exist yet, say so — that is a work
+  item, and it belongs in [Next steps](#next-steps).*
+- **Offline reconstructibility** — *one of the three verdicts in [Appendix
+  C](#appendix-c-reconstructibility-verdicts). If `solver-side`, name the
+  information that is not recoverable.*
+- **Proof size** — *per firing, asymptotically; plus a measured figure with
+  provenance if there is one.*
+- **Gaps** — *whether this rule is logged at all, and whether the propagator is
+  weakened when proofs are enabled. `None.` is the expected answer.*
+
+## Evidence
+
+### Tests
+
+*What exists, and — as importantly — what it does not cover:*
+
+- *the enumeration tests, and whether they use `solve_for_tests_checking_gac`
+  (per-node GAC assertion) or plain `solve_for_tests`;*
+- *whether VeriPB actually runs in the tests, which is not true everywhere;*
+- *whether any test caps its runtime, and what the uncapped setting exercises;*
+- *whether the tests are seeded (`--seed=N`) and so byte-reproducible;*
+- *whether any real instance has been ported into a data-driven test, and
+  which repros have not been;*
+- *whether the derivation has been shown to be tight — a mutation that VeriPB
+  should refuse, and does.*
+
+### Benchmarks and examples
+
+*Which in-repo examples and MiniZinc Challenge instances exercise this family.
+Then split the recommendation, because they are different jobs: which instance
+and parameters are the right size for **CPU** benchmarking, and which for
+**proof verification** benchmarking. Note anything that must never be run
+uncapped.*
+
+### CPU performance
+
+*Where possible, against Gecode, Choco and ACE on an identical-search-tree
+benchmark that is dominated by this family. Caveat the comparison where the
+inference strengths differ, and especially where our default differs from
+theirs. Include search-shape columns — `recursions` and `propagations[0]` —
+because a wall-clock table without them cannot distinguish a faster propagator
+from a different search.*
+
+*Caption every table with the build, commit, date and machine.*
+
+### Proof performance
+
+*The proof axis, which the paper's headline table is made of: proof size, VeriPB
+verification time, the ratio of verification to solve time, and which instances
+are too large to verify at all. Same provenance requirement.*
+
+## Status, gaps, and next steps
+
+### Proof-logging gaps
+
+*Any inference the propagator makes that the proof does not justify, and any
+place we rely on an unchecked assertion. Separately: whether the propagator's
+strength **changes** when proof logging is enabled — that is, something we can
+propagate but cannot certify. The expected answer to both is `None.`, and
+anything else is either a filed issue or a new one.*
+
+### Known limitations
+
+*What the implementation does not do, phrased so a user would recognise their
+symptom in it. Include documented proof gaps: recording a limitation is often
+the right outcome, and better than a speculative solver change.*
+
+### Next steps
+
+*A ranked list. Each item: what to do, roughly what it would cost, what it
+would buy, and an issue number if one exists. This is the triage output, and
+the reason the audit was worth writing down.*
+
+## Prior art
+
+*Optional but wanted for the paper. Who proposed the propagation algorithm; who
+has certified this constraint before, if anyone, and in what proof system; and
+what is novel here. Without this the attribution has to be reconstructed for
+thirty families at writing time.*
+
+## Further reading
+
+*Annotated links to the long design notes that stay in `dev_docs/`. A sentence
+each on what is in them, not just a link.*
+
+## Developer commentary
+
+*Optional. Short pre-existing design notes appended here, and any commentary
+that does not fit the sections above. Some families were implemented by hand
+and have no such notes; there is no need to manufacture one.*
+
+---
+
+# Appendices
+
+## Appendix A: proof technique vocabulary
+
+Use these names verbatim in the **Proof technique** field. A rule may name more
+than one.
+
+| Name | Meaning |
+|---|---|
+| `RUP` | plain reverse unit propagation, no hints |
+| `RUP+hints` | RUP with explicit constraint-id hints |
+| `pol` | a cutting-planes derivation: linear combination, with `saturate` / division as needed |
+| `extended reason` | a hypothetical literal pinned into the reason so the inference becomes RUP-derivable |
+| `redundance` | extension-variable introduction, i.e. defining a `ProofFlag` |
+| `dominance` | a dominance-rule derivation |
+| `cases` | the VeriPB 3 `cases` rule |
+| `chain scaffolding` | root-level per-value chains that a later RUP resolves against, as the diagram-shaped constraints use |
+| `counting argument` | pigeonhole or an at-most-one recurrence carrying an exact coefficient |
+| `sorting network` | a derivation through a network's comparator rows |
+| `a` oracle | an unchecked assertion — **not** a proof, and always also a gap |
+| `not logged` | the inference is made but nothing is emitted — always also a gap |
+
+Adding a name here is fine; inventing one locally is not.
+
+## Appendix B: consistency level vocabulary
+
+| Name | Meaning |
+|---|---|
+| `GAC` | generalised arc consistency on the whole constraint |
+| `bounds(Z)` | bounds consistency over the integers |
+| `bounds(D)` | bounds consistency over the domains |
+| `range` | range consistency |
+| `partial` | a named subset of the above — say which, and on which variables |
+| `checker` | detects violation of a full assignment only |
+| `decomposition` | whatever the posted children achieve, which is weaker than GAC on the conjunction |
+
+GAC on two constraints separately is not GAC on their conjunction; a family
+implemented by decomposition says `decomposition`, not `GAC`.
+
+## Appendix C: reconstructibility verdicts
+
+For the **Offline reconstructibility** field. This is the field Matthew's tool
+is read off, so it is worth being strict about.
+
+| Verdict | Meaning |
+|---|---|
+| `offline` | the assertion alone determines the derivation; the tool needs nothing else |
+| `hinted` | the assertion plus the hint payload determines it |
+| `solver-side` | it needs information not recoverable from assertion and hint — the exact Hall set, the traversal order of a DP, which of several equally-valid explanation subsets was chosen. **Name the information.** |
+
+The `solver-side` rules are exactly the list of things the external tool cannot
+rebuild, and therefore exactly what a hints-only GCS mode has to carry. Getting
+this field wrong is more expensive than leaving it blank.
+
+## Appendix D: frontend coverage cells
+
+Inherited from `frontend-support-matrix.md`, which these tables replace.
+
+| Cell | Meaning |
+|---|---|
+| ✓ | fully supported |
+| `decompose` | supported by translating to other primitives at parse time — footnote how |
+| `unsupported` | the frontend deliberately does not handle this shape |
+| `solver gap (#nnn)` | the propagator does not exist yet |
+| `frontend gap (#nnn)` | the propagator exists, the binding does not |
+| `n/a` | the concept does not apply to this frontend |
+| `?` | not yet investigated |
+
+A `?` is an acceptable answer and marks a row that wants attention.
+
+---
+
+# The presolver variant
+
+Presolvers get a document too, under `dev_docs/presolvers/`, but not this
+template with the propagation sections deleted. A presolver does not infer; it
+rewrites the model before search. The differences:
+
+**Dropped.** Propagator inventory, mutable state and incrementality,
+idempotence, consistency level. A presolver runs once.
+
+**Replaced.** The inference catalogue becomes a **rewrite catalogue**, one
+entry per rewrite, with fields: what pattern is matched; what is posted or
+strengthened; whether the rewrite is posted in derived mode; the soundness
+argument; the proof technique that certifies the rewrite; and whether the
+rewrite is *neutral* with respect to the propagators that consume it (which is
+what makes a node-for-node soundness tripwire available).
+
+**Added, and these are the ones that matter.** Three sections with no analogue
+in a constraint document:
+
+- **Detection and its failure modes.** What the donor scan looks for, and how
+  detection **fails silently**. This is the recurring bug in this part of the
+  codebase: a scan couples to the constraint class it was written against and
+  simply finds nothing on a model built a slightly different way. Say which
+  constraint classes the scan actually recognises.
+- **Evidence that it fired.** A presolver that does nothing passes every test
+  in the suite. So: which counter, statistic or log line distinguishes "ran and
+  found nothing" from "ran and did nothing", and what the expected count is on
+  a named instance. Without this section a presolver document certifies
+  nothing.
+- **Can it weaken the model?** Whether the rewrite can ever lose solutions or
+  lose propagation strength, and what stops it. Include the `ia` step or
+  equivalent that pins the emitted row to the intended one — a sound derivation
+  of the *wrong* line is the failure a soundness argument alone does not catch.
+
+Everything else — status line, semantics, OPB and proof-time state, robustness,
+tests, benchmarks, both performance sections, gaps, next steps, prior art —
+carries over unchanged.
+
+---
+
+# Provisional family list
+
+The work plan, and the definition of "family". Provisional: the groupings
+marked *candidate merge* should be settled as the documents get written, and
+this table moves to `dev_docs/constraints/README.md` once it is stable.
+
+| Document | Covers | Notes |
+|---|---|---|
+| `all_different.md` | `all_different/` | GAC and VC variants, `AllDifferentExcept`, `ExceptZero` |
+| `all_equal.md` | `all_equal/` | |
+| `among.md` | `among/` | *candidate merge* with `count`, `global_cardinality`, `n_value` as one counting family |
+| `arithmetic.md` | `multiply/`, `divide_modulus/`, `plus_minus/`, `power/`, and the `plus.hh` / `minus.hh` / `divide.hh` / `modulus.hh` headers | one family over several directories; existing note is `arithmetic-proofs.md` |
+| `abs.md` | `abs/` | *candidate merge* into `arithmetic`; kept separate for now because of the view-proof gap |
+| `at_most_one.md` | `at_most_one/` | |
+| `bin_packing.md` | `bin_packing/` | existing note `bin-packing.md` |
+| `circuit.md` | `circuit/` | includes subcircuit |
+| `comparison.md` | `comparison/`, `equals/` | *candidate merge*: equality and inequality primitives, including `ReifiedEquals` |
+| `count.md` | `count/` | see `among` |
+| `cumulative.md` | `cumulative/` | the largest family; notes `cumulative-proof-logging.md`, `certified-makespan-bounds.md`, `rule-counters.md` |
+| `difference.md` | `difference/` | difference constraints; note `difference-logic.md`, whose presolver half belongs under `dev_docs/presolvers/` |
+| `disjunctive.md` | `disjunctive/`, `disjunctive_2d/` | one family, two dimensions; note `disjunctive-proof-logging.md` |
+| `element.md` | `element/` | `Element`, `Element2D` |
+| `global_cardinality.md` | `global_cardinality/` | see `among` |
+| `in.md` | `in/` | note `range_literals_spec.md` |
+| `increasing.md` | `increasing/` | `Increasing`, `Decreasing` |
+| `inverse.md` | `inverse/` | |
+| `knapsack.md` | `knapsack/` | existing note `knapsack.md`; `decision-diagram-proof-strategies.md` |
+| `lex.md` | `lex/`, `lex_smart_table.hh` | |
+| `linear.md` | `linear/` | note `linear-slack-waking.md`, `subset-sum-strengthening.md` |
+| `logical.md` | `logical/` | |
+| `mdd.md` | `mdd/` | `decision-diagram-proof-strategies.md` |
+| `min_distance.md` | `min_distance/` | note `min-distance-proofs.md` |
+| `min_max.md` | `min_max/` | |
+| `n_value.md` | `n_value/` | see `among` |
+| `nogoods.md` | `nogoods/` | search machinery rather than a posted constraint; notes `restarts-nogoods-weighting.md`, `refined-triggers.md` |
+| `parity.md` | `parity/` | |
+| `path.md` | `path/` | |
+| `reachable.md` | `reachable/` | |
+| `regular.md` | `regular/` | existing note `regular.md` |
+| `seq_precede_chain.md` | `seq_precede_chain/` | |
+| `smart_table.md` | `smart_table/` | *candidate merge* with `table` as one extensional family |
+| `sort.md` | `sort/` | `Sort`, `ArgSort`; existing note `sortedness.md` |
+| `subgraph.md` | `subgraph/` | |
+| `table.md` | `table/`, `extensional_utils.{hh,cc}` | `Table`, `NegativeTable`; see `smart_table` |
+| `tree.md` | `tree/` | |
+| `value_precede.md` | `value_precede/` | |
+
+Not families, and getting no document: `gcs/constraints/innards/` (shared
+helpers — documented where they are used, or in `constraints.md`).
+
+Presolvers, one document each under `dev_docs/presolvers/`: `auto_table`,
+`cumulative_strengthening`, `difference_logic`, `inferred_cumulative`,
+`inferred_disjunctive`. Existing notes: `cumulative-strengthening.md`,
+`inferred-cumulative.md`, `inferred-disjunctive.md`, and the presolver half of
+`difference-logic.md`.

--- a/dev_docs/constraints/equals.md
+++ b/dev_docs/constraints/equals.md
@@ -1,0 +1,905 @@
+# `Equals`: two operands are (or are not) the same value
+
+> **Maturity** production ·
+> **Audited** 2026-09-07 at `7d014207` ·
+> **Open issues** none open specific to this family; see [Next
+> steps](#next-steps) for the three this audit would file
+
+Six posted classes over one implementation: an equality between two operands,
+optionally reified, optionally negated. It is the smallest interesting
+constraint in the solver and one of the busiest — 71% of all propagator calls
+on `ortho_latin --all 6`, and 44% of the assertions in its proof — so its cost
+per call and its trigger set matter more than its algorithm does.
+
+## What it is
+
+### Semantics
+
+`Equals(v1, v2)` holds iff `v1 = v2`. `NotEquals(v1, v2)` holds iff `v1 ≠ v2`.
+The four reified forms take an `IntegerVariableCondition` `cond`:
+
+| Class | Semantics |
+|---|---|
+| `Equals(v1, v2)` | `v1 = v2` |
+| `NotEquals(v1, v2)` | `v1 ≠ v2` |
+| `EqualsIf(v1, v2, cond)` | `cond → v1 = v2` |
+| `EqualsIff(v1, v2, cond)` | `cond ↔ v1 = v2` |
+| `NotEqualsIf(v1, v2, cond)` | `cond → v1 ≠ v2` |
+| `NotEqualsIff(v1, v2, cond)` | `cond ↔ v1 ≠ v2` |
+
+All six are the one class `ReifiedEquals`, distinguished only by the
+`ReificationCondition` its constructor passes down. The `NotEquals*` variants
+do **not** flip any propagation logic; they negate the condition at
+construction, so `NotEqualsIff(v1, v2, c)` is stored as `Iff{¬c}` and reaches
+the same equality-enforcing code. Read the concrete variant's constructor to
+see what a given class actually installs; the `_neq` member is not the place to
+look (see [Known limitations](#known-limitations)).
+
+Degenerate cases:
+
+- **Aliased operands.** `NotEquals(x, x)` on a non-constant `x` throws
+  `InvalidProblemDefinitionException` at construction. The other five accept
+  aliasing; `EqualsIff(x, x, c)` correctly forces `c`, and `NotEqualsIf(x, x,
+  c)` correctly forces `¬c`, via the alias check in the undecided pass.
+- **Constant operands.** Two constants are a valid model, including two equal
+  constants under `NotEquals` — trivially infeasible, but a model, so it is not
+  rejected. Only genuine variable aliasing is.
+- **Views.** Accepted in either position, at a cost — see [Variable kinds and
+  views](#variable-kinds-and-views).
+
+### Concrete constraints and frontend coverage
+
+| C++ class | MiniZinc / FlatZinc | XCSP3 | CPMpy | SCP `s_expr` | Notes |
+|---|---|---|---|---|---|
+| `Equals` | ✓ `int_eq`, `bool2int`, `bool_eq`; also `decompose`[^lin] | ✓ `intension` eq (n-ary, chained pairwise), `instantiation`, top-level `iff` | ? | ✓ `equals` | |
+| `NotEquals` | ✓ `int_ne`, `bool_not`; also `decompose`[^lin] | ✓ `intension` ne | ? | ✓ `not_equals` | |
+| `EqualsIf` | frontend gap — no FlatZinc predicate maps to a half-reified equality | ✓ `ifThenElse` arms | ? | ✓ `equals_if` | |
+| `EqualsIff` | ✓ `int_eq_reif`, `bool_eq_reif`, `int_ne_reif`[^neg] | ✓ `intension` reified EQ, `iff` | ? | ✓ `equals_iff` | |
+| `NotEqualsIf` | frontend gap — as `EqualsIf` | unsupported | ? | ✓ `not_equals_if` | |
+| `NotEqualsIff` | ✓ via `EqualsIff` with a negated condition | ✓ `intension` reified NE | ? | ✓ — but writes as `equals_iff`[^flip] | |
+
+[^lin]: MiniZinc rewrites `x = y` and `x != y` between two variables into a
+    two-term `int_lin_eq` / `int_lin_ne`, emitting `int_eq` / `int_ne` only for
+    reified forms. Across 75 sampled challenge instances: 13,605 two-term
+    unit-coefficient `int_lin_eq` in 37 of them and 24,636 `int_lin_ne` in 6,
+    against **zero** `int_eq` and 125 `int_ne`. `fzn_glasgow.cc` therefore
+    recovers the two-variable shape from any two unit coefficients and posts
+    `Equals` / `NotEquals` instead of `LinearEquality` / `LinearNotEquals`.
+    Without that recovery this family would be almost unreachable from
+    MiniZinc. For `_eq` the recovery is a strength gain as well as a speed one:
+    the generic linear equality is bounds(Z) and cannot carry a hole across,
+    where `Equals` intersects the domains. For `_ne` both are GAC, so it is
+    purely the cheaper propagator.
+
+[^neg]: `int_ne_reif` posts `EqualsIff{v1, v2, reif != 1}` — the negation goes
+    into the condition rather than into a different class.
+
+[^flip]: The `not_equals_iff` keyword exists in the reader and in
+    `verified_encodings/scp_cases/not_equals_iff_sat.scp`, but the writer never
+    emits it. See [Known limitations](#known-limitations).
+
+### Options
+
+`None.` The family has no tunables: no consistency-level knob, no algorithm
+selection, no incrementality threshold. Everything the six classes differ by is
+a constructor argument, not an option.
+
+This is worth stating rather than omitting, because the neighbouring linear
+family does have `with_consistency` and `with_incremental_threshold`, and a
+reader coming from there will look for the equivalent here.
+
+### Variable kinds and views
+
+Both operands are `IntegerVariableID`, so plain variables, constants and views
+are all accepted, and the propagator is instantiated over the `visit` of both
+operand kinds.
+
+Views are where the proof and the propagator diverge:
+
+- **Propagation** treats a view like anything else; the inferences go through
+  the same `infer_*` calls and the view layer translates them.
+- **Proof.** One rule — the interval-wise symmetric difference — is only
+  available when *both* operands are a bare `SimpleIntegerVariableID`. It is
+  guarded on exactly that (`both_simple`), and a view or constant in either
+  position falls back to a per-value rule that is correct but emits one
+  inference and one proof line per removed *value* instead of per removed
+  *interval*. The reason is a proof-layer limitation, not a propagation one: the
+  bridge lemmas that carry a range literal across the equality need a plain
+  variable on the far side.
+
+The view sweep in the test binary exercises both positions
+(`add_view_tests(equals_constraint equals_test 2)`), so the fallback path is
+covered; it is not free, and a model built entirely out of views pays the
+per-value cost.
+
+### Reification
+
+All four reified forms are first-class here rather than bolted on: the class
+*is* `ReifiedEquals` and `Equals` / `NotEquals` are the degenerate
+`MustHold` / `MustNotHold` cases. The machinery is
+`install_reified_dispatcher` (see `dev_docs/reification.md`), which installs a
+single propagator and dispatches on the condition's current state.
+
+Two things are specific to this family:
+
+- The condition's own literal is passed into every pass and appears in every
+  reason. The propagator never consults the reification *policy* — which
+  literal to infer for which verdict is the dispatcher's decision, driven by
+  `evaluated_reif::Undecided`'s three flags.
+- When the condition is already decided at install time, the dispatcher installs
+  a propagator that runs one enforce pass directly, with no per-call
+  `test_reification_condition`. That is the path `Equals` and `NotEquals`
+  always take, and it is also what a FlatZinc-generated constraint with an
+  already-fixed reification literal takes.
+
+### Relation to other families
+
+**Decomposes into this family.** The not-equals clique encoding of an
+all-different — one `NotEquals` per pair — is the source of essentially all the
+call volume in [CPU performance](#cpu-performance). Note that this is the
+*model's* choice, not `AllDifferent`'s: `ortho_latin --all-different
+not-equals` posts the clique itself in a double loop, and `AllDifferent` has no
+such mode. `gcs::AllEqual` likewise has its own propagator and does not
+decompose here.
+
+What does land here: XCSP3's `instantiation` (one `Equals` to a constant per
+variable), its n-ary `intension` eq (chained pairwise), its `intension` ne and
+reified eq/ne, its `ifThenElse` arms and top-level `iff`; FlatZinc's `int_eq` /
+`int_ne` / `bool2int` / `bool_eq` / `bool_not` and the two reified forms; and
+the two-term linear recovery in `fzn_glasgow.cc`, which is where almost all of
+the MiniZinc traffic arrives.
+
+**Posts as children.** Nothing. `ReifiedEquals::prepare` allocates nothing and
+posts nothing.
+
+**Shares code with.** `enforce_equality` is exported from `gcs::innards` and
+called by `Element` (`element.cc:699`) to tie a result variable to a selected
+array entry. Any change to its inference set or its return value is an
+`Element` change too — this is the one cross-family coupling in the file.
+
+**Presolvers.** None rewrite or target this family. `DifferenceLogic` scans for
+`x - y ≤ d` shapes and does not recognise an `Equals`.
+
+**Nearly, but not, the same family.** `gcs/constraints/comparison/` is a
+parallel hierarchy of twelve classes over `ReifiedCompareLessThanOrMaybeEqual`,
+with the same reified-dispatcher shape and the same cosmetic-negation-flag
+design — but a separate encoding, separate propagator and separate `hints.hh`.
+The template's family list flags `comparison`+`equals` as a candidate merge;
+**this audit says keep them separate.** They share a pattern, not code, and
+merging the documents would bury two distinct OPB encodings in one section.
+
+## The proof model
+
+### OPB encoding
+
+The operands are compared through their **bit** (binary) encodings, not their
+order literals. Writing `⟦v⟧` for the bit sum of `v`:
+
+```
+MustHold      (Equals)          ⟦v1⟧ - ⟦v2⟧ = 0
+                                  split into two rows, le and ge
+
+MustNotHold   (NotEquals)       ne                     ->  ⟦v1⟧ - ⟦v2⟧ >= 1
+                                ¬ne                    ->  ⟦v1⟧ - ⟦v2⟧ <= -1
+                                  with one fresh flag ne per constraint
+
+If            (EqualsIf)        cond                   ->  ⟦v1⟧ - ⟦v2⟧ = 0
+                                  split into le and ge, each half-reified
+
+NotIf         (NotEqualsIf)     gt                     ->  ⟦v1⟧ - ⟦v2⟧ >= 1
+                                ¬gt                    ->  ⟦v1⟧ - ⟦v2⟧ <= 0
+                                lt                     ->  ⟦v1⟧ - ⟦v2⟧ <= -1
+                                ¬lt                    ->  ⟦v1⟧ - ⟦v2⟧ >= 0
+                                lt + gt + ¬cond        >=  1
+
+Iff           (EqualsIff,       cond                   ->  ⟦v1⟧ - ⟦v2⟧ = 0
+               NotEqualsIff)      split into le and ge, each half-reified
+                                gt                     ->  ⟦v1⟧ - ⟦v2⟧ >= 1
+                                lt                     ->  ⟦v1⟧ - ⟦v2⟧ <= -1
+                                lt + gt + cond         >=  1
+```
+
+The encoding is **definitional**: every row states part of what the constraint
+means, and no row is a consequence. There is no scaffolding, no auxiliary
+integer variable, and no per-value row — so the encoding is **logarithmic in
+domain size**, which is why this family is one of the few that is comfortable
+at a domain width of 10⁹.
+
+Two details that only show up in the emitted file. The half-reification
+coefficient is the worst-case violation, so it scales with the domain width
+(`8 ~b[_1][ne]` for a width-4 domain); this is the reification layer's
+choice, not the constraint's, but it means the OPB's *coefficients* grow with
+domain size even though its *row count* does not. And `NotIf` reifies its two
+selectors **fully** (both `[r]` and `[f]` halves) where `Iff` reifies them only
+forward (`[r]`), because in the `Iff` case the `le`/`ge` rows already supply the
+other direction.
+
+An `Equals` between two operands of a width-4 domain is two rows:
+
+```
+@c[_1][le] -1 i[x][b0] -2 i[x][b1] -4 i[x][b2] 1 i[y][b0] 2 i[y][b1] 4 i[y][b2] >= 0;
+@c[_1][ge]  1 i[x][b0]  2 i[x][b1]  4 i[x][b2] -1 i[y][b0] -2 i[y][b1] -4 i[y][b2] >= 0;
+```
+
+### Labels
+
+Every row is labelled, and every label is load-bearing — the whole point of the
+labelling here is to match what `cake_pb_cp` assigns, so that a proof citing a
+row parses against cake's re-derived model.
+
+| Label | Row | Used by |
+|---|---|---|
+| `@c[id][le]`, `@c[id][ge]` | the two halves of the equality | `MustHold`, `If`, `Iff` |
+| `@c[id][gt]`, `@c[id][lt]` | the two strict comparisons | `MustNotHold` |
+| `@b[id][gt][r]`, `@b[id][gt][f]` | forward/reverse halves of the `gt` selector | `NotIf` (both), `Iff` (`[r]` only) |
+| `@b[id][lt][r]`, `@b[id][lt][f]` | ditto for `lt` | `NotIf` (both), `Iff` (`[r]` only) |
+| `@c[id][al1]` | the at-least-one tying `lt`, `gt` and the condition | `NotIf`, `Iff` |
+
+The selector-flag rows are labelled with the flag's own name plus a role suffix
+(`pb_file_string_for(flag) + "[r]"`), not with `@c[id][...]`, because that is
+what cake does. Getting this wrong is not a soundness bug but a hard parse
+failure: a proof citing a label cake never assigns will not load.
+
+### Cake conformity
+
+Conformant, and the best-covered family in the SCP chain suite: all six
+variants have a case, five of them `_sat` and three `_unsat`.
+
+```
+equals_sat  equals_unsat  equals_if_sat  equals_iff_sat  binary_equals_unsat
+not_equals_sat  not_equals_unsat  not_equals_if_sat  not_equals_iff_sat
+```
+
+Each comment in `define_proof_model` names the cake function it conforms to
+(`encode_equal`, `cencode_equal_1`, the `nev` / `gtv` / `ltv` selectors).
+
+One divergence, benign but worth naming: the writer's own output for
+`NotEqualsIff` is an `equals_iff` s-expression with a negated condition rather
+than a `not_equals_iff` one. Both describe the same constraint — verified by
+round-tripping all six variants through `read_scp` and getting identical
+solution counts (8/24/20/16/28/16) — but it means the `not_equals_iff` reader
+path is exercised only by the hand-written case file, never by writer output.
+See [Known limitations](#known-limitations).
+
+### Proof-time state
+
+**Nothing at the root, nothing lazily, nothing deleted.** This family creates
+no scaffolding at all. `install_initialiser` is not used; `define_proof_model`
+emits between two and five rows and stops.
+
+The only proof-time objects are the selector flags — `b[id][ne]` for
+`MustNotHold`, `b[id][gt]` and `b[id][lt]` for `NotIf` and `Iff` — and they are
+**in the OPB**, created by `model.create_proof_flag` at definition time and
+fully reified there. So:
+
+- an external justifier locates everything this family refers to from the OPB
+  alone, by the labels in the table above, plus the constraint id in the hint;
+- there is no proof-only auxiliary, hence no question of whether unit
+  propagation determines it on `solx`;
+- there is no proof-only vector to index, hence none of the dangling-index
+  hazard that proof-only state carries;
+- the `del` lines that appear near this family's inferences belong to the
+  shared range-literal and order-literal layers, not to it.
+
+The temporary lemmas two of the rules emit (`ProofLevel::Temporary`) are the
+one exception to "nothing deleted", and they are deleted by the level
+machinery rather than by anything here.
+
+## The implementation
+
+### Initialisation and global data
+
+`prepare()` evaluates the reification condition against the initial state once
+and stores the result; that is all. No auxiliary variables, no backtrackable
+state, no precomputation, and no root cost worth measuring.
+
+Argument validation is in the *constructors*, not in `prepare`: only
+`NotEquals` validates anything, rejecting genuine variable aliasing. That
+placement means a bad model throws at `post` rather than at solve.
+
+### Propagator inventory
+
+One propagator, whichever variant is posted. The trigger set is what differs,
+and it is the only tuned thing in the family.
+
+| Propagator | Triggers | Rule(s) | Enabled by | Idempotent? | Self-disables? |
+|---|---|---|---|---|---|
+| dispatcher, decided must-hold | `on_change` both operands | 1–4 | `Equals`, and `If`/`Iff` fixed true at install | never claims | yes, once an operand is fixed |
+| dispatcher, decided must-not-hold | `on_instantiated` both operands | 5 | `NotEquals`, and `NotIf`/`Iff` fixed false at install | never claims | yes, once it has acted |
+| dispatcher, undecided | `on_change` both operands **and** the condition | 1–9 | the four reified forms while `cond` is open | claims stripped | yes, on any verdict |
+
+**The narrow trigger is the one design decision here** (issue #819). An
+unconditional `NotEquals` only ever runs rule 5, which reads nothing but
+`optional_single_value` and disables itself until backtrack once it has acted —
+so `on_instantiated` cannot miss a wake, and the wakes it drops are the
+expensive ones. Fixing a vertex removes one value from each of its *d*
+neighbours, and under `on_change` every one of those interior removals woke
+every other not-equals on that neighbour only to find neither end fixed. On
+`ortho_latin --all 6` this is 321.7M calls against 55.4M.
+
+The cost is not free and the accounting is subtle: narrowing a trigger *delays*
+an inference by a round whenever the dropped wake would have caught it early,
+which fragments the changes a co-registered propagator sees into more, smaller
+instalments — and an O(n·d) propagator pays per *run*, not per change. So
+`ortho_latin` gained 16.5% while `colour` lost 3.6–5.2% on two of three
+instances, at an identical search tree. Both were measured before the change
+landed; see [CPU performance](#cpu-performance).
+
+**Idempotence.** No pass ever returns `EnableButIdempotent`, so no claim is
+made. Note that the runtime-dispatch path would not forward such a claim even
+if one were made, because a re-run of the dispatcher also re-tests the
+reification condition and that interplay has not been audited. The two
+install-time-decided paths do forward claims, since there the run is exactly
+the enforce call.
+
+**Self-disabling.** Rules 1, 2 and 5 return `DisableUntilBacktrack` — once an
+operand is fixed, an equality has nothing left to say at this node or below.
+Any verdict from the undecided pass also disables. This is a large part of why
+the per-call cost is so low.
+
+### Mutable state and incrementality
+
+`None.` Nothing persists between calls: no `add_constraint_state`, no watch
+scratch, no cached bounds. Every call re-reads the operands' state.
+
+That is the right answer for this family rather than an omission. The most
+expensive pass materialises two `IntervalSet`s and merge-walks them; there is
+nothing worth carrying across a call that would not cost more to keep valid
+than to recompute. The one thing a reader might expect — remembering that the
+domains were already equal — is subsumed by `DisableUntilBacktrack`.
+
+### Robustness and limits
+
+**Large domains.** The bounds rule is fine and the encoding is logarithmic:
+`Equals` over two operands of width 10⁹ solves in 0 ms and emits two OPB rows.
+The symmetric-difference rule is interval-based, so it too is insensitive to
+width.
+
+**One rule is not.** The reified no-overlap rule (rule 9) walks *every integer
+between v1's bounds*, building one reason literal per value:
+
+| v1 bounds width | wall time, proofs **off** |
+|---|---|
+| 10⁴ | 0 ms |
+| 10⁶ | 29 ms |
+| 10⁷ | 350 ms |
+| 10⁹ | `std::bad_alloc` after 2.6 GB |
+
+Linear in domain width, in both time and memory, and paid even when proofs are
+off — see [Proof-logging gaps](#proof-logging-gaps) for why that last part is a
+bug rather than an inherent cost. Measured with `EqualsIff{x, y, b == 1}`,
+`x ∈ [0, w/2]`, `y ∈ [w/2+1, w]`, so that the rule fires once at the root.
+
+**Unbounded domains.** Not separately probed. The bounds and
+symmetric-difference rules have no per-value work and should be unaffected;
+rule 9 will not terminate in any useful time, by the scaling above.
+
+**Negative values and zero.** Fine, and covered: the test data includes
+`[-10, 10]` ranges, negative constants, and the `{-2,-2}`/`{-3,-3}` fixtures.
+
+**Overflow.** Checked, not merely unlikely. `Integer` arithmetic throws
+`IntegerOverflow` rather than wrapping — `operator+` goes through
+`add_overflows`, and `operator++`/`--` guard the extremes — so the
+`bounds.second + 1_i` pattern in rule 4 would throw a diagnosable exception if
+an operand's upper bound were `Integer::max_value()`, not silently wrap.
+Verified UBSan-clean with both operands at `LLONG_MAX/2`.
+
+**Per-value costs.** Two rules are per-value rather than per-interval: rule 3
+(the view/constant fallback) and rule 9. Everything else is per-interval or
+constant.
+
+## Inference catalogue
+
+Nine rules. The first four are the must-hold pass (`enforce_equality`), the
+fifth is the must-not-hold pass, and the last four are the reified verdicts of
+the undecided pass.
+
+Two facts hold for all nine and are not repeated in each entry. Every one is
+attributed to the hint type `hints::Equals`, whose wire form is
+`(constraint_id <id>)` and which carries **no operand data** — everything an
+external justifier needs must be recoverable from the asserted literal, the
+reason, and the OPB rows. And no rule reads `state` from inside a
+justification; rule 9's emitter is the sole holder of a `State *`, and it is
+valid only because the verdict is consumed synchronously (see [Next
+steps](#next-steps)).
+
+### Rule: equal-to-fixed-operand
+
+- **Infers** — `other = v`, where one operand is fixed to `v`.
+- **Fires when** — either operand becomes a singleton, in the must-hold pass.
+- **Strength** — `GAC` on its own, for two distinct operands.
+- **Algorithm** — two `optional_single_value` reads. O(1).
+- **Why it is true** — immediate from `v1 = v2`.
+- **Proof technique** — `RUP`.
+- **Reason** — the base reason (the condition literal) plus `v1 = *val1`.
+  Minimal.
+- **Assertion** — the clause `other = v ∨ ¬(v1 = v) ∨ ¬cond`, e.g.
+  `a 1 i[y][eq1] 1 ~i[x][eq1] >= 1`.
+- **Hint** — `hints::Equals{owner}`.
+- **Offline reconstructibility** — `offline`. One RUP against `@c[id][le]` and
+  `@c[id][ge]`; the asserted clause names both literals.
+- **Proof size** — one line.
+- **Gaps** — `None.`
+
+### Rule: symmetric-difference-intervals
+
+- **Infers** — `pruned ∉ [lo, hi]` for each contiguous interval of the
+  symmetric difference of the two domains, in both directions.
+- **Fires when** — either domain has a hole, neither operand is fixed, and
+  **both** operands are bare `SimpleIntegerVariableID`.
+- **Strength** — `GAC` for two distinct operands: the two domains end up equal
+  to their intersection.
+- **Algorithm** — materialise both domains (`copy_of_values`), then merge-walk
+  via `each_interval_minus`. O(intervals(v1) + intervals(v2) + |output|) — in
+  *intervals*, not values, which is the whole point of the rule.
+- **Why it is true** — if `v1 = v2` then any value in neither domain is in
+  neither variable's support.
+- **Proof technique** — `RUP+hints` — two bound lemmas, then the conclusion.
+- **Reason** — the base reason plus `not_in_range(other, lo, hi)`. A fresh
+  snapshot per interval, so the justification's repeated materialisations do
+  not see an accumulating literal. Minimal.
+- **Assertion** — `¬(pruned ∈ [lo,hi]) ∨ (other ∈ [lo,hi])`, e.g.
+  `a 1 ~i[y][in4_6] 1 i[x][in4_6] >= 1`.
+- **Hint** — `hints::Equals{owner}`. **Indistinguishable on the wire from
+  rule 1**, despite needing a two-lemma bridge rather than a bare RUP; the
+  discriminator is that the asserted literal is a range literal. See [Next
+  steps](#next-steps).
+- **Offline reconstructibility** — `hinted`, with a caveat. The two bridge
+  lemmas
+  ```
+  rup ¬(pruned ≥ lo) ∨ (other ≥ lo) ∨ <reason>
+  rup ¬(other ≥ hi+1) ∨ (pruned ≥ hi+1) ∨ <reason>
+  ```
+  are determined by the asserted range literal's endpoints, so a justifier can
+  rebuild them — but only if it knows to, which today means recognising the
+  literal shape rather than reading a subhint.
+- **Proof size** — three lines per removed interval, plus the shared
+  range-literal definitions and linking clauses (which belong to the
+  range-literal layer, not here).
+- **Gaps** — `None.` The rule is skipped, not weakened, when an operand is not
+  simple; rule 3 covers that case at a worse cost.
+
+Why the bridge is needed at all: a range literal asserts only *order* atoms,
+never bits, and the equality rows are a *bit*-sum equality — so
+`¬(y ∈ [4,6])` is not RUP from `¬(x ∈ [4,6])` on its own. Each bridge lemma is
+RUP because its negation supplies a pair of opposing bounds that contradict the
+equality at the bit level. The lemmas mention no range literal, so any literal
+sharing those endpoints can reuse them. The pairing assumes a **same-sign**
+link; a sign-flipped link, as `Abs` has, needs the mirrored pairing.
+
+### Rule: symmetric-difference-values
+
+- **Infers** — `pruned ≠ val`, one value at a time.
+- **Fires when** — as rule 2, but at least one operand is a view or a constant.
+- **Strength** — `GAC`. Same fixpoint as rule 2, reached one value at a time.
+- **Algorithm** — the same merge-walk, then a per-value loop over each removed
+  interval. O(removed **values**).
+- **Why it is true** — as rule 2.
+- **Proof technique** — `RUP`.
+- **Reason** — the base reason plus `other ≠ val`, rebuilt per value. Minimal.
+- **Assertion** — `pruned ≠ val ∨ ¬(other ≠ val) ∨ ¬cond`.
+- **Hint** — `hints::Equals{owner}`.
+- **Offline reconstructibility** — `offline`.
+- **Proof size** — one line per removed value.
+- **Gaps** — `None.`, in the sense that the inference is fully justified. It is
+  a proof-*size* regression against rule 2, not a proof-strength one.
+
+### Rule: bounds-intersection
+
+- **Infers** — up to four bounds: each operand's lower bound raised to the
+  other's, each upper bound lowered to the other's.
+- **Fires when** — neither domain has a hole, neither operand is fixed, and the
+  two bound pairs differ.
+- **Strength** — `GAC`, because with no holes the bounds intersection *is* the
+  domain intersection.
+- **Algorithm** — two `bounds` reads, four `infer_*` calls. O(1).
+- **Why it is true** — immediate from `v1 = v2`.
+- **Proof technique** — `RUP`.
+- **Reason** — the base reason plus the one bound literal being carried across.
+  Minimal.
+- **Assertion** — e.g. `v2 ≥ lb1 ∨ ¬(v1 ≥ lb1) ∨ ¬cond`.
+- **Hint** — `hints::Equals{owner}`.
+- **Offline reconstructibility** — `offline`.
+- **Proof size** — one line per bound moved, so at most four.
+- **Gaps** — `None.`
+
+Note the four inferences are emitted unconditionally once the bound pairs
+differ at all, so up to three of them can be no-ops. This is deliberate:
+`Inference::NoChange` costs less than four comparisons would.
+
+### Rule: not-equal-to-fixed-operand
+
+- **Infers** — `other ≠ v`, where one operand is fixed to `v`.
+- **Fires when** — either operand becomes a singleton, in the must-not-hold
+  pass. This is the `on_instantiated`-triggered rule of issue #819.
+- **Strength** — `GAC`. For a binary disequality, pruning only when one side is
+  fixed *is* GAC.
+- **Algorithm** — two `optional_single_value` reads. O(1). This is the busiest
+  rule in the solver on clique-encoded models.
+- **Why it is true** — immediate from `v1 ≠ v2`.
+- **Proof technique** — `RUP`.
+- **Reason** — stated outright as `{cond, v1 = *value1}` rather than deferred,
+  since the value is already in hand and both literals sit inline. Guarded on
+  `want_reasons()`, so it costs nothing when nothing will read it. Minimal.
+- **Assertion** — `other ≠ v ∨ ¬(v1 = v) ∨ ¬cond`.
+- **Hint** — `hints::Equals{owner}`.
+- **Offline reconstructibility** — `offline`.
+- **Proof size** — one line.
+- **Gaps** — `None.`
+
+Uses the non-throwing `infer_not_equal_or_stop`, returning `Enable` on
+contradiction so the propagate loop sees `tracker.contradicted()` instead of
+paying for a throw.
+
+### Rule: reified-alias
+
+- **Infers** — the constraint must hold, hence the condition literal the
+  reification kind licenses.
+- **Fires when** — the two operands are the same non-constant variable handle,
+  in the undecided pass. Fires at the root.
+- **Strength** — `GAC` on the condition.
+- **Algorithm** — one handle comparison. O(1).
+- **Why it is true** — `x = x`.
+- **Proof technique** — `RUP`.
+- **Reason** — `NoReason{}`; the fact is unconditional.
+- **Assertion** — the condition literal alone.
+- **Hint** — `hints::Equals{owner}`.
+- **Offline reconstructibility** — `offline`.
+- **Proof size** — one line.
+- **Gaps** — `None.`
+
+Without this rule the verdict would wait until search fixed the variable, and
+`NotEqualsIf(x, x, c)` would leave `c` unpruned — the "propagator silent on
+alias" bug the dup tests were added for.
+
+### Rule: reified-both-fixed
+
+- **Infers** — must-hold if the two fixed values are equal, must-not-hold
+  otherwise.
+- **Fires when** — both operands are singletons, in the undecided pass.
+- **Strength** — `GAC` on the condition.
+- **Algorithm** — two `optional_single_value` reads and a comparison. O(1).
+- **Why it is true** — the constraint is decided by the assignment.
+- **Proof technique** — `RUP`.
+- **Reason** — `{v1 = *value1, v2 = *value2}`. Minimal.
+- **Assertion** — the condition literal, plus the negations of the two
+  equalities.
+- **Hint** — `hints::Equals{owner}`.
+- **Offline reconstructibility** — `offline`.
+- **Proof size** — one line.
+- **Gaps** — `None.`
+
+### Rule: reified-one-fixed-unsupported
+
+- **Infers** — must-not-hold.
+- **Fires when** — exactly one operand is a singleton and its value is absent
+  from the other's domain.
+- **Strength** — `GAC` on the condition.
+- **Algorithm** — one `optional_single_value` and one `in_domain`. O(1) or
+  O(log intervals) depending on the domain representation.
+- **Why it is true** — the fixed value has no partner.
+- **Reason** — `{v1 = *value1, v2 ≠ *value1}`. Minimal.
+- **Proof technique** — `RUP`.
+- **Assertion** — `¬cond ∨ ¬(v1 = v) ∨ ¬(v2 ≠ v)`.
+- **Hint** — `hints::Equals{owner}`.
+- **Offline reconstructibility** — `offline`.
+- **Proof size** — one line.
+- **Gaps** — `None.`
+
+### Rule: reified-no-overlap
+
+- **Infers** — must-not-hold, from the two domains being disjoint.
+- **Fires when** — neither operand is fixed, the condition is undecided, and
+  `domains_intersect` is false.
+- **Strength** — `GAC` on the condition.
+- **Algorithm** — one `domains_intersect`, then a walk over **every integer
+  between v1's bounds**. O(width of v1's bounds range), in values. This is the
+  family's only super-logarithmic cost and its only large-domain failure; see
+  [Robustness and limits](#robustness-and-limits).
+- **Why it is true** — no value is in both domains, so no assignment satisfies
+  the equality. The witness is per-value: for each `val` in v1's bounds range,
+  either `val ∉ dom(v1)` or (since the domains are disjoint) `val ∉ dom(v2)`.
+- **Proof technique** — `RUP+hints` — one per-value lemma each, then the
+  conclusion.
+- **Reason** — v1's two bound literals, then one literal per value in the
+  range: `v2 ≠ val` when `val ∈ dom(v1)`, and `v1 ≠ val` when it is not. So
+  `2 + width` literals. **Not** minimal in any useful sense, and not guarded on
+  `want_reasons()`.
+- **Assertion** — the conclusion clause, e.g. for `x ∈ [1,3]`, `y ∈ [7,9]`:
+  ```
+  a 1 ~i[b][b0] 1 ~i[x][ge1] 1 i[x][ge4] 1 i[y][eq1] 1 i[y][eq2] 1 i[y][eq3] >= 1
+      ::equals:((constraint_id _1) (subhint no_overlap));
+  ```
+- **Hint** — `hints::EqualsNoOverlap`, wire form
+  `(constraint_id <id>) (subhint no_overlap)`. The struct additionally holds a
+  `State *`, both operands, v1's bounds and the condition literal, but **none of
+  that reaches the wire** — it is held for the internal emitter only.
+- **Offline reconstructibility** — `hinted`. The subhint says which shape to
+  build, and the asserted clause carries everything needed to build it: the two
+  bound literals give the range, and each per-value literal's *variable* says
+  which branch that value took (`y = val` for a value in v1's domain, `x = val`
+  for one outside it). So the emitter's `State *` is a convenience, not
+  information the justifier lacks. This is the one rule in the family where the
+  verdict is worth checking rather than assuming.
+- **Proof size** — `width + 1` lines: one lemma per value in v1's bounds range,
+  plus the conclusion. Emitted at `ProofLevel::Temporary`, so the lemmas are
+  deleted.
+- **Gaps** — the inference is fully justified. The *cost* is a bug: see
+  [Proof-logging gaps](#proof-logging-gaps).
+
+## Evidence
+
+### Tests
+
+Two binaries. `gcs/constraints/equals/equals_test.cc` is the enumeration
+suite, plus a view sweep (`add_view_tests(equals_constraint equals_test 2)`).
+`gcs/innards/proofs/range_infer_test.cc` is a dedicated single-purpose proof
+test for rule 2: a plain `Equals` where each side carries a contiguous hole, so
+each loses one interval to the other, run under `run_test_and_verify.bash`. Its
+hole on `x` is deliberately wide (`[10..30]` out of `[0..40]`) so that the
+inference's *width-independence* is exercised on a non-trivial interval — it is
+the evidence that an interval of `infer_not_equal` really does collapse into one
+`infer_not_in_range` without re-encoding `Equals`.
+
+- **Enumeration with per-node GAC assertion.** `solve_for_tests_checking_gac`
+  for the main matrix, so every value left in a domain at every node is
+  asserted to be supported by some solution. The no-overlap fixture uses
+  `solve_for_tests_checking_consistency` instead, marking `c` as `None`:
+  `c = 1` is unsupported only by a deduction across all thirteen posted
+  constraints, which no individual propagator can make. That distinction is
+  spelled out in the test rather than fudged.
+- **VeriPB really runs**, for every case, gated on `can_run_veripb()`. A seeded
+  run is 284 proofs, all verifying, in 1.26 s.
+- **SCP round-trip** on every proving case, via
+  `check_scp_writer_reader_symmetry` — but see below for what it does not
+  check.
+- **Seeded.** `establish_and_announce_seed`, reproducible with `--seed=N`.
+- **Coverage of the awkward cases**: all-constant operands in both directions
+  (issue #254), aliasing for all six variants, negative domains, disjoint
+  domains, singleton domains, and the `NotEquals(x, x)` rejection.
+- **No runtime caps.** Nothing here is slow enough to need one.
+
+What the tests do **not** cover:
+
+- **No large-domain case.** Every domain in `equals_test.cc` is inside
+  `[-10, 10]`, and `range_infer_test`, though it checks that one rule's proof is
+  independent of *interval* width, works inside `[0, 40]`. Nothing in either
+  suite would have caught the rule-9 blow-up, which needs a domain wide enough
+  to be worth walking. This is the gap that matters most.
+- **The SCP symmetry check is a readability check, not a semantic one.** It
+  asserts that `read_scp` can parse whatever the writer emitted; it does not
+  check that what was parsed means the same thing. The `NotEqualsIff` keyword
+  flip passes it. A semantic round-trip is available —
+  `cake_probe_chain` — but only under `GCS_TEST_CAKE`.
+- **No mutation evidence recorded.** Nothing in the file or in this document
+  demonstrates that VeriPB *refuses* a mangled equals derivation, so the
+  derivations are not known to be tight.
+
+### Benchmarks and examples
+
+In-repo examples posting this family: `ortho_latin`, `colour`, `sudoku`,
+`skyscrapers`, `talent`, `hitori`, `seat_moving`, `n_fractions`,
+`circuit_random`, `skeleton_puzzle`. From the frontends, any MiniZinc model
+with a two-variable `=` or `!=` reaches it via the two-term linear recovery.
+
+- **For CPU benchmarking: `ortho_latin --all 6`** with the default
+  `--all-different not-equals`. Already curated in `dev_docs/benchmarking.md`
+  as `ortho_latin_6_all`. It is dominated by this family (71% of calls) and has
+  a fixed, deterministic search tree, so a before/after is meaningful.
+  Secondary: `colour`, which is where a trigger change shows its downside — its
+  single `ArrayMax` was measured under #819 at 82% of its propagation time, so
+  anything that makes `ArrayMax` run more often costs there.
+- **For proof benchmarking: `ortho_latin --all 5`.** Size 6 must be capped
+  (`dev_docs/proof-benchmarks.md`); size 5 is 5.7 MB and there is nothing in
+  between.
+- **Do not** pin `circuit_random` results without `--seed=N`; it defaults to a
+  random seed.
+
+### CPU performance
+
+*Measured 2026-09-07 at `7d014207`, Release + `GCS_WERROR=ON`, g++ 15.2.0,
+AMD Ryzen 9 9950X3D, 30 GB. Min of three.*
+
+| Benchmark | Time | Recursions | Propagator calls | Busiest type |
+|---|---|---|---|---|
+| `ortho_latin --all 6` | 20.49 s | 1,339,912 | 77,784,903 | `not_equals`, 55,435,743 (71%) |
+
+Under `GCS_PROPAGATOR_STATS=time`, `not_equals` takes **18% of 19.06 s** of
+propagation while making 71% of the calls — about 57 ns a call. That ratio is
+the family's whole performance story: the algorithm is already as cheap as a
+propagator gets, so the only lever left is *how often it is woken*, which is
+what issue #819 addressed. A timed run's own wall clock (23.29 s here) is not
+comparable with an uninstrumented one.
+
+**Cross-solver comparison: `Not measured.`** Doing it properly needs an
+identical-search-tree harness against Gecode, Choco and ACE on a
+clique-encoded model, and a note on the fact that those solvers would normally
+use a specialised all-different rather than a disequality clique — which makes
+"the same benchmark" the hard part, not the timing. Flagged in [Next
+steps](#next-steps).
+
+**Historical A/B, measured elsewhere (issue #819, pre-merge):**
+`ortho_latin --all 6` 24.29 s → 20.28 s (−16.5%), 321.7M → 55.4M
+`not_equals` calls; `colour` +3.6% and +5.2% on two instances and neutral on a
+third; identical search trees throughout. Those figures are from the issue, not
+from this machine on this date, and the two sets should not be mixed in one
+table.
+
+### Proof performance
+
+*Same build and machine. `ortho_latin --all 5`: 607 recursions, 18 solutions,
+0.044 s to solve and write.*
+
+| Assertion level | Proof size | Assertions | VeriPB | Verdict |
+|---|---|---|---|---|
+| `Off` (justify everything) | 5.66 MB | 0 | 2.30 s | `VERIFIED COMPLETE ENUMERATION` |
+| `Links` | 3.33 MB | 31,069 | — | — |
+| `Inferences` | 3.15 MB | 30,064 | 0.04 s | `UNDER ASSERTIONS` |
+
+Verification is **52× the solve time** fully justified. Asserting inferences
+cuts the proof by 44% and, since `a` is an oracle rather than a checked rule,
+the "verification" becomes free — which is exactly the input an external
+justifier is meant to consume, and exactly why its output has to be checked
+again afterwards.
+
+Of the 30,064 assertions at `Inferences` level, **13,323 (44%) carry the
+`equals` hint** — more than any other family in that proof
+(`modulus` 8,280, `linear_equality` 4,032, `divide` 3,804). All 13,323 are the
+bare `((constraint_id _N))` form; the `no_overlap` subhint does not arise in
+`ortho_latin`, since disjoint domains do not occur there.
+
+Per-rule proof sizes are in the catalogue. The family's own contribution is one
+to three lines per inference; a fully-justified proof of an equals-heavy model
+is dominated by the *shared* order-literal and equality-literal definitions
+that the variable-encoding layer emits on demand, not by this constraint.
+
+## Status, gaps, and next steps
+
+### Proof-logging gaps
+
+**Nothing is left unjustified, and no rule is weakened when proofs are
+enabled.** There is no `a`-oracle use, no unlogged inference, and no
+strength difference between a proving and a non-proving run.
+
+There is one cost gap in the other direction, which is a genuine bug:
+
+**Rule 9 pays its proof cost when proofs are off.**
+`no_overlap_justification` builds a reason of `2 + width` literals
+unconditionally, and `SimpleInferenceTracker::materialises_reasons` is
+`false`, so with proofs off that vector is built and thrown away. The
+`InferenceTracker` header states the rule this breaks — "a propagator whose
+reason is expensive to assemble (a `ConcatReason` allocation, **a long
+extra-literal walk**) should guard that assembly on this query" — and the
+must-not-hold pass in the *same file* does guard, added by commit `fea9508d`
+("equals: guard the reified must-not-hold reason on want_reasons"). This site
+was missed. It is what turns a wide-domain `EqualsIff` into a `std::bad_alloc`.
+
+Guarding it does not remove the O(width) cost when proofs *are* on — that is
+inherent to the per-value witness — but it does confine it to proving runs, and
+it is a one-line change with the pattern already in the file's history.
+
+### Known limitations
+
+**`ReifiedEquals::clone()` drops `_neq`, which silently disables a deliberate
+fix.** The clone is `make_unique<ReifiedEquals>(_v1, _v2, _cond)` — no fourth
+argument — so `_neq` defaults to `false`. `Problem::post` clones, and
+`create_propagators` clones again, so by the time anything reads `_neq` it is
+always `false`. Consequences, all verified by running the six variants:
+
+1. The `cond_to_write` un-negation in `s_expr()` is **unreachable**. Its guard
+   is `_neq && holds_alternative<reif::Iff>`, and `_neq` is never true.
+2. `NotEqualsIff{x, y, b == 1}` therefore writes `(_1 equals_iff (b != 1) x y)`
+   where the code comment intends `(_1 not_equals_iff (b = 1) x y)`.
+3. The OPB provenance comment for a `NotEqualsIff` reads
+   `* constraint equals _1`.
+
+None of this is a correctness bug **because the two errors cancel exactly**:
+`¬c ↔ x = y` and `c ↔ x ≠ y` are the same constraint, and all six variants
+round-trip through `read_scp` to identical solution counts. The comparison is
+instructive: `ReifiedLinearEquality::clone()` *does* pass its equivalent flag
+(`_flipped_cond`) through, which is why the same commit's fix was load-bearing
+there — `linear_test` `ne_iff` went 0/68 to 68/68 — while `equals_test` showed
+no change at all. That silence was the only signal that the fix had not taken.
+
+The danger is a partial repair. Fixing `clone()` alone flips the emitted
+keyword and the condition together, and stays correct. Fixing either half on
+its own emits the *opposite* constraint, and the SCP symmetry check will not
+catch it, because it only checks that the keyword parses.
+
+**Two derivations share one wire hint.** Rules 1 and 2 both emit
+`equals:((constraint_id N))`, but rule 1 is a bare RUP and rule 2 needs two
+bridge lemmas first. An external justifier has to discriminate on whether the
+asserted literal is a range literal, rather than on the hint. The mechanism for
+saying so already exists and is already used by rule 9 — a subhint.
+
+**Aliased operands are not GAC**, deliberately: a GAC algorithm for distinct
+variables does not generally give GAC under aliasing, and the dup tests check
+the solution set and the proof only. Documented rather than fixed.
+
+**The view/constant fallback costs one proof line per value.** Documented
+above; it is a proof-size limitation of the range-literal bridge, which needs
+a plain variable on the far side.
+
+### Next steps
+
+Ranked. None of these are filed yet; the first three are what this audit would
+open.
+
+1. **Guard `no_overlap_justification` on `want_reasons()`.** One line, removes
+   a `std::bad_alloc` on wide domains with proofs off, and follows a pattern
+   already applied to the neighbouring pass in `fea9508d`. Add a wide-domain
+   case to the test file at the same time — the current suite tops out at
+   `[-10, 10]` and cannot see this.
+2. **Fix `clone()` to pass `_neq`, and check the emitted `.scp` changes as
+   expected.** Small, but it must be done as one change: it flips both the
+   keyword and the condition, and half of it is silently wrong. Worth pairing
+   with a semantic round-trip assertion (solve the re-read model, compare
+   solution counts) so the symmetry check stops passing on an equivalent-but-
+   unintended description. Also makes the `not_equals_iff` reader path reachable
+   from the writer.
+3. **Give the not-in-range bridge its own subhint.** Removes the one place in
+   this family where an external justifier must key off literal shape instead
+   of the hint. Cheap, and the pattern is already there in
+   `EqualsNoOverlap`.
+4. **Consider an interval-wise no-overlap witness.** Rule 9's per-value walk is
+   the only super-logarithmic thing here. Whether an interval-wise certificate
+   exists is a real question, not a refactor: the witness genuinely is
+   per-value, since it says *for each value* which side excludes it. A cheaper
+   alternative may be to bound the rule and fall back to leaving the verdict
+   undecided when the range is wide — a strength loss, but a bounded one.
+5. **Measure against Gecode, Choco and ACE.** Needs an identical-search-tree
+   harness and a defensible choice of model, since those solvers would not
+   normally encode an all-different as a disequality clique.
+6. **Record a mutation.** Show that VeriPB refuses a mangled equals
+   derivation, so the derivations are known to be tight rather than merely
+   accepted.
+7. **Drop the `State *` from `EqualsNoOverlap`.** The reconstructibility
+   analysis above shows the asserted clause already carries what the emitter
+   reads it for. Removing it would make the family's justifications uniformly
+   free of `state` access, which is the invariant everywhere else.
+
+## Prior art
+
+There is none to speak of, and that is the point worth making in a survey: a
+binary (dis)equality is not a constraint anyone publishes a propagation
+algorithm for, and the interesting content here is entirely on the proof side.
+Two things are worth citing:
+
+- The bit-level bound-opposition argument the bridge lemmas rely on is what
+  the code calls the "Theorem 2.9 / Justification Procedure 3.2" configuration;
+  the range-literal layer that needs it is specified in
+  `dev_docs/range_literals_spec.md`, and `range_infer_test.cc` is the worked
+  single-inference demonstration.
+- The trigger-narrowing result (issue #819) is an ordinary engineering
+  measurement, but the *shape* of it — that an avoided no-op wake is worth
+  ~15 ns while a delayed inference costs a co-registered O(n·d) propagator a
+  whole extra run — is the transferable finding, and it generalises to every
+  cheap binary constraint in the solver.
+
+## Further reading
+
+- `dev_docs/constraints.md` — the generic three-phase structure, the inference
+  and justification APIs, and the OPB building blocks this family uses without
+  extending.
+- `dev_docs/reification.md` — `ReificationCondition`,
+  `EvaluatedReificationCondition` and `install_reified_dispatcher`, which
+  carry all four reified forms here.
+- `dev_docs/range_literals_spec.md` — the interval-literal proof layer, and why
+  a range literal cannot cross a bit-sum equality without the bridge.
+- `dev_docs/variable-encodings.md` — the in-OPB versus in-proof axis this
+  family sits entirely on the OPB side of.
+- `dev_docs/refined-triggers.md` — the per-literal watch mechanism. Not used
+  here, and the contrast is informative: this family's trigger win came from
+  coarsening `on_change` to `on_instantiated`, not from watching literals.
+- `dev_docs/infer-redesign.md` — the typed assertion hints in
+  `gcs::innards::hints` and the `JustifyExplicitly` / `JustifyUsingRUP` split.
+- `dev_docs/benchmarking.md`, `dev_docs/proof-benchmarks.md` — where
+  `ortho_latin` sits in the curated sets, and the size cap on the size-6 proof.
+
+## Developer commentary
+
+`None.` The family predates the practice of writing design notes, and the
+inline comments in `equals.cc` are unusually thorough — the cake conformity
+notes in `define_proof_model`, the `#819` trigger rationale, and the bridge
+explanation in `enforce_equality` are all worth reading in place. This document
+does not duplicate them.

--- a/dev_docs/constraints/equals.md
+++ b/dev_docs/constraints/equals.md
@@ -806,6 +806,14 @@ keyword and the condition together, and stays correct. Fixing either half on
 its own emits the *opposite* constraint, and the SCP symmetry check will not
 catch it, because it only checks that the keyword parses.
 
+The fix is also known to be local: a sweep of every `clone()` under
+`gcs/constraints/` and `gcs/presolvers/` found this to be the **only** one that
+drops a constructor argument. The two constraints with the closest shape both
+pass everything through —
+`ReifiedCompareLessThanOrMaybeEqual(_v1, _v2, _reif_cond, _or_equal, _vars_swapped)`
+and the corresponding `LexCompareGreaterThanOrMaybeEqual`. So this is one
+missing argument in one function, not a pattern to hunt down.
+
 **Two derivations share one wire hint.** Rules 1 and 2 both emit
 `equals:((constraint_id N))`, but rule 1 is a bare RUP and rule 2 needs two
 bridge lemmas first. An external justifier has to discriminate on whether the

--- a/dev_docs/constraints/equals.md
+++ b/dev_docs/constraints/equals.md
@@ -218,30 +218,32 @@ merging the documents would bury two distinct OPB encodings in one section.
 ### OPB encoding
 
 The operands are compared through their **bit** (binary) encodings, not their
-order literals. Writing `⟦v⟧` for the bit sum of `v`:
+order literals. Writing `BinEnc(v)` for the bit-sum encoding of `v` --- the
+notation [`justification-techniques.md`](../justification-techniques.md) and
+the thesis both use:
 
 ```
-MustHold      (Equals)          ⟦v1⟧ - ⟦v2⟧ = 0
+MustHold      (Equals)          BinEnc(v1) - BinEnc(v2) = 0
                                   split into two rows, le and ge
 
-MustNotHold   (NotEquals)       ne                     ->  ⟦v1⟧ - ⟦v2⟧ >= 1
-                                ¬ne                    ->  ⟦v1⟧ - ⟦v2⟧ <= -1
+MustNotHold   (NotEquals)       ne                     ->  BinEnc(v1) - BinEnc(v2) >= 1
+                                ¬ne                    ->  BinEnc(v1) - BinEnc(v2) <= -1
                                   with one fresh flag ne per constraint
 
-If            (EqualsIf)        cond                   ->  ⟦v1⟧ - ⟦v2⟧ = 0
+If            (EqualsIf)        cond                   ->  BinEnc(v1) - BinEnc(v2) = 0
                                   split into le and ge, each half-reified
 
-NotIf         (NotEqualsIf)     gt                     ->  ⟦v1⟧ - ⟦v2⟧ >= 1
-                                ¬gt                    ->  ⟦v1⟧ - ⟦v2⟧ <= 0
-                                lt                     ->  ⟦v1⟧ - ⟦v2⟧ <= -1
-                                ¬lt                    ->  ⟦v1⟧ - ⟦v2⟧ >= 0
-                                lt + gt + ¬cond        >=  1
+NotIf         (NotEqualsIf)     gt                     ->  BinEnc(v1) - BinEnc(v2) >= 1
+                                ¬gt                    ->  BinEnc(v1) - BinEnc(v2) <= 0
+                                lt                     ->  BinEnc(v1) - BinEnc(v2) <= -1
+                                ¬lt                    ->  BinEnc(v1) - BinEnc(v2) >= 0
+                                cond                   ->  lt + gt >= 1
 
-Iff           (EqualsIff,       cond                   ->  ⟦v1⟧ - ⟦v2⟧ = 0
+Iff           (EqualsIff,       cond                   ->  BinEnc(v1) - BinEnc(v2) = 0
                NotEqualsIff)      split into le and ge, each half-reified
-                                gt                     ->  ⟦v1⟧ - ⟦v2⟧ >= 1
-                                lt                     ->  ⟦v1⟧ - ⟦v2⟧ <= -1
-                                lt + gt + cond         >=  1
+                                gt                     ->  BinEnc(v1) - BinEnc(v2) >= 1
+                                lt                     ->  BinEnc(v1) - BinEnc(v2) <= -1
+                                ¬cond                  ->  lt + gt >= 1
 ```
 
 The encoding is **definitional**: every row states part of what the constraint
@@ -278,7 +280,7 @@ row parses against cake's re-derived model.
 | `@c[id][gt]`, `@c[id][lt]` | the two strict comparisons | `MustNotHold` |
 | `@b[id][gt][r]`, `@b[id][gt][f]` | forward/reverse halves of the `gt` selector | `NotIf` (both), `Iff` (`[r]` only) |
 | `@b[id][lt][r]`, `@b[id][lt][f]` | ditto for `lt` | `NotIf` (both), `Iff` (`[r]` only) |
-| `@c[id][al1]` | the at-least-one tying `lt`, `gt` and the condition | `NotIf`, `Iff` |
+| `@c[id][al1]` | the at-least-one: `cond -> lt + gt >= 1` for `NotIf`, `¬cond -> lt + gt >= 1` for `Iff` | `NotIf`, `Iff` |
 
 The selector-flag rows are labelled with the flag's own name plus a role suffix
 (`pb_file_string_for(flag) + "[r]"`), not with `@c[id][...]`, because that is
@@ -523,7 +525,24 @@ Nine rules. The first four are the must-hold pass (`enforce_equality`), the
 fifth is the must-not-hold pass, and the last four are the reified verdicts of
 the undecided pass.
 
-Three facts hold for all nine and are not repeated in each entry.
+Four facts hold for all nine and are not repeated in each entry.
+
+**What licenses the RUP.** Every rule here is an instance of a published
+justification procedure, except rule 9, which is ours. The chain is always the
+same: our encoding gives each operand atomic bound and equality literals over a
+binary backbone, `Inv1` plus **Theorem 3.3** make unit propagation complete for
+the implied atomic literals *within* one variable, and one of
+**Theorems 2.7–2.9** carries a fact *across* the equality rows.
+[`justification-techniques.md`](../justification-techniques.md) states those
+facts and their preconditions; each rule below names the procedure it is an
+instance of. The reification condition rides along in every reason by
+**Theorem 2.6**, which reduces a step stated under a conjunction of literals to
+the same step with those literals assumed — so it is never mentioned again.
+
+The precondition that matters for this family is Theorem 2.9's **`B ∈ {0,1}`**.
+The equality is two rows, `BinEnc(v1) - BinEnc(v2) >= 0` and `<= 0`, so each
+half has degree 0 and a bound crosses it. A family whose row degree could grow
+past 1 would lose that licence; see Example 2.15 for the counterexample.
 
 **No hint carries operand data.** All three hint types in the family derive
 from `hints::Equals`, whose wire form is `(constraint_id <id>)`, and nothing
@@ -566,7 +585,12 @@ reason is what the conclusion is asserted under.
 - **Strength** — `GAC` on its own, for two distinct operands.
 - **Algorithm** — two `optional_single_value` reads. O(1).
 - **Why it is true** — immediate from `v1 = v2`.
-- **Proof technique** — `RUP`.
+- **Proof technique** — `RUP`, by **JP 3.12 (equality propagation)**, whose
+  correctness proof is **Theorem 2.8** applied twice: the negated conclusion
+  propagates `v1 = v` and `¬(v2 = v)`, the first of which fixes every bit of
+  `BinEnc(v1)`, the equality rows then fix every bit of `BinEnc(v2)`, and that
+  contradicts the definition of `v2 = v`. This is the inference the thesis uses
+  to introduce that procedure.
 - **Reason** — the base reason (the condition literal) plus `v1 = *val1`.
   Minimal.
 - **Assertion** — the clause `other = v ∨ ¬(v1 = v) ∨ ¬cond`, e.g.
@@ -596,6 +620,13 @@ reason is what the conclusion is asserted under.
 - **Why it is true** — if `v1 = v2` then any value in neither domain is in
   neither variable's support.
 - **Proof technique** — `RUP+hints` — two bound lemmas, then the conclusion.
+  Each lemma is an instance of **JP 3.2 (comparison)** against one half of the
+  equality, licensed by **Theorem 2.9** with `B = 0`: the lemma's negation
+  supplies a lower bound on one operand, the equality half, and an upper bound
+  on the other, which is exactly 2.9's contradictory triple. The *conclusion*
+  is then a plain RUP once the lemmas are in place. Nothing here is novel; what
+  is specific to us is only that the conclusion is spelled as a range literal,
+  which is why the lemmas are needed at all (below).
 - **Reason** — the base reason plus `not_in_range(other, lo, hi)`. A fresh
   snapshot per interval, so the justification's repeated materialisations do
   not see an accumulating literal. Minimal.
@@ -635,13 +666,26 @@ reason is what the conclusion is asserted under.
   unaided. The lemmas are load-bearing in general, and a narrow fixture would
   have reported that they are not.
 
-Why the bridge is needed at all: a range literal asserts only *order* atoms,
-never bits, and the equality rows are a *bit*-sum equality — so
-`¬(y ∈ [4,6])` is not RUP from `¬(x ∈ [4,6])` on its own. Each bridge lemma is
-RUP because its negation supplies a pair of opposing bounds that contradict the
-equality at the bit level. The lemmas mention no range literal, so any literal
-sharing those endpoints can reuse them. The pairing assumes a **same-sign**
-link; a sign-flipped link, as `Abs` has, needs the mirrored pairing.
+Why the bridge is needed at all, and this is the part worth being precise
+about, because the neighbouring facts are easy to conflate:
+
+- **A range literal cannot cross the equality.** It asserts only *order* atoms,
+  never bits, and the equality rows are a *bit*-sum equality — so
+  `¬(y ∈ [4,6])` is not RUP from `¬(x ∈ [4,6])` on its own. Nothing in
+  Theorems 2.7–2.9 applies to a literal that never touches the bit sum.
+- **A single bound can.** Each bridge lemma's negation supplies a lower bound on
+  one operand, an equality half, and an upper bound on the other, which is
+  Theorem 2.9's contradictory triple with `B = 0`. So the lemmas do not work
+  around a limitation of bounds; they *convert* the range literal's endpoints
+  into bounds, which are the only thing that crosses.
+- **What Example 2.15 rules out is neither of those.** It is the counterexample
+  to relaxing `B ∈ {0,1}`, over a middle row of degree 3. An equality half has
+  degree 0, so it is inside the theorem, and a two-term linear row with a
+  larger constant is outside it.
+
+The lemmas mention no range literal, so any literal sharing those endpoints can
+reuse them. The pairing assumes a **same-sign** link; a sign-flipped link, as
+`Abs` has, needs the mirrored pairing.
 
 ### Rule: symmetric-difference-values
 
@@ -651,7 +695,7 @@ link; a sign-flipped link, as `Abs` has, needs the mirrored pairing.
 - **Algorithm** — the same merge-walk, then a per-value loop over each removed
   interval. O(removed **values**).
 - **Why it is true** — as rule 2.
-- **Proof technique** — `RUP`.
+- **Proof technique** — `RUP`, by **JP 3.12** per value, exactly as rule 1.
 - **Reason** — the base reason plus `other ≠ val`, rebuilt per value. Minimal.
 - **Assertion** — `pruned ≠ val ∨ ¬(other ≠ val) ∨ ¬cond`.
 - **Hint** — `hints::Equals{owner}`.
@@ -673,7 +717,10 @@ link; a sign-flipped link, as `Abs` has, needs the mirrored pairing.
   domain intersection.
 - **Algorithm** — two `bounds` reads, four `infer_*` calls. O(1).
 - **Why it is true** — immediate from `v1 = v2`.
-- **Proof technique** — `RUP`.
+- **Proof technique** — `RUP`, by **JP 3.2 (comparison)** against one half of
+  the equality, licensed by **Theorem 2.9** with `B = 0` — the same licence as
+  rule 2's bridge lemmas, and the same shape: a lone bound *does* cross a
+  bit-sum equality, because each half is a difference row of degree 0.
 - **Reason** — the base reason plus the one bound literal being carried across.
   Minimal.
 - **Assertion** — e.g. `v2 ≥ lb1 ∨ ¬(v1 ≥ lb1) ∨ ¬cond`.
@@ -699,7 +746,10 @@ differ at all, so up to three of them can be no-ops. This is deliberate:
 - **Algorithm** — two `optional_single_value` reads. O(1). This is the busiest
   rule in the solver on clique-encoded models.
 - **Why it is true** — immediate from `v1 ≠ v2`.
-- **Proof technique** — `RUP`.
+- **Proof technique** — `RUP`, by **JP 3.1 (not-equals)**, licensed by
+  **Theorem 2.8**: the negated conclusion propagates `v1 = v` and `v2 = v`,
+  which by 2.8 fix both bit sums to `v`, contradicting the `ne` flag's
+  reification.
 - **Reason** — stated outright as `{cond, v1 = *value1}` rather than deferred,
   since the value is already in hand and both literals sit inline. Guarded on
   `want_reasons()`, so it costs nothing when nothing will read it. Minimal.
@@ -729,7 +779,11 @@ paying for a throw.
 - **Strength** — `GAC` on the condition.
 - **Algorithm** — one handle comparison. O(1).
 - **Why it is true** — `x = x`.
-- **Proof technique** — `RUP`.
+- **Proof technique** — `RUP`. No procedure needed and none applies: the
+  asserted literal is unit, so its negation alone falsifies the `al1` row
+  against the reification of `lt` and `gt`, both of which are unsatisfiable
+  with the operands aliased. **Theorem 2.6** is what lets the step be stated
+  with no reason at all.
 - **Reason** — `NoReason{}`; the fact is unconditional.
 - **Assertion** — the condition literal alone.
 - **Hint** — `hints::Equals{owner}`.
@@ -752,7 +806,10 @@ alias" bug the dup tests were added for.
 - **Strength** — `GAC` on the condition.
 - **Algorithm** — two `optional_single_value` reads and a comparison. O(1).
 - **Why it is true** — the constraint is decided by the assignment.
-- **Proof technique** — `RUP`.
+- **Proof technique** — `RUP`, by **JP 3.1** or **JP 3.12** according to which
+  way the verdict falls, with **Theorem 2.6** carrying it through the
+  reification: the two equality literals fix both bit sums by **Theorem 2.8**,
+  and the selector flags' reifications then decide the condition.
 - **Reason** — `{v1 = *value1, v2 = *value2}`. Minimal.
 - **Assertion** — the condition literal, plus the negations of the two
   equalities.
@@ -773,7 +830,11 @@ alias" bug the dup tests were added for.
   O(log intervals) depending on the domain representation.
 - **Why it is true** — the fixed value has no partner.
 - **Reason** — `{v1 = *value1, v2 ≠ *value1}`. Minimal.
-- **Proof technique** — `RUP`.
+- **Proof technique** — `RUP`, by **JP 3.12** against the `cond ->` equality
+  half: `v1 = v` fixes `BinEnc(v1)` by **Theorem 2.8**, the half-reified rows
+  would fix `BinEnc(v2)` to `v` under `cond`, and `v2 ≠ v` contradicts that —
+  so `cond` cannot hold. **Theorem 2.6** is doing the reified step here rather
+  than riding along.
 - **Assertion** — `¬cond ∨ ¬(v1 = v) ∨ ¬(v2 ≠ v)`.
 - **Hint** — `hints::Equals{owner}`.
 - **Offline reconstructibility** — `offline`.
@@ -801,21 +862,34 @@ alias" bug the dup tests were added for.
   be wherever `v2` is. `p` strictly increases, so the walk stops after at most
   one move per interval, and it stops by running `p` off the top of one of the
   two domains, which is the contradiction the conclusion needs. The six moves,
-  and what each costs:
+  and the fact each one states:
 
-  | Move | Reason literal | Lemmas |
-  |---|---|---|
-  | start at v1's lower bound | `v1 ≥ lb1` | — |
-  | v2 starts higher, jump to it | `v2 ≥ lb2` | 1 |
-  | a hole of v1 | `¬[v1 ∈ lo..hi]` | — |
-  | a run where v2 is empty | `¬[v2 ∈ lo..hi]` | 2 |
-  | p ran off the top of v1 | `v1 ≤ ub1` | — |
-  | p ran off the top of v2 | `v2 ≤ ub2` | 1 |
+  | Move | Fact stated |
+  |---|---|
+  | start at v1's lower bound | `v1 ≥ lb1` |
+  | v2 starts higher, jump to it | `v2 ≥ lb2` |
+  | a hole of v1 | `¬[v1 ∈ lo..hi]` |
+  | a run where v2 is empty | `¬[v2 ∈ lo..hi]` |
+  | p ran off the top of v1 | `v1 ≤ ub1` |
+  | p ran off the top of v2 | `v2 ≤ ub2` |
 
-  A hole of `v1` is free: the range literal's own reverse reification steps
-  `p` over it. A run where `v2` is empty costs the two bound-crossing lemmas.
+  Nothing above is about VeriPB: the walk is sound as an argument about
+  integers, and someone auditing that can stop reading here. What each move
+  *costs to certify* — nothing for a move inside `v1`, one or two lemmas for a
+  move that crosses to `v2` — is under **Proof size**.
 - **Proof technique** — `RUP+hints` — at most two lemmas per run, then the
-  conclusion.
+  conclusion. **No published procedure: this rule is ours.** The thesis states
+  the same fact as **JP 3.13 (equality infeasibility)**, one RUP line per
+  surviving value followed by a contradiction against the generic reason, which
+  is what gcs emitted until #881 and is O(domain width). The interval walk
+  below replaces it and is argued from scratch under *Why it is true*; each
+  individual lemma is still an instance of **JP 3.2** against one half-reified
+  equality row, licensed by **Theorem 2.9** with `B = 0`, and the extra `! cond`
+  each carries is **Theorem 2.6**.
+
+  This is the one rule in either audited family that an external justifier
+  cannot rebuild by replaying a procedure it already knows, which is why the
+  reconstructibility verdict below is the interesting one.
 - **Reason** — one literal per move of the walk, so one per run rather than
   one per value. For the common shape — two hole-free domains on opposite
   sides of a point — that is `{v2 ≥ lb2, v1 ≤ ub1}`, **two literals at any
@@ -850,9 +924,24 @@ alias" bug the dup tests were added for.
   consecutive `NotEqual`s, which is what a view's run degrades to) is a run,
   and a `Less` is the stop; whose variable it names says whether lemmas are
   owed.
-- **Proof size** — two lines per run where the run belongs to `v2`, none where
-  it belongs to `v1`, plus one conclusion. Emitted at `ProofLevel::Temporary`,
-  so the lemmas are deleted.
+- **Proof size** — per move of the walk, which is where *Why it is true*'s
+  table stops and this one starts:
+
+  | Move | Lemmas |
+  |---|---|
+  | start at v1's lower bound | — |
+  | v2 starts higher, jump to it | 1 |
+  | a hole of v1 | — |
+  | a run where v2 is empty | 2 |
+  | p ran off the top of v1 | — |
+  | p ran off the top of v2 | 1 |
+
+  A move inside `v1` is free: the range literal's own reverse reification steps
+  `p` over it, which is `Inv1` and Theorem 3.3 doing the work within one
+  variable. A move that crosses to `v2` needs Theorem 2.9's triple assembled,
+  which costs the two bound lemmas. So: two lines per run belonging to `v2`,
+  none for a run belonging to `v1`, plus one conclusion. Emitted at
+  `ProofLevel::Temporary`, so the lemmas are deleted.
 
   *Measured 2026-09-08 at `76bfd836`, same machine and build as [Robustness
   and limits](#robustness-and-limits). `v1` the even values of `[0, 2n)`, `v2`
@@ -1257,21 +1346,30 @@ binary (dis)equality is not a constraint anyone publishes a propagation
 algorithm for, and the interesting content here is entirely on the proof side.
 Two things are worth citing:
 
-- The bit-level bound-opposition argument the bridge lemmas rely on is what
-  the code calls the "Theorem 2.9 / Justification Procedure 3.2" configuration;
-  the range-literal layer that needs it is specified in
-  `dev_docs/range_literals_spec.md`, and `range_infer_test.cc` is the worked
-  single-inference demonstration.
+- **Almost every rule here is a published justification procedure**, from
+  McIlree's thesis (2026): JP 3.1 for the not-equals pruning, JP 3.12 for the
+  equality propagation, JP 3.2 for every bound that crosses, resting on
+  Theorems 2.7–2.9 for the unit-propagation facts and Theorem 3.3 with `Inv1`
+  for completeness within a variable. The code cites the same results as the
+  "Theorem 2.9 / Justification Procedure 3.2" configuration, and
+  `range_infer_test.cc` is the worked single-inference demonstration.
+  [`justification-techniques.md`](../justification-techniques.md) collects them;
+  the attribution for this family is essentially all to that thesis.
+- **One rule is not**, and it is the family's only novel proof content: the
+  interval-wise disjointness witness (#867/#881) replaces JP 3.13's per-value
+  statement — see below.
 - The trigger-narrowing result (issue #819) is an ordinary engineering
   measurement, but the *shape* of it — that an avoided no-op wake is worth
   ~15 ns while a delayed inference costs a co-registered O(n·d) propagator a
   whole extra run — is the transferable finding, and it generalises to every
   cheap binary constraint in the solver.
-- The **interval-wise disjointness certificate** (#867/#881) is, as far as
-  this audit found, novel — and it is the one thing in this family that is a
-  proof technique rather than an application of one. "These two domains do not
-  overlap" has an obvious per-value witness and no obvious interval-wise one,
-  because the fact really is stated value by value. Restating it as a *walk* —
+- The **interval-wise disjointness certificate** (#867/#881) is the rule
+  referred to above, and as far as this audit found it is novel — the one thing
+  in this family that is a proof technique rather than an application of one.
+  The published alternative is **JP 3.13**, which states the same fact one
+  value at a time, and which is what gcs emitted until #881. "These two domains
+  do not overlap" has an obvious per-value witness and no obvious interval-wise
+  one, because the fact really is stated value by value. Restating it as a *walk* —
   an invariant `v1 ≥ p` carried up the number line, one move per maximal run
   `v1` cannot occupy, ending by pushing `p` off the top of one domain — makes
   it cost one literal per run and at most two lines per run, at any domain
@@ -1285,6 +1383,12 @@ Two things are worth citing:
 
 ## Further reading
 
+- [`dev_docs/justification-techniques.md`](../justification-techniques.md) —
+  **read this alongside the inference catalogue.** It is what licenses the
+  `RUP` in every rule's Proof technique field: the unit-propagation facts
+  (Theorems 2.6–2.9), the completeness invariant `Inv1` and Theorem 3.3, the
+  published justification procedures each rule instantiates, and the
+  precondition (`B ∈ {0,1}`) that says when the argument stops working.
 - `dev_docs/constraints.md` — the generic three-phase structure, the inference
   and justification APIs, and the OPB building blocks this family uses without
   extending.

--- a/dev_docs/constraints/equals.md
+++ b/dev_docs/constraints/equals.md
@@ -2,8 +2,9 @@
 
 > **Maturity** production ·
 > **Audited** 2026-09-07 at `7d014207` ·
-> **Open issues** none open specific to this family; see [Next
-> steps](#next-steps) for the three this audit would file
+> **Open issues** #864, #865, #866, #867, #870 specific to this family; #868 and
+> #869 are audit-wide prerequisites it also blocks on. All seven were filed by
+> this audit; tracked under #871.
 
 Six posted classes over one implementation: an equality between two operands,
 optionally reified, optionally negated. It is the smallest interesting
@@ -620,7 +621,8 @@ alias" bug the dup tests were added for.
   which branch that value took (`y = val` for a value in v1's domain, `x = val`
   for one outside it). So the emitter's `State *` is a convenience, not
   information the justifier lacks. This is the one rule in the family where the
-  verdict is worth checking rather than assuming.
+  verdict is worth checking rather than assuming, and the reason **#870** holds
+  that the `State *` is removable.
 - **Proof size** — `width + 1` lines: one lemma per value in v1's bounds range,
   plus the conclusion. Emitted at `ProofLevel::Temporary`, so the lemmas are
   deleted.
@@ -671,9 +673,9 @@ What the tests do **not** cover:
   check that what was parsed means the same thing. The `NotEqualsIff` keyword
   flip passes it. A semantic round-trip is available —
   `cake_probe_chain` — but only under `GCS_TEST_CAKE`.
-- **No mutation evidence recorded.** Nothing in the file or in this document
-  demonstrates that VeriPB *refuses* a mangled equals derivation, so the
-  derivations are not known to be tight.
+- **No mutation evidence recorded (#869).** Nothing in the file or in this
+  document demonstrates that VeriPB *refuses* a mangled equals derivation, so
+  the derivations are accepted but not known to be tight.
 
 ### Benchmarks and examples
 
@@ -711,7 +713,9 @@ propagator gets, so the only lever left is *how often it is woken*, which is
 what issue #819 addressed. A timed run's own wall clock (23.29 s here) is not
 comparable with an uninstrumented one.
 
-**Cross-solver comparison: `Not measured.`** Doing it properly needs an
+**Cross-solver comparison: `Not measured.`** Filed as **#868**, which is an
+audit-wide prerequisite rather than an equals task — every family document will
+have to leave this section empty until it exists. Doing it properly needs an
 identical-search-tree harness against Gecode, Choco and ACE on a
 clique-encoded model, and a note on the fact that those solvers would normally
 use a specialised all-different rather than a disequality clique — which makes
@@ -776,7 +780,8 @@ was missed. It is what turns a wide-domain `EqualsIff` into a `std::bad_alloc`.
 
 Guarding it does not remove the O(width) cost when proofs *are* on — that is
 inherent to the per-value witness — but it does confine it to proving runs, and
-it is a one-line change with the pattern already in the file's history.
+it is a one-line change with the pattern already in the file's history. Filed as
+**#864**; whether a cheaper certificate exists at all is **#867**.
 
 ### Known limitations
 
@@ -806,7 +811,8 @@ keyword and the condition together, and stays correct. Fixing either half on
 its own emits the *opposite* constraint, and the SCP symmetry check will not
 catch it, because it only checks that the keyword parses.
 
-The fix is also known to be local: a sweep of every `clone()` under
+Filed as **#865**. The fix is also known to be local: a sweep of every
+`clone()` under
 `gcs/constraints/` and `gcs/presolvers/` found this to be the **only** one that
 drops a constructor argument. The two constraints with the closest shape both
 pass everything through —
@@ -814,7 +820,7 @@ pass everything through —
 and the corresponding `LexCompareGreaterThanOrMaybeEqual`. So this is one
 missing argument in one function, not a pattern to hunt down.
 
-**Two derivations share one wire hint.** Rules 1 and 2 both emit
+**Two derivations share one wire hint (#866).** Rules 1 and 2 both emit
 `equals:((constraint_id N))`, but rule 1 is a bare RUP and rule 2 needs two
 bridge lemmas first. An external justifier has to discriminate on whether the
 asserted literal is a range literal, rather than on the hint. The mechanism for
@@ -830,38 +836,38 @@ a plain variable on the far side.
 
 ### Next steps
 
-Ranked. None of these are filed yet; the first three are what this audit would
-open.
+Ranked, and all filed. #864 and #865 are small and self-contained; #867 is a
+research question rather than a fix.
 
-1. **Guard `no_overlap_justification` on `want_reasons()`.** One line, removes
+1. **#864 — Guard `no_overlap_justification` on `want_reasons()`.** One line, removes
    a `std::bad_alloc` on wide domains with proofs off, and follows a pattern
    already applied to the neighbouring pass in `fea9508d`. Add a wide-domain
    case to the test file at the same time — the current suite tops out at
    `[-10, 10]` and cannot see this.
-2. **Fix `clone()` to pass `_neq`, and check the emitted `.scp` changes as
-   expected.** Small, but it must be done as one change: it flips both the
+2. **#865 — Fix `clone()` to pass `_neq`, and check the emitted `.scp` changes
+   as expected.** Small, but it must be done as one change: it flips both the
    keyword and the condition, and half of it is silently wrong. Worth pairing
    with a semantic round-trip assertion (solve the re-read model, compare
    solution counts) so the symmetry check stops passing on an equivalent-but-
    unintended description. Also makes the `not_equals_iff` reader path reachable
    from the writer.
-3. **Give the not-in-range bridge its own subhint.** Removes the one place in
+3. **#866 — Give the not-in-range bridge its own subhint.** Removes the one place in
    this family where an external justifier must key off literal shape instead
    of the hint. Cheap, and the pattern is already there in
    `EqualsNoOverlap`.
-4. **Consider an interval-wise no-overlap witness.** Rule 9's per-value walk is
+4. **#867 — Consider an interval-wise no-overlap witness.** Rule 9's per-value walk is
    the only super-logarithmic thing here. Whether an interval-wise certificate
    exists is a real question, not a refactor: the witness genuinely is
    per-value, since it says *for each value* which side excludes it. A cheaper
    alternative may be to bound the rule and fall back to leaving the verdict
    undecided when the range is wide — a strength loss, but a bounded one.
-5. **Measure against Gecode, Choco and ACE.** Needs an identical-search-tree
+5. **#868 — Measure against Gecode, Choco and ACE.** Needs an identical-search-tree
    harness and a defensible choice of model, since those solvers would not
    normally encode an all-different as a disequality clique.
-6. **Record a mutation.** Show that VeriPB refuses a mangled equals
+6. **#869 — Record a mutation.** Show that VeriPB refuses a mangled equals
    derivation, so the derivations are known to be tight rather than merely
    accepted.
-7. **Drop the `State *` from `EqualsNoOverlap`.** The reconstructibility
+7. **#870 — Drop the `State *` from `EqualsNoOverlap`.** The reconstructibility
    analysis above shows the asserted clause already carries what the emitter
    reads it for. Removing it would make the family's justifications uniformly
    free of `state` access, which is the invariant everywhere else.

--- a/dev_docs/constraints/equals.md
+++ b/dev_docs/constraints/equals.md
@@ -1199,11 +1199,9 @@ per-value cost (#864 and #867, fixed in #873 and #881).
 ### Next steps
 
 Ranked. **No propagation or proof bug in this family is outstanding**: the
-seven the first audit filed are #864–#870, and only #868 is still open. The
-first three items below are a shared mechanism, an engine cost and a
-benchmark, all reached through this family rather than owned by it; the fourth
-is a hole in its own test coverage that writing the per-rule tightness field
-surfaced.
+seven the first audit filed are #864–#870, and only #868 is still open. All
+three items below are a shared mechanism, an engine cost and a benchmark, all
+reached through this family rather than owned by it.
 
 1. **#882 — Give views a range literal.** The largest remaining item, and this
    family is where the price is most visible: rule 2 is skipped wholesale for
@@ -1230,20 +1228,27 @@ surfaced.
    other two solvers. The hard part is settled and worth reusing — the model
    has to come from an external suite, because the natural gcs benchmark for
    this family is a disequality clique and no other solver would be given one.
-4. **Thread the proof mutation through the must-not-hold pass.** Not filed as
-   an issue yet, and small. `with_proof_mutation` reaches `enforce_equality`, so
-   `fixed_operand_reason` corrupts rule 1's reason but not rule 5's — and rule
-   5 is the busiest rule in the solver and 13,309 of the 13,323 equals-hinted
-   assertions in the family's own proof benchmark. The corruption already
-   exists; only the lambda's capture list and one lane registration are
-   missing. Worth doing before the next family's mutation lane is written,
-   since "the corruption exists but does not reach the rule I care about" is
-   the shape of mistake it demonstrates.
 
-**Not to do, having been considered:** bounding rule 9 and leaving the verdict
-undecided when the range is wide. That was the fallback the first audit
-proposed in case an interval-wise certificate did not exist. It does exist
-(#881), so a deliberate strength loss buys nothing.
+**Not to do, having been considered.** Two.
+
+*Bounding rule 9* and leaving the verdict undecided when the range is wide.
+That was the fallback the first audit proposed in case an interval-wise
+certificate did not exist. It does exist (#881), so a deliberate strength loss
+buys nothing.
+
+*Filling in the six `Not shown.` tightness fields.* Mutation coverage is a
+development tool, not a completeness target — it earns its keep while a rule's
+derivation is being written or changed, and mutating the other six rules for
+the sake of the tally would not. So the fields say which rules have the
+evidence and which do not, and the answer to "should I add a lane" is decided
+by what is being changed, not by the count.
+
+The one worth knowing about, if a lane is ever wanted here: `with_proof_mutation`
+reaches `enforce_equality`, so `fixed_operand_reason` corrupts rule 1's reason
+but not **rule 5's** — the busiest rule in the solver, and 13,309 of the 13,323
+equals-hinted assertions in the family's own proof benchmark. The corruption
+already exists; only the lambda's capture list and one lane registration are
+missing. Cheap if that rule is ever touched, and not worth doing before then.
 
 ## Prior art
 
@@ -1335,11 +1340,12 @@ wanted and could not find, which is the same test the first pass applied.
 - **A rule entry gains a `Tightness` field.** The template asked under Tests
   "whether the derivation has been shown to be tight", which is the right
   question at the wrong altitude: a mutation lane corrupts *one rule's* step,
-  so the evidence is per-rule and belongs beside that rule's proof size.
-  Putting it there is what surfaced the gap now ranked fourth in [Next
-  steps](#next-steps) — six of nine rules answer `Not shown.`, and one of
-  those six is the busiest rule in the solver. Under the old shape this family
-  could answer "yes, tight" and stop.
+  so the evidence is per-rule and belongs beside that rule's proof size. Under
+  the old shape this family could answer "yes, tight" for the family and stop,
+  where three of its five lanes are one rule and six of its nine rules have no
+  lane at all. The point of the field is **not** to be filled in everywhere —
+  see [Next steps](#next-steps) — it is that someone changing a rule can see at
+  a glance whether a lane will catch them.
 - **Say what the family's own benchmark does not exercise.** `ortho_latin`
   reaches two of nine rules. That was true at the first audit too and went
   unsaid; it is the sort of thing a cross-family pivot over these documents

--- a/dev_docs/constraints/equals.md
+++ b/dev_docs/constraints/equals.md
@@ -1,16 +1,46 @@
 # `Equals`: two operands are (or are not) the same value
 
 > **Maturity** production ·
-> **Audited** 2026-09-07 at `7d014207` ·
-> **Open issues** #864, #865, #866, #867, #870 specific to this family; #868 and
-> #869 are audit-wide prerequisites it also blocks on. All seven were filed by
-> this audit; tracked under #871.
+> **Audited** 2026-09-07 at `7d014207`; re-audited 2026-09-08 at `76bfd836` ·
+> **Open issues** #882 (views have no range literal) and #895 (the
+> refined-watch scan) reach into this family without being about it; #868 is
+> an audit-wide prerequisite, now half done. The first pass filed #864–#870
+> and six of those seven are fixed. Tracked under #871.
 
 Six posted classes over one implementation: an equality between two operands,
 optionally reified, optionally negated. It is the smallest interesting
 constraint in the solver and one of the busiest — 71% of all propagator calls
 on `ortho_latin --all 6`, and 44% of the assertions in its proof — so its cost
 per call and its trigger set matter more than its algorithm does.
+
+**What the second pass changed.** The first audit filed seven issues and this
+document was the argument for them; six are now closed. One more fix arrived
+from outside the audit (#889), and it lands in the same place the audit's
+findings did — the trigger set. Between them they changed what this document
+*says*, not only what the code does:
+
+| Fixed | What it changed here |
+|---|---|
+| #864 → #873 | the no-overlap reason is guarded on `want_reasons()`, so it is not assembled and thrown away with proofs off |
+| #865 → #883 | `clone()` carries `_neq`, so all six variants write their own `.scp` keyword |
+| #866 → #884 | the interval bridge carries its own subhint, so the family's wire inventory is three forms, not two |
+| #867 → #881 | the no-overlap certificate is **interval-wise**: two lines plus the conclusion at any domain width, against `width + 1` |
+| #869 → #886 | five mutation lanes and a control, so the derivations are known to be tight rather than merely accepted |
+| #870 → #885 | no justification in the family reads `state`, which was the last exception to an invariant the rest of the solver keeps |
+| #889 → #894 | a constant-operand reified equals wakes on a refined watch, not `on_change` |
+
+Two of those are worth reading before the rest of this document, because they
+are the load-bearing changes rather than tidying. The interval-wise witness
+removed the family's only large-domain failure and its only super-logarithmic
+cost, which is most of what [Robustness and limits](#robustness-and-limits)
+used to be about. And the trigger change is the second instance of the
+family's one real performance lever — how often the propagator wakes — this
+time in the opposite direction from #819: *narrower* than any coarse trigger
+can express, rather than coarser.
+
+Every figure below was measured again at `76bfd836` on an idle machine, except
+the cross-solver table, which is `238c7836` and labelled as such. Where a
+number moved, it says so.
 
 ## What it is
 
@@ -33,8 +63,10 @@ All six are the one class `ReifiedEquals`, distinguished only by the
 do **not** flip any propagation logic; they negate the condition at
 construction, so `NotEqualsIff(v1, v2, c)` is stored as `Iff{¬c}` and reaches
 the same equality-enforcing code. Read the concrete variant's constructor to
-see what a given class actually installs; the `_neq` member is not the place to
-look (see [Known limitations](#known-limitations)).
+see what a given class actually installs. The `_neq` member reaches no
+propagation at all: it picks the keyword the constraint describes itself by in
+the `.scp` and nothing else — and until #883 it did not reach that either,
+because `clone()` dropped it (see [Cake conformity](#cake-conformity)).
 
 Degenerate cases:
 
@@ -57,7 +89,7 @@ Degenerate cases:
 | `EqualsIf` | frontend gap — no FlatZinc predicate maps to a half-reified equality | ✓ `ifThenElse` arms | ? | ✓ `equals_if` | |
 | `EqualsIff` | ✓ `int_eq_reif`, `bool_eq_reif`, `int_ne_reif`[^neg] | ✓ `intension` reified EQ, `iff` | ? | ✓ `equals_iff` | |
 | `NotEqualsIf` | frontend gap — as `EqualsIf` | unsupported | ? | ✓ `not_equals_if` | |
-| `NotEqualsIff` | ✓ via `EqualsIff` with a negated condition | ✓ `intension` reified NE | ? | ✓ — but writes as `equals_iff`[^flip] | |
+| `NotEqualsIff` | ✓ via `EqualsIff` with a negated condition | ✓ `intension` reified NE | ? | ✓ `not_equals_iff`[^flip] | |
 
 [^lin]: MiniZinc rewrites `x = y` and `x != y` between two variables into a
     two-term `int_lin_eq` / `int_lin_ne`, emitting `int_eq` / `int_ne` only for
@@ -75,9 +107,11 @@ Degenerate cases:
 [^neg]: `int_ne_reif` posts `EqualsIff{v1, v2, reif != 1}` — the negation goes
     into the condition rather than into a different class.
 
-[^flip]: The `not_equals_iff` keyword exists in the reader and in
-    `verified_encodings/scp_cases/not_equals_iff_sat.scp`, but the writer never
-    emits it. See [Known limitations](#known-limitations).
+[^flip]: Until #883 the writer emitted `equals_iff` over a *negated* condition
+    for this class, so the `not_equals_iff` keyword existed in the reader and in
+    `verified_encodings/scp_cases/not_equals_iff_sat.scp` but was never reached
+    by writer output. Both halves were negated, so the two errors cancelled and
+    nothing failed. See [Cake conformity](#cake-conformity).
 
 ### Options
 
@@ -99,19 +133,29 @@ Views are where the proof and the propagator diverge:
 
 - **Propagation** treats a view like anything else; the inferences go through
   the same `infer_*` calls and the view layer translates them.
-- **Proof.** One rule — the interval-wise symmetric difference — is only
-  available when *both* operands are a bare `SimpleIntegerVariableID`. It is
-  guarded on exactly that (`both_simple`), and a view or constant in either
-  position falls back to a per-value rule that is correct but emits one
-  inference and one proof line per removed *value* instead of per removed
-  *interval*. The reason is a proof-layer limitation, not a propagation one: the
-  bridge lemmas that carry a range literal across the equality need a plain
-  variable on the far side.
+- **Proof.** Two rules degrade, for the same underlying reason: **a view has
+  no range literal** (#882), so nothing interval-shaped can be said about one.
+
+  The interval-wise symmetric difference (rule 2) is guarded on both operands
+  being a bare `SimpleIntegerVariableID` (`both_simple`) and falls back
+  wholesale to a per-value rule when either is not — correct, but one
+  inference and one proof line per removed *value* rather than per removed
+  interval. The bridge lemmas that carry a range literal across the equality
+  need a plain variable on the far side.
+
+  The no-overlap witness (rule 9) degrades more narrowly, and deliberately so:
+  it spells out only the *runs whose variable is a view*, value by value,
+  leaving the rest of the walk alone. So a view there pays for its own holes
+  and not for the width of anything. That is the granularity the general fix
+  wants, and it is the difference between the eighth view detour in the solver
+  and the seventh — both are `equals.cc`, and #882 counts them separately for
+  exactly this reason.
 
 The view sweep in the test binary exercises both positions
 (`add_view_tests(equals_constraint equals_test 2)`), so the fallback path is
-covered; it is not free, and a model built entirely out of views pays the
-per-value cost.
+covered, and `run_holey_no_overlap_view_equals_test` covers the one shape
+whose witness is not spelled entirely in intervals. Neither is free, and a
+model built entirely out of views pays rule 2's per-value cost.
 
 ### Reification
 
@@ -254,13 +298,25 @@ not_equals_sat  not_equals_unsat  not_equals_if_sat  not_equals_iff_sat
 Each comment in `define_proof_model` names the cake function it conforms to
 (`encode_equal`, `cencode_equal_1`, the `nev` / `gtv` / `ltv` selectors).
 
-One divergence, benign but worth naming: the writer's own output for
-`NotEqualsIff` is an `equals_iff` s-expression with a negated condition rather
-than a `not_equals_iff` one. Both describe the same constraint — verified by
-round-tripping all six variants through `read_scp` and getting identical
-solution counts (8/24/20/16/28/16) — but it means the `not_equals_iff` reader
-path is exercised only by the hand-written case file, never by writer output.
-See [Known limitations](#known-limitations).
+**No divergences**, since #883. There was one: a `NotEqualsIff` described
+itself as an `equals_iff` over a negated condition, because
+`ReifiedEquals::clone()` omitted `_neq` and both `Problem::post` and
+`Problem::create_propagators` clone, so the flag was always `false` by the
+time `s_expr()` read it. That is the same constraint said backwards — all six
+variants still round-tripped through `read_scp` to identical solution counts
+(8/24/20/16/28/16) — and the un-negation written for this case was therefore
+unreachable. All six now write their own keyword, `not_equals_iff` included,
+and the OPB provenance comment for one says `not_equals` rather than `equals`.
+
+What pins it is two checks per variant, because the old bug was invisible to
+the obvious one. The description is read out of the `.scp` and matched, which
+catches a flag that stops reaching `s_expr()`; then it is read back with
+`read_scp`, re-solved, and its solution **set** compared with the posted
+model's, which catches a keyword and a condition that no longer agree.
+`check_scp_writer_reader_symmetry` asks only whether the reader has a *case*
+for the keyword it was handed. Repairing either half of the old bug alone
+emits the opposite constraint — with the same number of solutions — which is
+why the comparison is of sets and not of counts.
 
 ### Proof-time state
 
@@ -274,7 +330,8 @@ The only proof-time objects are the selector flags — `b[id][ne]` for
 fully reified there. So:
 
 - an external justifier locates everything this family refers to from the OPB
-  alone, by the labels in the table above, plus the constraint id in the hint;
+  alone, by the labels in the table above, plus the constraint id and subhint
+  in the annotation;
 - there is no proof-only auxiliary, hence no question of whether unit
   propagation determines it on `solx`;
 - there is no proof-only vector to index, hence none of the dangling-index
@@ -308,23 +365,46 @@ and it is the only tuned thing in the family.
 | dispatcher, decided must-hold | `on_change` both operands | 1–4 | `Equals`, and `If`/`Iff` fixed true at install | never claims | yes, once an operand is fixed |
 | dispatcher, decided must-not-hold | `on_instantiated` both operands | 5 | `NotEquals`, and `NotIf`/`Iff` fixed false at install | never claims | yes, once it has acted |
 | dispatcher, undecided | `on_change` both operands **and** the condition | 1–9 | the four reified forms while `cond` is open | claims stripped | yes, on any verdict |
+| — with **one constant operand** | `on_instantiated` both **and** a refined watch on `other != c`, plus the condition | 1, 5, 7, 8 | any variant with exactly one constant operand | as above | as above |
 
-**The narrow trigger is the one design decision here** (issue #819). An
-unconditional `NotEquals` only ever runs rule 5, which reads nothing but
-`optional_single_value` and disables itself until backtrack once it has acted —
-so `on_instantiated` cannot miss a wake, and the wakes it drops are the
-expensive ones. Fixing a vertex removes one value from each of its *d*
-neighbours, and under `on_change` every one of those interior removals woke
-every other not-equals on that neighbour only to find neither end fixed. On
-`ortho_latin --all 6` this is 321.7M calls against 55.4M.
+**The trigger set is the only tuned thing in the family, and it has now been
+tuned twice in opposite directions.** Both times the lever was how often the
+propagator wakes, never what it does when it does; see [CPU
+performance](#cpu-performance) for both sets of figures.
 
-The cost is not free and the accounting is subtle: narrowing a trigger *delays*
-an inference by a round whenever the dropped wake would have caught it early,
-which fragments the changes a co-registered propagator sees into more, smaller
-instalments — and an O(n·d) propagator pays per *run*, not per change. So
-`ortho_latin` gained 16.5% while `colour` lost 3.6–5.2% on two of three
-instances, at an identical search tree. Both were measured before the change
-landed; see [CPU performance](#cpu-performance).
+*Coarser, for the unconditional disequality* (#819). `NotEquals` only ever
+runs rule 5, which reads nothing but `optional_single_value` and disables
+itself until backtrack once it has acted — so `on_instantiated` cannot miss a
+wake, and the wakes it drops are the expensive ones. Fixing a vertex removes
+one value from each of its *d* neighbours, and under `on_change` every one of
+those interior removals woke every other not-equals on that neighbour only to
+find neither end fixed. On `ortho_latin --all 6` this is 321.7M calls against
+55.4M.
+
+The cost is not free and the accounting is subtle: narrowing a trigger
+*delays* an inference by a round whenever the dropped wake would have caught
+it early, which fragments the changes a co-registered propagator sees into
+more, smaller instalments — and an O(n·d) propagator pays per *run*, not per
+change. So `ortho_latin` gained 16.5% while `colour` lost 3.6–5.2% on two of
+three instances, at an identical search tree.
+
+*Finer than any coarse trigger can express, for a constant operand* (#889).
+With `v2` pinned at `c`, everything the propagator reads collapses: the
+undecided pass never reaches its `domains_intersect` arm, and reports MustHold
+exactly when `v1` is instantiated to `c` and MustNotHold exactly when `c`
+leaves `v1`'s domain. So the propagator turns on two facts — is the other
+operand instantiated, and is `c` still in it. `on_instantiated` states the
+first. The second is a *literal*, and `on_change` is the finest coarse
+granularity there is but is still per *variable*, so it woke the propagator
+for every removal from `v1`. A model posting one such propagator per
+(variable, value) pair — FlatZinc's `int_eq_reif` against a constant, which is
+what `x == sum(bool2int(xs[i] == v))` flattens to — then wakes *d* of them per
+removal and *d* − 1 find nothing. A refined watch on `other != c` wakes only
+the one whose value went.
+
+Two constants need no special case: `on_change` registers no wake for a
+constant either, and every pass decides outright on the one call every
+propagator gets when search starts.
 
 **Idempotence.** No pass ever returns `EnableButIdempotent`, so no claim is
 made. Note that the runtime-dispatch path would not forward such a claim even
@@ -332,6 +412,16 @@ if one were made, because a re-run of the dispatcher also re-tests the
 reification condition and that interplay has not been audited. The two
 install-time-decided paths do forward claims, since there the run is exactly
 the enforce call.
+
+That the family makes no claim of its own is why the engine bug #894 fixed
+alongside the watch survived so long: the round-boundary replay fired refined
+watches from `requeue` but not from `requeue_unless_already_seen`, the variant
+taken when *some* propagator in the round claims — so in any round with a
+claimant every watch fire was dropped, and dropped for good, since each
+inference is replayed exactly once. A dropped wake costs pruning and not
+soundness, so nothing failed; what showed it was the learned-nogood store,
+also a refined-watch client, exploring a different tree on the refined path
+than on the scan oracle.
 
 **Self-disabling.** Rules 1, 2 and 5 return `DisableUntilBacktrack` — once an
 operand is fixed, an equality has nothing left to say at this node or below.
@@ -351,29 +441,66 @@ domains were already equal — is subsumed by `DisableUntilBacktrack`.
 
 ### Robustness and limits
 
-**Large domains.** The bounds rule is fine and the encoding is logarithmic:
-`Equals` over two operands of width 10⁹ solves in 0 ms and emits two OPB rows.
-The symmetric-difference rule is interval-based, so it too is insensitive to
-width.
+**Large domains: no rule is width-sensitive any more.** The bounds rule is
+O(1) and the encoding is logarithmic; the symmetric-difference rule is
+interval-based; and since #881 so is the reified no-overlap rule, which was
+the one exception. `Equals` over two operands of width 10⁹ solves in 0 ms and
+emits two OPB rows.
 
-**One rule is not.** The reified no-overlap rule (rule 9) walks *every integer
-between v1's bounds*, building one reason literal per value:
+Rule 9 was the family's only large-domain failure. It walked *every integer
+between v1's bounds*, building one reason literal per value. Two changes
+closed it, and they are separate:
 
-| v1 bounds width | wall time, proofs **off** |
-|---|---|
-| 10⁴ | 0 ms |
-| 10⁶ | 29 ms |
-| 10⁷ | 350 ms |
-| 10⁹ | `std::bad_alloc` after 2.6 GB |
+- #873 guarded the reason's assembly on `want_reasons()`, which confines the
+  cost to proving runs. That is the pattern the file's neighbouring pass had
+  already been given in `fea9508d`, and it is not the whole fix — it leaves
+  the proof's own per-value cost, which is genuine.
+- #881 replaced the certificate. Disjointness is a statement about **runs**,
+  so the witness is a walk that carries one invariant (`v1 ≥ p`) up the number
+  line, one move per maximal run `v1` cannot occupy. See [rule
+  9](#rule-reified-no-overlap) for the six moves and what each costs.
 
-Linear in domain width, in both time and memory, and paid even when proofs are
-off — see [Proof-logging gaps](#proof-logging-gaps) for why that last part is a
-bug rather than an inherent cost. Measured with `EqualsIff{x, y, b == 1}`,
-`x ∈ [0, w/2]`, `y ∈ [w/2+1, w]`, so that the rule fires once at the root.
+*What it cost before, measured elsewhere and not to be put in a table beside
+the figures below.* At `7d014207`, this audit's first pass, proofs **off**: 29
+ms at width 10⁶, 350 ms at 10⁷, and `std::bad_alloc` after 2.6 GB at 10⁹.
+Proofs **on**, from #881's own pre-merge table: 6,525 proof lines at width
+10³, 65,025 at 10⁴ taking veripb 8.2 s, and 650,025 at 10⁵ which veripb did
+not finish inside 900 s. Both sets are from different runs on different
+commits, and #873's audit-lane figures (160 s and 78 GB at 10⁹) are from a 2
+TB node, which is why the same shape died at 2.6 GB where it was reported — a
+`bad_alloc` is a fact about the machine.
 
-**Unbounded domains.** Not separately probed. The bounds and
-symmetric-difference rules have no per-value work and should be unaffected;
-rule 9 will not terminate in any useful time, by the scaling above.
+*Measured 2026-09-08 at `76bfd836`, Release + `GCS_WERROR=ON`, g++ 15.2.0, AMD
+Ryzen 9 9950X3D, otherwise idle, `taskset -c 4`, `ulimit -v 4000000`. One
+`EqualsIff{x, y, b == 1}` with `x ∈ [0, w/2]` and `y ∈ [w/2+1, w]`, so the
+rule fires once at the root; root propagation only.*
+
+| width | proofs off | proof lines | proof size | VeriPB |
+|---|---|---|---|---|
+| 10³ | 0 ms | 13 | 965 B | verified |
+| 10⁴ | 0 ms | 13 | 1.2 KB | verified |
+| 10⁶ | 0 ms | 13 | 1.7 KB | verified |
+| 10⁹ | 0 ms | 13 | 2.6 KB | verified |
+
+Thirteen lines at every width, of which **two are the witness** — one lemma
+and the conclusion — six define the two order literals they mention, and five
+are proof preamble. The bounds-disjoint case is not special-cased; it falls
+out, because nothing anchors on `v1`'s lower bound when `v2` starts above it,
+so the reason is `{v2 ≥ lb2, v1 ≤ ub1}`. That is also a strictly more general
+nogood than the per-value reason it replaces.
+
+The guard is still load-bearing, and `equals.cc`'s no-overlap reason still
+carries a `LargeDomainIterationCounter` (one of three such sites in the
+solver, alongside `element.cc` and `all_equal.cc`) — because what it counts is
+now *moves of an interval walk* rather than values, and a domain can have as
+many runs as it has values. See `dev_docs/large-domains.md`, which records the
+audit row and the two things that generalise: that a `Clean` row nothing
+instruments is only as strong as the box it ran on, and that a **reason** is a
+place a search for pruning loops will not reach.
+
+**Unbounded domains.** Not separately probed, and no longer expected to
+matter: every rule is now per-interval or O(1) except rule 3, whose cost is
+the number of values actually removed rather than the domain's width.
 
 **Negative values and zero.** Fine, and covered: the test data includes
 `[-10, 10]` ranges, negative constants, and the `{-2,-2}`/`{-3,-3}` fixtures.
@@ -385,9 +512,10 @@ rule 9 will not terminate in any useful time, by the scaling above.
 an operand's upper bound were `Integer::max_value()`, not silently wrap.
 Verified UBSan-clean with both operands at `LLONG_MAX/2`.
 
-**Per-value costs.** Two rules are per-value rather than per-interval: rule 3
-(the view/constant fallback) and rule 9. Everything else is per-interval or
-constant.
+**Per-value costs.** One rule is, and only because of views: rule 3, the
+view/constant fallback for the symmetric difference. Rule 9 spells out the
+runs of a *view* operand value by value for the same reason (#882) and nothing
+else. Both are proof-layer limitations, not propagation ones.
 
 ## Inference catalogue
 
@@ -395,14 +523,41 @@ Nine rules. The first four are the must-hold pass (`enforce_equality`), the
 fifth is the must-not-hold pass, and the last four are the reified verdicts of
 the undecided pass.
 
-Two facts hold for all nine and are not repeated in each entry. Every one is
-attributed to the hint type `hints::Equals`, whose wire form is
-`(constraint_id <id>)` and which carries **no operand data** — everything an
-external justifier needs must be recoverable from the asserted literal, the
-reason, and the OPB rows. And no rule reads `state` from inside a
-justification; rule 9's emitter is the sole holder of a `State *`, and it is
-valid only because the verdict is consumed synchronously (see [Next
-steps](#next-steps)).
+Three facts hold for all nine and are not repeated in each entry.
+
+**No hint carries operand data.** All three hint types in the family derive
+from `hints::Equals`, whose wire form is `(constraint_id <id>)`, and nothing
+beyond the constraint id and an optional subhint reaches the wire — everything
+an external justifier needs must be recoverable from the asserted literal, the
+reason and the OPB rows. Two of the three hold extra fields for the internal
+emitter's use only.
+
+**The wire inventory is a closed list of three forms**, and this is what
+distinguishes derivations of different length:
+
+| Wire form | Hint type | Means | Rules |
+|---|---|---|---|
+| `equals:((constraint_id N))` | `hints::Equals` | one RUP against the equality rows | 1, 3, 4, 5, 6, 7, 8 |
+| `equals:((constraint_id N) (subhint not_in_range))` | `hints::EqualsNotInRange` | two bound lemmas, then the conclusion | 2 |
+| `equals:((constraint_id N) (subhint no_overlap))` | `hints::EqualsNoOverlap` | the disjointness walk, then the conclusion | 9 |
+
+Before #884 rule 2 wore the bare form, and the only way to tell its three-line
+derivation from a one-line pruning was to notice that the asserted literal was
+spelled as a range — keying off literal spelling, which is exactly what a hint
+vocabulary exists to avoid. `run_hint_inventory_equals_test` reads the
+inventory off real proofs at `AssertionLevel::Inferences` and fails on a
+subhint outside this table, so a fourth form has to be added here as well as
+there.
+
+**No rule reads `state` from inside a justification.** Since #885 this is
+uniform: rule 9's emitter re-walks the reason's own literals rather than the
+domains, and holds no `State *`. It was the family's only exception, and it
+was on the wrong side of an invariant the rest of the solver keeps — a
+justification does not run at the moment its inference was decided, so a
+domain read there can be narrower than the one the reason was built from, at
+which point the lemmas stop lining up with the literals they exist to let unit
+propagation see through. Reading the reason cannot go stale, because the
+reason is what the conclusion is asserted under.
 
 ### Rule: equal-to-fixed-operand
 
@@ -421,6 +576,11 @@ steps](#next-steps)).
   `@c[id][ge]`; the asserted clause names both literals.
 - **Proof size** — one line.
 - **Gaps** — `None.`
+- **Tightness** — shown. The `fixed_operand_reason` mutation lane drops the
+  fixed operand's value from the reason, so the pruning claims to follow from
+  the reification condition alone, and VeriPB rejects it. That is the reason's
+  minimality in the sense that matters here: the equality rows say the two
+  operands agree, not what either of them is.
 
 ### Rule: symmetric-difference-intervals
 
@@ -441,24 +601,39 @@ steps](#next-steps)).
   not see an accumulating literal. Minimal.
 - **Assertion** — `¬(pruned ∈ [lo,hi]) ∨ (other ∈ [lo,hi])`, e.g.
   `a 1 ~i[y][in4_6] 1 i[x][in4_6] >= 1`.
-- **Hint** — `hints::Equals{owner}`. **Indistinguishable on the wire from
-  rule 1**, despite needing a two-lemma bridge rather than a bare RUP; the
-  discriminator is that the asserted literal is a range literal. See [Next
-  steps](#next-steps).
-- **Offline reconstructibility** — `hinted`, with a caveat. The two bridge
-  lemmas
+- **Hint** — `hints::EqualsNotInRange`, wire form `(constraint_id <id>)
+  (subhint not_in_range)`. Nothing beyond the subhint: the emission is a
+  lambda at the call site rather than an `emit_justification`, and the
+  interval and the operands come out of the asserted literal and the reason.
+- **Offline reconstructibility** — `hinted`. The two bridge lemmas
   ```
   rup ¬(pruned ≥ lo) ∨ (other ≥ lo) ∨ <reason>
   rup ¬(other ≥ hi+1) ∨ (pruned ≥ hi+1) ∨ <reason>
   ```
-  are determined by the asserted range literal's endpoints, so a justifier can
-  rebuild them — but only if it knows to, which today means recognising the
-  literal shape rather than reading a subhint.
+  are determined by the asserted range literal's endpoints, and since #884 the
+  subhint says which shape to build, so a justifier no longer has to recognise
+  that the asserted literal is spelled as a range in order to know that two
+  lemmas are missing from what it can see. At `AssertionLevel::Inferences`
+  those two lines are not in the proof at all, which is why the annotation and
+  not the proof has to carry the distinction.
 - **Proof size** — three lines per removed interval, plus the shared
   range-literal definitions and linking clauses (which belong to the
   range-literal layer, not here).
 - **Gaps** — `None.` The rule is skipped, not weakened, when an operand is not
   simple; rule 3 covers that case at a worse cost.
+- **Tightness** — shown, and it is the mutation that tests a *design* claim
+  rather than an arithmetic step. The `bridge_lemmas` lane emits the
+  conclusion with no bound lemmas before it, so it claims to be RUP across the
+  equality unaided; VeriPB rejects it. If it did not,
+  `justify_not_in_range_across_equality` would be unnecessary here.
+
+  Worth knowing before writing a fixture for this: over `{0..w}` with the
+  middle third removed, VeriPB **accepts** the lemma-free proof at w = 5 and w
+  = 11 and rejects it at 6, 7, 8, 9, 10, 12, 14, 16, 20, 100 and 1000. Both
+  exceptions put an interval endpoint on a bit boundary, where the bound is
+  one literal rather than a sum and unit propagation crosses the equality
+  unaided. The lemmas are load-bearing in general, and a narrow fixture would
+  have reported that they are not.
 
 Why the bridge is needed at all: a range literal asserts only *order* atoms,
 never bits, and the equality rows are a *bit*-sum equality — so
@@ -484,6 +659,9 @@ link; a sign-flipped link, as `Abs` has, needs the mirrored pairing.
 - **Proof size** — one line per removed value.
 - **Gaps** — `None.`, in the sense that the inference is fully justified. It is
   a proof-*size* regression against rule 2, not a proof-strength one.
+- **Tightness** — `Not shown.` The `fixed_operand_reason` corruption would
+  apply in principle (this reason is also the base reason plus one literal),
+  but the lane exercises rule 1's site, not this one.
 
 ### Rule: bounds-intersection
 
@@ -503,6 +681,9 @@ link; a sign-flipped link, as `Abs` has, needs the mirrored pairing.
 - **Offline reconstructibility** — `offline`.
 - **Proof size** — one line per bound moved, so at most four.
 - **Gaps** — `None.`
+- **Tightness** — `Not shown.` No lane corrupts a bound push. It is the shape
+  most similar to rule 1's, which is shown, and the reason is one literal, so
+  there is little room between minimal and empty.
 
 Note the four inferences are emitted unconditionally once the bound pairs
 differ at all, so up to three of them can be no-ops. This is deliberate:
@@ -527,6 +708,13 @@ differ at all, so up to three of them can be no-ops. This is deliberate:
 - **Offline reconstructibility** — `offline`.
 - **Proof size** — one line.
 - **Gaps** — `None.`
+- **Tightness** — `Not shown.`, and this is the one worth caring about: it is
+  the busiest rule in the solver on clique-encoded models and 13,309 of the
+  13,323 equals-hinted assertions in `ortho_latin --all 5`'s proof. The
+  corruption exists — it is `fixed_operand_reason`'s, dropping the fixed
+  operand's value — but `with_proof_mutation` reaches `enforce_equality` and
+  this rule lives in the must-not-hold pass, which the mutation is not
+  threaded through. Cheap to add, and it should be.
 
 Uses the non-throwing `infer_not_equal_or_stop`, returning `Enable` on
 contradiction so the propagate loop sees `tracker.contradicted()` instead of
@@ -548,6 +736,9 @@ paying for a throw.
 - **Offline reconstructibility** — `offline`.
 - **Proof size** — one line.
 - **Gaps** — `None.`
+- **Tightness** — `Not shown.`, and there is nothing to show: the reason is
+  `NoReason{}` and the assertion is a single literal, so the only available
+  corruption is to assert something else.
 
 Without this rule the verdict would wait until search fixed the variable, and
 `NotEqualsIf(x, x, c)` would leave `c` unpruned — the "propagator silent on
@@ -569,6 +760,8 @@ alias" bug the dup tests were added for.
 - **Offline reconstructibility** — `offline`.
 - **Proof size** — one line.
 - **Gaps** — `None.`
+- **Tightness** — `Not shown.` Dropping either of the two equality literals
+  from the reason is the obvious corruption and no lane does it.
 
 ### Rule: reified-one-fixed-unsupported
 
@@ -586,6 +779,7 @@ alias" bug the dup tests were added for.
 - **Offline reconstructibility** — `offline`.
 - **Proof size** — one line.
 - **Gaps** — `None.`
+- **Tightness** — `Not shown.` As rule 7.
 
 ### Rule: reified-no-overlap
 
@@ -593,41 +787,107 @@ alias" bug the dup tests were added for.
 - **Fires when** — neither operand is fixed, the condition is undecided, and
   `domains_intersect` is false.
 - **Strength** — `GAC` on the condition.
-- **Algorithm** — one `domains_intersect`, then a walk over **every integer
-  between v1's bounds**. O(width of v1's bounds range), in values. This is the
-  family's only super-logarithmic cost and its only large-domain failure; see
-  [Robustness and limits](#robustness-and-limits).
-- **Why it is true** — no value is in both domains, so no assignment satisfies
-  the equality. The witness is per-value: for each `val` in v1's bounds range,
-  either `val ∉ dom(v1)` or (since the domains are disjoint) `val ∉ dom(v2)`.
-- **Proof technique** — `RUP+hints` — one per-value lemma each, then the
+- **Algorithm** — one `domains_intersect`, then `walk_no_overlap` over the two
+  materialised domains. One move per interval of either domain, so
+  O(intervals(v1) + intervals(v2)) — in *intervals*, since #881. It was
+  O(width of v1's bounds range) in values, which was the family's only
+  super-logarithmic cost and its only large-domain failure.
+- **Why it is true** — disjointness is a statement about **runs**, and the
+  walk is what states it. It carries one invariant up the number line: at each
+  point `p`, the facts stated so far — together with the reification
+  condition, which makes the two operands equal — force `v1 ≥ p`. Each move
+  pushes `p` past one maximal run `v1` cannot occupy, either because `v1` has
+  nothing there or because *`v2`* has nothing there and under `cond` `v1` must
+  be wherever `v2` is. `p` strictly increases, so the walk stops after at most
+  one move per interval, and it stops by running `p` off the top of one of the
+  two domains, which is the contradiction the conclusion needs. The six moves,
+  and what each costs:
+
+  | Move | Reason literal | Lemmas |
+  |---|---|---|
+  | start at v1's lower bound | `v1 ≥ lb1` | — |
+  | v2 starts higher, jump to it | `v2 ≥ lb2` | 1 |
+  | a hole of v1 | `¬[v1 ∈ lo..hi]` | — |
+  | a run where v2 is empty | `¬[v2 ∈ lo..hi]` | 2 |
+  | p ran off the top of v1 | `v1 ≤ ub1` | — |
+  | p ran off the top of v2 | `v2 ≤ ub2` | 1 |
+
+  A hole of `v1` is free: the range literal's own reverse reification steps
+  `p` over it. A run where `v2` is empty costs the two bound-crossing lemmas.
+- **Proof technique** — `RUP+hints` — at most two lemmas per run, then the
   conclusion.
-- **Reason** — v1's two bound literals, then one literal per value in the
-  range: `v2 ≠ val` when `val ∈ dom(v1)`, and `v1 ≠ val` when it is not. So
-  `2 + width` literals. **Not** minimal in any useful sense, and not guarded on
-  `want_reasons()`.
-- **Assertion** — the conclusion clause, e.g. for `x ∈ [1,3]`, `y ∈ [7,9]`:
+- **Reason** — one literal per move of the walk, so one per run rather than
+  one per value. For the common shape — two hole-free domains on opposite
+  sides of a point — that is `{v2 ≥ lb2, v1 ≤ ub1}`, **two literals at any
+  width**, and a strictly more general nogood than the per-value reason it
+  replaces. Guarded on `want_reasons()` since #873, and carrying a
+  `LargeDomainIterationCounter` because a domain can have as many runs as
+  values.
+- **Assertion** — the conclusion clause: the condition literal negated, then
+  one literal per move. For `x ∈ [1,3]`, `y ∈ [7,9]` the walk is one jump and
+  one stop, so it is two:
   ```
-  a 1 ~i[b][b0] 1 ~i[x][ge1] 1 i[x][ge4] 1 i[y][eq1] 1 i[y][eq2] 1 i[y][eq3] >= 1
+  a 1 ~i[b][b0] 1 ~i[y][ge7] 1 i[x][ge4] >= 1
       ::equals:((constraint_id _1) (subhint no_overlap));
   ```
-- **Hint** — `hints::EqualsNoOverlap`, wire form
-  `(constraint_id <id>) (subhint no_overlap)`. The struct additionally holds a
-  `State *`, both operands, v1's bounds and the condition literal, but **none of
-  that reaches the wire** — it is held for the internal emitter only.
-- **Offline reconstructibility** — `hinted`. The subhint says which shape to
-  build, and the asserted clause carries everything needed to build it: the two
-  bound literals give the range, and each per-value literal's *variable* says
-  which branch that value took (`y = val` for a value in v1's domain, `x = val`
-  for one outside it). So the emitter's `State *` is a convenience, not
-  information the justifier lacks. This is the one rule in the family where the
-  verdict is worth checking rather than assuming, and the reason **#870** holds
-  that the `State *` is removable.
-- **Proof size** — `width + 1` lines: one lemma per value in v1's bounds range,
-  plus the conclusion. Emitted at `ProofLevel::Temporary`, so the lemmas are
-  deleted.
-- **Gaps** — the inference is fully justified. The *cost* is a bug: see
-  [Proof-logging gaps](#proof-logging-gaps).
+  For interleaved domains it is one literal per run, alternating between the
+  operands, ending in the stop:
+  ```
+  rup 1 ~i[_3][b0] 1 ~i[_2][ge1] 1 i[_1][eq1] 1 i[_2][eq2] 1 i[_1][eq3]
+      ... 1 i[_1][ge15] >= 1;
+  ```
+- **Hint** — `hints::EqualsNoOverlap`, wire form `(constraint_id <id>)
+  (subhint no_overlap)`. The struct additionally holds the two operands and
+  the condition literal — which is what the lemmas are *about* — and, in a
+  testing-only build, a mutation selector. **None of that reaches the wire**,
+  nothing in it describes the domains, and since #885 it holds no `State *`.
+- **Offline reconstructibility** — `hinted`, and this is the one rule in the
+  family where the verdict is *exercised* rather than argued. The subhint says
+  which shape to build and the asserted clause carries everything needed to
+  build it, so the emitter reads the walk back out of the reason's literals —
+  from exactly the literals an external justifier is handed. A `GreaterEqual`
+  literal is an anchor or a jump, a `NotInRange` (or a maximal run of
+  consecutive `NotEqual`s, which is what a view's run degrades to) is a run,
+  and a `Less` is the stop; whose variable it names says whether lemmas are
+  owed.
+- **Proof size** — two lines per run where the run belongs to `v2`, none where
+  it belongs to `v1`, plus one conclusion. Emitted at `ProofLevel::Temporary`,
+  so the lemmas are deleted.
+
+  *Measured 2026-09-08 at `76bfd836`, same machine and build as [Robustness
+  and limits](#robustness-and-limits). `v1` the even values of `[0, 2n)`, `v2`
+  the odd ones, so every run is one value long and every second run costs
+  lemmas — the walk's worst case.*
+
+  | runs (n) | total proof lines | the witness's own | the shared literal layers |
+  |---|---|---|---|
+  | 2 | 25 | 4 | 21 |
+  | 8 | 97 | 16 | 81 |
+  | 32 | 385 | 64 | 321 |
+  | 128 | 1,537 | 256 | 1,281 |
+
+  Exactly `2n` lines of witness against `10n + 1` of shared order- and
+  equality-literal definitions, so **five sixths of the proof is not this
+  rule** even in the shape that costs it most. In the bounds-disjoint shape
+  the witness is two lines at any width, out of thirteen.
+- **Gaps** — `None.` The inference is fully justified and, since #881, at a
+  cost that is independent of domain width. The one residual is that a run
+  belonging to a *view* is spelled value by value, because a view has no range
+  literal (#882) — one run, not the rule.
+- **Tightness** — shown, by three of the five mutation lanes, which between
+  them cover the rule's whole proof surface. `no_overlap_stop` drops the
+  walk's last reason literal, so the reason climbs to a position and never
+  says the position is impossible. `no_overlap_lemmas` emits no lemmas at all,
+  which is the control for the rule: it says whether the walk is load-bearing
+  before asking whether any particular move of it is. `no_overlap_selector`
+  states the lemmas under `cond` rather than `¬cond` — the one-character
+  version of the mistake that is easiest to make in a reified derivation and
+  hardest to see by reading, since the lemmas are still about the right
+  operands, bounds and direction, and every one of them is false. VeriPB
+  rejects all three.
+
+  The lane's instance had to be built with care, and the reason generalises:
+  see [Tests](#tests).
 
 ## Evidence
 
@@ -650,32 +910,87 @@ the evidence that an interval of `infer_not_equal` really does collapse into one
   `c = 1` is unsupported only by a deduction across all thirteen posted
   constraints, which no individual propagator can make. That distinction is
   spelled out in the test rather than fudged.
-- **VeriPB really runs**, for every case, gated on `can_run_veripb()`. A seeded
-  run is 284 proofs, all verifying, in 1.26 s.
+- **VeriPB really runs**, for every case, gated on `can_run_veripb()`. A
+  seeded run is **296 proofs, all verifying, in 1.13 s** (`--seed=1` at
+  `76bfd836`; 284 in 1.26 s at `7d014207`).
 - **SCP round-trip** on every proving case, via
-  `check_scp_writer_reader_symmetry` — but see below for what it does not
-  check.
+  `check_scp_writer_reader_symmetry`, plus the two-check description pinning
+  described under [Cake conformity](#cake-conformity) for each of the six
+  variants.
 - **Seeded.** `establish_and_announce_seed`, reproducible with `--seed=N`.
 - **Coverage of the awkward cases**: all-constant operands in both directions
   (issue #254), aliasing for all six variants, negative domains, disjoint
   domains, singleton domains, and the `NotEquals(x, x)` rejection.
 - **No runtime caps.** Nothing here is slow enough to need one.
 
+Six lanes were added by the fixes, and each covers a shape the original suite
+structurally could not reach. They are worth listing individually, because
+five of the six exist for a reason that will recur in the next family:
+
+| Lane | What it covers, and why nothing else could |
+|---|---|
+| `run_wide_no_overlap_equals_test` | width 10⁹, proofs off. Every other domain in the file is inside `[-10, 10]`; `range_infer_test` works inside `[0, 40]`. It pins the **answer**, not the cost — it would have passed before #873 too, slowly — and says so. |
+| `run_wide_proved_no_overlap_equals_test` | the same shape at 10⁶, **proved**, asserting the proof is under a thousand lines before handing it to veripb. This is the lane that pins the cost. The bound is deliberately loose and not a pinned figure: most of a proof this small is fixed overhead, and any threshold separates a constant from a million lines. 10⁶ rather than 10⁹ so that a regression fails rather than filling the disk. |
+| `run_holey_no_overlap_equals_test`, both orders | interleaved disjoint domains, which is the only shape reaching the two moves that carry a range literal. Both orders, because the walk climbs `v1`'s domain and so is not symmetric; between them they reach all six moves. |
+| `run_holey_no_overlap_view_equals_test` | one operand a **view**, the only shape whose witness is not spelled entirely in intervals. Checked by diffing proof bytes, not by a lane going red: leaving the run in pieces still verifies, at exactly nine more lines at every seed tried. |
+| `run_value_indicator_equals_test` | the `nmseq` shape in miniature — one reified equality per (variable, value) — with a **driver** that punches a value out of the interior on its own. Every other lane posts a single constraint over its operands, so nothing removes an interior value and a trigger that sees only instantiations passes. Checked as consistency at every node, since a missed wake loses no solutions. |
+| `run_hint_inventory_equals_test` | the wire inventory, read off two real proofs at `AssertionLevel::Inferences`, failing on a subhint outside the family's closed list. |
+
+**The derivations are known to be tight** (#886). `EqualsProofMutation` is
+five corruptions behind a testing-only `with_proof_mutation()`, each changing
+the proof and nothing else, registered as `equals_mutation_*` ctest lanes that
+pass only if veripb *refuses* the result. Two corrupt reasons and three
+corrupt emitted lemmas, which between them are the family's whole proof
+surface — every step here is a RUP, so there is nowhere else for a mistake to
+live. A sixth lane is the **control**: the same instances, uncorrupted,
+verified. Without it a lane could be green because its instance does not
+verify either.
+
+This matters more here than in most families and not less: almost every
+inference is a single RUP against a two-row encoding, "veripb accepted a
+one-line RUP" is the weakest evidence in the suite because an over-broad
+conclusion can be RUP for a reason unrelated to the rule that drew it, and a
+corrupted *proof* changes no answers — so neither the solution checks nor
+veripb had anything to say about it before.
+
+Two findings about the *instances*, which cost more work than the corruptions
+and are recorded in `equals_mutations.hh` and generalised in
+`dev_docs/constraints.md`:
+
+- **Dropping a reason literal is only a corruption when that literal traces to
+  a search decision.** Anything a propagator derived is written to the proof
+  as a clause of its own, so the checker has it whether or not the reason
+  repeats it, and a root-firing rule's reason merely restates the database.
+  Two of the obvious no-overlap instances accept the mutation for exactly that
+  reason before the third bites; the lane's instance puts the bound push
+  behind a decision, with a fixed branching order so it is taken first.
+- **A narrow fixture would have said the bridge lemmas are unnecessary.** See
+  [rule 2](#rule-symmetric-difference-intervals) for the two widths at which
+  VeriPB accepts the lemma-free proof.
+
+Of the issue's original mutation candidates, one has no site: "cite the wrong
+half of the equality" cannot be done, because no step in this family cites a
+proof line by label at all.
+
 What the tests do **not** cover:
 
-- **No large-domain case.** Every domain in `equals_test.cc` is inside
-  `[-10, 10]`, and `range_infer_test`, though it checks that one rule's proof is
-  independent of *interval* width, works inside `[0, 40]`. Nothing in either
-  suite would have caught the rule-9 blow-up, which needs a domain wide enough
-  to be worth walking. This is the gap that matters most.
-- **The SCP symmetry check is a readability check, not a semantic one.** It
-  asserts that `read_scp` can parse whatever the writer emitted; it does not
-  check that what was parsed means the same thing. The `NotEqualsIff` keyword
-  flip passes it. A semantic round-trip is available —
-  `cake_probe_chain` — but only under `GCS_TEST_CAKE`.
-- **No mutation evidence recorded (#869).** Nothing in the file or in this
-  document demonstrates that VeriPB *refuses* a mangled equals derivation, so
-  the derivations are accepted but not known to be tight.
+- **No `cake_probe_chain` semantic round-trip by default.** The two-check
+  `.scp` pinning described under [Cake conformity](#cake-conformity) compares
+  solution *sets* through `read_scp`, which is the check
+  `check_scp_writer_reader_symmetry` is not; but the full chain against cake's
+  own re-derived model runs only under `GCS_TEST_CAKE`.
+- **The view coverage is a byte-diff, not a lane.** Leaving a view's run in
+  pieces still produces a proof that verifies, so nothing goes red if the
+  regrouping regresses — only a nine-line proof-size difference, which is
+  checked by hand against a parent commit rather than by the suite.
+- **No lane holds the `no_overlap` walk's *reason length* down.** The
+  proof-line budget in `run_wide_proved_no_overlap_equals_test` catches a
+  per-value witness in a proving run; with proofs off, the guard added in #873
+  means the reason is not built at all, so a regression to a per-value reason
+  would be caught by the large-domain audit lane rather than by this file.
+- **`ortho_latin`, the family's own benchmark, exercises two of the nine
+  rules.** See [Proof performance](#proof-performance) — worth knowing before
+  reading any conclusion off it.
 
 ### Benchmarks and examples
 
@@ -693,184 +1008,242 @@ with a two-variable `=` or `!=` reaches it via the two-term linear recovery.
   anything that makes `ArrayMax` run more often costs there.
 - **For proof benchmarking: `ortho_latin --all 5`.** Size 6 must be capped
   (`dev_docs/proof-benchmarks.md`); size 5 is 5.7 MB and there is nothing in
-  between.
+  between. Know what it does *not* cover before reading a per-inference cost
+  off it: two of the family's nine rules, and neither subhint — see [Proof
+  performance](#proof-performance).
+- **For the reified arm: `magic_series 300`** (in `minicp_benchmarks/`, and
+  the size is positional — it takes no `--size` and no `--stats`).
+  `ortho_latin` is all unreified `NotEquals`, so it says nothing about the
+  four reified forms. `magic_series` posts `EqualsIff{series[j],
+  constant_variable(i), ...}` per (position, value) pair, which is the
+  constant-operand shape exactly, and it has a fixed search tree — 1,193
+  recursions, 1,181 failures. It is what #889's C++ half was measured on.
+- **For a cross-solver comparison**, neither of the above: take the model from
+  `minizinc-benchmarks` — `queens/queens.mzn` for the unreified arm and
+  `nmseq/nmseq.mzn` for the reified one, the latter pinning its own
+  `int_search`. See `dev_docs/cross-solver-benchmarking.md` for why posting
+  our own clique would not do.
 - **Do not** pin `circuit_random` results without `--seed=N`; it defaults to a
   random seed.
 
 ### CPU performance
 
-*Measured 2026-09-07 at `7d014207`, Release + `GCS_WERROR=ON`, g++ 15.2.0,
-AMD Ryzen 9 9950X3D, 30 GB. Min of three.*
+*Measured 2026-09-08 at `76bfd836`, Release + `GCS_WERROR=ON`, g++ 15.2.0, AMD
+Ryzen 9 9950X3D, 30 GB, otherwise idle, `taskset -c 4`. Min of three.*
 
 | Benchmark | Time | Recursions | Propagator calls | Busiest type |
 |---|---|---|---|---|
-| `ortho_latin --all 6` | 20.49 s | 1,339,912 | 77,784,903 | `not_equals`, 55,435,743 (71%) |
+| `ortho_latin --all 6` | 20.64 s | 1,339,912 | 77,784,903 | `not_equals`, 55,435,743 (71%) |
 
-Under `GCS_PROPAGATOR_STATS=time`, `not_equals` takes **18% of 19.06 s** of
-propagation while making 71% of the calls — about 57 ns a call. That ratio is
+Under `GCS_PROPAGATOR_STATS=time`, `not_equals` takes **18% of 17.88 s** of
+propagation while making 71% of the calls — about 58 ns a call. That ratio is
 the family's whole performance story: the algorithm is already as cheap as a
 propagator gets, so the only lever left is *how often it is woken*, which is
-what issue #819 addressed. A timed run's own wall clock (23.29 s here) is not
-comparable with an uninstrumented one.
+what both trigger changes did. A timed run's own wall clock (23.55 s here) is
+not comparable with an uninstrumented one.
 
-**Cross-solver comparison: `Not measured.`** Filed as **#868**, which is an
-audit-wide prerequisite rather than an equals task — every family document will
-have to leave this section empty until it exists. Doing it properly needs an
-identical-search-tree harness against Gecode, Choco and ACE on a
-clique-encoded model, and a note on the fact that those solvers would normally
-use a specialised all-different rather than a disequality clique — which makes
-"the same benchmark" the hard part, not the timing. Flagged in [Next
-steps](#next-steps).
+The search shape is identical to the first audit's, to the digit, and the time
+is 0.7% higher — 20.49 s at `7d014207`. That is not noise and it is accounted
+for: #894 put the watch-index test on the inference replay path, which its own
+`perf stat` measured at +0.69% of `ortho_latin`'s instructions. The index is
+empty for this model, so it is pure overhead here; hoisting it out is #895.
 
-**Historical A/B, measured elsewhere (issue #819, pre-merge):**
-`ortho_latin --all 6` 24.29 s → 20.28 s (−16.5%), 321.7M → 55.4M
-`not_equals` calls; `colour` +3.6% and +5.2% on two instances and neutral on a
-third; identical search trees throughout. Those figures are from the issue, not
-from this machine on this date, and the two sets should not be mixed in one
-table.
+**Cross-solver comparison.** Measured for this family, which it was not at the
+first audit — the harness #868 asked for now exists, in the `gcs-benchmarks`
+repo, with the method written up in `dev_docs/cross-solver-benchmarking.md`.
+Both models come from `minizinc-benchmarks` rather than being posted here,
+which matters: the natural gcs benchmark for this family is a disequality
+clique, and no other solver would be given one.
+
+*Measured elsewhere — gcs `238c7836` against Gecode 6.3.0 via the MiniZinc
+2.9.7 bundle, 2026-09-07, on this machine but not in this table's build.
+`gcs-benchmarks` holds the authoritative tables. Identical trees throughout,
+verified on `nodes`.*
+
+| Model | Arm | Instance | nodes (both) | gcs / gecode |
+|---|---|---|---|---|
+| `queens --all` | unreified `!=` | n=12 | 292,203 | 0.93x |
+| `queens --all` | unreified `!=` | n=14 | 8,396,439 | 0.97x |
+| `nmseq` | reified `==` | n=100 | 767 | 6.20x |
+| `nmseq` | reified `==` | n=200 | 1,567 | 6.40x |
+
+The unreified arm is level with Gecode, marginally ahead. The reified arm was
+6.3x behind for the reason this family's whole performance story predicts —
+82% of propagation time in `Equals`, at 130,756 calls per node of which 4.4%
+were effectful, at a per-call cost (52 ns) that was already fine. #894 took
+that to **2.6x at both sizes**; see below. Choco and ACE are still unmeasured,
+which is what keeps #868 open.
+
+**Historical A/B, measured elsewhere.** Two, and neither should be put in a
+table beside the figures above.
+
+*Issue #819, pre-merge:* `ortho_latin --all 6` 24.29 s → 20.28 s (−16.5%),
+321.7M → 55.4M `not_equals` calls; `colour` +3.6% and +5.2% on two instances
+and neutral on a third; identical search trees throughout.
+
+*Issue #889, in PR #894:* upstream `nmseq`, same binary, same tree, min of
+three — `Equals` calls 100.3M → 4.43M at n=100 (22.6x) and 1.594G → 35.4M at
+n=200 (45.0x), effectful share 4.4% → 98.6% and 2.2% → 99.3%, `solveTime`
+4.455 s → 2.097 s and 80.881 s → 32.847 s. `magic_series 300` from
+`minicp_benchmarks/` is the same shape in C++: identical search, propagations
+41.9M → 15.9M, 10.5% fewer instructions. The rest of the `benchmarking.md` set
+is unchanged by it.
 
 ### Proof performance
 
-*Same build and machine. `ortho_latin --all 5`: 607 recursions, 18 solutions,
-0.044 s to solve and write.*
+*Same build and machine. `ortho_latin --all 5`: 607 recursions, 33,258
+propagations, 18 solutions; 0.010 s to solve, 0.040 s to solve and write the
+fully-justified proof. VeriPB 3.0.2, min of three.*
 
 | Assertion level | Proof size | Assertions | VeriPB | Verdict |
 |---|---|---|---|---|
-| `Off` (justify everything) | 5.66 MB | 0 | 2.30 s | `VERIFIED COMPLETE ENUMERATION` |
+| `Off` (justify everything) | 5.66 MB | 0 | 1.83 s | `VERIFIED COMPLETE ENUMERATION` |
 | `Links` | 3.33 MB | 31,069 | — | — |
 | `Inferences` | 3.15 MB | 30,064 | 0.04 s | `UNDER ASSERTIONS` |
 
-Verification is **52× the solve time** fully justified. Asserting inferences
-cuts the proof by 44% and, since `a` is an oracle rather than a checked rule,
-the "verification" becomes free — which is exactly the input an external
-justifier is meant to consume, and exactly why its output has to be checked
-again afterwards.
+Byte-for-byte the same proof as at the first audit at all three levels, and
+the same assertion counts: none of the six fixes touched what this model
+emits. Verification is **46× the solve time** fully justified. (It was 52× at
+the first audit — 2.30 s against the 1.83 s measured here for an identical
+proof. Which of the two runs was the anomalous one is not established; only
+this one was taken `taskset`-pinned on a verified-idle machine, so it is the
+one quoted.) Asserting inferences cuts the proof by 44% and, since `a` is an
+oracle rather than a checked rule, the "verification" becomes free — which is
+exactly the input an external justifier is meant to consume, and exactly why
+its output has to be checked again afterwards.
 
 Of the 30,064 assertions at `Inferences` level, **13,323 (44%) carry the
-`equals` hint** — more than any other family in that proof
-(`modulus` 8,280, `linear_equality` 4,032, `divide` 3,804). All 13,323 are the
-bare `((constraint_id _N))` form; the `no_overlap` subhint does not arise in
-`ortho_latin`, since disjoint domains do not occur there.
+`equals` hint** — more than any other family in that proof (`modulus` 8,280,
+`linear_equality` 4,032, `divide` 3,804).
 
-Per-rule proof sizes are in the catalogue. The family's own contribution is one
-to three lines per inference; a fully-justified proof of an equals-heavy model
-is dominated by the *shared* order-literal and equality-literal definitions
-that the variable-encoding layer emits on demand, not by this constraint.
+**All 13,323 are the bare `((constraint_id _N))` form, and this is a fact
+about the benchmark rather than about the family.** Neither subhint arises
+here. Reading the asserted clauses back: every literal in all 13,323 is an
+`eq` atom, 13,309 of them a two-literal clause with both literals negated at
+the same value and 14 of them a single positive literal. That is **rule 5**
+(13,309, the not-equal-to-fixed-operand pruning of the clique) and **rule 1
+against a constant** (14, the puzzle's fixed cells), and nothing else.
+`ortho_latin` exercises two of the family's nine rules in its proof — no bound
+push, no interval bridge, no disjointness walk — so the interesting
+derivations are covered by `equals_test` and the hint-inventory lane, not by
+the family's own proof benchmark. Anyone reading a per-inference cost off this
+table should know which two inferences it is an average over.
+
+Per-rule proof sizes are in the catalogue. **The family's own contribution is
+a minority of the proof even where it is most expensive.** For the
+disjointness walk over interleaved domains, measured above, it is `2n` lines
+against `10n + 1` of shared order- and equality-literal definitions that the
+variable-encoding layer emits on demand — one sixth. For the bounds-disjoint
+shape it is two lines out of thirteen. A fully-justified proof of an
+equals-heavy model is dominated by those shared layers, not by this
+constraint.
 
 ## Status, gaps, and next steps
 
 ### Proof-logging gaps
 
 **Nothing is left unjustified, and no rule is weakened when proofs are
-enabled.** There is no `a`-oracle use, no unlogged inference, and no
-strength difference between a proving and a non-proving run.
+enabled.** There is no `a`-oracle use, no unlogged inference, and no strength
+difference between a proving and a non-proving run. Since #886 the derivations
+are also known to be **tight**: five corruptions of them are rejected by
+VeriPB, against a control that shows the same instances verify uncorrupted.
 
-There is one cost gap in the other direction, which is a genuine bug:
+`None.` on cost gaps, too, which was not true at the first audit. The one that
+was — rule 9 assembling a `2 + width` reason unconditionally, so that with
+proofs off it was built, never read and thrown away — is fixed twice over: #873
+guarded the assembly on `want_reasons()`, and #881 made the witness
+interval-wise so the width does not enter even when proofs are on.
 
-**Rule 9 pays its proof cost when proofs are off.**
-`no_overlap_justification` builds a reason of `2 + width` literals
-unconditionally, and `SimpleInferenceTracker::materialises_reasons` is
-`false`, so with proofs off that vector is built and thrown away. The
-`InferenceTracker` header states the rule this breaks — "a propagator whose
-reason is expensive to assemble (a `ConcatReason` allocation, **a long
-extra-literal walk**) should guard that assembly on this query" — and the
-must-not-hold pass in the *same file* does guard, added by commit `fea9508d`
-("equals: guard the reified must-not-hold reason on want_reasons"). This site
-was missed. It is what turns a wide-domain `EqualsIff` into a `std::bad_alloc`.
-
-Guarding it does not remove the O(width) cost when proofs *are* on — that is
-inherent to the per-value witness — but it does confine it to proving runs, and
-it is a one-line change with the pattern already in the file's history. Filed as
-**#864**; whether a cheaper certificate exists at all is **#867**.
+The one thing left in this direction is not this family's: **a view has no
+range literal** (#882), so rule 2 falls back wholesale to per-value pruning
+when either operand is a view, and rule 9 spells a view's runs out value by
+value. Both are proof-size costs on a correct proof, and #882 prices them
+alongside the solver's other six such detours. Recording it here rather than
+working around it again is deliberate — the family already carries the
+smallest workaround available, which is degrading a run rather than a rule.
 
 ### Known limitations
-
-**`ReifiedEquals::clone()` drops `_neq`, which silently disables a deliberate
-fix.** The clone is `make_unique<ReifiedEquals>(_v1, _v2, _cond)` — no fourth
-argument — so `_neq` defaults to `false`. `Problem::post` clones, and
-`create_propagators` clones again, so by the time anything reads `_neq` it is
-always `false`. Consequences, all verified by running the six variants:
-
-1. The `cond_to_write` un-negation in `s_expr()` is **unreachable**. Its guard
-   is `_neq && holds_alternative<reif::Iff>`, and `_neq` is never true.
-2. `NotEqualsIff{x, y, b == 1}` therefore writes `(_1 equals_iff (b != 1) x y)`
-   where the code comment intends `(_1 not_equals_iff (b = 1) x y)`.
-3. The OPB provenance comment for a `NotEqualsIff` reads
-   `* constraint equals _1`.
-
-None of this is a correctness bug **because the two errors cancel exactly**:
-`¬c ↔ x = y` and `c ↔ x ≠ y` are the same constraint, and all six variants
-round-trip through `read_scp` to identical solution counts. The comparison is
-instructive: `ReifiedLinearEquality::clone()` *does* pass its equivalent flag
-(`_flipped_cond`) through, which is why the same commit's fix was load-bearing
-there — `linear_test` `ne_iff` went 0/68 to 68/68 — while `equals_test` showed
-no change at all. That silence was the only signal that the fix had not taken.
-
-The danger is a partial repair. Fixing `clone()` alone flips the emitted
-keyword and the condition together, and stays correct. Fixing either half on
-its own emits the *opposite* constraint, and the SCP symmetry check will not
-catch it, because it only checks that the keyword parses.
-
-Filed as **#865**. The fix is also known to be local: a sweep of every
-`clone()` under
-`gcs/constraints/` and `gcs/presolvers/` found this to be the **only** one that
-drops a constructor argument. The two constraints with the closest shape both
-pass everything through —
-`ReifiedCompareLessThanOrMaybeEqual(_v1, _v2, _reif_cond, _or_equal, _vars_swapped)`
-and the corresponding `LexCompareGreaterThanOrMaybeEqual`. So this is one
-missing argument in one function, not a pattern to hunt down.
-
-**Two derivations share one wire hint (#866).** Rules 1 and 2 both emit
-`equals:((constraint_id N))`, but rule 1 is a bare RUP and rule 2 needs two
-bridge lemmas first. An external justifier has to discriminate on whether the
-asserted literal is a range literal, rather than on the hint. The mechanism for
-saying so already exists and is already used by rule 9 — a subhint.
 
 **Aliased operands are not GAC**, deliberately: a GAC algorithm for distinct
 variables does not generally give GAC under aliasing, and the dup tests check
 the solution set and the proof only. Documented rather than fixed.
 
-**The view/constant fallback costs one proof line per value.** Documented
-above; it is a proof-size limitation of the range-literal bridge, which needs
-a plain variable on the far side.
+**The view/constant fallback costs one proof line per value.** Rule 2 is
+skipped wholesale when either operand is not a bare `SimpleIntegerVariableID`,
+and rule 3 covers the case one value at a time. It is a proof-size limitation
+of the range-literal bridge, which needs a plain variable on the far side, and
+the general form of it is #882 — where this family holds two of the eight view
+detours in the solver.
+
+**A constant-operand propagator's refined watch is scanned, not indexed**
+(#895). The engine tests every watch armed on a variable against each
+inference on it, so the scan is as long as the coarse trigger list was and
+only the per-item body got cheaper — a `test_literal` instead of a full
+propagator call. That is still where the `nmseq` shape's remaining `Equals`
+cost is after #894. Indexing watches by value would need the inference replay
+to carry the value, which is an engine change rather than a constraint one.
+
+**A model of nothing but reified equalities against constants pays a second
+`Equals` it does not need.** FlatZinc's `int_eq_reif(s[j], c, b)` plus
+`bool2int(b, x)` is two propagators where one would do, which #889 raised. It
+is a frontend question rather than a propagator one, and after #894 it is not
+where that model spends itself.
+
+*Three limitations recorded at the first audit are gone rather than
+outstanding*: the `clone()` gap that dropped `_neq` (#865, fixed in #883 — and
+the sweep behind it stands, since it was the **only** `clone()` under
+`gcs/constraints/` or `gcs/presolvers/` dropping a constructor argument), the
+shared wire hint between rules 1 and 2 (#866, fixed in #884), and rule 9's
+per-value cost (#864 and #867, fixed in #873 and #881).
 
 ### Next steps
 
-Ranked, and all filed. #864 and #865 are small and self-contained; #867 is a
-research question rather than a fix.
+Ranked. **No propagation or proof bug in this family is outstanding**: the
+seven the first audit filed are #864–#870, and only #868 is still open. The
+first three items below are a shared mechanism, an engine cost and a
+benchmark, all reached through this family rather than owned by it; the fourth
+is a hole in its own test coverage that writing the per-rule tightness field
+surfaced.
 
-1. **#864 — Guard `no_overlap_justification` on `want_reasons()`.** One line, removes
-   a `std::bad_alloc` on wide domains with proofs off, and follows a pattern
-   already applied to the neighbouring pass in `fea9508d`. Add a wide-domain
-   case to the test file at the same time — the current suite tops out at
-   `[-10, 10]` and cannot see this.
-2. **#865 — Fix `clone()` to pass `_neq`, and check the emitted `.scp` changes
-   as expected.** Small, but it must be done as one change: it flips both the
-   keyword and the condition, and half of it is silently wrong. Worth pairing
-   with a semantic round-trip assertion (solve the re-read model, compare
-   solution counts) so the symmetry check stops passing on an equivalent-but-
-   unintended description. Also makes the `not_equals_iff` reader path reachable
-   from the writer.
-3. **#866 — Give the not-in-range bridge its own subhint.** Removes the one place in
-   this family where an external justifier must key off literal shape instead
-   of the hint. Cheap, and the pattern is already there in
-   `EqualsNoOverlap`.
-4. **#867 — Consider an interval-wise no-overlap witness.** Rule 9's per-value walk is
-   the only super-logarithmic thing here. Whether an interval-wise certificate
-   exists is a real question, not a refactor: the witness genuinely is
-   per-value, since it says *for each value* which side excludes it. A cheaper
-   alternative may be to bound the rule and fall back to leaving the verdict
-   undecided when the range is wide — a strength loss, but a bounded one.
-5. **#868 — Measure against Gecode, Choco and ACE.** Needs an identical-search-tree
-   harness and a defensible choice of model, since those solvers would not
-   normally encode an all-different as a disequality clique.
-6. **#869 — Record a mutation.** Show that VeriPB refuses a mangled equals
-   derivation, so the derivations are known to be tight rather than merely
-   accepted.
-7. **#870 — Drop the `State *` from `EqualsNoOverlap`.** The reconstructibility
-   analysis above shows the asserted clause already carries what the emitter
-   reads it for. Removing it would make the family's justifications uniformly
-   free of `state` access, which is the invariant everywhere else.
+1. **#882 — Give views a range literal.** The largest remaining item, and this
+   family is where the price is most visible: rule 2 is skipped wholesale for
+   a view operand and rule 3 covers it one value at a time, which is a domain
+   width rather than a constant now that the interval vocabulary is the
+   ordinary one. Two candidate designs, and #881 sharpened the case for the
+   second of them — define range literals over a registered view's own bits
+   and let the two order *cuts* cross the view's defining equality, since the
+   no-overlap walk showed that a range literal never crosses an equality, only
+   its cuts do, one bound at a time. That is a hand UP analysis, so it is a
+   reason to test the design and not to adopt it.
+2. **#895 — Hoist the refined-watch empty-index test, and index watches by
+   value.** Two costs, both measured while doing #889. The first is 1.7% of
+   `tsp`'s instructions and 0.69% of `ortho_latin`'s, all of it paid by models
+   that arm no watches at all, and it is a template parameter away from
+   compiling out. The second is what is left of this family's cost in the
+   `nmseq` shape. Both are engine work, and the first is worth doing carefully
+   rather than quickly: the invariant it needs is about the hottest loop in
+   the solver, and what it would protect against getting wrong is exactly the
+   silent wake loss #894 fixed.
+3. **#868 — Measure against Choco and ACE.** Half done: the harness exists,
+   the method is written up, and Gecode is measured on both arms of this
+   family (`dev_docs/cross-solver-benchmarking.md`). What is missing is the
+   other two solvers. The hard part is settled and worth reusing — the model
+   has to come from an external suite, because the natural gcs benchmark for
+   this family is a disequality clique and no other solver would be given one.
+4. **Thread the proof mutation through the must-not-hold pass.** Not filed as
+   an issue yet, and small. `with_proof_mutation` reaches `enforce_equality`, so
+   `fixed_operand_reason` corrupts rule 1's reason but not rule 5's — and rule
+   5 is the busiest rule in the solver and 13,309 of the 13,323 equals-hinted
+   assertions in the family's own proof benchmark. The corruption already
+   exists; only the lambda's capture list and one lane registration are
+   missing. Worth doing before the next family's mutation lane is written,
+   since "the corruption exists but does not reach the rule I care about" is
+   the shape of mistake it demonstrates.
+
+**Not to do, having been considered:** bounding rule 9 and leaving the verdict
+undecided when the range is wide. That was the fallback the first audit
+proposed in case an interval-wise certificate did not exist. It does exist
+(#881), so a deliberate strength loss buys nothing.
 
 ## Prior art
 
@@ -889,6 +1262,21 @@ Two things are worth citing:
   ~15 ns while a delayed inference costs a co-registered O(n·d) propagator a
   whole extra run — is the transferable finding, and it generalises to every
   cheap binary constraint in the solver.
+- The **interval-wise disjointness certificate** (#867/#881) is, as far as
+  this audit found, novel — and it is the one thing in this family that is a
+  proof technique rather than an application of one. "These two domains do not
+  overlap" has an obvious per-value witness and no obvious interval-wise one,
+  because the fact really is stated value by value. Restating it as a *walk* —
+  an invariant `v1 ≥ p` carried up the number line, one move per maximal run
+  `v1` cannot occupy, ending by pushing `p` off the top of one domain — makes
+  it cost one literal per run and at most two lines per run, at any domain
+  width. Two things in it generalise past this constraint: that the witness
+  and the reason must come out of the *same* walk in the same order, since the
+  lemmas exist precisely to let unit propagation see that reason's literals
+  through, and that the moves which cost nothing are the ones stepping over a
+  run *inside* one variable, where the variable's own reverse reification does
+  the work. `dev_docs/range_literals_spec.md` records it as the range-literal
+  layer's second consumer.
 
 ## Further reading
 
@@ -902,9 +1290,24 @@ Two things are worth citing:
   a range literal cannot cross a bit-sum equality without the bridge.
 - `dev_docs/variable-encodings.md` — the in-OPB versus in-proof axis this
   family sits entirely on the OPB side of.
-- `dev_docs/refined-triggers.md` — the per-literal watch mechanism. Not used
-  here, and the contrast is informative: this family's trigger win came from
-  coarsening `on_change` to `on_instantiated`, not from watching literals.
+- `dev_docs/refined-triggers.md` — the per-literal watch mechanism, which this
+  family uses for its constant-operand arm (#889) and which the first audit
+  recorded as unused here. Also the place the one-shot-subscription rule and
+  the claim-path replay invariant are written down, both of which #894
+  established.
+- `dev_docs/propagator-performance.md` — where the "when every coarse trigger
+  is too coarse, watch the literal" case is generalised, with this family's
+  figures as the worked example, and the caveat that a watch scan is as long
+  as the trigger list was.
+- `dev_docs/cross-solver-benchmarking.md` — how to compare gcs against another
+  solver at an identical search tree, and the two `minizinc-benchmarks` models
+  this family's arms are measured on. Written for #868; read it before quoting
+  any cross-solver ratio.
+- `dev_docs/large-domains.md` — the `GCS_LARGE_DOMAIN_GUARD` audit lane, this
+  family's row in it, and the two generalisable findings the rule-9 blow-up
+  produced: that a `Clean` row nothing instruments is only as strong as the
+  box it ran on, and that a *reason* is a place a search for pruning loops
+  will not reach.
 - `dev_docs/infer-redesign.md` — the typed assertion hints in
   `gcs::innards::hints` and the `JustifyExplicitly` / `JustifyUsingRUP` split.
 - `dev_docs/benchmarking.md`, `dev_docs/proof-benchmarks.md` — where
@@ -914,6 +1317,50 @@ Two things are worth citing:
 
 `None.` The family predates the practice of writing design notes, and the
 inline comments in `equals.cc` are unusually thorough — the cake conformity
-notes in `define_proof_model`, the `#819` trigger rationale, and the bridge
-explanation in `enforce_equality` are all worth reading in place. This document
-does not duplicate them.
+notes in `define_proof_model`, the trigger rationale for both #819 and #889,
+the bridge explanation in `enforce_equality`, and `walk_no_overlap`'s
+statement of the invariant it carries are all worth reading in place. This
+document does not duplicate them.
+`gcs/constraints/innards/equals_mutations.hh` is the other one to read: it
+argues why this family needs a mutation lane more than most rather than less,
+and records what its instances cost to build.
+
+**What the second pass changed in the template**, on the evidence of having
+re-audited a family rather than written one. All four are things this rewrite
+wanted and could not find, which is the same test the first pass applied.
+
+- **A re-audit is a distinct event, and the status line carries both dates**
+  plus an `issue → PR → what it changed here` table. A reader needs to know
+  which commit each figure was taken at, and which sections moved.
+- **A rule entry gains a `Tightness` field.** The template asked under Tests
+  "whether the derivation has been shown to be tight", which is the right
+  question at the wrong altitude: a mutation lane corrupts *one rule's* step,
+  so the evidence is per-rule and belongs beside that rule's proof size.
+  Putting it there is what surfaced the gap now ranked fourth in [Next
+  steps](#next-steps) — six of nine rules answer `Not shown.`, and one of
+  those six is the busiest rule in the solver. Under the old shape this family
+  could answer "yes, tight" and stop.
+- **Say what the family's own benchmark does not exercise.** `ortho_latin`
+  reaches two of nine rules. That was true at the first audit too and went
+  unsaid; it is the sort of thing a cross-family pivot over these documents
+  would silently average over. Read it off the proof's assertions rather than
+  guessing — it took one `awk` over the polarity of 13,323 clauses.
+- **The own-versus-shared proof-size split wants a measurement, not an
+  estimate.** The first pass asserted that the shared layers dominate; the
+  second varied the run count and measured `2n` against `10n + 1`. The
+  template already demanded the separation, and now demands a number.
+
+**And one thing the re-audit did not change.** The first pass's structural bet
+— that the repeated unit is the inference *rule* and not the family — held up
+under a rewrite driven by code changes rather than by reading, though not as
+cleanly as it might have. Three of the seven fixes (#866, #867, #870) are
+changes to one rule's derivation, and each landed in that rule's entry plus at
+most one section of shared context; the rule catalogue is where a
+proof-technique change goes, and it took the weight. The other four cut across
+it, and two of those cut widely: `clone()` (#865) touched the semantics, the
+frontend table, cake conformity and the limitations, because a flag that
+decides how a constraint *describes itself* is not a property of any rule; and
+the mutation lanes (#869) touched every rule entry at once, which is exactly
+why the evidence now has a field there. That is the honest version — a
+rule-shaped change is cheap to document, and the audit's findings are not all
+rule-shaped.

--- a/dev_docs/frontend-support-matrix.md
+++ b/dev_docs/frontend-support-matrix.md
@@ -1,5 +1,12 @@
 # Frontend support matrix
 
+> **This document is being retired.** Its rows are migrating into the
+> "Concrete constraints and frontend coverage" table of each per-family
+> document under `dev_docs/constraints/`, which is why those tables use the
+> cell vocabulary below. Update the family document rather than this file, and
+> delete this one once every family carries its rows. See
+> [`constraints/TEMPLATE.md`](constraints/TEMPLATE.md).
+
 The same constraint shows up under three frontends — FlatZinc/MiniZinc
 (`minizinc/`), XCSP3 (`xcsp/`), and (planned) CPMpy. This document is the
 single source of truth for "which gcs propagator do we have, and which

--- a/dev_docs/justification-techniques.md
+++ b/dev_docs/justification-techniques.md
@@ -1,0 +1,174 @@
+# Justification techniques: why our proof steps are RUP
+
+Every rule in a [constraint family document](constraints/TEMPLATE.md) carries a
+**Proof technique** field, and for most rules in most families that field says
+`RUP`. On its own that is a claim, not an argument: reverse unit propagation
+succeeds only for particular shapes of constraint over particular encodings,
+and "we emit `rup` and VeriPB accepts it" is evidence about one instance rather
+than a reason it will always work.
+
+This document is what licenses those names. It collects the small number of
+unit-propagation facts the whole solver leans on, says which published result
+proves each, and maps them onto the justification procedures our families
+actually use. **A family document should cite a procedure and a theorem from
+here rather than restating the argument** — and, where a family departs from a
+published procedure, say so, because that is exactly where an external
+justifier cannot replay a known recipe.
+
+The results are Matthew McIlree's, *Pseudo-Boolean Proof Logging for Constraint
+Propagation Algorithms* (University of Glasgow, 2026;
+<https://theses.gla.ac.uk/86049/>). **Cite the final accepted version's
+numbering**, which is what this document uses: Chapter 2's theorems and
+Chapter 3's Encoding and Justification Procedures are unchanged from the
+pre-examination draft, but the Chapter 2 examples and the Chapter 3 equation
+numbers both shifted, so a number copied out of the draft may be wrong by one.
+
+## What the arguments rest on
+
+Chapter 3 is the authoritative treatment of our integer encoding; read it
+before theorising about either the encoding or the proof framework. Three
+things from it are load-bearing here.
+
+**Two kinds of atomic variable, and only two.** A CP variable `X` gets *bound*
+variables `x≥v` and *equality* variables `x=v`, the latter **defined on the
+bound variables** rather than being their peer. Everything a propagator states
+is a literal over those, so every question in this document is "does unit
+propagation get from these atomic literals to that one".
+
+**A binary backbone underneath.** `BinEnc(X)` is the bit-sum encoding of `X`
+(two's complement when the lower bound is negative), O(log domain) variables,
+and the linking constraints tie the atomic literals to it. This is what makes
+the encoding logarithmic instead of per-value, and it is also why the facts
+below are all about sums of the form `Σ 2ⁱ ℓᵢ`.
+
+**The linking invariant `Inv1`.** Between any two defined bound literals on the
+same variable there must be either an intervening defined bound or an explicit
+implication between them. Maintaining it costs two RUP steps per bound literal
+used, and it buys **Theorem 3.3 (complete propagation of implied atomic
+literals)**: given any set of atomic literals on one variable, unit propagation
+derives every atomic literal they imply. That is what "our careful literal
+setup" means in practice, and it is the reason a propagator can state a bound
+or an equality and expect the encoding to do the rest *within* that variable.
+Getting from one variable to another is what the next section is for.
+
+The framework-level results are **Theorems 3.4 and 3.5** with invariants `Inv2`
+and `Inv3`: a solver that logs a propagation justification `R ⇒ ℓ ≥ 1` and a
+conflict justification `R ⇒ 0 ≥ 1` for every inference, and maintains the
+invariants, produces a checkable proof. Those are the reason the *shape* of
+what we emit is right; the facts below are the reason each individual step goes
+through.
+
+## The four facts
+
+| Fact | Result | Statement | What it licenses |
+|---|---|---|---|
+| Opposing bounds on one bit sum | **Thm 2.7** | `Σ2ⁱℓᵢ ≥ A` together with `Σ2ⁱℓᵢ ≤ B`, for `A > B`, always unit propagates to contradiction | any contradiction from two bounds on the same variable |
+| An equality on a bit sum fixes every bit | **Thm 2.8** | `Σ2ⁱℓᵢ ≥ A` together with `Σ2ⁱℓᵢ ≤ A`, for `0 ≤ A < 2ᵏ`, always unit propagates to a complete assignment of the bits summing to `A` | a *value* crossing an equality — the fact behind `[x = v] ⊢ [y = v]` |
+| A bound, a difference row, a bound | **Thm 2.9** | for `A + B − C > 0` and **`B ∈ {0,1}`**, a lower bound on one bit sum, a row `BinEnc(X) − BinEnc(Y) ≥ B`, and an upper bound on the other always unit propagate to contradiction | a *bound* crossing an equality half or a comparison row |
+| A reified step reduces to its consequent | **Thm 2.6** | for `C := ρ ⇒ D`, `¬C` propagates every literal of `ρ`, so `C` is RUP with respect to `F` exactly when `D` is RUP with respect to `F↾ρ` | every reified verdict, and every justification stated under a reason |
+
+Theorem 2.6 is why a reason costs nothing structurally: stating an inference
+under a conjunction of literals reduces to the unreified question with those
+literals assumed. Theorems 2.7 to 2.9 are, in the thesis's own words, relied on
+implicitly in several published works and had not been written down anywhere
+before it.
+
+### Where the third one stops
+
+**Theorem 2.9's `B ∈ {0,1}` precondition is load-bearing, and the boundary is
+sharp.** It is tempting to assume the same triple propagates for any
+`A + B − C > 0`; it does not. **Example 2.15** is a concrete counterexample
+over two's-complement four-bit sums with a middle row of degree 3, and the
+slack computation showing why unit propagation stalls.
+
+What this means for us in practice:
+
+- **An equality is covered.** Our equality encoding is two rows,
+  `BinEnc(X) − BinEnc(Y) ≥ 0` and `≤ 0`, so each half has `B = 0` and a bound
+  crosses it.
+- **A comparison is covered.** `X ≤ Y` is `Y − X ≥ 0` and `X < Y` is
+  `Y − X ≥ 1`, which is the whole of the `B ∈ {0,1}` range and the whole of the
+  comparison family's encoding.
+- **A general linear row is not.** A two-term inequality with a constant
+  outside `{0,1}` is outside the theorem, which is why the linear family
+  justifies its bound pushes through its own procedure (JP 3.15) rather than by
+  appeal to 2.9.
+
+That boundary also shows up empirically, which is worth knowing because it
+makes fixtures misleading. The `equals` mutation lane that removes the bridge
+lemmas is *accepted* by VeriPB at two domain widths out of thirteen tried —
+both of them putting an interval endpoint on a bit boundary, where the bound is
+a single literal rather than a sum and propagation crosses unaided. A narrow
+fixture would have concluded the lemmas were unnecessary.
+
+## The procedures we use
+
+Chapter 3 §3.4 sets out a ladder of justification procedures — single-RUP,
+multiple-RUP, cutting-planes, reified — and gives named procedures with
+correctness proofs for the common constraints. These are the ones our audited
+families land on:
+
+| Procedure | Shape | Licensed by | Used by |
+|---|---|---|---|
+| **JP 3.1** (Not-Equals) | `rup x=v ∧ y=v ⇒ 0 ≥ 1` | Thm 2.8 | `equals`'s not-equal-to-fixed-operand rule |
+| **JP 3.2** (Comparison) | `rup y≥v ∧ x≥u ⇒ 0 ≥ 1`, precondition `B ∈ {0,1}` | Thm 2.9 | every bound transfer in `comparison`, and `equals`'s bounds-intersection and interval-bridge rules |
+| **JP 3.12** (Equality propagation) | `rup y=v ⇒ x=v ≥ 1` | Thm 2.8, twice | `equals`'s equal-to-fixed-operand rule, and its per-value symmetric-difference fallback |
+| **JP 3.13** (Equality infeasibility) | a per-value RUP for each surviving value, then a generic-reason contradiction | JP 3.12 for each line | **nothing any more** — see below |
+
+JP 3.2's correctness proof is worth reading rather than taking on trust,
+because it is careful about a case our encoding hits: if either operand is
+*not* two's-complement encoded, the three constraints are not literally
+Theorem 2.9's, but are in the state 2.9's own proof reaches after propagating
+the most significant bit, so the argument still applies.
+
+A transfer and an infeasibility are the same clause written two ways. JP 3.2 is
+stated as a contradiction from two reason literals; a propagator that pushes a
+bound emits the same clause with one literal moved to the conclusion, which is
+the reified form Theorem 2.6 reduces back to the stated one.
+
+### Where we depart from a published procedure
+
+**`equals`'s disjointness witness no longer follows JP 3.13.** The published
+procedure states "these two domains do not overlap" one value at a time: a RUP
+line per surviving value, then a contradiction against the generic reason. That
+is what gcs did until #881, and it is O(domain width) in both proof size and
+reason length. The witness now used is an **interval walk** — an invariant
+`v1 ≥ p` carried up the number line, one move per maximal run, at most two
+lines per run — which is not in the thesis and is argued from scratch in
+[`constraints/equals.md`](constraints/equals.md).
+
+That distinction is the one an external justifier most needs. Everywhere a
+family cites a procedure number, a tool that knows the procedure can rebuild
+the derivation from the assertion. Where a family says it departs, the tool
+cannot, and the family document owes it a full argument instead. **So a rule
+whose technique is a published procedure and a rule whose technique is ours are
+different kinds of entry, and the field should say which.**
+
+## How to cite this from a family document
+
+In a rule's **Proof technique** field, give the technique name from
+[Appendix A](constraints/TEMPLATE.md#appendix-a-proof-technique-vocabulary),
+then the licence:
+
+```
+- **Proof technique** — `RUP`, by JP 3.12 (equality propagation), which is
+  Theorem 2.8 applied twice; the condition literal comes along by Theorem 2.6.
+```
+
+and where there is no published procedure:
+
+```
+- **Proof technique** — `RUP+hints`. **No published procedure**: JP 3.13 states
+  this per value, and the interval witness below is ours. Argued in full under
+  *Why it is true*.
+```
+
+Two rules about scope, both learned the hard way:
+
+- **Do not restate an argument that is proved somewhere.** A citation plus one
+  sentence saying which literals play which role is more useful than a
+  paraphrase, and cannot drift out of step with the source.
+- **Do state the preconditions**, because they are what a reader needs in order
+  to know whether the citation still applies after a change. `B ∈ {0,1}` is the
+  example: a family whose row degree could grow past 1 has lost its licence and
+  needs a different one.


### PR DESCRIPTION
Three commits: the per-family document template, the first family document written to it, and — new — the re-audit of that document against the code that the first pass's findings changed. Plus a fourth reframing the mutation-coverage policy, after review, and a fifth answering @mmcilree's review.

**Review round 1 is addressed** — see the review thread for the full response. In short: 14 of the 16 rules across the two audited families asserted a bare `RUP` with no argument. The arguments turned out to be published already, in @mmcilree's thesis, so a new `dev_docs/justification-techniques.md` collects the four unit-propagation facts (Thm 2.6–2.9), the completeness invariant behind them (`Inv1`, Thm 3.3), the `B ∈ {0,1}` precondition and its counterexample (Example 2.15), and the procedures we instantiate (JP 3.1, 3.2, 3.12) — and every rule now cites its procedure and theorem instead. Where a rule *departs* from a published procedure it says so outright, which is the distinction an external justifier needs; `equals`'s disjointness witness is the arc's first. `⟦v⟧` became `BinEnc(v)` to match the thesis, the at-least-one rows are written as implications, and "lemma" stays with the template now recording why it is deliberately undefined.

Tracker #871 has been brought into line too.

Rebased onto `main` at `76bfd836`.

## What changed since you last looked

The first pass filed seven issues (#864–#870) and this document was the argument for them. **Six are fixed**, one more arrived from outside the audit (#889), and four of the seven changed what the document *says* rather than only what the code does — so it was out of date in substance, not just in its numbers.

| Fixed | What it changed in the document |
|---|---|
| #864 → #873 | the no-overlap reason is guarded on `want_reasons()` |
| #865 → #883 | `clone()` carries `_neq`, so all six variants write their own `.scp` keyword |
| #866 → #884 | the interval bridge has its own subhint, so the wire inventory is three forms, not two |
| #867 → #881 | the no-overlap certificate is **interval-wise** |
| #869 → #886 | five mutation lanes and a control |
| #870 → #885 | no justification in the family reads `state` |
| #889 → #894 | a constant-operand reified equals wakes on a refined watch |

Two of those are load-bearing rather than tidying. The **interval-wise witness** removed the family's only large-domain failure and its only super-logarithmic cost, which is most of what "Robustness and limits" used to be about, and it is the one thing in this family that is a proof *technique* rather than an application of one — so it is now argued in Prior art as novel. The **trigger change** is the family's one real performance lever pulled in the opposite direction from #819: finer than any coarse trigger can express, rather than coarser.

The rule catalogue took most of the weight, which is the structural bet holding up — three of the seven fixes are changes to one rule's derivation and each landed in that rule's entry plus at most one section of shared context. The document says where it did *not* hold up, too: `clone()` touched four sections, because a flag deciding how a constraint describes itself is not a property of any rule.

## Everything was measured again

At `76bfd836`, Release + `GCS_WERROR=ON`, g++ 15.2.0, Ryzen 9 9950X3D, verified idle, `taskset`-pinned, min of three. Where a figure moved, the document says so and why.

**The no-overlap rule, which is what #881 changed.** One `EqualsIff` over two bounds-disjoint domains, root propagation only:

| width | proofs off | proof lines | proof size | VeriPB |
|---|---|---|---|---|
| 10³ | 0 ms | 13 | 965 B | verified |
| 10⁴ | 0 ms | 13 | 1.2 KB | verified |
| 10⁶ | 0 ms | 13 | 1.7 KB | verified |
| 10⁹ | 0 ms | 13 | 2.6 KB | verified |

Thirteen lines at every width, of which **two are the witness** — one lemma and the conclusion — six define the two order literals they mention, and five are proof preamble. Against `std::bad_alloc` at 10⁹ before.

**Its per-run cost**, which nothing had measured: `v1` the even values of `[0, 2n)` and `v2` the odd ones, so every run is one value long and every second run costs lemmas — the walk's worst case.

| runs (n) | total lines | witness | shared literal layers |
|---|---|---|---|
| 2 | 25 | 4 | 21 |
| 8 | 97 | 16 | 81 |
| 32 | 385 | 64 | 321 |
| 128 | 1,537 | 256 | 1,281 |

Exactly `2n` against `10n + 1`, so **five sixths of the proof is not this rule** even in the shape that costs it most. The first pass asserted that the shared layers dominate; this is the number, and wanting it is one of the template changes.

**CPU.** `ortho_latin --all 6` is 20.64 s against 20.49 s, at an identical search tree to the digit. That 0.7% is not noise and is accounted for: #894 put the watch-index test on the inference replay path, which its own `perf stat` measured at +0.69% of this model's instructions. Hoisting it out is #895.

**Proof.** `ortho_latin --all 5` is byte-identical at all three assertion levels — none of the six fixes touched what this model emits. VeriPB 1.83 s against the first audit's 2.30 s for the same proof; only this run was pinned on a verified-idle machine, so it is the one quoted and the discrepancy is stated rather than smoothed over.

**And one finding that came out of reading those assertions back.** All 13,323 equals-hinted assertions are the bare wire form, and it is not because no subhint exists: every literal in all of them is an `eq` atom, 13,309 being a two-literal clause with both literals negated at the same value and 14 a single positive literal. That is rule 5 and rule 1-against-a-constant, and nothing else. **`ortho_latin` exercises two of the family's nine rules in its proof** — no bound push, no interval bridge, no disjointness walk. That was true at the first audit too and went unsaid, and it is exactly what a cross-family pivot over these documents would silently average over.

## Cross-solver CPU performance is no longer `Not measured.`

#888 built the harness #868 asked for, and Gecode is measured on both arms — `queens` for unreified (0.93x–0.97x, level with Gecode) and `nmseq` for reified (6.2x–6.4x before #894, 2.6x after). Both models come from `minizinc-benchmarks` rather than being posted by us, which is the part worth reusing: the natural gcs benchmark for this family is a disequality clique, and no other solver would be given one. #868 stays open for Choco and ACE.

## Three template changes

All things this rewrite wanted and could not find, which is the same test the pilot applied.

- **A re-audit is a distinct event**, and the status line carries both dates plus an `issue → PR → what it changed here` table. A reader needs to know which commit each figure was taken at.
- **A rule entry gains a `Tightness` field.** The template asked under Tests "whether the derivation has been shown to be tight", which is the right question at the wrong altitude — a mutation lane corrupts *one rule's* step. At family altitude this one could answer "yes, tight" and stop, where three of its five lanes are one rule and six of its nine rules have no lane at all. The field is there so someone changing a rule can see whether a lane will catch them; `Not shown.` is an ordinary answer and **not** a coverage target, which the template now says outright.
- **The own-versus-shared proof-size split wants a measurement**, not an estimate. "2n against 10n + 1" is a finding; "the shared layers dominate" is a guess that happens to be right.

Plus, under CPU performance, a requirement to say what the chosen benchmark does **not** exercise, read off the proof's assertions rather than guessed.

## One finding, recorded rather than actioned

`with_proof_mutation` reaches `enforce_equality`, so `fixed_operand_reason` corrupts rule 1's reason but **not rule 5's** — the busiest rule in the solver, and 13,309 of the 13,323 equals-hinted assertions in the family's own proof benchmark. The corruption already exists; only the lambda's capture list and one lane registration are missing.

Not filed and not on the ranked list, per your call that mutation coverage is a development tool rather than something to have everywhere for its own sake. It sits under "Not to do, having been considered" with enough detail to act on if that rule is ever touched, and the third commit reframes the template the same way: `Not shown.` is an ordinary answer, partial coverage is the expected state, and the remainder is not carried as outstanding work.

## Checks

Docs only; no code touched. `ctest` **810/810 with nothing skipped**, including the six `equals_mutation` lanes and their control. `equals_test --seed=1` is **296 proofs verifying in 1.13 s**. Every table caption carries its commit, date and machine, and the two sets of figures measured elsewhere (#819's and #889's pre-merge A/Bs, and the cross-solver snapshot at `238c7836`) are in their own labelled paragraphs rather than beside fresh ones.

Two errors in #894's own PR body are corrected here rather than propagated: `magic_series` lives in `minicp_benchmarks/`, not `examples/`, and takes its size positionally — it has no `--size` and no `--stats`. Verified by running it: 1,193 recursions, 15,926,749 propagations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L3ZKTGi1UDpFSJbYmQFA8C

