### PR TITLE
Give the equals interval bridge its own subhint (#866)

### DIFF
--- a/gcs/constraints/equals/equals.cc
+++ b/gcs/constraints/equals/equals.cc
@@ -243,6 +243,13 @@ auto gcs::innards::enforce_equality(ProofLogger * const logger, const auto & v1,
         // first; each is RUP via the contradictory-binary-sums configuration. See
         // justify_not_in_range_across_equality. Views and constants take the
         // per-value path.
+        //
+        // Hence the not_in_range subhint rather than the family's base hint: at
+        // AssertionLevel::Inferences the lemmas are not written, and a justifier
+        // reading only the annotation would otherwise see this three-line
+        // derivation and a one-line RUP pruning wearing the same wire form
+        // (issue #866). The per-value fallback below is a genuine one-line RUP,
+        // so it keeps the base hint.
         auto both_simple = std::holds_alternative<SimpleIntegerVariableID>(IntegerVariableID{v1}) &&
             std::holds_alternative<SimpleIntegerVariableID>(IntegerVariableID{v2});
 
@@ -262,7 +269,8 @@ auto gcs::innards::enforce_equality(ProofLogger * const logger, const auto & v1,
                     ReasonLiterals not_in_range_reason = reason;
                     not_in_range_reason.emplace_back(not_in_range(IntegerVariableID{other}, lo, hi));
                     inference.infer_not_in_range(logger, pruned, lo, hi,
-                        JustifyExplicitly{[=](const ReasonLiterals & r) { bridge(pruned, other, lo, hi, r); }, ThenRUP::Yes, hints::Equals{owner}},
+                        JustifyExplicitly{
+                            [=](const ReasonLiterals & r) { bridge(pruned, other, lo, hi, r); }, ThenRUP::Yes, hints::EqualsNotInRange{{owner}}},
                         ExplicitReason{std::move(not_in_range_reason)});
                 }
                 else

--- a/gcs/constraints/equals/equals_test.cc
+++ b/gcs/constraints/equals/equals_test.cc
@@ -6,6 +6,7 @@
 #include <gcs/solve.hh>
 #include <gcs/stats.hh>
 
+#include <algorithm>
 #include <cstdlib>
 #include <fstream>
 #include <functional>
@@ -31,6 +32,7 @@ using std::string;
 using std::tuple;
 using std::variant;
 using std::vector;
+using std::ranges::includes;
 
 #if defined(__cpp_lib_print) && defined(__cpp_lib_format)
 using std::print;
@@ -335,6 +337,125 @@ auto run_wide_proved_no_overlap_equals_test() -> void
     verify_proof_and_clean_up(proof_name);
 }
 
+// The family's assertion-hint inventory, read off a real proof.
+//
+// At AssertionLevel::Inferences the solver emits `a` lines and hints and
+// nothing else: the lemmas an explicit derivation writes are absent, and an
+// external justifier is expected to rebuild each derivation from the
+// annotation, the asserted literal and the reason. So the annotation has to say
+// which derivation it was. Until issue #866 the interval bridge -- a conclusion
+// that is only RUP once two bound lemmas have carried its endpoints across the
+// equality -- arrived under the same `equals:((constraint_id _N))` as the
+// family's one-line RUP prunings, and the only way to tell a three-line
+// derivation from a one-line one was to notice that the asserted literal was
+// spelled as a range. That is keying off literal spelling, which is what the
+// hint vocabulary exists to avoid.
+//
+// Two instances, because no one instance fires all three shapes: a holey
+// Equals reaches the bridge and, once search fixes an operand, the
+// fixed-operand RUP; a bounds-disjoint reified one reaches the no-overlap walk.
+//
+// An unrecognised subhint fails as well. The inventory is a closed list that
+// the family document quotes rule by rule, so a fourth shape should have to
+// come here and be named rather than appearing on the wire unannounced.
+namespace
+{
+    struct EqualsHintsSeen
+    {
+        bool bare = false;
+        set<string> subhints;
+        int annotations = 0;
+    };
+
+    auto equals_hints_in_proof(const string & proof_name) -> EqualsHintsSeen
+    {
+        const string annotation = "::equals:(", field = "(subhint ";
+
+        EqualsHintsSeen seen;
+        std::ifstream proof{proof_name + ".pbp"};
+        if (! proof)
+            throw UnexpectedException{"equals hint inventory test wrote no proof for " + proof_name};
+        for (string line; getline(proof, line);) {
+            auto at = line.find(annotation);
+            if (at == string::npos)
+                continue;
+            ++seen.annotations;
+            auto subhint = line.find(field, at);
+            if (subhint == string::npos)
+                seen.bare = true;
+            else {
+                auto from = subhint + field.size();
+                auto to = line.find(')', from);
+                if (to == string::npos)
+                    throw UnexpectedException{"unterminated (subhint ...) in " + proof_name + ".pbp: " + line};
+                seen.subhints.insert(line.substr(from, to - from));
+            }
+        }
+        return seen;
+    }
+
+    auto prove_at_inference_assertion_level(Problem & p, const string & proof_name) -> EqualsHintsSeen
+    {
+        auto options = ProofOptions{ProofFileNames{proof_name}};
+        options.set_assertion_level(AssertionLevel::Inferences);
+        solve_with(p, SolveCallbacks{.stats_report = silent_stats_report()}, make_optional(options));
+
+        auto seen = equals_hints_in_proof(proof_name);
+        if (0 == seen.annotations)
+            throw UnexpectedException{
+                "equals hint inventory test found no equals annotations at all in " + proof_name + ".pbp, so it is not testing what it thinks it is"};
+        dispose_of_proof_files(proof_name);
+        return seen;
+    }
+}
+
+auto run_hint_inventory_equals_test() -> void
+{
+    const set<string> inventory{"no_overlap", "not_in_range"};
+
+    // {0..5} against {0,1,4,5}: the symmetric difference is the single run
+    // {2,3}, which is a range-literal conclusion and so takes the bridge, and
+    // once search fixes the surviving operand the other is forced by a plain
+    // RUP. Both operands are bare handles, or the bridge degrades to per-value
+    // prunings that really are one-line RUPs (#882).
+    println(cerr, "equals hint inventory, interval bridge: expecting a not_in_range subhint and a bare hint");
+    {
+        Problem p;
+        auto x = p.create_integer_variable(0_i, 5_i);
+        auto y = p.create_integer_variable(vector<Integer>{0_i, 1_i, 4_i, 5_i});
+        p.post(Equals{x, y});
+
+        auto seen = prove_at_inference_assertion_level(p, "equals_test_hints_bridge");
+        if (! seen.subhints.contains("not_in_range"))
+            throw UnexpectedException{"the equals interval bridge did not annotate its conclusion with the not_in_range subhint, so a justifier "
+                                      "cannot tell a three-line derivation from a one-line RUP"};
+        if (! seen.bare)
+            throw UnexpectedException{"the equals hint inventory instance produced no bare-hint assertion, so it is not showing that the two wire "
+                                      "forms are distinguishable"};
+        if (! includes(inventory, seen.subhints))
+            throw UnexpectedException{"the equals interval bridge instance carried a subhint outside the family's inventory: add it here and to "
+                                      "dev_docs/constraints/equals.md"};
+    }
+
+    // Bounds-disjoint operands under an iff: the undecided pass forces the
+    // condition false, which is the walk.
+    println(cerr, "equals hint inventory, no-overlap walk: expecting a no_overlap subhint");
+    {
+        Problem p;
+        auto x = p.create_integer_variable(0_i, 3_i);
+        auto y = p.create_integer_variable(5_i, 8_i);
+        auto b = p.create_integer_variable(0_i, 1_i);
+        p.post(EqualsIff{x, y, b == 1_i});
+
+        auto seen = prove_at_inference_assertion_level(p, "equals_test_hints_no_overlap");
+        if (! seen.subhints.contains("no_overlap"))
+            throw UnexpectedException{"the equals no-overlap walk did not annotate its verdict with the no_overlap subhint"};
+        if (! includes(inventory, seen.subhints))
+            throw UnexpectedException{"the equals no-overlap instance carried a subhint outside the family's inventory: add it here and to "
+                                      "dev_docs/constraints/equals.md"};
+    }
+}
+
 // What the constraint *says* it is, and whether it means what it says.
 //
 // The equals family writes six descriptions, and one of them used to be a
@@ -470,6 +591,11 @@ auto main(int argc, char * argv[]) -> int
             else
                 run_wide_no_overlap_equals_test();
         }
