### PR TITLE
Show that VeriPB refuses a mangled equals derivation (#869)

### DIFF
--- a/dev_docs/constraints.md
+++ b/dev_docs/constraints.md
@@ -918,6 +918,23 @@ reason. And check that the run being mutated really produced the inference at
 all, or the harness is checking an empty proof. If a mutation verifies anyway,
 that is a finding about the honest derivation.
 
+Registering a **control** alongside the lanes is what makes them mean
+something: the same instances, uncorrupted, and veripb must accept. A lane whose
+instance does not verify honestly either is green for no reason at all. The
+equals family's `--mutate=control` is the pattern (`equals_mutation_control`).
+
+Mutating a **reason** rather than an emitted step has a trap of its own, and it
+is not obvious. Dropping a literal from a reason is only a corruption when that
+literal traces back to a *search decision*. Anything a propagator derived is
+written into the proof as a clause in its own right, so the checker has it
+whether or not the reason repeats it — which means a rule that fires during root
+propagation has a reason that merely restates the database, and dropping from it
+changes nothing veripb can see. Such a lane goes green on an empty corruption.
+Arrange for the fact to arrive under a decision (a reified constraint whose
+condition the search sets, say, with a fixed branching order so it is set first),
+or mutate an emitted lemma instead. `equals_mutations.hh` records two instances
+that accept the mutation for this reason before the third one bites.
+
 ## Adding a new constraint: checklist
 
 1. Header file with class declaration, Doxygen comments, the phases it

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -575,6 +575,18 @@ if(GCS_BUILD_TESTS)
             COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:element_test> ${mode})
     endforeach()
     add_test(NAME equals_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:equals_test>)
+    # Mutation lanes (#869): each corrupts one step of an equals derivation and
+    # passes only if veripb refuses the result. The control comes first because
+    # it is what makes the other five mean anything -- it checks that the same
+    # four instances verify when they are not corrupted. equals_mutations.hh
+    # records which instance each lane needs and why a smaller one is slack.
+    add_test(NAME equals_mutation_control
+        COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:equals_test> --mutate=control)
+    foreach(mutation fixed_operand_reason bridge_lemmas no_overlap_stop no_overlap_lemmas no_overlap_selector)
+        add_test(NAME equals_mutation_${mutation}
+            COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_expect_verify_failure.bash
+                --basename equals_mutation_${mutation} $<TARGET_FILE:equals_test> --mutate=${mutation})
+    endforeach()
     foreach(linmode incremental stateless)
         add_test(NAME linear_constant_constraint_${linmode}
             COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:linear_constant_test>)

--- a/gcs/constraints/equals/equals.cc
+++ b/gcs/constraints/equals/equals.cc
@@ -1,5 +1,6 @@
 #include <gcs/constraints/equals/equals.hh>
 #include <gcs/constraints/equals/hints.hh>
+#include <gcs/constraints/innards/equals_mutations.hh>
 #include <gcs/constraints/innards/justify_not_in_range.hh>
 #include <gcs/constraints/innards/reified_dispatcher.hh>
 #include <gcs/exception.hh>
@@ -162,11 +163,20 @@ namespace gcs::innards::hints
         // that makes it RUP, exactly as in justify_not_in_range_across_equality
         // (which cannot be reused directly here only because these halves are
         // reified, so the lemmas carry the extra `! cond`).
+        //
+        // Testing only, and never on by default: `omit` emits no lemmas at all,
+        // and `selector` states each of them under cond rather than ! cond. See
+        // EqualsProofMutation.
+        auto omit = std::holds_alternative<equals_proof_mutation::OmitNoOverlapLemmas>(w.mutation);
+        auto selector = std::holds_alternative<equals_proof_mutation::FlipNoOverlapSelector>(w.mutation) ? Literal{w.cond} : Literal{! w.cond};
+
         auto v2_lower_reaches_v1 = [&](Integer k) {
-            logger.emit_rup_proof_line(WPBSum{} + 1_i * ! w.cond + 1_i * (w.v2 < k) + 1_i * (w.v1 >= k) >= 1_i, ProofLevel::Temporary);
+            if (! omit)
+                logger.emit_rup_proof_line(WPBSum{} + 1_i * selector + 1_i * (w.v2 < k) + 1_i * (w.v1 >= k) >= 1_i, ProofLevel::Temporary);
         };
         auto v1_lower_reaches_v2 = [&](Integer k) {
-            logger.emit_rup_proof_line(WPBSum{} + 1_i * ! w.cond + 1_i * (w.v1 < k) + 1_i * (w.v2 >= k) >= 1_i, ProofLevel::Temporary);
+            if (! omit)
+                logger.emit_rup_proof_line(WPBSum{} + 1_i * selector + 1_i * (w.v1 < k) + 1_i * (w.v2 >= k) >= 1_i, ProofLevel::Temporary);
         };
 
         // The walk is re-read out of the reason, not out of the domains. Both
