### PR TITLE
Carry _neq through ReifiedEquals::clone() (#865)

### DIFF
--- a/gcs/constraints/equals/equals.cc
+++ b/gcs/constraints/equals/equals.cc
@@ -407,7 +407,14 @@ ReifiedEquals::ReifiedEquals(const IntegerVariableID v1, const IntegerVariableID
 
 auto ReifiedEquals::clone() const -> unique_ptr<Constraint>
 {
-    return make_unique<ReifiedEquals>(_v1, _v2, _cond);
+    // _neq must come along: both Problem::post and Problem::create_propagators
+    // clone, so a clone that drops it is the only ReifiedEquals anything ever
+    // reads, and the flag is false everywhere it is asked (issue #865). It
+    // controls the written description, not the propagation -- the semantic
+    // flip lives in the derived constructors' negated conditions -- so dropping
+    // it made a NotEqualsIff describe itself as an equals_iff over a negated
+    // condition, which is the same constraint said backwards.
+    return make_unique<ReifiedEquals>(_v1, _v2, _cond, _neq);
 }
 
 auto ReifiedEquals::prepare(Propagators &, State & initial_state, ProofModel * const) -> bool

--- a/gcs/constraints/equals/equals_test.cc
+++ b/gcs/constraints/equals/equals_test.cc
@@ -335,6 +335,78 @@ auto run_wide_proved_no_overlap_equals_test() -> void
     verify_proof_and_clean_up(proof_name);
 }
 
+// What the constraint *says* it is, and whether it means what it says.
+//
+// The equals family writes six descriptions, and one of them used to be a
+// description of a different constraint: a NotEqualsIff came out as an
+// `equals_iff` over a negated condition, because ReifiedEquals::clone() dropped
+// the flag that picks the keyword and Problem::post clones (issue #865). That is
+// the same constraint said backwards, so it cost nothing -- until half of it
+// were repaired, at which point the two negations stop cancelling and the .scp
+// says the opposite of what was posted.
+//
+// So both halves are pinned here, because either alone passes on the bug. The
+// keyword and its condition are read out of the .scp, which is what catches a
+// flag that stops reaching s_expr(); and the description is read back with
+// read_scp and re-solved, which is what catches a keyword and a condition that
+// no longer agree with each other. Every other proving test in this file
+// exercises the writer, and none of them can see either failure:
+// check_scp_writer_reader_symmetry asks only that the reader has a case.
+//
+// Named variables and bare handles, deliberately: an instance has to be one
+// read_scp can rebuild for the semantic half to run at all.
+template <typename Constraint_>
+auto run_scp_description_equals_test(const string & which, const string & description, const function<auto(int, int, int)->bool> & is_satisfying)
+    -> void
+{
+    println(cerr, "equals scp description {}: expecting ({})", which, description);
+
+    Problem p;
+    auto x = p.create_integer_variable(0_i, 3_i, "x");
+    auto y = p.create_integer_variable(0_i, 3_i, "y");
+    auto b = p.create_integer_variable(0_i, 1_i, "b");
+    if constexpr (is_same_v<Constraint_, Equals> || is_same_v<Constraint_, NotEquals>)
+        p.post(Constraint_{x, y});
+    else
+        p.post(Constraint_{x, y, b == 1_i});
+
+    set<vector<int>> expected;
+    for (int xv = 0; xv <= 3; ++xv)
+        for (int yv = 0; yv <= 3; ++yv)
+            for (int bv = 0; bv <= 1; ++bv)
+                if (is_satisfying(xv, yv, bv))
+                    expected.insert(vector{xv, yv, bv});
+
+    const string proof_name = "equals_test_scp_" + which;
+    set<vector<int>> actual;
+    solve_for_tests_with_callbacks(
+        p, make_optional(proof_name),
+        [&](const CurrentState & s) -> bool {
+            actual.insert(vector{extract_from_state(s, x), extract_from_state(s, y), extract_from_state(s, b)});
+            return true;
+        },
+        [](const CurrentState &) -> bool { return true; });
+
+    if (actual != expected)
+        throw UnexpectedException{"equals scp description test for " + which + " found " + std::to_string(actual.size()) + " solutions, expecting " +
+            std::to_string(expected.size())};
+
+    // The label is whatever the constraint id came out as, so match from the
+    // space after it; without that leading space "equals x y)" is a substring of
+    // "not_equals x y)" and the plain form's pin would pass on the negated one.
+    std::ifstream scp{proof_name + ".scp"};
+    if (! scp)
+        throw UnexpectedException{"equals scp description test for " + which + " wrote no .scp"};
+    const string scp_text{std::istreambuf_iterator<char>{scp}, std::istreambuf_iterator<char>{}};
+    if (scp_text.find(" " + description + ")") == string::npos) {
+        println(cerr, "the .scp for {} does not describe itself as ({}):\n{}", which, description, scp_text);
+        throw UnexpectedException{"equals scp description test for " + which + " wrote a description other than (" + description + ")"};
+    }
+
+    check_scp_round_trip_solutions(proof_name, {"x", "y", "b"}, expected);
+    verify_proof_and_clean_up(proof_name);
+}
+
 auto main(int argc, char * argv[]) -> int
 {
     establish_and_announce_seed(argc, argv);
@@ -397,6 +469,21 @@ auto main(int argc, char * argv[]) -> int
                 run_wide_proved_no_overlap_equals_test();
             else
                 run_wide_no_overlap_equals_test();
+        }
+        // Bare handles under names of our own choosing, so read_scp can rebuild
+        // what the writer wrote; proofs on, because the .scp is only written
+        // when a proof is.
+        if (proofs && view_wrap_config_is_effectively_bare(view_cfg, n_positions)) {
+            run_scp_description_equals_test<Equals>("equals", "equals x y", [](int xv, int yv, int) { return xv == yv; });
+            run_scp_description_equals_test<EqualsIf>(
+                "equals_if", "equals_if (b = 1) x y", [](int xv, int yv, int bv) { return (! bv) || xv == yv; });
+            run_scp_description_equals_test<EqualsIff>(
+                "equals_iff", "equals_iff (b = 1) x y", [](int xv, int yv, int bv) { return (xv == yv) == (bv == 1); });
+            run_scp_description_equals_test<NotEquals>("not_equals", "not_equals x y", [](int xv, int yv, int) { return xv != yv; });
+            run_scp_description_equals_test<NotEqualsIf>(
+                "not_equals_if", "not_equals_if (b = 1) x y", [](int xv, int yv, int bv) { return (! bv) || xv != yv; });
+            run_scp_description_equals_test<NotEqualsIff>(
+                "not_equals_iff", "not_equals_iff (b = 1) x y", [](int xv, int yv, int bv) { return (xv != yv) == (bv == 1); });
         }
         for (auto & [r1, r2] : data) {
             run_equals_test<Equals>("equals", proofs, view_cfg, r1, r2, [](int a, int b, int) { return a == b; });

--- a/gcs/constraints/innards/constraints_test_utils.hh
+++ b/gcs/constraints/innards/constraints_test_utils.hh
@@ -7,6 +7,7 @@
 #include <gcs/scp_reader.hh>
 #include <gcs/search_heuristics.hh>
 #include <gcs/solve.hh>
+#include <gcs/stats.hh>
 
 #include <gcs/constraints/innards/cake_probe.hh>
 
@@ -25,6 +26,7 @@
 #include <map>
 #include <optional>
 #include <random>
+#include <set>
 #include <string>
 #include <tuple>
 #include <unordered_set>
@@ -207,6 +209,92 @@ namespace gcs::test_innards
         }
         catch (const std::exception &) {
             // Not a missing keyword, so not this guard's business: see above.
+        }
+    }
+
+    /**
+     * \brief Assert that the model read back from a test's `.scp` has the
+     * solution set the model that wrote it had.
+     *
+     * check_scp_writer_reader_symmetry above asks whether read_scp has a *case*
+     * for what the writer emitted. It cannot ask whether that case rebuilds the
+     * same constraint, and a description that parses can still say something
+     * else: issue #865 was a NotEqualsIff describing itself as an `equals_iff`
+     * over a negated condition, which is a different sentence about the same
+     * solution set and so invisible to a reader that only has to parse it. Two
+     * cancelling errors are one repair away from being one error, and that
+     * repair -- fixing the keyword, or the condition, but not both -- emits the
+     * opposite constraint. This is what notices.
+     *
+     * Solution sets rather than counts: the values are already in hand, and a
+     * count is a weak witness for a family whose modes differ by which half of
+     * the space they keep.
+     *
+     * Opt-in, and strict where the symmetry check is deliberately forgiving.
+     * read_scp does not promise that every *instance* round-trips -- a view
+     * operand does not render as a term the grammar parses, and the anonymous
+     * `_N` variable names a test usually gets are not names Problem::check_name()
+     * accepts -- so a caller has to hand this an instance that can round-trip,
+     * bare handles under names of its own choosing. In exchange, anything thrown
+     * from here is a finding about the writer rather than a limitation of the
+     * probe.
+     */
+    inline auto check_scp_round_trip_solutions(
+        const std::string & proof_name, const std::vector<std::string> & variable_names, const std::set<std::vector<int>> & expected) -> void
+    {
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+        using std::println;
+#else
+        using fmt::println;
+#endif
+        std::ifstream scp_in{proof_name + ".scp"};
+        if (! scp_in)
+            throw UnexpectedException{"no .scp was written for " + proof_name + ", so its description cannot be read back"};
+        std::string scp{std::istreambuf_iterator<char>{scp_in}, std::istreambuf_iterator<char>{}};
+
+        Problem rebuilt;
+        auto model = read_scp(rebuilt, scp);
+
+        std::vector<IntegerVariableID> vars;
+        for (const auto & name : variable_names) {
+            auto v = model.variables.find(name);
+            if (v == model.variables.end())
+                throw UnexpectedException{"the .scp written for " + proof_name + " has no variable named " + name};
+            vars.push_back(v->second);
+        }
+
+        std::set<std::vector<int>> actual;
+        solve_with(rebuilt,
+            SolveCallbacks{
+                .solution = [&](const CurrentState & s) -> bool {
+                    std::vector<int> values;
+                    for (const auto & v : vars)
+                        values.push_back(s(v).raw_value);
+                    actual.insert(std::move(values));
+                    return true;
+                },
+                .stats_report = silent_stats_report() //
+            });
+
+        if (actual != expected) {
+            // Reported as a set difference, not a pair of counts, because the
+            // counts are exactly what does not move: #865's partial-repair shape
+            // hands back the opposite constraint, whose solution set is the same
+            // size as the intended one. A count-based check would print two
+            // equal numbers and pass.
+            std::size_t only_here = 0, only_there = 0;
+            for (const auto & solution : actual)
+                if (! expected.contains(solution))
+                    ++only_here;
+            for (const auto & solution : expected)
+                if (! actual.contains(solution))
+                    ++only_there;
+            println(std::cerr,
+                "the model read back from {}.scp has {} solutions against {}, {} of them not solutions of the posted model, and {} of the posted "
+                "model's missing",
+                proof_name, actual.size(), expected.size(), only_here, only_there);
+            throw UnexpectedException{"the .scp written for " + proof_name +
+                " describes a different constraint from the one that was posted: it parses, but it does not mean the same thing"};
         }
     }
 