+        // Reads its own proof rather than solving twice, and needs bare handles
+        // for the same reason as the descriptions below.
+        if (proofs && view_wrap_config_is_effectively_bare(view_cfg, n_positions))
+            run_hint_inventory_equals_test();
+
         // Bare handles under names of our own choosing, so read_scp can rebuild
         // what the writer wrote; proofs on, because the .scp is only written
         // when a proof is.

--- a/gcs/constraints/equals/hints.hh
+++ b/gcs/constraints/equals/hints.hh
@@ -22,12 +22,41 @@ namespace gcs::innards::hints
      * verdicts). RUP-derivable, so no emit_justification and no subhint; it takes
      * the default `(constraint_id <originator>)` wire form.
      *
+     * The bare form therefore means "one RUP against the equality rows" and
+     * nothing else. Every derivation in the family that needs lemmas emitted
+     * ahead of its conclusion names a subhint: EqualsNotInRange below for the
+     * interval bridge, EqualsNoOverlap for the disjointness walk.
+     *
      * \ingroup Innards
      */
     struct Equals
     {
         ConstraintID originator;
         static constexpr std::string_view hint_name = "equals";
+    };
+
+    /**
+     * \brief equals's "not in this interval, across the equality" hint.
+     *
+     * The symmetric-difference rule's conclusion is a range literal, and a range
+     * literal asserts only order atoms while the equality rows are a bit-sum, so
+     * the conclusion is not RUP on its own: two ge-layer bound lemmas have to
+     * carry its endpoints across first (justify_not_in_range_across_equality).
+     * That makes it a three-line derivation wearing, until issue #866, the same
+     * wire form as the family's one-line RUP prunings -- so the only way to tell
+     * them apart was to notice that the asserted literal was spelled as a range,
+     * which is keying off literal spelling, exactly what the hint vocabulary
+     * exists to avoid.
+     *
+     * Nothing beyond the subhint: the emission is a lambda at the call site
+     * rather than an emit_justification here, and an external justifier gets the
+     * interval and the operands from the asserted literal and the reason.
+     *
+     * \ingroup Innards
+     */
+    struct EqualsNotInRange : Equals
+    {
+        static constexpr std::string_view subhint_name = "not_in_range";
     };
 
     /**


### PR DESCRIPTION
Closes #866. Stacked on #865 — review the top commit only.

At `AssertionLevel::Inferences` the solver writes `a` lines and hints and
nothing else, and two structurally different derivations arrived under the same
annotation:

```
a 1 i[y][eq1]     1 ~i[x][eq1]     >= 1::equals:((constraint_id _2));
a 1 ~i[x][in2_3]  1 i[y][in2_3]    >= 1::equals:((constraint_id _2));
```

The first is one RUP against the equality rows. The second is a range literal,
which asserts only order atoms while the rows are a bit-sum, so it is not RUP
until two ge-layer bound lemmas have carried its endpoints across — and at this
assertion level those two lines are not in the proof for a justifier to see. The
only way to tell them apart was to notice the asserted literal was spelled as a
range, i.e. to key off literal spelling: the thing the hint vocabulary exists to
avoid.

The bridge now carries `(subhint not_in_range)`, the way the no-overlap walk
already carries `(subhint no_overlap)`, so the bare form means "one RUP"
unambiguously. The per-value fallback keeps the bare hint, because there it
really is one RUP per value.

### Tests

The inventory is read off a proof rather than checked by inspection: one holey
instance for the bridge and the fixed-operand RUP, one bounds-disjoint reified
one for the walk. Each shape must arrive under the subhint it should, and
nothing may arrive under a subhint outside the family's closed list — so a
fourth shape has to come to that test and be named. Reverting the hint at the
call site fails it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
