### PR TITLE
Hand a negated view its values in ascending order (#890)

### DIFF
--- a/dev_docs/state-and-variables.md
+++ b/dev_docs/state-and-variables.md
@@ -304,6 +304,18 @@ constants:
   not rely on that, since it is allowed to be optimised in future to
   avoid the copy. `CurrentState` exposes a single `each_value` (forward)
   and `each_value_reversed` (descending) for callback-time consumers.
+- **Ascending means ascending in the variable's own values, views
+  included** — and that is worth spelling out because it was not true
+  until #890. A view's values are produced by applying the view to the
+  underlying domain as it is walked, and a *negated* view reverses the
+  order while doing so, so an ascending walk of the stored intervals
+  handed a negated view's values out largest first. The four entry
+  points now walk the stored set backwards when `negate_first` is set,
+  which costs nothing; `copy_of_values()` was already re-sorting, so it
+  and `each_value_reversed()` (built on it) were right all along, and it
+  was the cheap path that disagreed with them. The symptom was
+  `value_order::smallest_first()` yielding the largest value first, and
+  being indistinguishable from `largest_first`.
 - `for_each_value_immutable(var, cb)`, `for_each_value_mutable(var, cb)` —
   the same two contracts, delivered by calling `cb(value)` in ascending
   order rather than returning a generator. A `cb` returning `bool` stops

--- a/gcs/current_state.hh
+++ b/gcs/current_state.hh
@@ -128,7 +128,14 @@ namespace gcs
         [[nodiscard]] auto in_domain(const IntegerVariableID, Integer) const -> bool;
 
         /**
-         * \brief Returns a generator that gives each value in the variable's domain.
+         * \brief Returns a generator that gives each value in the variable's domain,
+         * in ascending order.
+         *
+         * Ascending in the variable's own values, so a negated view's values come out
+         * smallest first even though the underlying domain is walked backwards to do
+         * it (issue #890).
+         *
+         * \sa CurrentState::each_value_reversed()
          */
         [[nodiscard]] auto each_value(const IntegerVariableID) const -> std::generator<Integer>;
 

--- a/gcs/innards/state.cc
+++ b/gcs/innards/state.cc
@@ -683,16 +683,28 @@ auto State::domains_intersect(const IntegerVariableID & var1, const IntegerVaria
 
 namespace
 {
-    auto each_value_generator(IntervalSet<Integer> set, std::function<auto(Integer)->Integer> apply) -> generator<Integer>
+    auto each_value_generator(IntervalSet<Integer> set, std::function<auto(Integer)->Integer> apply, bool descending_underlying) -> generator<Integer>
     {
         // Counted as the values are handed out rather than checked against the
         // domain's width up front: a caller that reads one value from a very
         // wide domain -- which is what a branching heuristic does -- is doing
         // nothing wrong, and only a caller that walks the whole thing is.
         LargeDomainIterationCounter guard{"the number of values one each_value_*() generator has yielded"};
-        for (auto i : set.each()) {
-            guard.step();
-            co_yield apply(i);
+        if (descending_underlying) {
+            // A negated view maps the underlying domain order onto its own
+            // reversed, so walking the stored set backwards is what yields the
+            // view's values in ascending order. See the ascending() note in the
+            // header: this costs nothing, where re-sorting afterwards would.
+            for (auto i : set.each_reversed()) {
+                guard.step();
+                co_yield apply(i);
+            }
+        }
+        else {
+            for (auto i : set.each()) {
+                guard.step();
+                co_yield apply(i);
+            }
         }
     }
 
@@ -710,7 +722,8 @@ auto State::each_value_immutable(const VarType_ & var) const -> generator<Intege
     auto apply = [negate_first = negate_first, then_add = then_add](Integer v) -> Integer { return apply_view(v, negate_first, then_add); };
 
     return visit_actual(
-        actual_var, [&](const SimpleIntegerVariableID & v) { return each_value_generator(state_of(v), apply); },
+        actual_var,
+        [&, negate_first = negate_first](const SimpleIntegerVariableID & v) { return each_value_generator(state_of(v), apply, negate_first); },
         [&](const ConstantIntegerVariableID & v) { return each_value_constant_generator(v.const_value, apply); });
 }
 
@@ -722,7 +735,8 @@ auto State::each_value_mutable(const VarType_ & var) const -> generator<Integer>
     auto apply = [negate_first = negate_first, then_add = then_add](Integer v) -> Integer { return apply_view(v, negate_first, then_add); };
 
     return visit_actual(
-        actual_var, [&](const SimpleIntegerVariableID & v) { return each_value_generator(state_of(v), apply); },
+        actual_var,
+        [&, negate_first = negate_first](const SimpleIntegerVariableID & v) { return each_value_generator(state_of(v), apply, negate_first); },
         [&](const ConstantIntegerVariableID & v) { return each_value_constant_generator(v.const_value, apply); });
 }
 

--- a/gcs/innards/state.hh
+++ b/gcs/innards/state.hh
@@ -396,9 +396,17 @@ namespace gcs::innards
         [[nodiscard]] auto has_single_value(const IntegerVariableID) const -> bool;
 
         /**
-         * Provide a generator that iterates over each value in a variable's domain. The
-         * variable's domain must not be modified whilst the generator is alive. Call using
-         * either IntegerVariableID or one of its more specific types.
+         * Provide a generator that iterates over each value in a variable's domain,
+         * **in ascending order**. The variable's domain must not be modified whilst
+         * the generator is alive. Call using either IntegerVariableID or one of its
+         * more specific types.
+         *
+         * Ascending in the *variable's own* values, which for a negated view is the
+         * reverse of the underlying domain's order: the walk goes backwards over the
+         * stored intervals, which costs nothing, rather than sorting afterwards,
+         * which would. Getting this wrong made value_order::smallest_first() hand
+         * out the largest value first, and made it indistinguishable from
+         * largest_first (issue #890).
          *
          * \sa State::each_value_mutable(), State::for_each_value_immutable()
          */
@@ -406,10 +414,14 @@ namespace gcs::innards
         auto each_value_immutable(const VarType_ &) const -> std::generator<Integer>;
 
         /**
-         * Provide a generator that iterates over each value in a variable's domain. The
-         * variable's domain may be modified whilst the generator is alive, but the generator
-         * will run over the values pre-modification. Call using either IntegerVariableID or
-         * one of its more specific types.
+         * Provide a generator that iterates over each value in a variable's domain,
+         * **in ascending order**. The variable's domain may be modified whilst the
+         * generator is alive, but the generator will run over the values
+         * pre-modification. Call using either IntegerVariableID or one of its more
+         * specific types.
+         *
+         * Ascending in the variable's own values; see State::each_value_immutable()
+         * for what that means for a negated view.
          *
          * \sa State::each_value_immutable(), State::for_each_value_mutable()
          */
@@ -418,7 +430,9 @@ namespace gcs::innards
 
         /**
          * Non-coroutine alternative to each_value_immutable(). Calls \p cb(value)
-         * for each value in the variable's domain, in ascending order. Avoids the
+         * for each value in the variable's domain, in ascending order --- of the
+         * variable's own values, so a negated view walks the stored intervals
+         * backwards (issue #890). Avoids the
          * std::generator frame allocation, the std::function the view-application
          * needs in the generator version, and copying the underlying IntervalSet.
          *
@@ -435,10 +449,17 @@ namespace gcs::innards
                 actual_var,
                 [&, negate_first = negate_first, then_add = then_add](const SimpleIntegerVariableID & v) {
                     LargeDomainIterationCounter guard{"the number of values one for_each_value_immutable() call has visited"};
-                    state_of_for_iteration(v).for_each([&](Integer i) {
+                    auto step = [&](Integer i) {
                         guard.step();
                         return cb(state_detail::apply_view(i, negate_first, then_add));
-                    });
+                    };
+                    // A negated view reverses the underlying domain's order, so
+                    // walking the stored set backwards is what hands the view's
+                    // values out ascending.
+                    if (negate_first)
+                        state_of_for_iteration(v).for_each_reversed(step);
+                    else
+                        state_of_for_iteration(v).for_each(step);
                 },
                 [&, negate_first = negate_first, then_add = then_add](
                     const ConstantIntegerVariableID & v) { cb(state_detail::apply_view(v.const_value, negate_first, then_add)); });
@@ -447,7 +468,8 @@ namespace gcs::innards
         /**
          * Non-coroutine alternative to each_value_mutable(). The variable's
          * domain may be modified by \p cb; iteration walks a snapshot of the
-         * pre-modification domain. If \p cb returns \c bool, returning \c false
+         * pre-modification domain, in ascending order of the variable's own
+         * values (issue #890). If \p cb returns \c bool, returning \c false
          * stops iteration early.
          *
          * \sa State::each_value_mutable(), State::for_each_value_immutable()
@@ -461,10 +483,14 @@ namespace gcs::innards
                 [&, negate_first = negate_first, then_add = then_add](const SimpleIntegerVariableID & v) {
                     auto snapshot = state_of_for_iteration(v);
                     LargeDomainIterationCounter guard{"the number of values one for_each_value_mutable() call has visited"};
-                    snapshot.for_each([&](Integer i) {
+                    auto step = [&](Integer i) {
                         guard.step();
                         return cb(state_detail::apply_view(i, negate_first, then_add));
-                    });
+                    };
+                    if (negate_first)
+                        snapshot.for_each_reversed(step);
+                    else
+                        snapshot.for_each(step);
                 },
                 [&, negate_first = negate_first, then_add = then_add](
                     const ConstantIntegerVariableID & v) { cb(state_detail::apply_view(v.const_value, negate_first, then_add)); });

--- a/gcs/innards/state_test.cc
+++ b/gcs/innards/state_test.cc
@@ -358,8 +358,15 @@ TEST_CASE("Every way of iterating a domain hands values out in ascending order")
     };
 
     for (auto var : {IntegerVariableID{x}, IntegerVariableID{x + 100_i}, IntegerVariableID{-x}, IntegerVariableID{-x + 20_i}}) {
+        // Bound to a local rather than iterated off the temporary:
+        // IntervalSet::each() borrows the set it is called on, and only
+        // P2718R0's extended lifetime for range-init temporaries makes
+        // `copy_of_values(var).each()` safe --- so on a compiler without it, the
+        // set is gone before the first value is read. GCC 15 has it and GCC 14
+        // does not, which is a difference between two of the CI lanes.
+        auto values = state.copy_of_values(var);
         vector<Integer> from_copy;
-        for (auto v : state.copy_of_values(var).each())
+        for (auto v : values.each())
             from_copy.push_back(v);
 
         vector<Integer> immutable, mutable_, for_immutable, for_mutable;
@@ -379,7 +386,7 @@ TEST_CASE("Every way of iterating a domain hands values out in ascending order")
         // And the reversed generator really is the other direction, rather than
         // accidentally agreeing with a walk that was already backwards.
         vector<Integer> reversed;
-        for (auto v : state.copy_of_values(var).each_reversed())
+        for (auto v : values.each_reversed())
             reversed.push_back(v);
         auto flipped = from_copy;
         std::reverse(flipped.begin(), flipped.end());

--- a/gcs/innards/state_test.cc
+++ b/gcs/innards/state_test.cc
@@ -338,3 +338,74 @@ TEST_CASE("copy_of_values / domains_intersect on multi-interval negated views")
         CHECK(state.domains_intersect(d, -a)); // symmetry
     }
 }
+
+TEST_CASE("Every way of iterating a domain hands values out in ascending order")
+{
+    // Issue #890: the each_value family applied a view to the underlying domain
+    // in stored order, and negation reverses that, so a negated view's values
+    // came out descending --- where copy_of_values() and each_value_reversed()
+    // sorted them. The four entry points and copy_of_values() have to agree,
+    // and ascending has to mean ascending in the *variable's own* values.
+    State state;
+    auto x = state.allocate_integer_variable_with_state(0_i, 9_i);
+    for (auto h : {2_i, 3_i, 6_i})
+        REQUIRE(Inference::Contradiction != state.infer_not_equal(x, h));
+    // x is now {0, 1, 4, 5, 7, 8, 9}: holes, so a single-interval walk would not
+    // catch a reversal, and an even count, so a symmetric one would not either.
+
+    auto ascending = [](const vector<Integer> & vs) {
+        return std::is_sorted(vs.begin(), vs.end()) && std::adjacent_find(vs.begin(), vs.end()) == vs.end();
+    };
+
+    for (auto var : {IntegerVariableID{x}, IntegerVariableID{x + 100_i}, IntegerVariableID{-x}, IntegerVariableID{-x + 20_i}}) {
+        vector<Integer> from_copy;
+        for (auto v : state.copy_of_values(var).each())
+            from_copy.push_back(v);
+
+        vector<Integer> immutable, mutable_, for_immutable, for_mutable;
+        for (auto v : state.each_value_immutable(var))
+            immutable.push_back(v);
+        for (auto v : state.each_value_mutable(var))
+            mutable_.push_back(v);
+        state.for_each_value_immutable(var, [&](Integer v) { for_immutable.push_back(v); });
+        state.for_each_value_mutable(var, [&](Integer v) { for_mutable.push_back(v); });
+
+        CHECK(ascending(from_copy));
+        CHECK(immutable == from_copy);
+        CHECK(mutable_ == from_copy);
+        CHECK(for_immutable == from_copy);
+        CHECK(for_mutable == from_copy);
+
+        // And the reversed generator really is the other direction, rather than
+        // accidentally agreeing with a walk that was already backwards.
+        vector<Integer> reversed;
+        for (auto v : state.copy_of_values(var).each_reversed())
+            reversed.push_back(v);
+        auto flipped = from_copy;
+        std::reverse(flipped.begin(), flipped.end());
+        CHECK(reversed == flipped);
+    }
+
+    // A constant is a one-value domain whichever way it is asked for.
+    vector<Integer> constant;
+    for (auto v : state.each_value_immutable(ConstantIntegerVariableID{7_i}))
+        constant.push_back(v);
+    CHECK(constant == vector<Integer>{7_i});
+}
+
+TEST_CASE("Early exit from a domain walk stops at the smallest values, views included")
+{
+    // The other half of ascending: for_each_value_*'s early exit has to give up
+    // the *first* values in the variable's own order, or a caller that stops
+    // after k of them gets the wrong k for a negated view.
+    State state;
+    auto x = state.allocate_integer_variable_with_state(0_i, 5_i);
+    auto var = IntegerVariableID{-x + 10_i}; // 5..10
+
+    vector<Integer> first_three;
+    state.for_each_value_immutable(var, [&](Integer v) {
+        first_three.push_back(v);
+        return first_three.size() < 3;
+    });
+    CHECK(first_three == vector<Integer>{5_i, 6_i, 7_i});
+}

--- a/gcs/interval_set.hh
+++ b/gcs/interval_set.hh
@@ -541,6 +541,34 @@ namespace gcs
         }
 
         /**
+         * \brief Calls \p f(value) for each value in the set in descending order.
+         *
+         * Non-coroutine alternative to each_reversed(), and the mirror of
+         * for_each(): no heap-allocated generator frame, the iteration inlines
+         * into the caller.
+         *
+         * If \p f returns \c bool, returning \c false stops iteration early.
+         * If \p f returns \c void, iteration always runs to completion.
+         *
+         * \sa for_each(), each_reversed()
+         */
+        template <typename F_>
+        auto for_each_reversed(F_ && f) const -> void
+        {
+            if constexpr (std::is_void_v<std::invoke_result_t<F_ &, Int_>>) {
+                for (auto lu = intervals.rbegin(); lu != intervals.rend(); ++lu)
+                    for (Int_ i = lu->second; i >= lu->first; --i)
+                        f(i);
+            }
+            else {
+                for (auto lu = intervals.rbegin(); lu != intervals.rend(); ++lu)
+                    for (Int_ i = lu->second; i >= lu->first; --i)
+                        if (! f(i))
+                            return;
+            }
+        }
+
+        /**
          * \brief Returns a generator that yields each stored interval as a
          * (lower, upper) pair, in ascending order.
          *

--- a/gcs/interval_set_test.cc
+++ b/gcs/interval_set_test.cc
@@ -1087,3 +1087,47 @@ TEST_CASE("nth_value rejects a position outside the set")
     IntervalSet<int> empty;
     CHECK_THROWS_AS(empty.nth_value(0), UnexpectedException);
 }
+
+TEST_CASE("for_each_reversed matches each_reversed")
+{
+    // The non-coroutine mirror of for_each(). State's for_each_value_* use it to
+    // hand a negated view's values out ascending without a generator frame
+    // (issue #890), so it has to agree with each_reversed() exactly.
+    IntervalSet<int> s1(5, 9), s2, s3;
+    s2.insert_at_end(1, 2);
+    s2.insert_at_end(7, 7);
+    s2.insert_at_end(10, 13);
+    // s3 stays empty.
+
+    for (const auto & set : {s1, s2, s3}) {
+        vector<int> from_generator, from_callback;
+        for (auto v : set.each_reversed())
+            from_generator.push_back(v);
+        set.for_each_reversed([&](int v) { from_callback.push_back(v); });
+        CHECK(from_callback == from_generator);
+
+        vector<int> forwards;
+        set.for_each([&](int v) { forwards.push_back(v); });
+        reverse(forwards);
+        CHECK(from_callback == forwards);
+    }
+}
+
+TEST_CASE("for_each_reversed stops early when the callback says so")
+{
+    IntervalSet<int> set;
+    set.insert_at_end(1, 3);
+    set.insert_at_end(8, 10);
+
+    vector<int> seen;
+    set.for_each_reversed([&](int v) {
+        seen.push_back(v);
+        return seen.size() < 4;
+    });
+    CHECK(seen == vector<int>{10, 9, 8, 3});
+
+    // A void callback runs to completion, as for_each() does.
+    vector<int> all;
+    set.for_each_reversed([&](int v) -> void { all.push_back(v); });
+    CHECK(all == vector<int>{10, 9, 8, 3, 2, 1});
+}

--- a/gcs/search_heuristics_test.cc
+++ b/gcs/search_heuristics_test.cc
@@ -500,3 +500,31 @@ TEST_CASE("random does not enumerate a domain the search only reads the start of
     CHECK(got[1] != got[2]);
     CHECK(got[0] != got[2]);
 }
+
+TEST_CASE("smallest_first and largest_first run the right way round on a negated view")
+{
+    // The symptom #890 was filed for. CurrentState::each_value() used to hand a
+    // negated view's values out descending, so smallest_first() yielded the
+    // largest first and was indistinguishable from largest_first(). These two
+    // cannot use a position query --- they want the lazy generator, which is
+    // exactly what makes them safe on a wide domain --- so the fix was to the
+    // iteration order itself.
+    State state;
+    auto x = state.allocate_integer_variable_with_state(0_i, 5_i);
+    for (auto h : {1_i, 4_i})
+        REQUIRE(Inference::Instantiated != state.infer_not_equal(x, h));
+    // x is {0, 2, 3, 5}, so -x + 10 is {5, 7, 8, 10}.
+    auto var = IntegerVariableID{-x + 10_i};
+    Stats stats;
+    Propagators propagators{stats};
+    auto current = state.current();
+
+    CHECK(conditions_from(value_order::smallest_first(), current, propagators, var) ==
+        vector<IntegerVariableCondition>{var == 5_i, var == 7_i, var == 8_i, var == 10_i});
+    CHECK(conditions_from(value_order::largest_first(), current, propagators, var) ==
+        vector<IntegerVariableCondition>{var == 10_i, var == 8_i, var == 7_i, var == 5_i});
+
+    // And the bound-reading pair still agree with them about which end is which.
+    CHECK(conditions_from(value_order::smallest_in(), current, propagators, var)[0] == (var == 5_i));
+    CHECK(conditions_from(value_order::largest_in(), current, propagators, var)[0] == (var == 10_i));
+}


### PR DESCRIPTION
Closes #890. Was stacked on #891, which has since merged; rebased onto `main`
(which also picked up #886 in the meantime) and retargeted. #891 is what turned
this up, and the two touch `search_heuristics_test.cc` in common.

`State`'s `each_value` family applies a view to the underlying domain as it walks
it, in stored order. A negated view maps that order onto its own reversed, so its
values came out **descending** — while `copy_of_values()` re-sorts, and
`CurrentState::each_value_reversed()` is built on `copy_of_values()`. So those two
were right and the cheap path disagreed with them.

The user-visible symptom:

```
plain x (0..4)                smallest_first yields: 0 1 2 3 4
plain x (0..4)                largest_first  yields: 4 3 2 1 0

negated view -x + 10 (6..10)  smallest_first yields: 10 9 8 7 6     <-- largest first
negated view -x + 10 (6..10)  largest_first  yields: 10 9 8 7 6     <-- and identical
```

Neither can be fixed the way #891 fixed the position-based value orders. They want
the lazy generator — which is exactly what makes them safe on a wide domain — so
there is nothing to ask a sorted copy for. The fix has to be the iteration order.

## The fix

When `negate_first` is set, walk the stored intervals **backwards**. That costs
nothing, where re-sorting afterwards would — which is why this is not simply
routed through `copy_of_values()`, whose negated path builds a `std::vector` of
intervals to reverse them. `for_each_value_*` exist to avoid the coroutine frame
that `each_value_*` pays, so they get `IntervalSet::for_each_reversed()` rather
than `each_reversed()`.

All four entry points now agree with `copy_of_values()` for every variable kind,
and `for_each_value_*`'s early exit gives up the *first* values in the variable's
own order rather than the last — which matters for any caller that stops after k.

`dev_docs/state-and-variables.md` already said `for_each_value_*` delivers "in
ascending order", so this is the documented contract being honoured rather than a
new one. The headers now say it too, since they did not.

## What moves

**172 proof artefacts, and zero `.opb`, zero `.scp`.** The models and their
encodings are untouched; what changes is the order in which a proof introduces
order-encoding atoms, and with it the relative `pol ... -N +` back-references that
count lines backwards. Every one of them still verifies.

All 172 are in the constraint tests' view lanes (`*_mixed`), bar one —
`stacktrace_logging_test`, whose only difference is the absolute worktree path
baked into a logged stack trace. That is the blast radius one would predict from
the change: only a negated view iterates differently, and only the `*_mixed`
lanes build one.

116 of the 126 moved proofs have an **identical line count**; the other ten are
within a handful either way (six longer, four shorter), netting **+42 lines over
803 651, +0.005%**. So this is a reordering, not a proof-size change.

Measured at a fixed seed against 50 073 artefacts under
`GCS_PRESERVE_PROOF_FILES=all`, with the 34 artefacts that differ between two runs
of the *same* binary excluded — see #891 for why an unseeded comparison here is
meaningless. That measurement was taken against #891's tip, before the rebase;
the rebase changed no source of mine, only what sits underneath it.

## Verification

- **810/810 GCC, zero skips**, `-DGCS_TEST_CAP_DEFAULTS=OFF`, with MiniZinc,
  `cake_pb_cp` and `opbdiff` on PATH — re-run after the rebase onto the merged
  `main`; it was 804/804 GCC and 808/808 clang before it, the six extra being
  #886's. Every moved proof is VeriPB-checked by that run.
- `-DGCS_WERROR=ON` clean; ASan+UBSan clean on `state_test`, `interval_set_test`,
  `search_heuristics_test`, `solve_test`; the large-domain guard lane green (180
  assertions, both tables).
- **Negative control**: suppress the reversal in both the generator and the
  `for_each` paths, and `state_test` fails 2 cases / 9 assertions and
  `search_heuristics_test` 1 case — so the tests bite on exactly this.

## Not done here

The `_immutable` / `_mutable` pair are still behaviourally identical (both copy
the `IntervalSet` into the coroutine frame), which
`dev_docs/state-and-variables.md` already records as a thing callers must not rely
on. Untouched by this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EdcpzKhRabS67Kcfq3eq9e

