### PR TITLE
An interval-wise no-overlap witness for reified equals (#867)

### DIFF
--- a/dev_docs/large-domains.md
+++ b/dev_docs/large-domains.md
@@ -292,6 +292,22 @@ Two kinds of check, and the difference matters:
   And a reason is a place to look that a search for pruning loops will not reach:
   guard the assembly on `InferenceTrackerBase::want_reasons()` first, then count
   the walk that survives it.
+
+  What the counter at that site now counts is *moves of an interval walk*, not
+  values (#867). A reason that says "these two domains do not overlap" one value
+  at a time is width-proportional by construction, and the guard is then the only
+  thing standing between a wide model and the cliff. Restating it over runs —
+  "v1 has nothing in [lo, hi]", "v2 has nothing in [lo, hi]", and the bounds that
+  separate them — makes the same fact cost one literal per run instead, which for
+  two hole-free domains on opposite sides of a point is two literals at any
+  width. **A width-proportional reason is worth trying to restate before it is
+  worth guarding**, because the guard only converts a hang into an exception,
+  whereas the restatement removes the width from the cost. The interval
+  vocabulary this uses is `dev_docs/range_literals_spec.md`; its one gap is
+  views, which have no range literal (#882), so a run of values a *view* cannot
+  take is still spelled out one value at a time and the counter still covers it.
+  Note the granularity: it is that run that degrades, not the rule, so a view
+  pays for its own holes rather than for the width of anything.
 * **`GCS_CHECK_LARGE_DOMAIN`** checks a size up front, for the H3 sites that
   commit to a whole array at once.
 

--- a/dev_docs/range_literals_spec.md
+++ b/dev_docs/range_literals_spec.md
@@ -160,6 +160,21 @@ it. Revisit only if a propagator's explicit scaffolding turns out to need
 the per-value spelling (it can always construct its reason explicitly), or
 if the small-interval overhead grows beyond the noise it currently is.
 
+*Second consumer (2026-09, #867):* `ReifiedEquals`' no-overlap rule is the
+first propagator to take the "construct it explicitly" route, and it is worth
+recording what that looked like, because it was not just a spelling change.
+Saying "these two domains are disjoint" per value costs one literal and one
+lemma per value; saying it over runs needs a *walk* — an invariant (`v1 >= p`)
+carried up the number line, one move per run, each move either a hole of v1
+(free: the range literal's own reverse reification steps `p` over it) or a run
+where v2 is empty (two bound-crossing lemmas, the reified analogue of
+`justify_not_in_range_across_equality`). The witness and the reason come out of
+the *same* walk, in the same order, because the lemmas exist precisely to let
+unit propagation see that reason's literals through; writing them as two
+independent functions is how they drift. A run whose variable is a view is
+spelled per value, per §9.1 — one run, not the whole rule, and the witness does
+not notice, because stepping over a run is internal to that variable either way.
+
 ## 5. Why this is believed complete (and what still needs proving)
 
 Intra-variable falsification induction: if interval F is truly excluded by
@@ -361,6 +376,17 @@ and which branching were active.
    (`ProofLogger::infer_not_in_range` already branches; reasons likewise).
    Folding views in = deview the interval onto the underlying variable;
    deferred, do not block on it.
+
+   *Priced (2026-09, #882):* eight sites now carry a view detour — three that
+   throw and five that degrade, two of those being the same code written twice
+   — and since the interval vocabulary became the ordinary one, the gap between
+   them is a domain width rather than a constant. #882 has the inventory, and
+   the two candidate designs: deview onto the underlying variable, or define
+   range literals over a registered view's own bits and let the *cuts* cross
+   the view's defining equality. The second is a live possibility because a
+   range literal never crosses an equality — only its two order cuts do, one
+   bound at a time (#867/#881) — but that is a hand UP analysis, so it is a
+   reason to test it, not to adopt it (§1).
 2. **Reasons are resolved at four sites** in `proof_logger.cc` (two `infer`
    paths, `emit_under_reason`, `reason_to_lits`). Any reason-vocabulary
    change must hit all four; missing one no-ops silently (cost a day, twice).

--- a/gcs/constraints/equals/equals.cc
+++ b/gcs/constraints/equals/equals.cc
@@ -11,6 +11,7 @@
 #include <gcs/innards/proofs/proof_model.hh>
 #include <gcs/innards/propagators.hh>
 #include <gcs/innards/s_expr.hh>
+#include <gcs/interval_set.hh>
 
 #include <util/overloaded.hh>
 
@@ -44,15 +45,159 @@ using std::print;
 using fmt::print;
 #endif
 
+namespace
+{
+    // One move of the no-overlap walk. The walk is the certificate that two
+    // domains are disjoint, stated over *runs* rather than values: see
+    // walk_no_overlap below for what it maintains and why these are the moves.
+    enum class NoOverlapStep
+    {
+        AnchorV1Lower,    ///< the walk starts at v1's lower bound: `v1 >= lo`.
+        JumpToV2Lower,    ///< `v2 >= lo`, so under cond v1 is there too. lo == hi.
+        SkipV1Hole,       ///< v1 has no value in [lo, hi], so it is already past hi.
+        SkipV2Hole,       ///< v2 has no value in [lo, hi], so under cond neither has v1.
+        StopAboveV1Upper, ///< `v1 <= lo` and the walk has reached hi > lo: contradiction.
+        StopAboveV2Upper  ///< `v2 <= lo` and the walk has reached hi > lo: contradiction, under cond.
+    };
+
+    // Walk two disjoint domains, reporting a certificate of their disjointness
+    // whose length is the number of runs it takes to say it, not the number of
+    // values the domains span.
+    //
+    // The walk carries one invariant up the number line: at each point p, the
+    // facts reported so far (together with the reification condition, which
+    // makes the two operands equal) force `v1 >= p`. It starts at v1's lower
+    // bound, and each move pushes p past one maximal run of values v1 cannot
+    // take -- either because v1 itself has nothing there, or because *v2* has
+    // nothing there and under cond v1 must be wherever v2 is. p is strictly
+    // increasing, so the walk stops after at most one move per interval of
+    // either domain, and it stops by running p off the top of one of the two
+    // domains, which is the contradiction the conclusion needs.
+    //
+    // Both consumers -- the reason builder, which turns each move into a
+    // literal, and emit_justification, which turns each move into zero, one or
+    // two lemmas -- go through here, because the lemmas' whole job is to let
+    // unit propagation see that reason's literals through, so the two must be
+    // reporting the same walk.
+    //
+    // \p d1 and \p d2 must be non-empty and disjoint, which is exactly the
+    // condition the rule fires under.
+    template <typename Step_>
+    auto walk_no_overlap(const IntervalSet<Integer> & d1, const IntervalSet<Integer> & d2, Step_ && step) -> void
+    {
+        vector<pair<Integer, Integer>> i1, i2;
+        for (const auto & i : d1.each_interval())
+            i1.push_back(i);
+        for (const auto & i : d2.each_interval())
+            i2.push_back(i);
+        if (i1.empty() || i2.empty())
+            throw UnexpectedException{"equals no-overlap walk over an empty domain"};
+
+        auto [lb1, ub1] = pair{i1.front().first, i1.back().second};
+        auto [lb2, ub2] = pair{i2.front().first, i2.back().second};
+
+        // Establish `v1 >= p` for the first time. If v2 starts above v1 does,
+        // v2's own lower bound gets us there and v1's is never mentioned --
+        // which is what makes the bounds-disjoint case a two-literal reason.
+        auto p = lb1;
+        if (p < lb2) {
+            step(NoOverlapStep::JumpToV2Lower, lb2, lb2);
+            p = lb2;
+        }
+        else
+            step(NoOverlapStep::AnchorV1Lower, lb1, lb1);
+
+        // The cursors only ever move forwards, because p does; each keeps the
+        // first interval of its domain that has not already been passed.
+        std::size_t j1 = 0, j2 = 0;
+        while (true) {
+            if (p > ub1) {
+                step(NoOverlapStep::StopAboveV1Upper, ub1, p);
+                return;
+            }
+            if (p > ub2) {
+                step(NoOverlapStep::StopAboveV2Upper, ub2, p);
+                return;
+            }
+
+            // p <= ub1 and p <= ub2, so neither search runs off the end.
+            while (i1[j1].second < p)
+                ++j1;
+            while (i2[j2].second < p)
+                ++j2;
+
+            if (p < i1[j1].first) {
+                // p is outside v1. It may be outside v2 as well, in which case
+                // the v2-free run from here could be the longer of the two and
+                // taking it would end the walk in fewer moves. Take v1's anyway:
+                // its move costs no lemmas, v2's costs two, and the choice only
+                // ever changes the move count by a constant factor -- the bound
+                // is one move per interval of either domain either way.
+                auto hi = i1[j1].first - 1_i;
+                step(NoOverlapStep::SkipV1Hole, p, hi);
+                p = hi + 1_i;
+            }
+            else {
+                // p is a value of v1, so disjointness says it is not one of v2,
+                // and v2's next interval starts strictly above it.
+                if (i2[j2].first <= p)
+                    throw UnexpectedException{"equals no-overlap walk over domains that do overlap"};
+                auto hi = i2[j2].first - 1_i;
+                step(NoOverlapStep::SkipV2Hole, p, hi);
+                p = hi + 1_i;
+            }
+        }
+    }
+
+}
+
 namespace gcs::innards::hints
 {
     auto emit_justification(ProofLogger & logger, const EqualsNoOverlap & w, const ReasonLiterals &) -> void
     {
-        for (Integer val = w.v1_bounds.first; val <= w.v1_bounds.second; ++val)
-            if (w.state->in_domain(w.v1, val))
-                logger.emit_rup_proof_line(WPBSum{} + 1_i * (w.v1 != val) + 1_i * (w.v2 == val) + 1_i * ! w.cond >= 1_i, ProofLevel::Temporary);
-            else
-                logger.emit_rup_proof_line(WPBSum{} + 1_i * (w.v2 != val) + 1_i * (w.v1 == val) + 1_i * ! w.cond >= 1_i, ProofLevel::Temporary);
+        // Two lemma shapes, each carrying one bound across the reified equality.
+        // The cond-guarded halves of the model constraint are `cond -> v1 <= v2`
+        // and `cond -> v1 >= v2`, so each lemma's negation supplies a pair of
+        // opposing bounds against one of them: the Theorem 2.9 configuration
+        // that makes it RUP, exactly as in justify_not_in_range_across_equality
+        // (which cannot be reused directly here only because these halves are
+        // reified, so the lemmas carry the extra `! cond`).
+        auto v2_lower_reaches_v1 = [&](Integer k) {
+            logger.emit_rup_proof_line(WPBSum{} + 1_i * ! w.cond + 1_i * (w.v2 < k) + 1_i * (w.v1 >= k) >= 1_i, ProofLevel::Temporary);
+        };
+        auto v1_lower_reaches_v2 = [&](Integer k) {
+            logger.emit_rup_proof_line(WPBSum{} + 1_i * ! w.cond + 1_i * (w.v1 < k) + 1_i * (w.v2 >= k) >= 1_i, ProofLevel::Temporary);
+        };
+
+        // What each move owes the conclusion's RUP check, given that the check
+        // has cond and the reason's literals as units and is carrying `v1 >= p`:
+        //
+        //   AnchorV1Lower       the reason literal is `v1 >= lo` itself.
+        //   JumpToV2Lower       `v2 >= lo` is a reason literal; one lemma turns
+        //                       it into `v1 >= lo`.
+        //   SkipV1Hole          nothing: `~[v1 in lo..hi]` and `v1 >= lo` meet in
+        //                       the range literal's own reverse reification,
+        //                       which gives `v1 >= hi + 1`.
+        //   SkipV2Hole          `v1 >= lo` crosses to `v2 >= lo`, that and
+        //                       `~[v2 in lo..hi]` give `v2 >= hi + 1` through
+        //                       v2's reverse reification, and that crosses back.
+        //   StopAboveV1Upper    nothing: `v1 >= hi` and the reason's `v1 <= lo`
+        //                       are opposite ends of v1's own order chain.
+        //   StopAboveV2Upper    `v1 >= hi` crosses to `v2 >= hi`, against the
+        //                       reason's `v2 <= lo`.
+        walk_no_overlap(w.state->copy_of_values(w.v1), w.state->copy_of_values(w.v2), [&](NoOverlapStep kind, Integer lo, Integer hi) {
+            switch (kind) {
+            case NoOverlapStep::AnchorV1Lower:
+            case NoOverlapStep::SkipV1Hole:
+            case NoOverlapStep::StopAboveV1Upper: break;
+            case NoOverlapStep::JumpToV2Lower: v2_lower_reaches_v1(lo); break;
+            case NoOverlapStep::SkipV2Hole:
+                v1_lower_reaches_v2(lo);
+                v2_lower_reaches_v1(hi + 1_i);
+                break;
+            case NoOverlapStep::StopAboveV2Upper: v1_lower_reaches_v2(hi); break;
+            }
+        });
     }
 }
 
@@ -177,36 +322,75 @@ namespace
     auto no_overlap_justification(const State & state, ProofLogger * const, IntegerVariableID v1, IntegerVariableID v2, Literal cond,
         const ConstraintID & owner, bool want_reasons) -> pair<hints::EqualsNoOverlap, Reason>
     {
-        auto v1_bounds = state.bounds(v1);
-        hints::EqualsNoOverlap no_overlap{{owner}, &state, v1, v2, v1_bounds, cond};
+        hints::EqualsNoOverlap no_overlap{{owner}, &state, v1, v2, cond};
 
-        // The reason below is one literal per value in v1's bounds range, so
-        // assembling it is linear in how wide the domain is. Unlike the walk in
-        // emit_justification, which is the same shape but only runs when a proof
-        // is actually being written, this one sits on the propagation path -- so
-        // with proofs off it is built, never read, and thrown away. That is the
-        // situation want_reasons() exists for, and the cost is not academic:
-        // issue #864 measured 78 GB and 160 s at width 10^9, and a bad_alloc on
-        // a smaller machine. The must-not-hold pass below was guarded for the
-        // same reason in fea9508d; this call site was missed.
-        //
-        // Nothing here confines the *proof's* per-value cost, which is genuine:
-        // see #867 for whether a cheaper certificate exists.
+        // Assembling the reason is linear in the length of the witness. Unlike
+        // the walk in emit_justification, which is the same shape but only runs
+        // when a proof is actually being written, this one sits on the
+        // propagation path -- so with proofs off it is built, never read, and
+        // thrown away. That is the situation want_reasons() exists for, and when
+        // this witness was per-value the cost was not academic: issue #864
+        // measured 78 GB and 160 s at width 10^9, and a bad_alloc on a smaller
+        // machine. The must-not-hold pass below was guarded for the same reason
+        // in fea9508d; this call site was missed.
         if (! want_reasons)
             return pair{no_overlap, Reason{}};
 
-        // State's own iterators are not involved -- this walks a bounds range and
-        // asks in_domain -- so the audit lane cannot see it without saying so.
-        LargeDomainIterationCounter guard{"the number of values one reified equals no-overlap reason has walked"};
-        ReasonLiterals reason{{v1 >= v1_bounds.first, v1 <= v1_bounds.second}};
+        // State's own iterators are not involved -- this walks domains directly
+        // -- so the audit lane cannot see it without saying so.
+        LargeDomainIterationCounter guard{"the number of literals one reified equals no-overlap reason has walked"};
+        ReasonLiterals reason;
 
-        for (Integer val = v1_bounds.first; val <= v1_bounds.second; ++val) {
-            guard.step();
-            if (state.in_domain(v1, val))
-                reason.emplace_back(v2 != val);
+        // A run of values one operand cannot take is one range condition -- unless
+        // that operand is a view, which has no range literal (#882), in which case
+        // it is spelled out, the same degradation generic_reason and
+        // ProofLogger::infer already make. Only the run is spelled out: the rest of
+        // the walk is unaffected, so a view pays for its own holes and not for the
+        // width of anything.
+        //
+        // The witness does not care which spelling a run got. Stepping `v1 >= lo`
+        // to `v1 >= hi + 1` is the range literal's reverse reification in one case
+        // and the eq atoms walking the order chain in the other; either way it is
+        // internal to that variable and needs no lemma from us. Which is why this
+        // is a fallback in the reason and nowhere else.
+        auto skip_run = [&](IntegerVariableID var, Integer lo, Integer hi) {
+            if (lo == hi || ! std::holds_alternative<ViewOfIntegerVariableID>(var)) {
+                guard.step();
+                reason.emplace_back(not_in_range(var, lo, hi));
+            }
             else
-                reason.emplace_back(v1 != val);
-        }
+                for (auto val = lo; val <= hi; ++val) {
+                    guard.step();
+                    reason.emplace_back(var != val);
+                }
+        };
+
+        // One literal per move of the walk: the runs that make the two domains
+        // disjoint, rather than the values in them. In the common shape -- two
+        // hole-free domains lying on opposite sides of some point -- that is the
+        // two bounds that separate them and nothing else.
+        walk_no_overlap(state.copy_of_values(v1), state.copy_of_values(v2), [&](NoOverlapStep kind, Integer lo, Integer hi) {
+            switch (kind) {
+            case NoOverlapStep::AnchorV1Lower:
+                guard.step();
+                reason.emplace_back(v1 >= lo);
+                break;
+            case NoOverlapStep::JumpToV2Lower:
+                guard.step();
+                reason.emplace_back(v2 >= lo);
+                break;
+            case NoOverlapStep::SkipV1Hole: skip_run(v1, lo, hi); break;
+            case NoOverlapStep::SkipV2Hole: skip_run(v2, lo, hi); break;
+            case NoOverlapStep::StopAboveV1Upper:
+                guard.step();
+                reason.emplace_back(v1 <= lo);
+                break;
+            case NoOverlapStep::StopAboveV2Upper:
+                guard.step();
+                reason.emplace_back(v2 <= lo);
+                break;
+            }
+        });
 
         return pair{no_overlap, ExplicitReason{reason}};
     }

--- a/gcs/constraints/equals/equals_test.cc
+++ b/gcs/constraints/equals/equals_test.cc
@@ -7,6 +7,7 @@
 #include <gcs/stats.hh>
 
 #include <cstdlib>
+#include <fstream>
 #include <functional>
 #include <iostream>
 #include <random>
@@ -189,6 +190,50 @@ auto run_no_overlap_equals_test(bool proofs) -> void
     check_results(proof_name, expected, actual);
 }
 
+// A reified equals whose operands are disjoint but *interleaved*: each one's
+// values sit in the other's holes, so no bound separates them and the witness
+// has to account for every run. This is the shape the interval certificate of
+// #867 exists for, and the only one in this file that reaches the two moves
+// that carry a range literal -- "v1 has nothing in [lo, hi]", which needs no
+// lemma, and "v2 has nothing in [lo, hi]", which needs two.
+//
+// Both orders are run, because the walk is not symmetric: it climbs v1's domain,
+// so which operand is first decides whether it starts at v1's lower bound or at
+// v2's, and whether it ends by running off the top of v1 or of v2. Between them
+// the two orders reach all six moves.
+//
+// Proofs on, and it is the proof that is the point: the reason is stated over
+// intervals, and the conclusion is only RUP if the lemmas emitted alongside it
+// let unit propagation see those interval literals through. Verified, so a
+// missing lemma is a red lane rather than a silently weaker proof.
+auto run_holey_no_overlap_equals_test(bool proofs, bool swapped) -> void
+{
+    print(cerr, "holey no overlap equals {}{}", swapped ? "swapped" : "plain", proofs ? " with proofs:" : ":");
+    cerr << flush;
+
+    // Two blocks each, interleaved: {0..3, 8..11} against {4..7, 12..15}.
+    vector<Integer> lower_first, upper_first;
+    for (Integer v = 0_i; v <= 15_i; ++v)
+        ((v / 4_i) % 2_i == 0_i ? lower_first : upper_first).push_back(v);
+
+    set<tuple<int, int, int>> expected, actual;
+    for (const auto & xv : swapped ? upper_first : lower_first)
+        for (const auto & yv : swapped ? lower_first : upper_first)
+            expected.emplace(static_cast<int>(xv.raw_value), static_cast<int>(yv.raw_value), 0);
+    println(cerr, " expecting {} solutions", expected.size());
+
+    Problem p;
+    auto x = p.create_integer_variable(swapped ? upper_first : lower_first);
+    auto y = p.create_integer_variable(swapped ? lower_first : upper_first);
+    auto b = p.create_integer_variable(0_i, 1_i);
+    p.post(EqualsIff{x, y, b == 1_i});
+
+    auto proof_name = proofs ? make_optional("equals_test_holey_" + string{swapped ? "swapped" : "plain"}) : nullopt;
+    solve_for_tests(p, proof_name, actual, tuple{x, y, b});
+
+    check_results(proof_name, expected, actual);
+}
+
 // A reified equals whose operands are wide and do not overlap. Nothing else in
 // this file goes anywhere near this shape: every other domain here lives inside
 // [-10, 10], and range_infer_test works inside [0, 40], so the no-overlap rule
@@ -202,11 +247,9 @@ auto run_no_overlap_equals_test(bool proofs) -> void
 // row of the large-domain audit lane is what holds that down, and it has the
 // guard instrumentation to fail rather than merely take a long time.
 //
-// Proofs off only, and deliberately. The rule's justification emits one RUP line
-// per value in the operand's range, so the proof genuinely is linear in the
-// width and a proving run at 10^9 is hopeless rather than merely slow; whether a
-// cheaper certificate exists is #867. run_no_overlap_equals_test above carries
-// the proof coverage, at a width a checker can survive.
+// Proofs off only, and deliberately: at this width the *reason* is the thing
+// under test and it is only built when reasons are wanted. The proof side has
+// its own test below, at a width whose regression is slow rather than fatal.
 //
 // Solutions are not enumerated: there are ~2.5e17 of them. Search stops at the
 // first node, which is reached only once root propagation has finished.
@@ -234,6 +277,62 @@ auto run_wide_no_overlap_equals_test() -> void
         throw UnexpectedException{"wide no overlap equals test never reached a node"};
     if (! condition_is_false)
         throw UnexpectedException{"wide no overlap equals did not force its condition false at the root"};
+}
+
+// The same shape, proved, and this one pins the *cost*: it fails if the witness
+// goes back to being one line per value.
+//
+// Before #867 the rule's justification emitted one RUP line per value in the
+// first operand's bounds range, so a proving run at this width wrote a hundred
+// megabytes of proof for a fact that two bounds settle -- which is why the test
+// above could only be run with proofs off. The interval witness states it in a
+// fixed handful of lines at any width, so the assertion is on the proof's line
+// count, checked before the proof is handed to veripb.
+//
+// The bound is loose, and deliberately not a pinned figure. Most of what a proof
+// this small contains is fixed overhead -- the header, the initial bound axioms,
+// the order-encoding definitions the conclusion's literals pull in -- and that
+// part is free to move as unrelated proof scaffolding changes, whereas the thing
+// under test is whether the witness is a constant or a million lines. Any
+// threshold between the two separates them; pinning the exact figure would only
+// buy a lane that goes red for reasons that have nothing to do with this rule.
+//
+// The width is 10^6 rather than the 10^9 above: a regression must fail, not
+// wedge, and at 10^9 a per-value witness would fill the disk before anything
+// could notice.
+auto run_wide_proved_no_overlap_equals_test() -> void
+{
+    const auto width = 1000000_i;
+    const auto line_budget = 1000;
+    println(cerr, "wide no overlap equals with proofs: expecting a proof of well under {} lines", line_budget);
+
+    Problem p;
+    auto x = p.create_integer_variable(0_i, width / 2_i);
+    auto y = p.create_integer_variable(width / 2_i + 1_i, width);
+    auto b = p.create_integer_variable(0_i, 1_i);
+    p.post(EqualsIff{x, y, b == 1_i});
+
+    // Solutions are not enumerated: there are ~2.5e11 of them. Stopping at the
+    // first node still completes a checkable proof, exactly as
+    // check_initialisation_only_for_tests does.
+    const string proof_name = "equals_test_wide_proved";
+    solve_with(
+        p, SolveCallbacks{.trace = [](const CurrentState &) -> bool { return false; }}, make_optional<ProofOptions>(ProofFileNames{proof_name}));
+
+    auto lines = 0;
+    {
+        std::ifstream proof{proof_name + ".pbp"};
+        if (! proof)
+            throw UnexpectedException{"wide proved no overlap equals wrote no proof"};
+        for (string line; getline(proof, line);)
+            ++lines;
+    }
+    println(cerr, "wide no overlap equals proof is {} lines", lines);
+    if (lines > line_budget)
+        throw UnexpectedException{"wide proved no overlap equals wrote " + std::to_string(lines) +
+            " proof lines, which is not a witness whose size is independent of the domain width"};
+
+    verify_proof_and_clean_up(proof_name);
 }
 
 auto main(int argc, char * argv[]) -> int
@@ -292,7 +391,11 @@ auto main(int argc, char * argv[]) -> int
             continue;
         if (run_no_overlap) {
             run_no_overlap_equals_test(proofs);
-            if (! proofs)
+            run_holey_no_overlap_equals_test(proofs, false);
+            run_holey_no_overlap_equals_test(proofs, true);
+            if (proofs)
+                run_wide_proved_no_overlap_equals_test();
+            else
                 run_wide_no_overlap_equals_test();
         }
         for (auto & [r1, r2] : data) {

--- a/gcs/constraints/equals/hints.hh
+++ b/gcs/constraints/equals/hints.hh
@@ -34,11 +34,16 @@ namespace gcs::innards::hints
      * \brief equals's "domains don't overlap" hint, carried in a reified verdict.
      *
      * Extends the base with the `no_overlap` subhint and the emit context the
-     * internal proof writer reads to emit the per-value RUP lemmas: the operands,
-     * the bounds walked over, and the reification condition. The State pointer is
-     * valid because the verdict is consumed synchronously while the constraint is
-     * live. The data is held for emit_justification only; with no own hint_sexpr
-     * the hint takes the default identity-plus-subhint wire form.
+     * internal proof writer reads to re-walk the disjointness: the operands and
+     * the reification condition. The State pointer is valid because the verdict
+     * is consumed synchronously while the constraint is live. The data is held
+     * for emit_justification only; with no own hint_sexpr the hint takes the
+     * default identity-plus-subhint wire form.
+     *
+     * Nothing here says how the reason spelled its runs, because the lemmas do
+     * not depend on it: a run is stepped over inside one variable, by its range
+     * literal's reverse reification or by its eq atoms walking the order chain,
+     * and either way the witness owes it nothing.
      *
      * \ingroup Innards
      */
@@ -47,7 +52,6 @@ namespace gcs::innards::hints
         static constexpr std::string_view subhint_name = "no_overlap";
         const State * state;
         IntegerVariableID v1, v2;
-        std::pair<Integer, Integer> v1_bounds;
         Literal cond;
     };
 


### PR DESCRIPTION
> **Merge order.** This is stacked on #873 and its base is
> `issue864-equals-no-overlap-guard`, not `main`. **Retarget this PR to `main`
> before merging #873**, not after: merging #873 with `--delete-branch` closes
> every PR that targets that branch, and GitHub then refuses both `gh pr reopen`
> and `gh pr edit --base`. Prefer a squash or merge commit for #873 as well — a
> rebase-merge replays it under a new SHA and leaves this branch reporting
> conflicts it does not have.

Stacked on #873. #873 stopped the no-overlap
reason being *built* when nothing reads it; this is the other half of the same
rule, and the question #867 actually asked: **when the proof genuinely is
wanted, is a cheaper certificate available at all?**

Yes. Option 3 of that issue — an interval-wise certificate for the general
case — and it subsumes option 2 rather than sitting beside it.

## The argument

The rule's witness said "no value is in both domains", enumerated. But
disjointness is a statement about *runs*, and the walk that states it carries
one invariant up the number line: at each point `p`, the facts stated so far —
together with the reification condition, which makes the two operands equal —
force `v1 >= p`. Every move pushes `p` past one maximal run `v1` cannot occupy:

| move | reason literal | lemmas |
|---|---|---|
| start at v1's lower bound | `v1 >= lb1` | — |
| v2 starts higher, jump to it | `v2 >= lb2` | 1 |
| a hole of v1 | `~[v1 in lo..hi]` | — |
| a run where v2 is empty | `~[v2 in lo..hi]` | 2 |
| p ran off the top of v1 | `v1 <= ub1` | — |
| p ran off the top of v2 | `v2 <= ub2` | 1 |

A hole of `v1` is free: the range literal's own reverse reification steps `p`
over it. A run where `v2` is empty costs the two bound-crossing lemmas — the
reified analogue of `justify_not_in_range_across_equality`, each RUP by the same
opposing-bounds configuration, carrying the extra `! cond` because the model's
`le` / `ge` halves are half-reified. The walk ends by pushing `p` off the top of
one of the two domains, which is the contradiction the conclusion needs.

So the reason is one literal per run and the proof at most two lines per run,
against `2 + width` and `width + 1`.

**The two hole-free domains case falls out rather than being special-cased.**
Nothing anchors on `v1`'s lower bound when `v2` starts above it, so the reason
is `{v2 >= lb2, v1 <= ub1}` — two literals, one lemma, at any width. That is
also a *strictly more general* nogood than the per-value reason it replaces.

**The witness and the reason come out of the same walk**, in the same order, via
one generator (`walk_no_overlap`). Not tidiness: the lemmas exist precisely to
let the conclusion's RUP check see that reason's literals through, so the two
drifting apart is a proof that stops checking.

## Measured

One `EqualsIff{x, y, b == 1}` with the operands on opposite sides of a point,
proofs on, `taskset`, root propagation only. Line counts are deterministic; the
0.10 s figures are veripb's own process floor on this box, and the 10^5 `before`
row hit a 900 s cap rather than finishing.

| width | before: proof | before: check | after: proof | after: check |
|---|---|---|---|---|
| 10^3 | 6,525 lines, 579 KB | 0.10 s | **13 lines, 965 B** | 0.10 s |
| 10^4 | 65,025 lines, 7.3 MB | 8.2 s | **13 lines, 1.2 KB** | 0.10 s |
| 10^5 | 650,025 lines, 85 MB | **timed out at 900 s** | **13 lines, 1.5 KB** | 0.10 s |
| 10^6 | 6,500,025 lines | — | **13 lines** | — |
| 10^9 | (hopeless) | — | **13 lines, 2.6 KB** | 0.10 s |

Thirteen lines at every width, because two hole-free domains on opposite sides
of a point need two bounds and one lemma however far apart they are. A
width-10^9 reified equals over disjoint operands now has a proof a checker reads
in a tenth of a second; before this it had 10^9 of them.

### And the case it does not help, which is the right answer

Interleaved domains — `x` the evens, `y` the odds — are the shape where every
run *is* one value, so a per-run witness is a per-value witness. It should cost
the same, and it does:

| width | before | after |
|---|---|---|
| 200 | 1,221 lines, 0.10 s | 1,207 lines, 0.10 s |
| 2,000 | 12,021 lines, 5.4 s | 12,007 lines, 5.1 s |
| 20,000 | 120,021 lines, timed out at 900 s | 120,007 lines, timed out at 900 s |

No regression, no win — the fourteen lines are the bound moves replacing
per-value ones at the two ends — and at 20,000 the proof is intractable either
way. "One line per run" is an honest bound rather than a disguised constant, and
this is what it looks like when the runs *are* the values. If that shape ever
matters, it needs a different argument (a parity or lattice one), not a better
walk.

## Views: one run at a time, and #882 for the general fix

Views have no range literal, so a run of values a *view* cannot take is spelled
out one value at a time. Three things about that:

- **It degrades the run, not the rule.** The rest of the walk is unaffected, so
  a view pays for its own holes and not for the width of anything, and the
  bounds-disjoint shape — #864's, and the common one — is on the interval path
  for views too. That is the same granularity `generic_reason` already uses.
- **The witness does not need telling.** Stepping `v1 >= lo` to `v1 >= hi + 1`
  is the range literal's reverse reification in one spelling and the eq atoms
  walking the order chain in the other; either way it happens inside that one
  variable and owes the proof nothing. So `emit_justification` has a single
  path and the hint carries no mode flag. Confirmed by instrumentation: the
  per-value arm is taken 61 / 37 / 28 times under `--view-position=mixed`,
  `--view-wrap=5 --view-position=1` and `--view-wrap=9 --view-position=all`,
  all veripb-verified.
- **The general fix is #882, not this.** That issue has the inventory — eight
  view detours, three that throw and five that degrade, two of the latter being
  the same code written twice — and the two candidate designs. It also records
  the one piece of theory this PR turned up that bears on it: a range literal
  never crosses an equality, only its two order cuts do, so the "unlinked
  literals" objection to defining them over a registered view's own bits may
  not bite. A reason to test that design, not to adopt it.

Constants and zero-one variables need no fallback at all: a run wider than one
value lies strictly inside its variable's bounds and misses its domain entirely,
which takes three values and two intervals, and neither has those.

## Tests

**The interleaved shape, both operand orders, veripb-verified.** This is what
reaches the two moves that carry a range literal; the walk is not symmetric (it
climbs `v1`), so the two orders between them reach all six moves — confirmed by
instrumenting the walk and counting.

**The lemma set is load-bearing, and no single lemma is.** Emitting no lemmas
fails at `equals_test_holey_plain.pbp:32`. Deleting any one of the four leaves
the suite green. That is §1 of the range-literal spec exactly — a RUP check is
strictly stronger than the UP pass later checks lean on, so every clause looks
deletable one at a time — which is why they all stay rather than being trimmed
to whatever the tests happen to notice.

**A cost test, not just an answer test.** #873's wide test could only pin the
answer; its comment says so. `run_wide_proved_no_overlap_equals_test` posts the
same shape at width 10^6, asserts on the proof's *line count* before handing it
to veripb, and fails rather than merely being slow. Its negative control is
real: built against this PR's base it reports 6,500,025 lines and throws. 10^6
rather than 10^9 because a regression must fail, not fill the disk.

## Verification

- `ctest` 804/804 with default caps, and 804/804 with `-DGCS_TEST_CAP_DEFAULTS=OFF`.
- clang + `-D_GLIBCXX_ASSERTIONS`: 668/668.
- GCC `-DGCS_WERROR=ON`: clean.
- `equals_test` under `--view-position=mixed` and five `--view-wrap=N
  --view-position=K` configurations, which is where the per-value fallback and
  the view/interval mix are exercised (both paths confirmed reached by
  instrumentation).

## Not done

The walk prefers a hole of `v1` over a run where `v2` is empty when both are
available, because that move costs no lemmas. It is not the greedy-longest
choice, so the move count is within a constant factor of minimal rather than
minimal.

Folding views into the interval vocabulary is **#882** and is deliberately not
in here: it is a change to the range-literal clause set, which carries the §8
witness-suite change protocol, and it deletes seven other sites as well as this
one.
