### PR TITLE
Re-walk the equals no-overlap witness from its reason (#870)

### DIFF
--- a/gcs/constraints/equals/equals.cc
+++ b/gcs/constraints/equals/equals.cc
@@ -153,7 +153,7 @@ namespace
 
 namespace gcs::innards::hints
 {
-    auto emit_justification(ProofLogger & logger, const EqualsNoOverlap & w, const ReasonLiterals &) -> void
+    auto emit_justification(ProofLogger & logger, const EqualsNoOverlap & w, const ReasonLiterals & reason) -> void
     {
         // Two lemma shapes, each carrying one bound across the reified equality.
         // The cond-guarded halves of the model constraint are `cond -> v1 <= v2`
@@ -169,35 +169,101 @@ namespace gcs::innards::hints
             logger.emit_rup_proof_line(WPBSum{} + 1_i * ! w.cond + 1_i * (w.v1 < k) + 1_i * (w.v2 >= k) >= 1_i, ProofLevel::Temporary);
         };
 
+        // The walk is re-read out of the reason, not out of the domains. Both
+        // are the same walk when nothing has moved, but a justification does not
+        // run at the moment its inference was decided: by the time it does,
+        // earlier pushes in the same propagation have landed, and a domain read
+        // here can be narrower than the one the reason was built from -- at
+        // which point the lemmas stop lining up with the literals they exist to
+        // let unit propagation see through, and the conclusion's RUP check
+        // fails. Reading the reason cannot go stale, because the reason is what
+        // the conclusion is asserted under. This rule was the family's only
+        // justification that touched state at all (issue #870).
+        //
+        // It is also the reconstructibility claim, exercised: the family
+        // document says an external justifier can rebuild this derivation from
+        // the assertion alone, and everything below is read from literals such a
+        // justifier is handed too.
+        //
         // What each move owes the conclusion's RUP check, given that the check
         // has cond and the reason's literals as units and is carrying `v1 >= p`:
         //
-        //   AnchorV1Lower       the reason literal is `v1 >= lo` itself.
-        //   JumpToV2Lower       `v2 >= lo` is a reason literal; one lemma turns
-        //                       it into `v1 >= lo`.
-        //   SkipV1Hole          nothing: `~[v1 in lo..hi]` and `v1 >= lo` meet in
-        //                       the range literal's own reverse reification,
-        //                       which gives `v1 >= hi + 1`.
-        //   SkipV2Hole          `v1 >= lo` crosses to `v2 >= lo`, that and
-        //                       `~[v2 in lo..hi]` give `v2 >= hi + 1` through
-        //                       v2's reverse reification, and that crosses back.
-        //   StopAboveV1Upper    nothing: `v1 >= hi` and the reason's `v1 <= lo`
-        //                       are opposite ends of v1's own order chain.
-        //   StopAboveV2Upper    `v1 >= hi` crosses to `v2 >= hi`, against the
-        //                       reason's `v2 <= lo`.
-        walk_no_overlap(w.state->copy_of_values(w.v1), w.state->copy_of_values(w.v2), [&](NoOverlapStep kind, Integer lo, Integer hi) {
-            switch (kind) {
-            case NoOverlapStep::AnchorV1Lower:
-            case NoOverlapStep::SkipV1Hole:
-            case NoOverlapStep::StopAboveV1Upper: break;
-            case NoOverlapStep::JumpToV2Lower: v2_lower_reaches_v1(lo); break;
-            case NoOverlapStep::SkipV2Hole:
-                v1_lower_reaches_v2(lo);
-                v2_lower_reaches_v1(hi + 1_i);
+        //   `v1 >= lo`          the anchor; the reason literal is the fact.
+        //   `v2 >= lo`          the same start reached through v2; one lemma
+        //                       turns it into `v1 >= lo`.
+        //   `~[v1 in lo..hi]`   nothing: that and `v1 >= lo` meet in the range
+        //                       literal's own reverse reification, which gives
+        //                       `v1 >= hi + 1`.
+        //   `~[v2 in lo..hi]`   `v1 >= lo` crosses to `v2 >= lo`, that and the
+        //                       literal give `v2 >= hi + 1` through v2's reverse
+        //                       reification, and that crosses back.
+        //   `v1 <= lo`          nothing: `v1 >= p` and it are opposite ends of
+        //                       v1's own order chain.
+        //   `v2 <= lo`          `v1 >= p` crosses to `v2 >= p`, against it.
+        if (reason.empty())
+            throw UnexpectedException{"equals no-overlap witness has no reason to re-walk"};
+
+        // A reason literal is a ProofLiteralOrFlag in general; every literal this
+        // witness's reason holds is a plain condition on one of the two operands.
+        auto as_condition = [](const ProofLiteralOrFlag & literal) -> const IntegerVariableCondition * {
+            if (const auto * proof_literal = std::get_if<ProofLiteral>(&literal))
+                if (const auto * plain = std::get_if<Literal>(proof_literal))
+                    return std::get_if<IntegerVariableCondition>(plain);
+            return nullptr;
+        };
+
+        auto p = optional<Integer>{};
+        for (std::size_t i = 0; i < reason.size();) {
+            const auto * cond = as_condition(reason[i]);
+            if (! cond || (cond->var != w.v1 && cond->var != w.v2))
+                throw UnexpectedException{"equals no-overlap witness cannot re-walk its own reason"};
+            auto on_v2 = (cond->var == w.v2);
+
+            switch (cond->op) {
+                using enum VariableConditionOperator;
+            case GreaterEqual:
+                if (on_v2)
+                    v2_lower_reaches_v1(cond->value);
+                p = cond->value;
+                ++i;
                 break;
-            case NoOverlapStep::StopAboveV2Upper: v1_lower_reaches_v2(hi); break;
+
+            case NotEqual:
+            case NotInRange: {
+                // One maximal run of values that operand cannot take, and the
+                // walk's position steps past it. A run is one range literal --
+                // unless the operand is a view, which has none, and is then
+                // spelled value by value (#882). So consecutive single-value
+                // literals on the same operand are one run, and cost the two
+                // lemmas a range literal would rather than two per value.
+                auto lo = cond->value;
+                auto hi = (cond->op == NotInRange ? cond->upper_value : cond->value);
+                for (++i; cond->op == NotEqual && i < reason.size(); ++i) {
+                    const auto * next = as_condition(reason[i]);
+                    if (! next || next->op != NotEqual || next->var != cond->var || next->value != hi + 1_i)
+                        break;
+                    hi = next->value;
+                }
+
+                if (on_v2) {
+                    v1_lower_reaches_v2(lo);
+                    v2_lower_reaches_v1(hi + 1_i);
+                }
+                p = hi + 1_i;
+            } break;
+
+            case Less:
+                if (on_v2) {
+                    if (! p)
+                        throw UnexpectedException{"equals no-overlap witness reached its stop before its anchor"};
+                    v1_lower_reaches_v2(*p);
+                }
+                ++i;
+                break;
+
+            default: throw UnexpectedException{"equals no-overlap witness cannot re-walk a reason literal of this shape"};
             }
-        });
+        }
     }
 }
 
@@ -330,13 +396,13 @@ namespace
     auto no_overlap_justification(const State & state, ProofLogger * const, IntegerVariableID v1, IntegerVariableID v2, Literal cond,
         const ConstraintID & owner, bool want_reasons) -> pair<hints::EqualsNoOverlap, Reason>
     {
-        hints::EqualsNoOverlap no_overlap{{owner}, &state, v1, v2, cond};
+        hints::EqualsNoOverlap no_overlap{{owner}, v1, v2, cond};
 
-        // Assembling the reason is linear in the length of the witness. Unlike
-        // the walk in emit_justification, which is the same shape but only runs
-        // when a proof is actually being written, this one sits on the
-        // propagation path -- so with proofs off it is built, never read, and
-        // thrown away. That is the situation want_reasons() exists for, and when
+        // Assembling the reason is linear in the length of the witness, and it
+        // is the *only* walk of the domains: emit_justification re-reads the
+        // walk out of the literals below rather than doing it again. This one
+        // sits on the propagation path, so with proofs off it is built, never
+        // read, and thrown away. That is the situation want_reasons() exists for, and when
         // this witness was per-value the cost was not academic: issue #864
         // measured 78 GB and 160 s at width 10^9, and a bad_alloc on a smaller
         // machine. The must-not-hold pass below was guarded for the same reason

--- a/gcs/constraints/equals/equals_test.cc
+++ b/gcs/constraints/equals/equals_test.cc
@@ -236,6 +236,58 @@ auto run_holey_no_overlap_equals_test(bool proofs, bool swapped) -> void
     check_results(proof_name, expected, actual);
 }
 
+// The same interleaved shape with a *view* as the second operand, which is the
+// one instance here whose witness is not spelled entirely in intervals.
+//
+// A view has no range literal (#882), so a run of values it cannot take is
+// spelled out value by value in the reason -- and the second operand is the one
+// whose runs cost lemmas. The witness has to recognise those single-value
+// literals as one run again, or it pays two lemmas per value instead of two per
+// run; the proof still verifies either way, which is why this is checked by
+// diffing proof bytes against the interval spelling rather than by a lane going
+// red. Measured on this instance: 527 proof lines, against 536 if the run is
+// not put back together.
+//
+// It matters more than a handful of lines because it is the only coverage of the
+// witness reading a run out of literals it did not write as a range: everything
+// else in this file hands it interval literals.
+auto run_holey_no_overlap_view_equals_test(bool proofs) -> void
+{
+    print(cerr, "holey no overlap equals with a view operand{}", proofs ? " with proofs:" : ":");
+    cerr << flush;
+
+    // {4..7, 12..15} against a view of {0..3, 8..11}: interleaved, disjoint, and
+    // the walk climbs the bare operand, so every run it steps over belongs to
+    // the view.
+    vector<Integer> lower_first, upper_first;
+    for (Integer v = 0_i; v <= 15_i; ++v)
+        ((v / 4_i) % 2_i == 0_i ? lower_first : upper_first).push_back(v);
+
+    set<tuple<int, int, int>> expected, actual;
+    for (const auto & xv : upper_first)
+        for (const auto & yv : lower_first)
+            expected.emplace(static_cast<int>(xv.raw_value), static_cast<int>(yv.raw_value), 0);
+    println(cerr, " expecting {} solutions", expected.size());
+
+    Problem p;
+    auto x = p.create_integer_variable(upper_first);
+
+    // A non-zero offset, deliberately: `v + 0` deviews onto the underlying
+    // variable in the proof and gets that variable's range literals, so it would
+    // not exercise the per-value spelling at all.
+    vector<Integer> shifted;
+    for (const auto & v : lower_first)
+        shifted.push_back(v - 1_i);
+    auto y = p.create_integer_variable(shifted) + 1_i;
+    auto b = p.create_integer_variable(0_i, 1_i);
+    p.post(EqualsIff{x, y, b == 1_i});
+
+    auto proof_name = proofs ? make_optional("equals_test_holey_view") : nullopt;
+    solve_for_tests(p, proof_name, actual, tuple{x, y, b});
+
+    check_results(proof_name, expected, actual);
+}
+
 // A reified equals whose operands are wide and do not overlap. Nothing else in
 // this file goes anywhere near this shape: every other domain here lives inside
 // [-10, 10], and range_infer_test works inside [0, 40], so the no-overlap rule
@@ -586,6 +638,7 @@ auto main(int argc, char * argv[]) -> int
             run_no_overlap_equals_test(proofs);
             run_holey_no_overlap_equals_test(proofs, false);
             run_holey_no_overlap_equals_test(proofs, true);
+            run_holey_no_overlap_view_equals_test(proofs);
             if (proofs)
                 run_wide_proved_no_overlap_equals_test();
             else

--- a/gcs/constraints/equals/hints.hh
+++ b/gcs/constraints/equals/hints.hh
@@ -5,12 +5,9 @@
 #include <gcs/innards/literal.hh>
 #include <gcs/innards/proofs/proof_logger-fwd.hh>
 #include <gcs/innards/reason.hh>
-#include <gcs/innards/state-fwd.hh>
-#include <gcs/integer.hh>
 #include <gcs/variable_id.hh>
 
 #include <string_view>
-#include <utility>
 
 namespace gcs::innards::hints
 {
@@ -62,24 +59,25 @@ namespace gcs::innards::hints
     /**
      * \brief equals's "domains don't overlap" hint, carried in a reified verdict.
      *
-     * Extends the base with the `no_overlap` subhint and the emit context the
-     * internal proof writer reads to re-walk the disjointness: the operands and
-     * the reification condition. The State pointer is valid because the verdict
-     * is consumed synchronously while the constraint is live. The data is held
-     * for emit_justification only; with no own hint_sexpr the hint takes the
-     * default identity-plus-subhint wire form.
+     * Extends the base with the `no_overlap` subhint and the only context the
+     * lemmas cannot be written without: the two operands and the reification
+     * condition, which is what the lemmas are *about*. The walk itself comes out
+     * of the reason at emit time, so nothing here describes the domains, and no
+     * State pointer is held -- a justification may read the reason and the
+     * model, and anything it reads out of state is a bound that has since moved
+     * (issue #870). The data is held for emit_justification only; with no own
+     * hint_sexpr the hint takes the default identity-plus-subhint wire form.
      *
-     * Nothing here says how the reason spelled its runs, because the lemmas do
-     * not depend on it: a run is stepped over inside one variable, by its range
-     * literal's reverse reification or by its eq atoms walking the order chain,
-     * and either way the witness owes it nothing.
+     * The reason's spelling of a run does not change the lemmas, though it does
+     * decide where they fall: a run is stepped over inside one variable, by its
+     * range literal's reverse reification or by its eq atoms walking the order
+     * chain, and either way the witness owes that step nothing.
      *
      * \ingroup Innards
      */
     struct EqualsNoOverlap : Equals
     {
         static constexpr std::string_view subhint_name = "no_overlap";
-        const State * state;
         IntegerVariableID v1, v2;
         Literal cond;
     };


### PR DESCRIPTION
Closes #870. Stacked on #866 — review the top commit only.

The no-overlap witness was the only justification in the family that read
`state`: it re-walked both operands' domains to decide, run by run, which lemma
shape to emit. Safe today, because the verdict is consumed synchronously — but
on the wrong side of an invariant that holds everywhere else. A justification
does not run at the moment its inference was decided, and by the time it does,
earlier pushes in the same propagation have landed, so a domain read there can
be narrower than the one the reason was built from. The lemmas would then stop
lining up with the literals they exist to let unit propagation see through, and
the conclusion's RUP check would fail. Reading the reason cannot go stale: the
reason is what the conclusion is asserted under.

So the walk comes out of the reason's literals, and `EqualsNoOverlap` drops its
`State *`. It is also the reconstructibility claim exercised rather than
asserted — the family document says an external justifier can rebuild this
derivation from the assertion alone, and this now rebuilds it from the same
literals.

A run spelled value by value is put back together, because a view has no range
literal (#882) and the second operand's runs are the ones that cost lemmas.

### Tests

Byte-identical proofs, which is the strongest check available here:

- all **1180** proof artifacts `equals_test` writes at a pinned seed, unchanged
  against the parent commit;
- an interleaved instance with an **offset view** operand, 527 proof lines,
  unchanged.

Leaving the run in pieces still verifies — 536 lines against 527 — so the
regrouping is pinned by that diff and not by a lane. The view instance is added
as a test: it was the only shape here whose witness is not spelled entirely in
intervals, and nothing covered it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
