### PR TITLE
Count the artefacts `GCS_PRESERVE_PROOF_FILES=1` actually leaves (#833)

### DIFF
--- a/dev_docs/large-domains.md
+++ b/dev_docs/large-domains.md
@@ -122,10 +122,14 @@ computing both algorithms in one binary reports zero disagreements over ten seed
 Look for this shape first; it is free.
 
 **Check byte-identity with `GCS_PRESERVE_PROOF_FILES=all`, not `=1`.** The latter
-keeps only the last instance's files, since every case writes to the same
-basename, so a run over 31 instances leaves six artefacts to compare out of 124.
-That is how the claim above this one came to be believed when it was false: the
-files that moved were not among the ones the check looked at.
+keeps only the last instance's files under each basename, and `among_test` writes
+its 31 proving instances under three basenames: 26 as `among_test_w0_pall`, 3 as
+`among_test_dup`, 2 as `among_test_selfref`. At four artefacts apiece — `.opb`,
+`.pbp`, `.scp`, `.varmap` — `=1` leaves twelve files to compare out of 124, and
+that is how the claim above this one came to be believed when it was false. The
+near miss is the part worth stating: the four proofs that moved are `w0_pall`
+0001, 0002, 0003 and 0006, and the only `w0_pall` proof `=1` leaves behind is
+0026 — so not one of the differences was ever in front of the check.
 
 H1a is the one worth looking for first, because it is not a trade-off at all.
 The tree already has the machinery: `IntervalSet::each_interval_minus()`,


### PR DESCRIPTION
`dev_docs/large-domains.md`'s preservation-policy warning had its two figures on
different bases: "six artefacts to compare out of 124" is 3 basenames × 2
extensions set against 31 instances × 4.

`=1` selects `ProofFilePreservation::Keep`, which keeps the last instance's files
under *each* basename, and `among_test` writes under three of them — 26
`among_test_w0_pall`, 3 `among_test_dup`, 2 `among_test_selfref` — at four
artefacts apiece (`.opb`, `.pbp`, `.scp`, `.varmap`). So `=1` leaves **twelve**
files out of 124, not six.

The mechanism the warning describes was right, and this also states the sharp
part of it: the four proofs that moved under #862's partition reuse are
`w0_pall` 0001, 0002, 0003 and 0006, while the only `w0_pall` proof `=1` leaves
behind is 0026. Not one of the differences was ever in front of the check, which
is precisely why the byte-identical claim looked true.

Instance counts read off `among_test.cc` (16 fixed cases + 10 generated =
26 `w0_pall`, 3 `dup`, 2 `selfref`) and the extension list off
`proof_file_extensions`; the four moved instance numbers are Ciaran's
measurement, not a re-run here. Documentation only — no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)