### PR TITLE
Correct two comments the reason re-walk left behind (#870)

### DIFF
--- a/gcs/constraints/equals/equals.cc
+++ b/gcs/constraints/equals/equals.cc
@@ -75,11 +75,11 @@ namespace
     // either domain, and it stops by running p off the top of one of the two
     // domains, which is the contradiction the conclusion needs.
     //
-    // Both consumers -- the reason builder, which turns each move into a
-    // literal, and emit_justification, which turns each move into zero, one or
-    // two lemmas -- go through here, because the lemmas' whole job is to let
-    // unit propagation see that reason's literals through, so the two must be
-    // reporting the same walk.
+    // Only the reason builder walks here, turning each move into a literal.
+    // emit_justification does not: it reads the same walk back out of those
+    // literals instead (#870), because the lemmas' whole job is to let unit
+    // propagation see that reason's literals through, and taking the walk from
+    // the reason is what makes the two certain to be reporting the same one.
     //
     // \p d1 and \p d2 must be non-empty and disjoint, which is exactly the
     // condition the rule fires under.

--- a/gcs/constraints/equals/equals_test.cc
+++ b/gcs/constraints/equals/equals_test.cc
@@ -247,8 +247,10 @@ auto run_holey_no_overlap_equals_test(bool proofs, bool swapped) -> void
 // literals as one run again, or it pays two lemmas per value instead of two per
 // run; the proof still verifies either way, which is why this is checked by
 // diffing proof bytes against the interval spelling rather than by a lane going
-// red. Measured on this instance: 527 proof lines, against 536 if the run is
-// not put back together.
+// red. Measured on this instance: putting the run back together saves nine
+// proof lines -- 759 against 768 at --seed=1, 755 against 764 at 424242, 742
+// against 751 at 999. The absolute size moves with the seed, since this test
+// enumerates under a randomised branching order; the nine lines do not.
 //
 // It matters more than a handful of lines because it is the only coverage of the
 // witness reading a run out of literals it did not write as a range: everything


### PR DESCRIPTION
Two comments that stopped being true when #885 landed, found while reviewing
that stack. Comments only — no code changes, and `ctest` is 810/810 either way.

### `walk_no_overlap`'s "both consumers"

Its doc comment says the reason builder *and* `emit_justification` both go
through it, "so the two must be reporting the same walk". Since #885 the
justifier does not: it reads the walk back out of the reason's literals, and
`walk_no_overlap` has exactly one caller. That is the sentence a future editor
would rely on, because it names this function as what keeps the two in step,
where what keeps them in step is now the reason itself. The replacement says so
and keeps the original point about why they have to agree.

### The view instance's "527 proof lines, against 536"

`run_holey_no_overlap_view_equals_test`'s comment reports those figures for
"this instance". The test enumerates 64 solutions under a randomised branching
order, so its proof is **742 to 759 lines depending on the seed** — the absolute
numbers are not reproducible from it.

The *difference* is exactly right, which is the part the sentence is actually
about: disabling the run regrouping adds precisely nine lines at every seed
tried. So the comment now states the nine, with the measurements behind it.

Measured against this branch's parent (`6aed1b7f`):

| seed | regrouped | run left in pieces | delta |
|---|---|---|---|
| 1 | 759 | 768 | 9 |
| 424242 | 755 | 764 | 9 |
| 999 | 742 | 751 | 9 |

Whatever the 527 was measured on, it was not this test. The commit message that
introduced it (`8803715d`) still quotes the pair; I have left that as its author
wrote it rather than rewriting someone else's record of what they measured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