@@ -268,15 +278,19 @@ namespace gcs::innards::hints
 }
 
 auto gcs::innards::enforce_equality(ProofLogger * const logger, const auto & v1, const auto & v2, const State & state, auto & inference,
-    const ReasonLiterals & reason, const ConstraintID & owner) -> PropagatorState
+    const ReasonLiterals & reason, const ConstraintID & owner, EqualsProofMutation mutation) -> PropagatorState
 {
+    // Testing only, and never on by default: see EqualsProofMutation.
+    auto drop_fixed_operand_reason = std::holds_alternative<equals_proof_mutation::DropFixedOperandReason>(mutation);
+
     auto val1 = state.optional_single_value(v1);
     if (val1) {
         inference.infer_equal(logger, v2, *val1, JustifyUsingRUP{hints::Equals{owner}},
             ExplicitReason{//
                 [&] {
                     auto r = reason;
-                    r.emplace_back(v1 == *val1);
+                    if (! drop_fixed_operand_reason)
+                        r.emplace_back(v1 == *val1);
                     return r;
                 }()});
         return PropagatorState::DisableUntilBacktrack;
@@ -288,7 +302,8 @@ auto gcs::innards::enforce_equality(ProofLogger * const logger, const auto & v1,
             ExplicitReason{//
                 [&] {
                     auto r = reason;
-                    r.emplace_back(v2 == *val2);
+                    if (! drop_fixed_operand_reason)
+                        r.emplace_back(v2 == *val2);
                     return r;
                 }()});
         return PropagatorState::DisableUntilBacktrack;
@@ -319,7 +334,10 @@ auto gcs::innards::enforce_equality(ProofLogger * const logger, const auto & v1,
         auto both_simple = std::holds_alternative<SimpleIntegerVariableID>(IntegerVariableID{v1}) &&
             std::holds_alternative<SimpleIntegerVariableID>(IntegerVariableID{v2});
 
-        auto bridge = [logger](const auto & pruned, const auto & other, Integer lo, Integer hi, const ReasonLiterals & r) {
+        auto omit_bridge_lemmas = std::holds_alternative<equals_proof_mutation::OmitBridgeLemmas>(mutation);
+        auto bridge = [logger, omit_bridge_lemmas](const auto & pruned, const auto & other, Integer lo, Integer hi, const ReasonLiterals & r) {
+            if (omit_bridge_lemmas)
+                return; // testing only: leaves the conclusion claiming to be RUP unaided
             // Plain equality pruned = other, so the flag forces other into the same [lo, hi].
             justify_not_in_range_across_equality(
                 *logger, r, std::get<SimpleIntegerVariableID>(IntegerVariableID{pruned}), lo, hi, IntegerVariableID{other}, lo, hi);
@@ -394,9 +412,9 @@ auto gcs::innards::enforce_equality(ProofLogger * const logger, const auto & v1,
 namespace
 {
     auto no_overlap_justification(const State & state, ProofLogger * const, IntegerVariableID v1, IntegerVariableID v2, Literal cond,
-        const ConstraintID & owner, bool want_reasons) -> pair<hints::EqualsNoOverlap, Reason>
+        const ConstraintID & owner, bool want_reasons, EqualsProofMutation mutation) -> pair<hints::EqualsNoOverlap, Reason>
     {
-        hints::EqualsNoOverlap no_overlap{{owner}, v1, v2, cond};
+        hints::EqualsNoOverlap no_overlap{{owner}, v1, v2, cond, mutation};
 
         // Assembling the reason is linear in the length of the witness, and it
         // is the *only* walk of the domains: emit_justification re-reads the
@@ -466,6 +484,12 @@ namespace
             }
         });
 
+        // Testing only: the walk's last literal is its stop, so without it the
+        // reason climbs to a position and never says the position is impossible.
+        // See EqualsProofMutation.
+        if (std::holds_alternative<equals_proof_mutation::DropNoOverlapStopLiteral>(mutation) && ! reason.empty())
+            reason.pop_back();
+
         return pair{no_overlap, ExplicitReason{reason}};
     }
 
@@ -479,6 +503,12 @@ ReifiedEquals::ReifiedEquals(const IntegerVariableID v1, const IntegerVariableID
 {
 }
 
+auto ReifiedEquals::with_proof_mutation(const EqualsProofMutation mutation) -> ReifiedEquals &
+{
+    _proof_mutation = mutation;
+    return *this;
+}
+
 auto ReifiedEquals::clone() const -> unique_ptr<Constraint>
 {
     // _neq must come along: both Problem::post and Problem::create_propagators
@@ -488,7 +518,9 @@ auto ReifiedEquals::clone() const -> unique_ptr<Constraint>
     // flip lives in the derived constructors' negated conditions -- so dropping
     // it made a NotEqualsIff describe itself as an equals_iff over a negated
     // condition, which is the same constraint said backwards.
-    return make_unique<ReifiedEquals>(_v1, _v2, _cond, _neq);
+    auto cloned = make_unique<ReifiedEquals>(_v1, _v2, _cond, _neq);
+    cloned->with_proof_mutation(_proof_mutation);
+    return cloned;
 }
 
 auto ReifiedEquals::prepare(Propagators &, State & initial_state, ProofModel * const) -> bool
@@ -558,9 +590,10 @@ auto ReifiedEquals::define_proof_model(ProofModel & model, const State &) -> voi
 
 auto ReifiedEquals::install_propagators(Propagators & propagators) -> void
 {
-    auto enforce_constraint_must_hold = [v1 = _v1, v2 = _v2, owner = constraint_id()](const State & state, auto & inference,
-                                            ProofLogger * const logger, const Literal & cond) -> PropagatorState {
-        return visit([&](auto & v1, auto & v2) { return enforce_equality(logger, v1, v2, state, inference, ReasonLiterals{cond}, owner); }, v1, v2);
+    auto enforce_constraint_must_hold = [v1 = _v1, v2 = _v2, owner = constraint_id(), mutation = _proof_mutation](const State & state,
+                                            auto & inference, ProofLogger * const logger, const Literal & cond) -> PropagatorState {
+        return visit(
+            [&](auto & v1, auto & v2) { return enforce_equality(logger, v1, v2, state, inference, ReasonLiterals{cond}, owner, mutation); }, v1, v2);
     };
 
     auto enforce_constraint_must_not_hold = [v1 = _v1, v2 = _v2, owner = constraint_id()](const State & state, auto & inference,
@@ -585,7 +618,8 @@ auto ReifiedEquals::install_propagators(Propagators & propagators) -> void
         return PropagatorState::Enable;
     };
 
-    auto infer_cond_when_undecided = [v1 = _v1, v2 = _v2, owner = constraint_id()](const State & state, auto & inference, ProofLogger * const logger,
+    auto infer_cond_when_undecided = [v1 = _v1, v2 = _v2, owner = constraint_id(), mutation = _proof_mutation](const State & state, auto & inference,
+                                         ProofLogger * const logger,
                                          const IntegerVariableCondition & cond) -> ReificationVerdictFor<EqualsJustification> {
         // Aliased non-constant operands: equality definitely holds regardless of
         // domain. Returning MustHold here lets the dispatcher pin the cond
@@ -630,7 +664,7 @@ auto ReifiedEquals::install_propagators(Propagators & propagators) -> void
         else {
             // not equals is forced if there's no overlap between domains
             if (! state.domains_intersect(v1, v2)) {
-                auto [no_overlap, reason] = no_overlap_justification(state, logger, v1, v2, cond, owner, inference.want_reasons());
+                auto [no_overlap, reason] = no_overlap_justification(state, logger, v1, v2, cond, owner, inference.want_reasons(), mutation);
                 return reification_verdict::MustNotHold<EqualsJustification>{
                     .justification = JustifyExplicitly{no_overlap, ThenRUP::Yes}, //
                     .reason = reason                                              //
@@ -732,6 +766,8 @@ auto ReifiedEquals::s_expr(const innards::ProofModel * const model) const -> SEx
 }
 
 template auto gcs::innards::enforce_equality(ProofLogger * const logger, const IntegerVariableID & v1, const IntegerVariableID & v2,
-    const State & state, SimpleInferenceTracker & inference, const ReasonLiterals & reason, const ConstraintID & owner) -> PropagatorState;
+    const State & state, SimpleInferenceTracker & inference, const ReasonLiterals & reason, const ConstraintID & owner, EqualsProofMutation mutation)
+    -> PropagatorState;
 template auto gcs::innards::enforce_equality(ProofLogger * const logger, const IntegerVariableID & v1, const IntegerVariableID & v2,
-    const State & state, EagerProofLoggingInferenceTracker & inference, const ReasonLiterals & reason, const ConstraintID & owner) -> PropagatorState;
+    const State & state, EagerProofLoggingInferenceTracker & inference, const ReasonLiterals & reason, const ConstraintID & owner,
+    EqualsProofMutation mutation) -> PropagatorState;

--- a/gcs/constraints/equals/equals.hh
+++ b/gcs/constraints/equals/equals.hh
@@ -2,6 +2,7 @@
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_EQUALS_EQUALS_HH
 
 #include <gcs/constraint.hh>
+#include <gcs/constraints/innards/equals_mutations.hh>
 #include <gcs/constraints/innards/reified_state.hh>
 #include <gcs/innards/proofs/proof_logger-fwd.hh>
 #include <gcs/innards/proofs/reification.hh>
@@ -16,7 +17,8 @@ namespace gcs
     namespace innards
     {
         auto enforce_equality(ProofLogger * const logger, const auto & v1, const auto & v2, const State & state, auto & inference,
-            const ReasonLiterals & reason, const ConstraintID & owner) -> PropagatorState;
+            const ReasonLiterals & reason, const ConstraintID & owner, EqualsProofMutation mutation = equals_proof_mutation::None{})
+            -> PropagatorState;
     }
 
     /**
@@ -30,6 +32,7 @@ namespace gcs
         IntegerVariableID _v1, _v2;
         ReificationCondition _cond;
         bool _neq;
+        innards::EqualsProofMutation _proof_mutation = innards::equals_proof_mutation::None{};
         innards::EvaluatedReificationCondition _evaluated_cond = innards::evaluated_reif::Deactivated{};
 
         virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
@@ -38,6 +41,11 @@ namespace gcs
 
     public:
         ReifiedEquals(const IntegerVariableID v1, const IntegerVariableID v2, ReificationCondition cond, bool neq = false);
+
+        /// Testing only: corrupt one step of the derivations this constraint
+        /// emits, so a mutation lane can check that veripb refuses the result.
+        /// See innards::EqualsProofMutation. Never use this outside a test.
+        auto with_proof_mutation(innards::EqualsProofMutation mutation) -> ReifiedEquals &;
 
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
         [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;

--- a/gcs/constraints/equals/equals_test.cc
+++ b/gcs/constraints/equals/equals_test.cc
@@ -1,5 +1,7 @@
+#include <gcs/constraints/comparison.hh>
 #include <gcs/constraints/equals.hh>
 #include <gcs/constraints/innards/constraints_test_utils.hh>
+#include <gcs/constraints/innards/equals_mutations.hh>
 #include <gcs/current_state.hh>
 #include <gcs/exception.hh>
 #include <gcs/problem.hh>
@@ -580,9 +582,206 @@ auto run_scp_description_equals_test(const string & which, const string & descri
     verify_proof_and_clean_up(proof_name);
 }
 
+// Mutation lanes: one deliberately corrupted proof, which
+// run_test_and_expect_verify_failure.bash passes only if veripb rejects. See
+// EqualsProofMutation for what each corruption is and why it is that one.
+//
+// Each lane also checks that the run it corrupted made the inference at all --
+// the pruning is still made, since these change only the proof -- because a
+// mutation lane over a rule that never fired is checking an empty proof and
+// passes for the wrong reason. What that check can be differs by rule: for the
+// two whose conclusion is a root-propagation fact, it is the fact; for the
+// fixed-operand rule, which fires only under a search assignment, it is that
+// the enumeration completed, since every solution of x = y over {0..3} is
+// reached through a node where one operand is fixed and the other is not.
+auto run_mutation_equals_test(const string & which, const string & proof_name) -> void
+{
+    using namespace gcs::innards::equals_proof_mutation;
+
+    auto root_only = [&](Problem & p, const function<auto(const CurrentState &)->void> & check) {
+        solve_with(p,
+            SolveCallbacks{
+                .trace = [&](const CurrentState & s) -> bool {
+                    check(s);
+                    return false;
+                },                                    //
+                .stats_report = silent_stats_report() //
+            },
+            make_optional<ProofOptions>(ProofFileNames{proof_name}));
+    };
+
+    // {0..20} against {0..5} + {14..20}: the symmetric difference is the run
+    // {6..13}, so the conclusion is a range literal and takes the two-lemma
+    // bridge.
+    //
+    // The width is not arbitrary, and neither are the endpoints. Omitting the
+    // lemmas from a *narrow* interval is not caught: on {0..5} against
+    // {0,1,4,5} the conclusion `~[x in 2..3]` is RUP against the equality rows
+    // unaided, and so is `~[x in 3..7]` of {0..11}, which is the same thing for
+    // a different reason -- an endpoint on a power of two is one bit rather
+    // than a sum. Measured across widths 5 to 16 with the hole at the middle
+    // third: rejected at every width but 5 and 11. So the lemmas are
+    // load-bearing, and a lane that says so has to be asked about an interval
+    // whose endpoints are not bit boundaries.
+    auto interval_bridge_instance = [&](innards::EqualsProofMutation mutation) {
+        vector<Integer> yv;
+        for (Integer v = 0_i; v <= 20_i; ++v)
+            if (v <= 5_i || v >= 14_i)
+                yv.push_back(v);
+
+        Problem p;
+        auto x = p.create_integer_variable(0_i, 20_i);
+        auto y = p.create_integer_variable(yv);
+        p.post(Equals{x, y}.with_proof_mutation(mutation));
+
+        auto fired = false;
+        root_only(p, [&](const CurrentState & s) { fired = ! s.in_domain(x, 6_i) && ! s.in_domain(x, 13_i); });
+        if (! fired)
+            throw UnexpectedException{"mutation lane " + which + ": the interval bridge did not prune, so its proof has nothing in it to corrupt"};
+    };
+
+    // Interleaved and disjoint under an iff, so the undecided pass forces the
+    // condition false through the walk, over several runs rather than one.
+    auto no_overlap_instance = [&](innards::EqualsProofMutation mutation) {
+        vector<Integer> lower_first, upper_first;
+        for (Integer v = 0_i; v <= 15_i; ++v)
+            ((v / 4_i) % 2_i == 0_i ? lower_first : upper_first).push_back(v);
+
+        Problem p;
+        auto x = p.create_integer_variable(lower_first);
+        auto y = p.create_integer_variable(upper_first);
+        auto b = p.create_integer_variable(0_i, 1_i);
+        p.post(EqualsIff{x, y, b == 1_i}.with_proof_mutation(mutation));
+
+        auto fired = false;
+        root_only(p, [&](const CurrentState & s) { fired = s.has_single_value(b) && s(b) == 0_i; });
+        if (! fired)
+            throw UnexpectedException{"mutation lane " + which +
+                ": the no-overlap rule did not decide the condition, so its proof has nothing in it "
+                "to corrupt"};
+    };
+
+    // A walk one of whose literals is not already in the proof's database, which
+    // is what it takes for dropping a reason literal to be a corruption at all.
+    //
+    // Every literal of a root-firing walk is one of the operands' bounds or
+    // holes. The bounds are OPB axioms, and a fact some other propagator derived
+    // at the root is a unit clause the checker has too -- so at the root the
+    // reason is a restatement of the database, dropping from it corrupts
+    // nothing, and the lane goes green on an empty corruption. (Both were tried:
+    // a bare {0..3, 8..11} against {4..7, 12..15}, and the same with x's upper
+    // bound pushed by an unconditional LessThanEqual. VeriPB accepts the
+    // mutation on each.) A search decision is the exception, because a decision
+    // is not written to the database: what is written is the implication from
+    // it. So the disjointness has to appear under one.
+    //
+    // Hence z, whose first decision pushes x's upper bound to 9 and leaves the
+    // two operands disjoint but neither of them fixed, which is the shape the
+    // walk fires on. Its stop is then `x <= 9`, a fact the reason has to carry
+    // because nothing else states it unconditionally. Branching in a fixed order
+    // rather than the tests' random one, since the lane needs that decision
+    // taken first and taken at all.
+    auto decided_bound_no_overlap_instance = [&](innards::EqualsProofMutation mutation) {
+        Problem p;
+        auto z = p.create_integer_variable(0_i, 1_i);
+        auto x = p.create_integer_variable(0_i, 20_i);
+        auto y = p.create_integer_variable(10_i, 15_i);
+        auto b = p.create_integer_variable(0_i, 1_i);
+        p.post(LessThanEqualIf{x, 9_c, z == 1_i});
+        p.post(EqualsIff{x, y, b == 1_i}.with_proof_mutation(mutation));
+
+        auto fired = false;
+        solve_with(p,
+            SolveCallbacks{
+                .solution = [&](const CurrentState & s) -> bool { return fired = fired || (s(z) == 1_i && s(b) == 0_i), true; }, //
+                .branch = branch_with(variable_order::in_order({z, x, y, b}), value_order::largest_first()),                     //
+                .stats_report = silent_stats_report()                                                                            //
+            },
+            make_optional<ProofOptions>(ProofFileNames{proof_name}));
+        if (! fired)
+            throw UnexpectedException{
+                "mutation lane " + which + ": no solution reached the decision the walk was to fire under, so the proof may not contain it"};
+    };
+
+    // The fixed-operand rule only fires under a search assignment, so this one
+    // enumerates; every solution of x = y over {0..3} is reached through a node
+    // where one operand is fixed and the other is not.
+    auto fixed_operand_instance = [&](innards::EqualsProofMutation mutation) {
+        Problem p;
+        auto x = p.create_integer_variable(0_i, 3_i);
+        auto y = p.create_integer_variable(0_i, 3_i);
+        p.post(Equals{x, y}.with_proof_mutation(mutation));
+
+        auto solutions = 0;
+        solve_with(p,
+            SolveCallbacks{
+                .solution = [&](const CurrentState &) -> bool { return ++solutions, true; }, //
+                .stats_report = silent_stats_report()                                        //
+            },
+            make_optional<ProofOptions>(ProofFileNames{proof_name}));
+        if (4 != solutions)
+            throw UnexpectedException{"mutation lane " + which + ": expected 4 solutions, got " + std::to_string(solutions)};
+    };
+
+    // The controls. A mutation lane that goes green because its instance's
+    // *honest* proof does not verify either is worth nothing, and these four
+    // shapes are not otherwise covered: three of them exist to give a rule a
+    // margin of one, which is not what the rest of this file is arranged for.
+    if (which == "control") {
+        if (! can_run_veripb()) {
+            println(cerr, "no veripb, so not checking the mutation lanes' honest proofs");
+            return;
+        }
+        // Spelled out rather than looped over: the four have four different
+        // closure types, and erasing them into a std::function just to iterate
+        // is both gratuitous and something MSVC would not parse.
+        fixed_operand_instance(None{});
+        verify_proof_and_clean_up(proof_name);
+        interval_bridge_instance(None{});
+        verify_proof_and_clean_up(proof_name);
+        no_overlap_instance(None{});
+        verify_proof_and_clean_up(proof_name);
+        decided_bound_no_overlap_instance(None{});
+        verify_proof_and_clean_up(proof_name);
+        println(cerr, "every mutation lane's instance verifies when it is not corrupted");
+        return;
+    }
+
+    if (which == "fixed_operand_reason")
+        fixed_operand_instance(DropFixedOperandReason{});
+    else if (which == "bridge_lemmas")
+        interval_bridge_instance(OmitBridgeLemmas{});
+    else if (which == "no_overlap_stop")
+        decided_bound_no_overlap_instance(DropNoOverlapStopLiteral{});
+    else if (which == "no_overlap_lemmas")
+        no_overlap_instance(OmitNoOverlapLemmas{});
+    else if (which == "no_overlap_selector")
+        no_overlap_instance(FlipNoOverlapSelector{});
+    else
+        throw UnexpectedException{"unknown equals mutation lane " + which};
+
+    println(cerr, "wrote a deliberately corrupted proof to {}.pbp", proof_name);
+}
+
 auto main(int argc, char * argv[]) -> int
 {
     establish_and_announce_seed(argc, argv);
+
+    // A mutation lane runs one instance, writes one knowingly wrong proof, and
+    // leaves the verdict to the wrapper script.
+    string mutation, proof_basename = "equals_test_mutation";
+    for (int a = 1; a < argc; ++a) {
+        string arg = argv[a];
+        if (arg.starts_with("--mutate="))
+            mutation = arg.substr(arg.find('=') + 1);
+        else if (arg == "--proof-files-basename" && a + 1 < argc)
+            proof_basename = argv[++a];
+    }
+    if (! mutation.empty()) {
+        run_mutation_equals_test(mutation, proof_basename);
+        return EXIT_SUCCESS;
+    }
+
     auto view_cfg = parse_view_wrap_config_from_argv(argc, argv);
 
     // Single-position config that names a position the constraint doesn't

--- a/gcs/constraints/equals/hints.hh
+++ b/gcs/constraints/equals/hints.hh
@@ -2,6 +2,7 @@
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_EQUALS_HINTS_HH
 
 #include <gcs/constraint_id.hh>
+#include <gcs/constraints/innards/equals_mutations.hh>
 #include <gcs/innards/literal.hh>
 #include <gcs/innards/proofs/proof_logger-fwd.hh>
 #include <gcs/innards/reason.hh>
@@ -73,6 +74,11 @@ namespace gcs::innards::hints
      * range literal's reverse reification or by its eq atoms walking the order
      * chain, and either way the witness owes that step nothing.
      *
+     * The mutation is testing-only and is carried here because this is the only
+     * place it can be: the emission is an emit_justification rather than a
+     * lambda at the call site, so the hint is the whole of what it is handed.
+     * See EqualsProofMutation.
+     *
      * \ingroup Innards
      */
     struct EqualsNoOverlap : Equals
@@ -80,6 +86,7 @@ namespace gcs::innards::hints
         static constexpr std::string_view subhint_name = "no_overlap";
         IntegerVariableID v1, v2;
         Literal cond;
+        EqualsProofMutation mutation = equals_proof_mutation::None{};
     };
 
     auto emit_justification(ProofLogger & logger, const EqualsNoOverlap & no_overlap, const ReasonLiterals & reason) -> void;

--- a/gcs/constraints/innards/equals_mutations.hh
+++ b/gcs/constraints/innards/equals_mutations.hh
@@ -1,0 +1,130 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_INNARDS_EQUALS_MUTATIONS_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_INNARDS_EQUALS_MUTATIONS_HH
+
+#include <variant>
+
+/**
+ * \file
+ *
+ * Deliberate corruptions of the equals family's proof steps, which exist so
+ * that a test can show its derivations are tight to what they claim. They live
+ * here, in the innards, rather than beside the constraint they corrupt: a
+ * header a user of the library includes should not advertise a way to make the
+ * solver emit deliberately wrong proofs. Issue #869, and the same reason
+ * CumulativeProofMutation and Am1FromPairsMutation are here.
+ *
+ * Why the family needs this more than most rather than less. Almost every
+ * inference here is a single RUP against a two-row OPB encoding, and "veripb
+ * accepted a one-line RUP" is the weakest evidence in the suite: an over-broad
+ * conclusion can be RUP for a reason that has nothing to do with the rule that
+ * drew it. Solutions matching brute force does not help either, since a
+ * corrupted *proof* changes no answers. So before this, nothing anywhere
+ * demonstrated that VeriPB refuses a mangled equals derivation.
+ *
+ * Each of these changes the proof and nothing else: the same inferences are
+ * made, the same solutions reported, and the OPB is untouched.
+ *
+ * **Measured.** VeriPB rejects all six of the lanes registered for these, and
+ * the control lane checks that the same four instances verify when they are not
+ * corrupted -- so the family's derivations are tight, which is what issue #869
+ * asked. What took work was the instances, not the corruptions, and in a way
+ * that generalises to the next family:
+ *
+ *  - Dropping a reason literal is only a corruption when that literal traces to
+ *    a **search decision**. A fact some propagator derived is written to the
+ *    proof as a clause of its own, so the checker has it whether or not the
+ *    reason repeats it, and a root-firing rule's reason is a restatement of the
+ *    database. Both of the obvious no-overlap instances -- an interleaved pair
+ *    of domains, and the same with one bound pushed by an unconditional
+ *    LessThanEqual -- accept the mutation for exactly that reason. The lane's
+ *    instance puts the bound push behind a decision instead.
+ *  - Omitting the bridge lemmas is caught at almost every domain width, and not
+ *    at two of them: over `{0..w}` with the middle third removed, VeriPB accepts
+ *    the lemma-free proof at w = 5 and w = 11 and rejects it at 6, 7, 8, 9, 10,
+ *    12, 14, 16, 20, 100 and 1000. Both exceptions have an interval endpoint on
+ *    a bit boundary, where the bound is one literal rather than a sum and unit
+ *    propagation can cross the equality unaided. So the lemmas are load-bearing
+ *    in general, and a narrow fixture would have said they were not.
+ */
+
+namespace gcs::innards
+{
+    /**
+     * \brief Deliberate corruptions of the equals family's derivations, for
+     * testing only. VeriPB must reject each of them.
+     *
+     * A mutation that still verifies is a finding about the honest derivation,
+     * not about the mutation.
+     *
+     * Two of the four kinds of thing that could go wrong here are reasons and
+     * two are emitted lemmas, which between them cover the family's whole
+     * proof surface -- there is nothing else. One candidate from issue #869 is
+     * deliberately absent: "cite the wrong half of the equality" has no site,
+     * because no step in this family cites a proof line by label at all. Every
+     * one is a RUP, which is why the reason and the lemmas are the only places
+     * a mistake can live.
+     *
+     * \ingroup Innards
+     */
+    namespace equals_proof_mutation
+    {
+        /// Emit the honest derivations.
+        struct None
+        {
+        };
+
+        /// Leave the fixed operand's value out of the reason for forcing the
+        /// other operand to it, so the pruning is claimed to follow from the
+        /// reification condition alone. Shows the reason is minimal in the sense
+        /// that matters: the equality rows say the operands agree, not what
+        /// either of them is.
+        struct DropFixedOperandReason
+        {
+        };
+
+        /// Leave the last literal out of the no-overlap witness's reason. That
+        /// literal is the walk's stop -- the one fact saying the position the
+        /// walk has climbed to is past the top of one of the two domains -- so
+        /// without it the reason establishes a lower bound and never that the
+        /// bound is impossible. The last rather than the first because the
+        /// witness re-walks the reason it was given (#870), and a reason with no
+        /// anchor is not a corrupt derivation but an unreadable one.
+        struct DropNoOverlapStopLiteral
+        {
+        };
+
+        /// Emit no bound lemmas before a `~[pruned in lo..hi]` conclusion, so it
+        /// is claimed to be RUP against the equality on its own. This is the
+        /// mutation that tests a design claim rather than an arithmetic step: a
+        /// range literal asserts only order atoms while the equality rows are a
+        /// bit-sum, which is the entire reason
+        /// justify_not_in_range_across_equality exists. If VeriPB accepts this,
+        /// that helper is unnecessary here.
+        struct OmitBridgeLemmas
+        {
+        };
+
+        /// Emit no lemmas at all in the no-overlap witness, leaving the walk's
+        /// interval literals to be seen through by unit propagation unaided.
+        /// The control for the rule: it says whether the walk is load-bearing
+        /// before asking whether any particular move of it is.
+        struct OmitNoOverlapLemmas
+        {
+        };
+
+        /// Emit the no-overlap witness's lemmas under `cond` instead of
+        /// `! cond`, which is the one-character version of the mistake that is
+        /// easiest to make in a reified derivation and the hardest to see by
+        /// reading: the lemmas are still about the right operands, the right
+        /// bounds and the right direction, and every one of them is false.
+        struct FlipNoOverlapSelector
+        {
+        };
+    }
+
+    using EqualsProofMutation =
+        std::variant<equals_proof_mutation::None, equals_proof_mutation::DropFixedOperandReason, equals_proof_mutation::DropNoOverlapStopLiteral,
+            equals_proof_mutation::OmitBridgeLemmas, equals_proof_mutation::OmitNoOverlapLemmas, equals_proof_mutation::FlipNoOverlapSelector>;
+}
+
+#endif


### PR DESCRIPTION
Closes #869. Stacked on #870 — review the top commit only.

Nothing demonstrated that VeriPB *refuses* a mangled equals derivation. The
proofs verifying shows they are accepted, not that they are tight, and this is
the family where that gap matters most: almost every inference is a single RUP
against a two-row encoding, an over-broad conclusion can be RUP for a reason
unrelated to the rule that drew it, and a corrupted proof changes no answers —
so neither the solution checks nor veripb had anything to say about it.

`EqualsProofMutation` follows `CumulativeProofMutation`: five corruptions behind
a testing-only `with_proof_mutation()`, each changing the proof and nothing
else. Two are reasons and three are emitted lemmas, which is the family's whole
proof surface. **VeriPB rejects all five**, and a sixth lane is the control —
the same four instances, uncorrupted, verified — without which a lane could be
green because its instance does not verify either.

| lane | corruption |
|---|---|
| `fixed_operand_reason` | the fixed operand's value left out of the reason for forcing the other operand to it |
| `bridge_lemmas` | no bound lemmas before a range-literal conclusion, so it claims to be RUP across the equality unaided |
| `no_overlap_stop` | the walk's stop left out of the witness's reason |
| `no_overlap_lemmas` | no lemmas at all in the walk |
| `no_overlap_selector` | the walk's lemmas under `cond` rather than `! cond` |

The issue's third candidate has no site: "cite the wrong half of the equality"
cannot be done, because no step in this family cites a proof line by label.

### What the instances cost, and why it is written down

Two findings, recorded in `equals_mutations.hh` and generalised in
`dev_docs/constraints.md`, because they are traps for the next family rather
than facts about this one:

- **Dropping a reason literal is only a corruption when that literal traces to a
  search decision.** Anything a propagator derived is written to the proof as a
  clause of its own, so the checker has it whether or not the reason repeats it,
  and a root-firing rule's reason merely restates the database. Two no-overlap
  instances accept the mutation for that reason before the third bites; the
  lane's instance puts the bound push behind a decision, with a fixed branching
  order so it is taken first.
- **Omitting the bridge lemmas is caught at almost every width, and not at two of
  them.** Over `{0..w}` with the middle third removed, VeriPB accepts the
  lemma-free proof at w = 5 and w = 11 and rejects it at 6, 7, 8, 9, 10, 12, 14,
  16, 20, 100 and 1000. Both exceptions put an interval endpoint on a bit
  boundary, where the bound is one literal rather than a sum and unit
  propagation crosses the equality unaided. The lemmas are load-bearing in
  general — and a narrow fixture would have reported that they are not.

The `equals.md` "whether the derivation has been shown to be tight" line can now
answer yes; that file is on #863's branch, so it is not updated here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