### PR DESCRIPTION
Closes #865.

`ReifiedEquals::clone()` omitted its fourth argument, and both `Problem::post`
and `Problem::create_propagators` clone, so `_neq` was `false` by the time
anything read it. Its only readers are `constraint_type()` and `s_expr()`, and
only in the `reif::Iff` case — exactly the case the flag exists for. A
`NotEqualsIff` therefore described itself as

```
(_1 equals_iff (b != 1) x y)          * constraint equals _1
```

Both halves were negated with respect to what was posted, so they cancelled:
every variant round-tripped through `read_scp` to the same solutions, and the
un-negation added for this case in `8bae05dc` could never run. Repairing either
half alone emits the *opposite* constraint.

Passing `_neq` flips both together. The description is now
`(_1 not_equals_iff (b = 1) x y)`, which is what cake reads as `cond <=> v1 != v2`,
and the provenance comment says `not_equals`.

### Tests

Nothing was watching this: `check_scp_writer_reader_symmetry` asks whether
`read_scp` has a *case* for the keyword, not whether that case means the same
thing. So both halves are pinned, per variant:

- the description is read out of the `.scp` and matched — catches a flag that
  stops reaching `s_expr()`;
- the description is read back with `read_scp`, re-solved, and its solution set
  compared with the posted model's — catches a keyword and a condition that no
  longer agree.

Sabotage confirms each half catches what the other cannot. Reverting `clone()`
fails the first. Dropping the un-negation while keeping the keyword fails the
second — **with 16 solutions against 16**, which is why the new helper compares
solution sets and reports a set difference rather than counting.

`ctest` 804/804 with proofs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
