### PR TITLE
Branching heuristics: ask the domain for a position, and draw random lazily (#879)

### DIFF
--- a/dev_docs/large-domains.md
+++ b/dev_docs/large-domains.md
@@ -345,7 +345,9 @@ but to nothing that evaluates the size being checked.
 `gcs/large_domain_audit_test.cc` posts every constraint class once over a
 `0..10^9` domain, installs it, propagates at the root and nowhere else. It is
 built always (so it cannot rot) but registered as a ctest case only when the
-guard is on, since without the guard every probe passes trivially.
+guard is on, since without the guard every probe passes trivially. A second
+table does the same for the branching heuristics; see below, and note that the
+first table cannot see them at all.
 
 Each row pins the outcome we currently expect, so the lane is green today and
 each piece of #833 flips rows rather than introducing failures. **A row that
@@ -365,8 +367,9 @@ is the part worth reading carefully:
 
 ### Where we stand
 
-70 probes. The lane itself is the authority — run it rather than trusting this
-table, which is a snapshot for orientation.
+70 constraint probes, plus 20 heuristic ones in the second table. The lane
+itself is the authority — run it rather than trusting this table, which is a
+snapshot for orientation.
 
 | | constraints |
 |---|---|
@@ -458,6 +461,85 @@ One deliberate non-axis: the lane runs **without proof logging**. `NValue`'s
 H2′ is caught anyway, because its per-value work is in `prepare()`, but a
 constraint whose *encoding* alone were per-value would not be. That is by
 design — see below.
+
+### Branching heuristics (#879)
+
+The constraint lane cannot see a heuristic, and that is not a gap in the probes
+but a gap in what the lane is pointed at. Seven of the thirteen value orders did
+work proportional to the domain's width, and they survived every other stage of
+this issue for two reasons at once: a heuristic is not a propagator, so no amount
+of sharpening a constraint's row reaches one; and the rows all take the *default*
+branch heuristic, which is one of the lazy ones, so nothing there ever asked a
+value order to do something expensive.
+
+The cost also lands in the worst place. A constraint's per-value site runs once at
+the root, or once per propagation; a value order runs at **every branching
+decision**. And the one most likely to meet a wide domain is
+`split_smallest_first`, because splitting is the standard answer to "too many
+values to enumerate" — so the heuristic reached for precisely because the domain
+is wide was one that could not survive it.
+
+`gcs/large_domain_audit_test.cc` now carries a second table, twenty rows: every
+value order against a fixed variable order, and every variable order against a
+fixed value order, so a row names one heuristic and nothing else. It needs no
+stopping rule of its own — `solve_with_state()` calls `branch_generator.begin()`
+*before* the trace callback, and `begin()` runs the value order up to its first
+`co_yield`, so the existing "stop at the root" probe has already made exactly one
+branching decision by the time it returns.
+
+Two shapes, and only one of them is an interval query:
+
+* **Six needed a position.** The three splits want the value at `size / 2 - 1`,
+  `median` the one at `size / 2`, and `random_out` and
+  `reject_random_interval` a uniformly drawn position. All six are
+  `IntervalSet::nth_value()`, which walks the interval list accumulating widths:
+  `O(intervals)` where counting values to reach the position was `O(n)`. That is
+  the whole fix, and it is the H1a shape again — the conclusion was already a
+  single value, only the search for it was per-value.
+* **`random` needed laziness, not a query.** A shuffled enumeration of the domain
+  really is `O(width)`; what was wrong was paying it up front. It is now
+  Fisher–Yates with the array left implicit — position `j` drawn uniformly from
+  `[j, size)`, with a map holding only the positions a draw has displaced — so it
+  costs what the search reads rather than what the domain holds. Same permutation
+  distribution, because it is the same algorithm. This is the same reason
+  `smallest_first` was always fine: the guard section above calls the lazy case
+  legitimate explicitly.
+
+The **variable** orders were all clean already, `dom_wdeg`'s weighting schemes
+included: they read `domain_size()` and bounds, never values. They get rows
+anyway, because "no heuristic does work proportional to a domain's width" is a
+property worth having checkable rather than argued — and because a row names its
+heuristic, which link-checks it. That is how `variable_order::with_largest_value`
+turned out to be declared and documented in the public header and never defined
+at all.
+
+**What it costs, measured per call at a fixed seed** (ns, one core of an EPYC
+7643, Release, mean of a long run; `split_sm` and `median` shown, the others
+track them):
+
+| domain | `split_smallest_first` before | after | `median` before | after |
+|---|---|---|---|---|
+| width 4 | 131 | 67 | 214 | 66 |
+| width 256 | 1 716 | 67 | 3 838 | 66 |
+| width 4096 | 25 822 | 67 | 55 812 | 67 |
+| width 4096, 64 holes | 26 234 | 243 | 56 504 | 243 |
+| width 10⁶ | 6 317 324 | 67 | 25 540 065 | 65 |
+| width 10⁸ | 629 960 951 | 68 | 2 899 422 752 | 68 |
+
+Flat in the width, as intended, and **faster at every width including the
+narrowest** — the old spelling paid for a `std::generator` frame and the
+`std::function` the view application needs, where the new one copies a
+two-element inline vector. The holey rows are the honest cost: `nth_value()` is
+`O(intervals)`, so 64 holes cost about four times one interval, and nothing about
+the domain's width enters either way.
+
+`random` is the one place where laziness is not free. Handing out a **full**
+enumeration of a narrow domain costs 25 ns per value eagerly and 79 ns lazily —
+a hash-map operation where there used to be a vector index. End to end that is
+invisible: a full-enumeration search over nine-value domains measured 3 940
+ns/node before and 3 912 after, i.e. no difference outside noise, because a
+branching decision is a per-cent of what a node costs. The trade is a constant
+against an asymptote, which is the right way round.
 
 ## Proofs
 

--- a/gcs/interval_set.hh
+++ b/gcs/interval_set.hh
@@ -1,6 +1,7 @@
 #ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_INTERVAL_SET_HH
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_INTERVAL_SET_HH
 
+#include <gcs/exception.hh>
 #include <gcs/interval_set-fwd.hh>
 
 #include <gch/small_vector.hpp>
@@ -132,6 +133,50 @@ namespace gcs
         [[nodiscard]] auto upper() const -> Int_
         {
             return intervals.back().second;
+        }
+
+        /**
+         * \brief Returns the value at zero-based position \p n, counting up from
+         * lower().
+         *
+         * nth_value(0) is lower(), and nth_value(size() - 1) is upper(). The
+         * position is an index into the *values*, not into the intervals: for
+         * {1..4, 8..10}, nth_value(3) is 4 and nth_value(4) is 8.
+         *
+         * Walks the stored intervals accumulating their widths, so this costs
+         * <code>O(intervals)</code> where counting values one at a time to reach
+         * position \p n costs <code>O(n)</code>. Selecting the middle value of a
+         * contiguous billion-value domain is a subtraction and an addition, not
+         * half a billion increments.
+         *
+         * This exists so that a caller wanting one value out of a set it has no
+         * reason to enumerate --- a branching heuristic choosing a split point, a
+         * median, or a uniformly random member --- need not walk the set to find
+         * it (issue #833).
+         *
+         * \note \p n must be at least zero and less than size(). Unlike lower()
+         * and upper(), which are undefined on an empty set, an out-of-range
+         * position throws: a silently wrong answer here is a wrong branching
+         * decision rather than a crash, and those are expensive to track down.
+         *
+         * \sa size(), lower(), upper()
+         */
+        [[nodiscard]] auto nth_value(Int_ n) const -> Int_
+        {
+            // Checked before the walk, not left to fall out of it: a negative
+            // position satisfies n < width against the first interval and would
+            // otherwise be answered with a value below lower().
+            if (n < Int_(0))
+                throw UnexpectedException{"IntervalSet::nth_value() asked for a negative position"};
+
+            for (const auto & [l, u] : intervals) {
+                auto width = u - l + Int_(1);
+                if (n < width)
+                    return l + n;
+                n -= width;
+            }
+
+            throw UnexpectedException{"IntervalSet::nth_value() asked for a position past the end of the set"};
         }
 
         /**

--- a/gcs/interval_set_test.cc
+++ b/gcs/interval_set_test.cc
@@ -1006,3 +1006,84 @@ TEST_CASE("intersect_with brute-force cross-check with multi-interval sets")
         for (const auto & b : {s0, s1, s2, s3, s4, s5})
             CHECK(expand(intersected_with(a, b)) == brute_force(a, b));
 }
+
+TEST_CASE("nth_value on a single interval")
+{
+    IntervalSet<int> set(5, 10);
+    for (int n = 0; n < set.size(); ++n)
+        CHECK(set.nth_value(n) == 5 + n);
+    CHECK(set.nth_value(0) == set.lower());
+    CHECK(set.nth_value(set.size() - 1) == set.upper());
+}
+
+TEST_CASE("nth_value crosses gaps")
+{
+    // The case a single-interval implementation gets wrong: position 4 is the
+    // first value after the hole, not lower() + 4.
+    IntervalSet<int> set;
+    set.insert_at_end(1, 4);
+    set.insert_at_end(8, 10);
+
+    CHECK(set.nth_value(0) == 1);
+    CHECK(set.nth_value(3) == 4);
+    CHECK(set.nth_value(4) == 8);
+    CHECK(set.nth_value(6) == 10);
+}
+
+TEST_CASE("nth_value brute-force cross-check against enumeration")
+{
+    // nth_value(n) must be the n'th value each() hands out, for every set in a
+    // small library of shapes: singletons, adjacent-but-for-one-value intervals,
+    // and a run of single-value intervals where every step crosses a gap.
+    IntervalSet<int> s1(7, 7), s2(-4, 3), s3, s4, s5;
+    s3.insert_at_end(1, 1);
+    s3.insert_at_end(3, 3);
+    s3.insert_at_end(5, 5);
+
+    s4.insert_at_end(-10, -8);
+    s4.insert_at_end(-6, -6);
+    s4.insert_at_end(0, 4);
+    s4.insert_at_end(100, 101);
+
+    s5.insert_at_end(2, 3);
+    s5.insert_at_end(5, 6);
+
+    for (const auto & set : {s1, s2, s3, s4, s5}) {
+        vector<int> expanded;
+        for (auto v : set.each())
+            expanded.push_back(v);
+
+        REQUIRE(int(expanded.size()) == set.size());
+        for (int n = 0; n < set.size(); ++n)
+            CHECK(set.nth_value(n) == expanded[n]);
+    }
+}
+
+TEST_CASE("nth_value does not walk the values it skips")
+{
+    // The property the branching heuristics need (issue #833): the cost is the
+    // number of intervals, not the position asked for. An interval set this wide
+    // cannot be enumerated at all, so a test that returns is itself the evidence.
+    IntervalSet<long long> huge(0, 4000000000LL);
+    CHECK(huge.nth_value(2000000000LL) == 2000000000LL);
+    CHECK(huge.nth_value(4000000000LL) == 4000000000LL);
+
+    IntervalSet<long long> holey;
+    holey.insert_at_end(0, 999999999LL);
+    holey.insert_at_end(3000000000LL, 3999999999LL);
+    CHECK(holey.nth_value(999999999LL) == 999999999LL);
+    CHECK(holey.nth_value(1000000000LL) == 3000000000LL);
+}
+
+TEST_CASE("nth_value rejects a position outside the set")
+{
+    IntervalSet<int> set;
+    set.insert_at_end(1, 2);
+    set.insert_at_end(9, 9);
+
+    CHECK_THROWS_AS(set.nth_value(3), UnexpectedException);
+    CHECK_THROWS_AS(set.nth_value(-1), UnexpectedException);
+
+    IntervalSet<int> empty;
+    CHECK_THROWS_AS(empty.nth_value(0), UnexpectedException);
+}

--- a/gcs/large_domain_audit_test.cc
+++ b/gcs/large_domain_audit_test.cc
@@ -583,6 +583,124 @@ namespace
 
 namespace
 {
+    /* Branching heuristics, which the constraint lane above cannot see.
+     *
+     * The rows above all use the default branch heuristic, and the default is
+     * one of the lazy ones, so nothing there ever asks a value order to do
+     * something expensive. Heuristics also sit outside the guard's remit in a
+     * second way: they are not propagators, so no amount of sharpening a
+     * constraint's probe reaches them. That combination is how #879 -- seven of
+     * the thirteen value orders doing work proportional to the domain's width,
+     * at *every* branching decision rather than once at the root -- survived the
+     * whole of the rest of this lane.
+     *
+     * These rows need no separate stopping rule. solve_with_state() calls
+     * branch_generator.begin() before the trace callback, and begin() runs the
+     * value order up to its first co_yield -- so probe()'s "stop at the root"
+     * has already made exactly one branching decision by the time it returns.
+     * One call of one heuristic over a 10^9 domain is precisely what is being
+     * measured here.
+     *
+     * The probe problem is two unconstrained wide variables. Nothing propagates,
+     * so whatever work a row does is the heuristic's own; two rather than one so
+     * that a variable order has something to choose between.
+     */
+    struct HeuristicProbe
+    {
+        string name;
+        Expect expect;
+        function<auto(const Problem &)->BranchHeuristic> branch;
+    };
+
+    auto heuristic_probe(const HeuristicProbe & probe_case) -> Result
+    {
+        try {
+            Problem problem;
+            auto vars = wide(problem, 2);
+            solve_with(problem,
+                SolveCallbacks{.solution = [](const CurrentState &) { return false; },
+                    .trace = [](const CurrentState &) { return false; },
+                    .branch = probe_case.branch(problem),
+                    .stats_report = silent_stats_report()});
+            return {false, false, {}};
+        }
+        catch (const LargeDomainGuardTripped & e) {
+            return {true, false, e.what()};
+        }
+        catch (const std::bad_alloc &) {
+            return {true, false, "std::bad_alloc, at a site the guard does not check"};
+        }
+        catch (const std::exception & e) {
+            return {false, true, e.what()};
+        }
+    }
+
+    auto all_heuristic_probes() -> vector<HeuristicProbe>
+    {
+        vector<HeuristicProbe> probes;
+
+        // Every value order is measured against the same variable order, and
+        // every variable order against the same value order, so a row names one
+        // heuristic and nothing else. smallest_in is the value order used for
+        // the variable-order rows because it reads one bound and stops.
+        auto add_value_order = [&](string name, Expect expect, BranchValueGenerator val) {
+            probes.push_back(HeuristicProbe{"value_order::" + name, expect,
+                [val = move(val)](const Problem & p) { return branch_with(variable_order::in_order(p.all_normal_variables()), val); }});
+        };
+
+        auto add_variable_order = [&](string name, Expect expect, function<auto(const Problem &)->BranchVariableHeuristic> var) {
+            probes.push_back(HeuristicProbe{
+                "variable_order::" + name, expect, [var = move(var)](const Problem & p) { return branch_with(var(p), value_order::smallest_in()); }});
+        };
+
+        // The six that read a bound, or hand values out lazily so that the
+        // search reads one and stops. dev_docs/large-domains.md calls the lazy
+        // case legitimate explicitly: asking for a generator over a billion
+        // values and reading one of them is not work proportional to the width.
+        add_value_order("smallest_in", Expect::Clean, value_order::smallest_in());
+        add_value_order("smallest_out", Expect::Clean, value_order::smallest_out());
+        add_value_order("largest_in", Expect::Clean, value_order::largest_in());
+        add_value_order("largest_out", Expect::Clean, value_order::largest_out());
+        add_value_order("smallest_first", Expect::Clean, value_order::smallest_first());
+        add_value_order("largest_first", Expect::Clean, value_order::largest_first());
+
+        // The three splits and the median, which used to walk to their chosen
+        // position a value at a time and now ask the domain's interval set for
+        // it (#879). split_smallest_first is the one that mattered most: it is
+        // the heuristic one naturally reaches *for* a wide domain.
+        add_value_order("split_smallest_first", Expect::Clean, value_order::split_smallest_first());
+        add_value_order("split_largest_first", Expect::Clean, value_order::split_largest_first());
+        add_value_order("split_random", Expect::Clean, value_order::split_random(1234));
+        add_value_order("median", Expect::Clean, value_order::median());
+
+        // The two that draw a random position, likewise.
+        add_value_order("random_out", Expect::Clean, value_order::random_out(1234));
+        add_value_order("reject_random_interval", Expect::Clean, value_order::reject_random_interval(1234));
+
+        // A shuffled enumeration of the domain, which is O(width) if it is
+        // produced up front. Drawn lazily instead, so like smallest_first it
+        // costs what the search reads rather than what the domain holds.
+        add_value_order("random", Expect::Clean, value_order::random(1234));
+
+        // Variable orders read domain *sizes* and bounds, never values --
+        // including dom_wdeg, whose weighting schemes take domain_size() into
+        // the score. Rows rather than a comment saying so, because that is the
+        // property #833 wants checkable rather than argued.
+        add_variable_order("in_order", Expect::Clean, [](const Problem & p) { return variable_order::in_order(p.all_normal_variables()); });
+        add_variable_order("dom", Expect::Clean, [](const Problem & p) { return variable_order::dom(p); });
+        add_variable_order("dom_then_deg", Expect::Clean, [](const Problem & p) { return variable_order::dom_then_deg(p); });
+        add_variable_order(
+            "dom_wdeg", Expect::Clean, [](const Problem & p) { return variable_order::dom_wdeg(p, WeightingScheme::CurrentArityCurrentDomain); });
+        add_variable_order("with_smallest_value", Expect::Clean, [](const Problem & p) { return variable_order::with_smallest_value(p); });
+        add_variable_order("with_largest_value", Expect::Clean, [](const Problem & p) { return variable_order::with_largest_value(p); });
+        add_variable_order("random", Expect::Clean, [](const Problem & p) { return variable_order::random(p, 1234); });
+
+        return probes;
+    }
+}
+
+namespace
+{
     /* How does the *proof* grow with the domain's width?
      *
      * Out of scope for fixing: several of these have no viable fix today, and a
@@ -694,6 +812,26 @@ TEST_CASE("Large domain audit")
         // updated, not a regression; a Clean that starts tripping is the
         // regression. Both are failures here on purpose: each row's outcome is
         // pinned, so the table cannot drift away from what the code does.
+        CHECK(result.tripped == expected_trip);
+    }
+}
+
+TEST_CASE("Large domain heuristic audit")
+{
+    // Same pinning rule as the constraint lane: a row that stops tripping is a
+    // failure too, so the table cannot drift away from what the code does.
+    println("");
+    println("{:<40} {:<16} {:<16} {}", "heuristic", "expected", "actual", "");
+    for (const auto & probe_case : all_heuristic_probes()) {
+        auto result = heuristic_probe(probe_case);
+        auto actual = result.broken ? "BROKEN PROBE" : (result.tripped ? "trips" : "survives");
+        auto expected_trip = (probe_case.expect == Expect::KnownTrip);
+        auto agrees = (! result.broken) && (result.tripped == expected_trip);
+        println("{:<40} {:<16} {:<16} {}", probe_case.name, describe(probe_case.expect), actual, agrees ? "" : "<-- MISMATCH");
+
+        INFO("heuristic: " << probe_case.name);
+        INFO("detail: " << result.detail);
+        CHECK_FALSE(result.broken);
         CHECK(result.tripped == expected_trip);
     }
 }

--- a/gcs/search_heuristics.cc
+++ b/gcs/search_heuristics.cc
@@ -1,10 +1,11 @@
 #include <gcs/innards/propagators.hh>
+#include <gcs/interval_set.hh>
 #include <gcs/search_heuristics.hh>
 
 #include <algorithm>
+#include <cstddef>
 #include <memory>
 #include <random>
-#include <ranges>
 
 using std::generator;
 using std::make_shared;
@@ -286,6 +287,31 @@ auto gcs::variable_order::with_smallest_value(vector<IntegerVariableID> vars) ->
 
 namespace
 {
+    // A position drawn as a size_t index, as the Integer position
+    // IntervalSet::nth_value() takes. The distributions below stay size_t-typed
+    // and keep their original bounds, so a given seed draws exactly what it drew
+    // when these heuristics read a materialised vector of values.
+    auto position(std::size_t index) -> Integer
+    {
+        return Integer(static_cast<long long>(index));
+    }
+
+    // Where the three splitting value orders cut: the value at position
+    // size / 2 - 1, the largest of the lower half, so that "var <= v" and
+    // "var > v" divide the domain as evenly as its size allows.
+    //
+    // Asked of the domain's interval set rather than by counting values up to
+    // that position. A domain the branching heuristics are most likely to meet
+    // this way is a wide one --- splitting is the standard answer to "too many
+    // values to enumerate" --- and dropping size / 2 - 1 values from an
+    // each_value() generator walked half of it at every branching decision
+    // (issue #879).
+    auto split_point(const CurrentState & s, const IntegerVariableID & var) -> Integer
+    {
+        auto values = s.copy_of_values(var);
+        return values.nth_value(values.size() / 2_i - 1_i);
+    }
+
     auto random_value_generator(shared_ptr<mt19937> rand) -> BranchValueGenerator
     {
         return [rand = move(rand)](
@@ -306,11 +332,9 @@ namespace
         return [rand = move(rand)](
                    const CurrentState & s, const innards::Propagators &, const IntegerVariableID & var) -> generator<IntegerVariableCondition> {
             return [](shared_ptr<mt19937> rand, const CurrentState & s, IntegerVariableID var) -> generator<IntegerVariableCondition> {
-                vector<Integer> values;
-                for (auto v : s.each_value(var))
-                    values.push_back(v);
-                uniform_int_distribution<size_t> dist(0, values.size() - 1);
-                auto val = values.at(dist(*rand));
+                auto values = s.copy_of_values(var);
+                uniform_int_distribution<size_t> dist(0, (values.size() - 1_i).as_index());
+                auto val = values.nth_value(position(dist(*rand)));
                 co_yield var != val;
                 co_yield var == val;
             }(rand, s, var);
@@ -322,27 +346,26 @@ namespace
         return [rand = move(rand)](
                    const CurrentState & s, const innards::Propagators &, const IntegerVariableID & var) -> generator<IntegerVariableCondition> {
             return [](shared_ptr<mt19937> rand, const CurrentState & s, IntegerVariableID var) -> generator<IntegerVariableCondition> {
-                vector<Integer> values;
-                for (auto v : s.each_value(var))
-                    values.push_back(v);
+                auto values = s.copy_of_values(var);
+                auto size = values.size();
                 // An interior interval needs a plain variable and at least three
                 // values (so lo/hi can both be strictly inside the bounds, making the
                 // reject branch a genuine hole). Otherwise fall back to a value reject.
                 const auto * svar = std::get_if<SimpleIntegerVariableID>(&var);
-                if (svar && values.size() >= 3) {
-                    uniform_int_distribution<size_t> dist(1, values.size() - 2);
+                if (svar && size >= 3_i) {
+                    uniform_int_distribution<size_t> dist(1, (size - 2_i).as_index());
                     auto i = dist(*rand);
                     auto j = dist(*rand);
                     if (i > j)
                         std::swap(i, j);
-                    auto lo = values.at(i);
-                    auto hi = values.at(j);
+                    auto lo = values.nth_value(position(i));
+                    auto hi = values.nth_value(position(j));
                     co_yield not_in_range(var, lo, hi);
                     co_yield in_range(var, lo, hi);
                 }
                 else {
-                    uniform_int_distribution<size_t> dist(0, values.size() - 1);
-                    auto val = values.at(dist(*rand));
+                    uniform_int_distribution<size_t> dist(0, (size - 1_i).as_index());
+                    auto val = values.nth_value(position(dist(*rand)));
                     co_yield var != val;
                     co_yield var == val;
                 }
@@ -417,8 +440,7 @@ auto gcs::value_order::split_smallest_first() -> BranchValueGenerator
 {
     return [](const CurrentState & s, const innards::Propagators &, const IntegerVariableID & var) -> generator<IntegerVariableCondition> {
         return [](const CurrentState & s, IntegerVariableID var) -> generator<IntegerVariableCondition> {
-            auto mid = s.domain_size(var) / 2_i;
-            auto v = *(s.each_value(var) | std::ranges::views::drop((mid - 1_i).as_index())).begin();
+            auto v = split_point(s, var);
             co_yield var <= v;
             co_yield var > v;
         }(s, var);
@@ -429,8 +451,7 @@ auto gcs::value_order::split_largest_first() -> BranchValueGenerator
 {
     return [](const CurrentState & s, const innards::Propagators &, const IntegerVariableID & var) -> generator<IntegerVariableCondition> {
         return [](const CurrentState & s, IntegerVariableID var) -> generator<IntegerVariableCondition> {
-            auto mid = s.domain_size(var) / 2_i;
-            auto v = *(s.each_value(var) | std::ranges::views::drop((mid - 1_i).as_index())).begin();
+            auto v = split_point(s, var);
             co_yield var > v;
             co_yield var <= v;
         }(s, var);
@@ -444,8 +465,7 @@ namespace
         return [rand = move(rand)](
                    const CurrentState & s, const innards::Propagators &, const IntegerVariableID & var) -> generator<IntegerVariableCondition> {
             return [](shared_ptr<mt19937> rand, const CurrentState & s, IntegerVariableID var) -> generator<IntegerVariableCondition> {
-                auto mid = s.domain_size(var) / 2_i;
-                auto v = *(s.each_value(var) | std::ranges::views::drop((mid - 1_i).as_index())).begin();
+                auto v = split_point(s, var);
                 if (uniform_int_distribution(0, 1)(*rand) == 0) {
                     co_yield var <= v;
                     co_yield var > v;
@@ -505,10 +525,8 @@ auto gcs::value_order::median() -> BranchValueGenerator
 {
     return [](const CurrentState & s, const innards::Propagators &, const IntegerVariableID & var) -> generator<IntegerVariableCondition> {
         return [](const CurrentState & s, IntegerVariableID var) -> generator<IntegerVariableCondition> {
-            vector<Integer> values;
-            for (auto v : s.each_value(var))
-                values.push_back(v);
-            auto v = values.at(values.size() / 2);
+            auto values = s.copy_of_values(var);
+            auto v = values.nth_value(values.size() / 2_i);
             co_yield var == v;
             co_yield var != v;
         }(s, var);

--- a/gcs/search_heuristics.cc
+++ b/gcs/search_heuristics.cc
@@ -2,10 +2,10 @@
 #include <gcs/interval_set.hh>
 #include <gcs/search_heuristics.hh>
 
-#include <algorithm>
 #include <cstddef>
 #include <memory>
 #include <random>
+#include <unordered_map>
 
 using std::generator;
 using std::make_shared;
@@ -14,11 +14,12 @@ using std::nullopt;
 using std::optional;
 using std::random_device;
 using std::shared_ptr;
+using std::size_t;
 using std::tuple;
 using std::uint_fast32_t;
 using std::uniform_int_distribution;
+using std::unordered_map;
 using std::vector;
-using std::ranges::shuffle;
 
 namespace
 {
@@ -317,12 +318,39 @@ namespace
         return [rand = move(rand)](
                    const CurrentState & s, const innards::Propagators &, const IntegerVariableID & var) -> generator<IntegerVariableCondition> {
             return [](shared_ptr<mt19937> rand, const CurrentState & s, IntegerVariableID var) -> generator<IntegerVariableCondition> {
-                vector<Integer> values;
-                for (auto v : s.each_value(var))
-                    values.push_back(v);
-                shuffle(values, *rand);
-                for (auto v : values)
-                    co_yield var == v;
+                // A shuffled enumeration of the domain, drawn a value at a time
+                // rather than materialised and shuffled up front. This is
+                // Fisher-Yates with the array left implicit: position j of the
+                // shuffle is drawn uniformly from [j, size), and the map holds
+                // only the positions a draw has displaced, so it grows with the
+                // values the search actually asks for rather than with the
+                // domain's width. Same permutation distribution as shuffling the
+                // whole domain --- it is the same algorithm --- but a search that
+                // reads one value from a billion-value domain and descends does
+                // not pay for the other billion (issue #879).
+                //
+                // Every other value order here is width-independent because it
+                // needs one value. This one is width-independent because it is
+                // lazy, which is the same reason smallest_first() always was.
+                auto values = s.copy_of_values(var);
+                auto size = values.size().as_index();
+                unordered_map<size_t, size_t> displaced;
+                auto at = [&](size_t i) {
+                    auto f = displaced.find(i);
+                    return f == displaced.end() ? i : f->second;
+                };
+
+                for (size_t j = 0; j < size; ++j) {
+                    // Swap the implicit array's j'th and r'th entries, then hand
+                    // out the j'th. Nothing reads position j again --- every later
+                    // draw is from [j + 1, size) --- so only the entry landing at
+                    // r has to be remembered.
+                    uniform_int_distribution<size_t> dist(j, size - 1);
+                    auto r = dist(*rand);
+                    auto picked = at(r);
+                    displaced[r] = at(j);
+                    co_yield var == values.nth_value(position(picked));
+                }
             }(rand, s, var);
         };
     }

--- a/gcs/search_heuristics.cc
+++ b/gcs/search_heuristics.cc
@@ -286,6 +286,19 @@ auto gcs::variable_order::with_smallest_value(vector<IntegerVariableID> vars) ->
         });
 }
 
+auto gcs::variable_order::with_largest_value(const Problem & problem) -> BranchVariableHeuristic
+{
+    return with_largest_value(problem.all_normal_variables());
+}
+
+auto gcs::variable_order::with_largest_value(vector<IntegerVariableID> vars) -> BranchVariableHeuristic
+{
+    return variable_order::in_order_of(
+        vars, [](const CurrentState & state, const innards::Propagators &, const IntegerVariableID & a, const IntegerVariableID & b) {
+            return state.upper_bound(a) > state.upper_bound(b);
+        });
+}
+
 namespace
 {
     // A position drawn as a size_t index, as the Integer position

--- a/gcs/search_heuristics_test.cc
+++ b/gcs/search_heuristics_test.cc
@@ -13,6 +13,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
 
+#include <algorithm>
 #include <optional>
 #include <vector>
 
@@ -419,4 +420,62 @@ TEST_CASE("Position-based value orders count positions from the smallest value o
     CHECK(conditions_from(value_order::split_largest_first(), current, propagators, var) == vector<IntegerVariableCondition>{var > 7_i, var <= 7_i});
     // Position 6 / 2 = 3, counting from 5, is 8. From the top it would be 7.
     CHECK(conditions_from(value_order::median(), current, propagators, var) == vector<IntegerVariableCondition>{var == 8_i, var != 8_i});
+}
+
+TEST_CASE("random is a permutation of the domain, drawn lazily")
+{
+    // It used to materialise the domain and shuffle it, which is O(width)
+    // whether or not the search reads more than one value. Drawn a value at a
+    // time instead (issue #879), it still has to be a permutation: every value
+    // exactly once, or search is unsound one way and incomplete the other.
+    State state;
+    auto x = IntegerVariableID{state.allocate_integer_variable_with_state(0_i, 12_i)};
+    for (auto h : {2_i, 3_i, 7_i, 11_i})
+        REQUIRE(Inference::Instantiated != state.infer_not_equal(x, h));
+
+    Stats stats;
+    Propagators propagators{stats};
+    auto current = state.current();
+    auto expected = values_of(current, x);
+    auto generate = value_order::random(31337);
+
+    // Several draws, because a permutation bug can hide behind one lucky one.
+    for (int draw = 0; draw < 50; ++draw) {
+        vector<Integer> got;
+        for (auto && cond : generate(current, propagators, x))
+            got.push_back(cond.value);
+
+        REQUIRE(got.size() == expected.size());
+        auto sorted = got;
+        std::sort(sorted.begin(), sorted.end());
+        CHECK(sorted == expected);
+    }
+}
+
+TEST_CASE("random does not enumerate a domain the search only reads the start of")
+{
+    // The laziness itself: a billion-value domain, of which the search takes
+    // three values before descending. dev_docs/large-domains.md calls exactly
+    // this legitimate for smallest_first; random now has the same property.
+    State state;
+    auto x = IntegerVariableID{state.allocate_integer_variable_with_state(0_i, 1000000000_i)};
+    REQUIRE(Inference::Instantiated != state.infer_not_in_range(x, 11_i, 499999999_i));
+
+    Stats stats;
+    Propagators propagators{stats};
+    auto current = state.current();
+
+    vector<Integer> got;
+    for (auto && cond : value_order::random(4)(current, propagators, x)) {
+        got.push_back(cond.value);
+        if (got.size() == 3)
+            break;
+    }
+
+    REQUIRE(got.size() == 3);
+    for (auto v : got)
+        CHECK(current.in_domain(x, v));
+    CHECK(got[0] != got[1]);
+    CHECK(got[1] != got[2]);
+    CHECK(got[0] != got[2]);
 }

--- a/gcs/search_heuristics_test.cc
+++ b/gcs/search_heuristics_test.cc
@@ -390,6 +390,27 @@ TEST_CASE("Position-based value orders wired into solve_with find every solution
     CHECK(solutions == 30);
 }
 
+TEST_CASE("with_largest_value branches on the variable whose domain reaches highest")
+{
+    // Declared and documented in the header since it was written, but never
+    // defined, so any caller got a link error; found by the large-domain
+    // heuristic audit lane, which names every heuristic and so link-checks them.
+    State state;
+    auto a = IntegerVariableID{state.allocate_integer_variable_with_state(0_i, 5_i)};
+    auto b = IntegerVariableID{state.allocate_integer_variable_with_state(0_i, 9_i)};
+    auto c = IntegerVariableID{state.allocate_integer_variable_with_state(0_i, 7_i)};
+
+    Problem dummy;
+    Stats stats;
+    Propagators propagators{stats};
+    auto select = variable_order::with_largest_value(vector{a, b, c})(dummy, state, propagators);
+    CHECK(select(state.current(), propagators) == b);
+
+    auto smallest = variable_order::with_smallest_value(vector{a, b, c})(dummy, state, propagators);
+    REQUIRE(Inference::Instantiated != state.infer_greater_than_or_equal(b, 3_i));
+    CHECK(smallest(state.current(), propagators) == a);
+}
+
 TEST_CASE("Position-based value orders count positions from the smallest value of a view")
 {
     // CurrentState::each_value() hands a *negated* view's values out in

--- a/gcs/search_heuristics_test.cc
+++ b/gcs/search_heuristics_test.cc
@@ -228,3 +228,195 @@ TEST_CASE("dom_wdeg wired into solve_with finds every solution")
 
     CHECK(solutions == 6);
 }
+
+// Every position-based value order used to materialise the domain, or walk to
+// its chosen position one value at a time, and index into it. Asking the
+// domain's interval set for the value at that position instead (issue #879)
+// has to agree exactly, holes and all: a split point that lands somewhere else
+// silently changes the shape of every search tree, and one that lands in a hole
+// is not a value the variable can take.
+namespace
+{
+    auto values_of(const CurrentState & s, IntegerVariableID var) -> vector<Integer>
+    {
+        vector<Integer> result;
+        for (auto v : s.each_value(var))
+            result.push_back(v);
+        return result;
+    }
+
+    auto conditions_from(const BranchValueGenerator & generate, const CurrentState & s, const Propagators & p, IntegerVariableID var)
+        -> vector<IntegerVariableCondition>
+    {
+        vector<IntegerVariableCondition> result;
+        for (auto && cond : generate(s, p, var))
+            result.push_back(cond);
+        return result;
+    }
+}
+
+TEST_CASE("Position-based value orders agree with enumerating the domain")
+{
+    // Shapes chosen so that the answer differs from lower() + position: a hole
+    // straddling the midpoint, a hole either side of it, and single-value
+    // intervals where every step crosses a gap. The contiguous case is in there
+    // too, as the control.
+    auto holes = GENERATE(vector<Integer>{}, vector<Integer>{5_i}, vector<Integer>{2_i, 3_i, 4_i}, vector<Integer>{8_i, 9_i},
+        vector<Integer>{2_i, 4_i, 6_i, 8_i}, vector<Integer>{1_i, 2_i, 3_i, 7_i, 8_i, 9_i});
+
+    State state;
+    auto x = IntegerVariableID{state.allocate_integer_variable_with_state(0_i, 10_i)};
+    for (const auto & h : holes)
+        REQUIRE(Inference::Instantiated != state.infer_not_equal(x, h));
+
+    Stats stats;
+    Propagators propagators{stats};
+    auto current = state.current();
+    auto values = values_of(current, x);
+    REQUIRE(values.size() >= 3);
+
+    // The definitions these heuristics had before they became interval queries.
+    auto split_at = values.at(values.size() / 2 - 1);
+    auto median_at = values.at(values.size() / 2);
+
+    CHECK(conditions_from(value_order::split_smallest_first(), current, propagators, x) ==
+        vector<IntegerVariableCondition>{x <= split_at, x > split_at});
+    CHECK(conditions_from(value_order::split_largest_first(), current, propagators, x) ==
+        vector<IntegerVariableCondition>{x > split_at, x <= split_at});
+    CHECK(conditions_from(value_order::median(), current, propagators, x) == vector<IntegerVariableCondition>{x == median_at, x != median_at});
+
+    // split_random picks one of the two orderings, but always about the same point.
+    auto split = conditions_from(value_order::split_random(7), current, propagators, x);
+    REQUIRE(split.size() == 2);
+    CHECK(((split[0] == (x <= split_at) && split[1] == (x > split_at)) || (split[0] == (x > split_at) && split[1] == (x <= split_at))));
+}
+
+TEST_CASE("Random value orders only ever draw a value the variable can take")
+{
+    // A position drawn uniformly used to index a vector of the domain's values,
+    // so it could not name a hole. nth_value() has to keep that property: a
+    // branch on x == v for a v not in the domain is an immediately failed
+    // subtree, and on x != v it is a wasted one.
+    State state;
+    auto x = IntegerVariableID{state.allocate_integer_variable_with_state(0_i, 20_i)};
+    for (auto h : {1_i, 2_i, 3_i, 7_i, 11_i, 12_i, 13_i, 14_i, 19_i})
+        REQUIRE(Inference::Instantiated != state.infer_not_equal(x, h));
+
+    Stats stats;
+    Propagators propagators{stats};
+    auto current = state.current();
+    auto generate_out = value_order::random_out(99), generate_reject = value_order::reject_random_interval(99);
+
+    for (int draw = 0; draw < 200; ++draw) {
+        auto out = conditions_from(generate_out, current, propagators, x);
+        REQUIRE(out.size() == 2);
+        CHECK(current.in_domain(x, out[0].value));
+
+        // reject_random_interval yields a range whose two ends are both drawn
+        // positions, so both have to be values; the interior may be holes.
+        auto reject = conditions_from(generate_reject, current, propagators, x);
+        REQUIRE(reject.size() == 2);
+        for (auto && cond : reject)
+            CHECK(current.in_domain(x, cond.value));
+    }
+}
+
+TEST_CASE("Position-based value orders do not walk the domain to find their value")
+{
+    // The property #879 is about. A domain this wide cannot be enumerated at
+    // all, so a test that returns at once is itself the evidence; the audit lane
+    // in large_domain_audit_test.cc pins the same thing against the guard.
+    State state;
+    auto x = IntegerVariableID{state.allocate_integer_variable_with_state(0_i, 1000000000_i)};
+    // {0..10} u {500000000..1000000000}: 500000012 values, so position
+    // 250000005 is the split point and 250000006 the median, both well inside
+    // the upper interval.
+    REQUIRE(Inference::Instantiated != state.infer_not_in_range(x, 11_i, 499999999_i));
+    REQUIRE(state.domain_size(x) == 500000012_i);
+
+    Stats stats;
+    Propagators propagators{stats};
+    auto current = state.current();
+
+    auto split_at = 500000000_i + 250000005_i - 11_i;
+    auto median_at = split_at + 1_i;
+    CHECK(conditions_from(value_order::split_smallest_first(), current, propagators, x) ==
+        vector<IntegerVariableCondition>{x <= split_at, x > split_at});
+    CHECK(conditions_from(value_order::median(), current, propagators, x) == vector<IntegerVariableCondition>{x == median_at, x != median_at});
+
+    auto out = conditions_from(value_order::random_out(5), current, propagators, x);
+    REQUIRE(out.size() == 2);
+    CHECK(current.in_domain(x, out[0].value));
+}
+
+TEST_CASE("Position-based value orders wired into solve_with find every solution")
+{
+    // Complete search over a domain with holes: which value a heuristic picks
+    // only changes the order the tree is explored in, so all of them must still
+    // enumerate the same solutions. The holes are the point --- an off-by-one in
+    // a position query shows up here as a lost or repeated solution.
+    auto which = GENERATE(0, 1, 2, 3, 4, 5);
+
+    Problem problem;
+    vector<IntegerVariableID> xs;
+    for (int i = 0; i < 3; ++i)
+        xs.push_back(problem.create_integer_variable(vector<Integer>{1_i, 2_i, 5_i, 8_i, 9_i}));
+    for (unsigned i = 0; i < xs.size(); ++i)
+        for (unsigned j = i + 1; j < xs.size(); ++j)
+            problem.post(NotEquals{xs[i], xs[j]});
+    problem.post(LessThan{xs[0], xs[2]});
+
+    auto val = [&]() -> BranchValueGenerator {
+        switch (which) {
+        case 0: return value_order::split_smallest_first();
+        case 1: return value_order::split_largest_first();
+        case 2: return value_order::split_random(which + 1);
+        case 3: return value_order::median();
+        case 4: return value_order::random_out(which + 1);
+        default: return value_order::reject_random_interval(which + 1);
+        }
+    }();
+
+    int solutions = 0;
+    solve_with(problem,
+        SolveCallbacks{.solution = [&](const CurrentState &) -> bool {
+                           ++solutions;
+                           return true;
+                       },
+            .branch = branch_with(variable_order::dom(problem), val)});
+
+    // 5 * 4 * 3 = 60 injective triples, halved by x[0] < x[2].
+    CHECK(solutions == 30);
+}
+
+TEST_CASE("Position-based value orders count positions from the smallest value of a view")
+{
+    // CurrentState::each_value() hands a *negated* view's values out in
+    // descending order --- it applies the view to the underlying domain in
+    // stored order, and negation reverses it --- where copy_of_values() sorts.
+    // So the old "materialise each_value() and index it" spelling counted
+    // positions from the top of a negated view's domain: median() picked the
+    // wrong value for an even-sized domain, and split_smallest_first() cut so
+    // that "var <= v" kept the *larger* part. The interval query counts from
+    // lower(), which is what a position means.
+    //
+    // Nothing in the tree branches on a view today, so no proof moved when this
+    // changed; the property is pinned here rather than left to that staying true.
+    State state;
+    auto x = state.allocate_integer_variable_with_state(0_i, 5_i);
+    auto var = IntegerVariableID{-x + 10_i}; // values 5..10, six of them
+    Stats stats;
+    Propagators propagators{stats};
+    auto current = state.current();
+
+    REQUIRE(current.domain_size(var) == 6_i);
+    REQUIRE(current.lower_bound(var) == 5_i);
+    REQUIRE(current.upper_bound(var) == 10_i);
+
+    // Six values, so the lower half is 5..7 and the split point is 7. Counted
+    // from the top --- what the old spelling did --- it would have been 8.
+    CHECK(conditions_from(value_order::split_smallest_first(), current, propagators, var) == vector<IntegerVariableCondition>{var <= 7_i, var > 7_i});
+    CHECK(conditions_from(value_order::split_largest_first(), current, propagators, var) == vector<IntegerVariableCondition>{var > 7_i, var <= 7_i});
+    // Position 6 / 2 = 3, counting from 5, is 8. From the top it would be 7.
+    CHECK(conditions_from(value_order::median(), current, propagators, var) == vector<IntegerVariableCondition>{var == 8_i, var != 8_i});
+}


### PR DESCRIPTION
Closes #879.

Seven of the **thirteen** value orders (the issue says eleven; it is thirteen)
did work proportional to the domain's width, at *every* branching decision
rather than once at the root. Heuristics sit outside the audit lane's remit
entirely, so no amount of sharpening a constraint's row would ever have found
them.

## Two shapes, and only one is an interval query

**Six wanted a position.** The three splits want the value at `size / 2 - 1`,
`median` the one at `size / 2`, and `random_out` and `reject_random_interval` a
uniformly drawn position. That is one new primitive — `IntervalSet::nth_value()`,
which walks the interval list accumulating widths — and six call sites. This is
the H1a shape again: the conclusion was already a single value, only the search
for it was per-value.

Adding it to `IntervalSet` rather than computing inside the heuristics was the
call to make. Six of the seven need exactly this one query, so inline meant
either the same interval walk written out four times or a private helper in
`search_heuristics.cc` with no access to `intervals` — i.e. an `IntervalSet`
method written outside `IntervalSet`, allocating a generator frame per node. It
is also the natural completion of the querying API: `lower()` is `nth_value(0)`
and `upper()` is `nth_value(size() - 1)`. `contains_all_of()` in #862 set the
precedent.

**`random` wanted laziness, not a query.** A shuffled enumeration of the domain
is `O(width)` however it is spelled; what was wrong was paying it up front.
It is now Fisher–Yates with the array left implicit — position `j` drawn from
`[j, size)`, a map holding only the positions a draw has displaced — so it costs
what the search reads. Same permutation distribution, same algorithm. This is
the property that made `smallest_first` legitimate all along.

## Measured

Per call, one core of an EPYC 7643, Release, ns:

| domain | `split_smallest_first` | | `median` | |
|---|---|---|---|---|
| | before | after | before | after |
| width 4 | 131 | **67** | 214 | **66** |
| width 256 | 1 716 | **67** | 3 838 | **66** |
| width 4096 | 25 822 | **67** | 55 812 | **67** |
| width 4096, 64 holes | 26 234 | **243** | 56 504 | **243** |
| width 10⁶ | 6 317 324 | **67** | 25 540 065 | **65** |
| width 10⁸ | 629 960 951 | **68** | 2 899 422 752 | **68** |

Flat in the width, and faster at every width *including the narrowest* — the old
spelling paid for a `std::generator` frame and the `std::function` the view
application needs, where this copies a two-element inline vector. The holey rows
are the honest cost: `nth_value()` is `O(intervals)`.

`random` is where laziness costs something, and it is the one number in this PR
that goes the wrong way. A **full** enumeration of a narrow domain is 79 ns per
value against 25 eagerly (127 against 25 with 64 holes) — a hash-map operation
where there was a vector index. End to end it is invisible: full-enumeration
search over nine-value domains, 3 940 ns/node before and 3 912 after, no
difference outside noise.

`rcpsp --value-order split` is unchanged in node counts (40 751 recursions,
516 275 propagations) at 0.889 s → 0.885 s.

## A latent bug this corrects, and one it does not

`CurrentState::each_value()` applies a view to the underlying domain in stored
order, and negation reverses it, so a **negated view's** values come out
descending where `copy_of_values()` sorts them. The old spelling therefore
counted positions from the *top* of such a domain: `median()` picked the wrong
value for an even-sized one, and `split_smallest_first()` cut so that `var <= v`
kept the larger part. A differential check over every variable kind and five
domain shapes reports zero disagreements on plain variables and offset views,
and disagreements only on negated ones. Nothing in the tree branches on a view
today, so no proof moves; there is a test pinning it rather than leaving it to
that staying true.

The same root cause makes `value_order::smallest_first()` yield *largest*-first
on a negated view, and makes `smallest_first` and `largest_first` identical
there. That is a different fix in a much more widely used function, so it is
filed as #890 rather than done here.

`variable_order::with_largest_value` turned out to be declared and documented in
the public header and defined nowhere — any caller got a link error. Fixed here,
in its own commit, because the lane rows are what found it: a row names its
heuristic, so building the lane link-checks every one.

## The lane

Twenty new rows in `large_domain_audit_test.cc`: every value order against a
fixed variable order, and every variable order against a fixed value order.
They need no stopping rule of their own — `solve_with_state()` calls
`branch_generator.begin()` *before* the trace callback, so the existing "stop at
the root" probe has already made one branching decision by the time it returns.

Variable orders were clean already (`dom_wdeg`'s weighting schemes included: they
read `domain_size()` and bounds). They get rows anyway, so the property is
checkable rather than argued.

**Negative control**: suppress the six position fixes and exactly those six rows
trip, nothing else moves.

## Verification

- **804/804 GCC, 808/808 clang, zero skips**, `-DGCS_TEST_CAP_DEFAULTS=OFF`,
  with MiniZinc, `cake_pb_cp` and `opbdiff` all on PATH.
- `-DGCS_WERROR=ON` clean; ASan+UBSan clean on the touched tests; the guard lane
  green (180 assertions, both tables); six rounds of `ctest -j 8` on the touched
  tests.
- **Proofs, at a fixed seed**: 50 637 artefacts compared under
  `GCS_PRESERVE_PROOF_FILES=all`. 35 differ — and 34 of those differ between two
  runs of the *same* binary too (the `*_random` examples generate their instances
  from `random_device`; so does the `minizinc/splitrandom` lane). The 35th,
  `stacktrace_logging_test`, differs only in the absolute worktree path baked
  into a logged stack trace.

  Worth recording how that check has to be done here: an unseeded before/after
  comparison reports **26 655 of 50 061** artefacts changed, 4 391 of them `.opb`
  files, which a branching change cannot possibly cause. The constraint tests
  draw a fresh `random_device` seed per run, so the suite is not reproducible run
  to run without pinning `--seed`, and any byte-identity claim made without
  pinning it is measuring the seed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EdcpzKhRabS67Kcfq3eq9e
