### PR TITLE
Do not assemble the equals no-overlap reason when nothing reads it (#864)

### DIFF
--- a/dev_docs/large-domains.md
+++ b/dev_docs/large-domains.md
@@ -261,17 +261,37 @@ Two kinds of check, and the difference matters:
   `State`'s iterators are not the only way a propagator walks a domain. It can
   build an `IntervalSet` of its own and walk that, or take an interval and expand
   it with a plain `for (Integer v = lo; v <= hi; ++v)`. `State` sees neither, so
-  each such loop needs its own counter declared at the loop. Two sites carry one:
-  `element.cc`'s sweep over unsupported result values (now only on its per-value
-  view path) and `all_equal.cc`'s expansion of the intersection difference. The
-  counter does not belong in `IntervalSet::each()` itself, which is a general
-  container used for deliberate enumeration — tabulation, and the tests.
+  each such loop needs its own counter declared at the loop. Three sites carry
+  one: `element.cc`'s sweep over unsupported result values (now only on its
+  per-value view path), `all_equal.cc`'s expansion of the intersection
+  difference, and `equals.cc`'s no-overlap reason. The counter does not belong in
+  `IntervalSet::each()` itself, which is a general container used for deliberate
+  enumeration — tabulation, and the tests.
 
-  Both were found the same way, and it is worth naming the smell: **a row that
-  starts passing when you did not fix it.** Neither site allocated a suspicious
-  amount or crashed; each simply ran for a minute or two and finished, so the row
-  came out `Clean` on a machine with 16 GB free and `KnownTrip` on a smaller one.
-  If a probe stops tripping, measure what it costs before believing it.
+  The first two were found the same way, and it is worth naming the smell: **a
+  row that starts passing when you did not fix it.** Neither site allocated a
+  suspicious amount or crashed; each simply ran for a minute or two and finished,
+  so the row came out `Clean` on a machine with 16 GB free and `KnownTrip` on a
+  smaller one. If a probe stops tripping, measure what it costs before believing
+  it.
+
+  The third was not found by the lane at all, and is the more uncomfortable case
+  (#864, from the `equals` family audit in #863). It is not a pruning loop but a
+  **reason**: one literal per value, assembled on the propagation path and then
+  discarded unread whenever the tracker does not materialise reasons. Two things
+  hid it. Its `ReifiedEquals` probe had *both* operands over the same wide
+  interval, so they always intersected and the rule never fired — the probe being
+  more extreme than necessary, exactly what the sharpening pass corrected
+  elsewhere. And once the probe was fixed to disjoint operands, it still reported
+  `Clean`: 160 s and 78 GB on a machine with 2 TB, where the same shape had died
+  with `bad_alloc` at 2.6 GB for the person who reported it.
+
+  Both halves generalise. **The lane's `bad_alloc` fallback is a property of the
+  machine, not of the code** — on a large-memory node it will not fire, so a
+  `Clean` row that nothing instruments is only as strong as the box it ran on.
+  And a reason is a place to look that a search for pruning loops will not reach:
+  guard the assembly on `InferenceTrackerBase::want_reasons()` first, then count
+  the walk that survives it.
 * **`GCS_CHECK_LARGE_DOMAIN`** checks a size up front, for the H3 sites that
   commit to a whole array at once.
 

--- a/gcs/constraints/equals/equals.cc
+++ b/gcs/constraints/equals/equals.cc
@@ -5,6 +5,7 @@
 #include <gcs/exception.hh>
 #include <gcs/innards/assertion_hints.hh>
 #include <gcs/innards/inference_tracker.hh>
+#include <gcs/innards/large_domain_guard.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/proofs/proof_model.hh>
@@ -174,18 +175,40 @@ auto gcs::innards::enforce_equality(ProofLogger * const logger, const auto & v1,
 namespace
 {
     auto no_overlap_justification(const State & state, ProofLogger * const, IntegerVariableID v1, IntegerVariableID v2, Literal cond,
-        const ConstraintID & owner) -> pair<hints::EqualsNoOverlap, Reason>
+        const ConstraintID & owner, bool want_reasons) -> pair<hints::EqualsNoOverlap, Reason>
     {
         auto v1_bounds = state.bounds(v1);
+        hints::EqualsNoOverlap no_overlap{{owner}, &state, v1, v2, v1_bounds, cond};
+
+        // The reason below is one literal per value in v1's bounds range, so
+        // assembling it is linear in how wide the domain is. Unlike the walk in
+        // emit_justification, which is the same shape but only runs when a proof
+        // is actually being written, this one sits on the propagation path -- so
+        // with proofs off it is built, never read, and thrown away. That is the
+        // situation want_reasons() exists for, and the cost is not academic:
+        // issue #864 measured 78 GB and 160 s at width 10^9, and a bad_alloc on
+        // a smaller machine. The must-not-hold pass below was guarded for the
+        // same reason in fea9508d; this call site was missed.
+        //
+        // Nothing here confines the *proof's* per-value cost, which is genuine:
+        // see #867 for whether a cheaper certificate exists.
+        if (! want_reasons)
+            return pair{no_overlap, Reason{}};
+
+        // State's own iterators are not involved -- this walks a bounds range and
+        // asks in_domain -- so the audit lane cannot see it without saying so.
+        LargeDomainIterationCounter guard{"the number of values one reified equals no-overlap reason has walked"};
         ReasonLiterals reason{{v1 >= v1_bounds.first, v1 <= v1_bounds.second}};
 
-        for (Integer val = v1_bounds.first; val <= v1_bounds.second; ++val)
+        for (Integer val = v1_bounds.first; val <= v1_bounds.second; ++val) {
+            guard.step();
             if (state.in_domain(v1, val))
                 reason.emplace_back(v2 != val);
             else
                 reason.emplace_back(v1 != val);
+        }
 
-        return pair{hints::EqualsNoOverlap{{owner}, &state, v1, v2, v1_bounds, cond}, ExplicitReason{reason}};
+        return pair{no_overlap, ExplicitReason{reason}};
     }
 
     // equals's reified verdicts are either a plain RUP (the singleton / forced
@@ -297,7 +320,7 @@ auto ReifiedEquals::install_propagators(Propagators & propagators) -> void
         return PropagatorState::Enable;
     };
 
-    auto infer_cond_when_undecided = [v1 = _v1, v2 = _v2, owner = constraint_id()](const State & state, auto &, ProofLogger * const logger,
+    auto infer_cond_when_undecided = [v1 = _v1, v2 = _v2, owner = constraint_id()](const State & state, auto & inference, ProofLogger * const logger,
                                          const IntegerVariableCondition & cond) -> ReificationVerdictFor<EqualsJustification> {
         // Aliased non-constant operands: equality definitely holds regardless of
         // domain. Returning MustHold here lets the dispatcher pin the cond
@@ -342,7 +365,7 @@ auto ReifiedEquals::install_propagators(Propagators & propagators) -> void
         else {
             // not equals is forced if there's no overlap between domains
             if (! state.domains_intersect(v1, v2)) {
-                auto [no_overlap, reason] = no_overlap_justification(state, logger, v1, v2, cond, owner);
+                auto [no_overlap, reason] = no_overlap_justification(state, logger, v1, v2, cond, owner, inference.want_reasons());
                 return reification_verdict::MustNotHold<EqualsJustification>{
                     .justification = JustifyExplicitly{no_overlap, ThenRUP::Yes}, //
                     .reason = reason                                              //

--- a/gcs/constraints/equals/equals_test.cc
+++ b/gcs/constraints/equals/equals_test.cc
@@ -1,8 +1,10 @@
 #include <gcs/constraints/equals.hh>
 #include <gcs/constraints/innards/constraints_test_utils.hh>
+#include <gcs/current_state.hh>
 #include <gcs/exception.hh>
 #include <gcs/problem.hh>
 #include <gcs/solve.hh>
+#include <gcs/stats.hh>
 
 #include <cstdlib>
 #include <functional>
@@ -187,6 +189,53 @@ auto run_no_overlap_equals_test(bool proofs) -> void
     check_results(proof_name, expected, actual);
 }
 
+// A reified equals whose operands are wide and do not overlap. Nothing else in
+// this file goes anywhere near this shape: every other domain here lives inside
+// [-10, 10], and range_infer_test works inside [0, 40], so the no-overlap rule
+// had never been asked a question whose answer depends on the width at all.
+//
+// What this pins is the *answer*: root propagation alone must decide the
+// condition, at a width where deciding it by looking at values cannot work.
+// Note what it does not pin. It would have passed before #864 was fixed too --
+// the unguarded reason walk gave the same answer, having spent 78 GB and 160 s
+// to do it, with proofs off. Cost is not checkable from here; the ReifiedEquals
+// row of the large-domain audit lane is what holds that down, and it has the
+// guard instrumentation to fail rather than merely take a long time.
+//
+// Proofs off only, and deliberately. The rule's justification emits one RUP line
+// per value in the operand's range, so the proof genuinely is linear in the
+// width and a proving run at 10^9 is hopeless rather than merely slow; whether a
+// cheaper certificate exists is #867. run_no_overlap_equals_test above carries
+// the proof coverage, at a width a checker can survive.
+//
+// Solutions are not enumerated: there are ~2.5e17 of them. Search stops at the
+// first node, which is reached only once root propagation has finished.
+auto run_wide_no_overlap_equals_test() -> void
+{
+    const auto width = 1000000000_i;
+    println(cerr, "wide no overlap equals: expecting the condition to be false after root propagation");
+
+    Problem p;
+    auto x = p.create_integer_variable(0_i, width / 2_i);
+    auto y = p.create_integer_variable(width / 2_i + 1_i, width);
+    auto b = p.create_integer_variable(0_i, 1_i);
+    p.post(EqualsIff{x, y, b == 1_i});
+
+    bool reached_a_node = false, condition_is_false = false;
+    auto check = [&](const CurrentState & s) {
+        reached_a_node = true;
+        condition_is_false = s.has_single_value(b) && s(b) == 0_i;
+        return false;
+    };
+
+    solve_with(p, SolveCallbacks{.solution = check, .trace = check, .stats_report = silent_stats_report()});
+
+    if (! reached_a_node)
+        throw UnexpectedException{"wide no overlap equals test never reached a node"};
+    if (! condition_is_false)
+        throw UnexpectedException{"wide no overlap equals did not force its condition false at the root"};
+}
+
 auto main(int argc, char * argv[]) -> int
 {
     establish_and_announce_seed(argc, argv);
@@ -241,8 +290,11 @@ auto main(int argc, char * argv[]) -> int
     for (bool proofs : {false, true}) {
         if (proofs && ! can_run_veripb())
             continue;
-        if (run_no_overlap)
+        if (run_no_overlap) {
             run_no_overlap_equals_test(proofs);
+            if (! proofs)
+                run_wide_no_overlap_equals_test();
+        }
         for (auto & [r1, r2] : data) {
             run_equals_test<Equals>("equals", proofs, view_cfg, r1, r2, [](int a, int b, int) { return a == b; });
             run_equals_test<EqualsIf>("equals if", proofs, view_cfg, r1, r2, [](int a, int b, int f) { return (! f) || (a == b); });

--- a/gcs/large_domain_audit_test.cc
+++ b/gcs/large_domain_audit_test.cc
@@ -244,9 +244,22 @@ namespace
             p.post(NotEquals{v[0], v[1]});
         });
         add("ReifiedEquals", Expect::Clean, [](Problem & p) {
-            auto v = wide(p, 2);
+            // Wide *and non-overlapping*, because that is the only shape in which
+            // the interesting rule fires. Two operands over the same wide interval
+            // -- what this probe used to be -- always intersect, so
+            // infer_cond_when_undecided returned StillUndecided and the no-overlap
+            // reason walk this row exists to test was never reached: the same
+            // "more extreme than necessary" mistake the probe-sharpening pass
+            // corrected elsewhere, and the reason #864 went unnoticed here.
+            //
+            // The walk is not one of State's iterators, so before #864 was fixed
+            // this probe still reported Clean: it cost 78 GB and 160 s and merely
+            // had the RAM to finish. Its guard coverage is hand-added in
+            // equals.cc, in the same way as Element's and AllEqual's.
+            auto lo = p.create_integer_variable(wide_lo, probe_width / 2_i);
+            auto hi = p.create_integer_variable(probe_width / 2_i + 1_i, probe_width);
             auto r = p.create_integer_variable(0_i, 1_i);
-            p.post(EqualsIff{v[0], v[1], r == 1_i});
+            p.post(EqualsIff{lo, hi, r == 1_i});
         });
 
         // --- Linear.


### PR DESCRIPTION
Two commits: the fix for #864, and the audit row that should have caught it.

## The fix

`ReifiedEquals`' no-overlap rule builds a reason of one literal per value in the first operand's bounds range and did not guard that assembly on `want_reasons()`. `SimpleInferenceTracker::materialises_reasons` is false, so with proofs off the whole vector was built, never read, and thrown away — linear in domain width in both time and memory.

The guard is the pattern already in the file: the must-not-hold pass was given it in `fea9508d`, and this call site was missed. `infer_cond_when_undecided` had left its tracker parameter unnamed, which is why the query was not to hand.

Standalone probe, proofs off, `taskset -c 4`, `EqualsIff{x, y, b == 1}` with `x` and `y` wide and disjoint:

| width | before | after |
|---|---|---|
| 10^6 | 152 ms | 1 ms |
| 10^7 | 1811 ms | 0 ms |
| 10^8 | 17296 ms | 0 ms |
| 10^9 | 160 s, 78 GB RSS | 0 ms |

**Proofs are untouched, by measurement rather than by argument**: 1136 preserved artefacts under `GCS_PRESERVE_PROOF_FILES=all` are byte-identical before and after. Reasons are materialised whenever a proof is being written, so the guard cannot fire there. What it does not do is remove the *proof's* own per-value cost, which is genuine and is #867.

## The audit row, and why it did not catch this

The `ReifiedEquals` probe posted `EqualsIff` over two operands drawn from the **same** wide interval, so they always intersected, `infer_cond_when_undecided` returned `StillUndecided` every time, and the rule the row exists to exercise was never reached. It was labelled `Clean` — which the lane defines as "has a position where a wide domain is meaningful, **and survives one**", a stronger claim than the probe supported. On the evidence it was a `HazardNotReached`.

That is the mistake the probe-sharpening pass named two screens further down: *a probe hidden by being more extreme than necessary*. Making both operands maximally wide is what made the hazard's precondition impossible.

**The second half is worse.** Sharpened to disjoint operands but with the walk still unguarded, the probe reports:

```
ReifiedEquals/disjoint                   Clean            survives
```

after 160 s and 78 GB, on a node with 2 TB. The lane's only fallback detector for an uninstrumented site is `std::bad_alloc`, and that is a fact about the machine — the same shape died at 2.6 GB where #864 was reported. So the walk gets a `LargeDomainIterationCounter` too: it is not one of `State`'s iterators, in the same way `element.cc`'s and `all_equal.cc`'s are not. With it, the row trips and the lane fails on exit 42, verified by suppressing the fix.

Outcome counts are unchanged at 37 `Clean` / 19 `KnownTrip` / 14 `NoWidePosition` — this sharpens a row rather than adding one — and the whole lane is 3.4 s and 22 MB.

## Tests

`equals_test` gains the wide non-overlapping case the file had no equivalent of: every other domain in it is inside `[-10, 10]`, and `range_infer_test` works inside `[0, 40]`, which is why nothing here could have caught this.

It pins the **answer**, not the cost — it would have passed before this fix too, slowly — and its comment says so and points at the audit row that does hold the cost down. Proofs off only, deliberately: the justification emits one RUP line per value, so a proving run at this width is hopeless rather than merely slow. `run_no_overlap_equals_test` carries the proof coverage at a width a checker can survive.

## Documentation

`dev_docs/large-domains.md` gains the third instrumented site and the two things that generalise: that a `Clean` row nothing instruments is only as strong as the box it ran on, and that a **reason** is a place a search for pruning loops will not reach — guard the assembly on `want_reasons()` first, then count the walk that survives.

## Verification

804/804 with GCC and 808/808 with clang, **no tests skipped** (MiniZinc 2.9.7, `cake_pb_cp` and `opbdiff` all on `PATH`). `equals_test` verifies 284 proofs under the guard build. Audit lane green with the guard on. clang-format 21.1.8 clean.

Fixes #864.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EdcpzKhRabS67Kcfq3eq9e
