### PR TITLE
Wake a constant-operand reified equals on the literal it turns on

### DIFF
--- a/dev_docs/constraints.md
+++ b/dev_docs/constraints.md
@@ -345,8 +345,17 @@ These wake the propagator on any change to a whole *variable*. A propagator that
 instead cares about specific *literals* (`x = v`, `x >= k`, ...) on many variables
 and is otherwise dormant can arm **refined per-literal watches** via
 `Triggers::refined` and the `RefinedWatchContext` — see [Refined
-triggers](refined-triggers.md). That is a specialised mechanism (its first client
-is the learned-nogood store); most constraints want the coarse triggers above.
+triggers](refined-triggers.md). Most constraints want the coarse triggers above;
+reach for a watch when the propagator's whole verdict turns on a literal and
+`on_change` would therefore wake it for every *other* value too. `ReifiedEquals`
+against a constant `c` is the small case — instantiation plus `x != c` is the
+whole of what it reads, where `on_change` woke it once per value in `x`'s domain
+(issue #889) — and the learned-nogood store is the large one.
+
+A refined-watch literal puts its variable in the propagator's **scope** (so
+degree and adjacency are unchanged) without arming a coarse trigger; use
+`Triggers::scope_only` to declare scope for a variable that neither mechanism
+mentions.
 
 ### install_initialiser
 

--- a/dev_docs/propagator-performance.md
+++ b/dev_docs/propagator-performance.md
@@ -160,6 +160,28 @@ ten-term not-equals and was a reproducible 6.9% there. Both had identical
 `nodes` *and* identical `effectfulPropagations` — which is the shape to insist
 on, and the one that says the fixpoint at every node is untouched.
 
+**When every coarse trigger is too coarse, watch the literal.** `on_change` is
+the finest coarse granularity there is, and it is still per *variable*: a
+propagator that only cares whether one particular value is still in a domain
+wakes for every removal from it. A model that posts one such propagator per
+(variable, value) pair then wakes `d` of them for each removal, `d - 1` of which
+find nothing. `nmseq` — FlatZinc's `int_eq_reif(x, c, b)`, from
+`x == sum(bool2int(xs[i] == v))` — did exactly that: 130,756 `Equals` calls per
+node at 4.4% effectful, 82% of the model's propagation time, at a per-call cost
+(52 ns) that was already fine. Registering the two literals the propagator
+actually turns on instead (`Triggers::refined`, see refined-triggers.md) took it
+to 4.4M calls at 98.6% effectful on an identical tree — 22.6x fewer, 2.1x faster
+end to end — and the C++ `magic_series --size=300`, the same shape, to 2.6x
+fewer propagations for 10.5% fewer instructions (issue #889). The lever is the
+same one as #807 and #819; what is different is that no coarse trigger could
+have expressed it.
+
+Watches are not free: the engine tests every watch armed on a variable against
+each inference on it, so the scan is the same length as the coarse trigger list
+and only the per-item body is cheaper (a `test_literal` against a full propagator
+call). Reach for one when the propagator's whole verdict turns on a *literal*,
+not when it merely reads a few values.
+
 **A `_micros` share is not necessarily wake cost.** `GCS_PROPAGATOR_STATS=time`
 brackets the propagator call, so a contradiction's `throw
 TrackedPropagationFailed` unwinds inside the sample. `lin_not_equals` on `tpp`

--- a/dev_docs/refined-triggers.md
+++ b/dev_docs/refined-triggers.md
@@ -111,6 +111,16 @@ The owner processes its fired set the next time it runs in the propagation queue
 — firing and processing are *decoupled* (the owner is the schedulable unit). This
 matters for one subtlety (*abandoned fires*, below).
 
+The round boundary replays the round's inferences through one of two variants:
+`requeue`, or `requeue_unless_already_seen` when some propagator in the round
+claimed `EnableButIdempotent`. **Both fire watches**, and the claim gates only the
+coarse triggers. A claim says the claimant need not be re-woken by what it has
+already seen, which for a coarse trigger costs at most a delay — the next change
+wakes it anyway — but for a watch costs the wake outright, because each inference
+is replayed exactly once and a watch not fired against it is never offered it
+again. Getting this wrong is invisible in everything but the node count; see
+issue #889, where it turned nmseq/100 from 767 nodes into 1,089,375.
+
 ### Trigger masks
 
 A literal can only *become* entailed on certain kinds of change, mirroring the
@@ -269,6 +279,11 @@ For anyone changing this code:
 - **Trigger masks must over-approximate.** A mask must include *every* `Inference`
   granularity that could make the literal newly entailed; too narrow a mask drops
   a fire (a missed inference). The differential catches this.
+- **Every replay path must fire watches.** A watch is a one-shot subscription and
+  each inference is replayed once, so any path that walks the round's inferences
+  and skips the watch index loses the wake permanently. `requeue` and
+  `requeue_unless_already_seen` share `fire_refined_watches` for exactly this
+  reason; a new variant must call it too.
 - **Catch-up runs at root re-propagation only**, keyed off an empty fired set.
   That is where new clauses appear (after a restart unwind) and where the edits
   land in the persistent root epoch, keeping the non-backtrackable `set_up`
@@ -293,6 +308,10 @@ refined path must behave byte-for-byte like the scan oracle:
   that exercises the engine mechanism directly (the index, fired-watch inbox,
   consume, re-arm, restore, `is_watching`), with a coarse-vs-refined laziness
   comparison. Retired once refined triggers fold into the real `Linear`.
+- `gcs/innards/propagators_test.cc` — a watch must fire whether or not the round
+  has an idempotence claimant. Neither vehicle above co-registers a claiming
+  propagator, which is how the claim-path gap in the replay survived (#889), so
+  this one is a pair of unit cases rather than a differential.
 
 Each load-bearing piece has a **mutation test** recorded in the relevant PR:
 inject the bug, confirm a differential catches it, before trusting the check.

--- a/gcs/constraints/equals/equals.cc
+++ b/gcs/constraints/equals/equals.cc
@@ -561,16 +561,49 @@ auto ReifiedEquals::install_propagators(Propagators & propagators) -> void
 
     // on_change for the shared set, because the undecided pass reads in_domain and
     // domains_intersect, and the must-hold pass intersects the two domains.
+    //
+    // Unless one operand is a constant, which collapses both of those reads. With
+    // v2 pinned at c its optional_single_value is always set, so the undecided pass
+    // never reaches the domains_intersect arm at all: it reports MustHold exactly
+    // when v1 is instantiated to c, and MustNotHold exactly when c leaves v1's
+    // domain -- its "v1 fixed to something other than c" and "! in_domain(v1, c)"
+    // arms being the same fact stated twice, since fixing v1 elsewhere removes c.
+    // The must-hold pass likewise finds the constant's single value and fixes v1 to
+    // it on its first wake, and the must-not-hold pass removes it, both returning
+    // DisableUntilBacktrack, so once the condition is decided the condition's own
+    // trigger is all that arm ever needs.
+    //
+    // So the propagator turns on two facts about the other operand: whether it is
+    // instantiated, and whether c is still in its domain. on_instantiated covers
+    // the first -- every State::change_state_for_* that leaves a domain a singleton
+    // reports Inference::Instantiated, whichever operation got it there. A refined
+    // watch on `other != c` covers the second, and wakes only the propagator whose
+    // value was the one removed, where on_change wakes every propagator posted on
+    // that variable. In a model that posts a reified equality per (variable, value)
+    // pair -- FlatZinc's int_eq_reif against a constant, which is what
+    // `x == sum(bool2int(xs[i] == v))` flattens to -- that is the difference
+    // between one wake per interior removal and one per value in the domain
+    // (issue #889).
+    //
+    // Two constant operands need no special case: on_change registers no wake for a
+    // constant either, and every pass decides outright on the one call every
+    // propagator gets when search starts.
     Triggers triggers;
-    triggers.on_change = {_v1, _v2};
+    if (is_constant_variable(_v1) != is_constant_variable(_v2)) {
+        auto [other, constant] = is_constant_variable(_v2) ? pair{_v1, constant_value_of(_v2)} : pair{_v2, constant_value_of(_v1)};
+        triggers.on_instantiated = {_v1, _v2};
+        triggers.refined.emplace_back(other != constant, 0u);
+    }
+    else
+        triggers.on_change = {_v1, _v2};
 
-    // But an unconditional NotEquals only ever runs the must-not-hold pass, which
-    // reads nothing but optional_single_value and disables itself until backtrack
-    // once it has acted -- so on_instantiated cannot miss its wake, and the wakes
-    // it drops are the expensive ones: fixing a vertex removes one value from each
-    // of its d neighbours, and under on_change each of those interior removals
-    // woke every other not-equals on that neighbour to find neither end fixed
-    // (issue #819).
+    // An unconditional NotEquals, constant operand or not, only ever runs the
+    // must-not-hold pass, which reads nothing but optional_single_value and
+    // disables itself until backtrack once it has acted -- so on_instantiated
+    // cannot miss its wake, and the wakes it drops are the expensive ones: fixing
+    // a vertex removes one value from each of its d neighbours, and under
+    // on_change each of those interior removals woke every other not-equals on
+    // that neighbour to find neither end fixed (issue #819).
     Triggers triggers_when_must_not_hold;
     triggers_when_must_not_hold.on_instantiated = {_v1, _v2};
 

--- a/gcs/constraints/equals/equals_test.cc
+++ b/gcs/constraints/equals/equals_test.cc
@@ -190,6 +190,75 @@ auto run_no_overlap_equals_test(bool proofs) -> void
     check_results(proof_name, expected, actual);
 }
 
+// The nmseq shape in miniature: an indicator b[v] per value, each posted as a
+// reified equality between x and the *constant* v, plus a driver g[v] that
+// punches v out of x's interior on its own.
+//
+// The driver is what makes this lane different from every other one here. Every
+// other test posts a single constraint over its operands, so nothing ever
+// removes an interior value from one: the only domain event a propagator is
+// asked about is an instantiation, and a trigger that can see nothing finer
+// passes. Nor is it enough to punch the hole with a disequality against another
+// branched variable -- tried, and the search fixed b[v] before it ever got round
+// to making the hole, so the interesting node was never reached. g[v] = 1 makes
+// the hole directly, from a variable the brancher can reach while b[v] is still
+// free, and then b[v] = 0 is a pruning nothing else in the model can make.
+//
+// A trigger that misses it loses no solutions -- search still finds the right
+// answer, just after exploring a subtree it should have pruned -- so this is
+// checked as consistency at every node, not as a solution set. It is what stands
+// behind the constant-operand triggers in ReifiedEquals::install_propagators;
+// dropping the refined watch and leaving only on_instantiated fails it. Note
+// that g[v]'s own constraint has a constant operand too, so the not-equals-if
+// arm of the same reasoning is under test alongside the equals-iff one. See
+// issue #889.
+auto run_value_indicator_equals_test(bool proofs, int n) -> void
+{
+    print(cerr, "value indicator equals {}{}", n, proofs ? " with proofs:" : ":");
+    cerr << flush;
+
+    // x takes some value; b says which; g[v] may forbid v, and may not forbid
+    // the value x actually takes.
+    set<tuple<int, vector<int>, vector<int>>> expected, actual;
+    for (int xv = 0; xv < n; ++xv) {
+        vector<int> bs;
+        for (int v = 0; v < n; ++v)
+            bs.push_back(xv == v ? 1 : 0);
+        for (int mask = 0; mask < (1 << n); ++mask) {
+            if (mask & (1 << xv))
+                continue;
+            vector<int> gs;
+            for (int v = 0; v < n; ++v)
+                gs.push_back((mask >> v) & 1);
+            expected.emplace(xv, bs, gs);
+        }
+    }
+    println(cerr, " expecting {} solutions", expected.size());
+
+    Problem p;
+    auto x = p.create_integer_variable(0_i, Integer{n - 1});
+    vector<IntegerVariableID> bs, gs;
+    for (int v = 0; v < n; ++v) {
+        bs.push_back(p.create_integer_variable(0_i, 1_i));
+        gs.push_back(p.create_integer_variable(0_i, 1_i));
+    }
+
+    for (int v = 0; v < n; ++v) {
+        p.post(EqualsIff{x, constant_variable(Integer{v}), bs[v] == 1_i});
+        p.post(NotEqualsIf{x, constant_variable(Integer{v}), gs[v] == 1_i});
+    }
+
+    // Every position is GAC, and each is achieved by a single propagator over
+    // its own scope: b[v] = 1 dies exactly when v leaves x, g[v] = 1 dies
+    // exactly when x is fixed at v, and x loses v exactly when b[v] = 0 or
+    // g[v] = 1. No deduction here crosses two constraints.
+    auto proof_name = proofs ? make_optional("equals_test_value_indicator_" + std::to_string(n)) : nullopt;
+    solve_for_tests_checking_consistency(
+        p, proof_name, expected, actual, tuple{pair{x, CheckConsistency::GAC}, pair{bs, CheckConsistency::GAC}, pair{gs, CheckConsistency::GAC}});
+
+    check_results(proof_name, expected, actual);
+}
+
 // A reified equals whose operands are disjoint but *interleaved*: each one's
 // values sit in the other's holes, so no bound separates them and the witness
 // has to account for every run. This is the shape the interval certificate of
@@ -391,6 +460,8 @@ auto main(int argc, char * argv[]) -> int
             continue;
         if (run_no_overlap) {
             run_no_overlap_equals_test(proofs);
+            run_value_indicator_equals_test(proofs, 4);
+            run_value_indicator_equals_test(proofs, 6);
             run_holey_no_overlap_equals_test(proofs, false);
             run_holey_no_overlap_equals_test(proofs, true);
             if (proofs)

--- a/gcs/innards/propagators.cc
+++ b/gcs/innards/propagators.cc
@@ -796,19 +796,43 @@ auto Propagators::propagate(const Literals & guesses, State & state, ProofLogger
         }
     };
 
-    auto requeue = [&](const SimpleIntegerVariableID & v, const Inference inf) {
+    // Wake whatever this inference wakes: the coarse triggers, and then any
+    // refined watch whose literal it has newly entailed.
+    //
+    // HonourClaims picks the round-boundary variant. A run that claimed
+    // idempotence must not be re-woken by an inference it had already seen
+    // (everything recorded up to its run's end, its own inferences included), so
+    // the replay passes true, with claim_protected flagging the claimants whose
+    // runs ended after the inference being replayed -- and only when the round
+    // produced claims at all, the claim-free path being the hot one. It is a
+    // template parameter so that the two variants can share one body without the
+    // shared part becoming a call: this body runs once per inference, and
+    // factoring just the watch loop out into a lambda they both call cost 1.1% of
+    // tsp's instructions, the compiler declining to inline it into a function this
+    // size. What this generates is what writing the body out twice generates.
+    //
+    // The claim gates the coarse triggers only. Every replay of an inference
+    // fires watches, because a watch is a one-shot subscription and each
+    // inference is replayed exactly once: a fire skipped here is a wake lost for
+    // good rather than merely deferred. Waking a claimant through its own watch
+    // costs it a re-run it may not need; not waking it silently drops pruning,
+    // which is the far worse trade and is invisible in everything but the node
+    // count (issue #889).
+    //
+    // A watch is only tested when the current inference granularity is in its
+    // trigger_mask -- e.g. an `x==v` watch is skipped on a mere bound move, since
+    // x==v can only become true when x is instantiated. This gates the expensive
+    // test_literal; the firing of a watch outside its mask would be a no-op
+    // anyway (the literal cannot have changed status), so this is
+    // semantics-preserving.
+    auto requeue_honouring = [&]<bool HonourClaims_>(const SimpleIntegerVariableID & v, const Inference inf) {
         if (v.index < _imp->iv_triggers.size())
             for (auto & [p, mask] : _imp->iv_triggers[v.index].ids_and_masks)
-                if (mask & (1 << to_underlying(inf)))
+                if ((mask & (1 << to_underlying(inf))) && (! HonourClaims_ || ! _imp->claim_protected[p]))
                     enqueue_if_idle(p);
 
-        // Refined watches: fire any whose literal is now entailed, delivering the
-        // payload to its owner and consuming the watch. A watch is only tested when
-        // the current inference granularity is in its trigger_mask -- e.g. an `x==v`
-        // watch is skipped on a mere bound move, since x==v can only become true when
-        // x is instantiated. This gates the expensive test_literal; the firing of a
-        // watch outside its mask would be a no-op anyway (the literal cannot have
-        // changed status), so this is semantics-preserving.
+        // Fire any watch whose literal is now entailed, delivering the payload to
+        // its owner and consuming the watch.
         if (v.index < _imp->refined_watches_by_var.size()) {
             const auto inf_bit = 1u << to_underlying(inf);
             auto & watches = _imp->refined_watches_by_var[v.index];
@@ -829,19 +853,10 @@ auto Propagators::propagate(const Literals & guesses, State & state, ProofLogger
         }
     };
 
-    // A run that claimed idempotence must not be re-woken by any inference it
-    // had already seen (everything recorded up to its run's end, its own
-    // inferences included): the round-boundary replay uses this variant, with
-    // claim_protected flagging the claimants whose runs ended after the
-    // inference being replayed, when (and only when) the round produced
-    // claims -- the plain requeue above keeps the claim-free hot path free of
-    // the extra load. Refined watches are consumed on their first fire in the
-    // requeue above, so this coarse-only replay does not re-fire them.
+    auto requeue = [&](const SimpleIntegerVariableID & v, const Inference inf) { requeue_honouring.template operator()<false>(v, inf); };
+
     auto requeue_unless_already_seen = [&](const SimpleIntegerVariableID & v, const Inference inf) {
-        if (v.index < _imp->iv_triggers.size())
-            for (auto & [p, mask] : _imp->iv_triggers[v.index].ids_and_masks)
-                if ((mask & (1 << to_underlying(inf))) && ! _imp->claim_protected[p])
-                    enqueue_if_idle(p);
+        requeue_honouring.template operator()<true>(v, inf);
     };
 
     // A contradiction or an abort ends a round without replaying it, so a

--- a/gcs/innards/propagators_test.cc
+++ b/gcs/innards/propagators_test.cc
@@ -274,6 +274,96 @@ TEST_CASE("A view of a distinct variable does not downgrade the claim")
     CHECK(runs == 1);
 }
 
+// A refined watch is a one-shot subscription to a literal, and each inference is
+// replayed to the wake machinery exactly once. So the round-boundary replay has
+// to fire watches whichever path it takes: the claim-free one, or the one that
+// gates coarse triggers on the already-seen rule. It did not, and because a
+// dropped wake costs only pruning, nothing failed --- the tree just grew. It
+// grew silently for the learned-nogood store, which is a watch client: refined
+// took 259,103 recursions on `langford --size=11 --restarts=100` where the scan
+// path it is meant to match took 258,670. And it grew catastrophically for the
+// first client whose whole verdict rides on a watch --- reified equals against a
+// constant, 767 nodes on nmseq/100 against 1,089,375 (issue #889).
+
+namespace
+{
+    // Fires once: removes 7 from the middle of x's domain. Interior, so it is
+    // exactly the granularity a `!= 7` watch subscribes to and a bounds trigger
+    // would miss.
+    auto install_hole_punching_propagator(Propagators & propagators, SimpleIntegerVariableID x, PropagatorState state_to_return, int & runs) -> void
+    {
+        Triggers triggers;
+        triggers.on_change = {x};
+        propagators.install(
+            ConstraintID{NumberedConstraint{1}},
+            [&runs, x, state_to_return](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+                ++runs;
+                if (state.in_domain(x, 7_i))
+                    inference.infer(logger, x != 7_i, NoJustificationNeeded{}, NoReason{});
+                return state_to_return;
+            },
+            triggers);
+    }
+
+    // Woken only by its watch: scope_only keeps x in scope (degree, adjacency)
+    // while arming no coarse trigger, so a second run can only be the watch.
+    auto install_watching_propagator(Propagators & propagators, SimpleIntegerVariableID x, int & runs) -> void
+    {
+        Triggers triggers;
+        triggers.scope_only = {x};
+        triggers.refined.emplace_back(x != 7_i, 0u);
+        propagators.install(
+            ConstraintID{NumberedConstraint{2}},
+            [&runs](const State &, auto &, ProofLogger * const) -> PropagatorState {
+                ++runs;
+                return PropagatorState::Enable;
+            },
+            triggers);
+    }
+}
+
+TEST_CASE("A refined watch fires when the round has an idempotence claimant")
+{
+    State state;
+    Stats stats;
+    Propagators propagators{stats};
+    auto x = state.allocate_integer_variable_with_state(0_i, 10_i);
+
+    int puncher_runs = 0, watcher_runs = 0;
+    install_hole_punching_propagator(propagators, x, PropagatorState::EnableButIdempotent, puncher_runs);
+    install_watching_propagator(propagators, x, watcher_runs);
+
+    REQUIRE(propagators.propagate(Literals{}, state, nullptr));
+    CHECK(! state.in_domain(x, 7_i));
+
+    // Both run in the first pass, before the hole exists. The puncher's claim
+    // sends the boundary down the already-seen path, which protects the puncher
+    // from its own inference -- and must still fire the watcher's watch.
+    CHECK(puncher_runs == 1);
+    CHECK(watcher_runs == 2);
+}
+
+TEST_CASE("A refined watch fires when the round has no idempotence claimant")
+{
+    State state;
+    Stats stats;
+    Propagators propagators{stats};
+    auto x = state.allocate_integer_variable_with_state(0_i, 10_i);
+
+    int puncher_runs = 0, watcher_runs = 0;
+    install_hole_punching_propagator(propagators, x, PropagatorState::Enable, puncher_runs);
+    install_watching_propagator(propagators, x, watcher_runs);
+
+    REQUIRE(propagators.propagate(Literals{}, state, nullptr));
+    CHECK(! state.in_domain(x, 7_i));
+
+    // The same wake, on the claim-free path: the watcher must not be able to
+    // tell the two apart. The puncher re-runs here because its own inference
+    // wakes it back through its coarse trigger.
+    CHECK(puncher_runs == 2);
+    CHECK(watcher_runs == 2);
+}
+
 // Propagators::shared_derived_data: the store that lets several constraints
 // over one shared input derive something from it once between them. Keyed by
 // (input address, type), created empty on the first ask, and the same object

--- a/gcs/solve_test.cc
+++ b/gcs/solve_test.cc
@@ -318,6 +318,62 @@ TEST_CASE("Learned nogoods: refined matches scan under restarts")
     CHECK(refined.solutions == scan.solutions);
 }
 
+// The same differential, over a model that contains an idempotence claimant.
+//
+// The pigeonhole above does not: NotEquals never claims, so every round ends on
+// the claim-free replay path, and the claim-gated one -- which for a long time
+// fired no refined watches at all -- was never reached. Element claims, so this
+// instance reaches it, and on the engine before issue #889 refined and scan part
+// company here: 30 restarts and 45 learned nogoods against 29 and 43. It is a
+// small copy of `langford --size=11 --restarts=100`, where the same gap is
+// 259,103 recursions against 258,670.
+//
+// Same rules as above: deterministic branching, so the trees can only differ
+// through propagation, and the instance has to restart and learn or the
+// differential says nothing. dom_then_deg is safe here despite reading degree,
+// because a refined-watch literal puts its variable in the propagator's scope
+// exactly as a coarse trigger does -- which is also why the two paths agree on
+// every count once the engine is fixed.
+TEST_CASE("Learned nogoods: refined matches scan under restarts, with a claimant")
+{
+    auto run = [](bool scan) -> Stats {
+        set_learned_nogoods_scan(scan);
+
+        Problem p;
+        const int k = 6;
+        vector<IntegerVariableID> position, solution;
+        for (int i = 0; i < 2 * k; ++i) {
+            position.emplace_back(p.create_integer_variable(0_i, Integer{2 * k - 1}));
+            solution.emplace_back(p.create_integer_variable(1_i, Integer{k}));
+        }
+        p.post(AllDifferent{position});
+        for (int i = 0; i < k; ++i) {
+            auto i_var = p.create_integer_variable(Integer{i + 1}, Integer{i + 1});
+            p.post(Element{i_var, position[i], &solution});
+            p.post(Element{i_var, position[i + k], &solution});
+            p.post(Plus{position[i + k], constant_variable(Integer{i + 2}), position[i]});
+        }
+
+        return solve_with(p,
+            SolveCallbacks{
+                .branch = branch_with(variable_order::dom_then_deg(p), value_order::smallest_first()), .restarts = RestartSchedule::luby(1)},
+            nullopt);
+    };
+
+    auto refined = run(false);
+    auto scan = run(true);
+    set_learned_nogoods_scan(false);
+
+    CHECK(refined.restarts > 0);
+    CHECK(refined.learned_nogoods > 0);
+
+    CHECK(refined.recursions == scan.recursions);
+    CHECK(refined.failures == scan.failures);
+    CHECK(refined.restarts == scan.restarts);
+    CHECK(refined.learned_nogoods == scan.learned_nogoods);
+    CHECK(refined.solutions == scan.solutions);
+}
+
 // An unsatisfiable Langford-pairing instance (size 5): rich enough that
 // AllDifferent and Element prune at the root, so the root node emits
 // guess-independent propagation that later restart passes do not re-derive.


### PR DESCRIPTION
Closes #889.

Two commits, because the second does not work without the first, and the first
is a bug in its own right.

## 1. Fire refined watches on the claim replay path too

`propagate()`'s round boundary replays the round's inferences through one of two
variants: `requeue`, or `requeue_unless_already_seen` when some propagator in the
round returned `EnableButIdempotent`. Only the first fired refined watches. Its
comment claimed the second did not need to — "refined watches are consumed on
their first fire in the requeue above" — but `requeue` is not called first, it is
the *other branch of the same `if`*. So in any round with a claimant, every watch
fire was dropped, and because each inference is replayed exactly once, dropped
for good rather than deferred.

A dropped wake costs pruning, not soundness, so nothing failed. **The learned
nogood store is a refined-watch client**, and `refined-triggers.md` states the
refined path must explore the identical tree as the legacy scan path. On
`langford --size=11 --restarts=100` it did not:

| | recursions | failures | learned nogoods |
|---|---|---|---|
| main, refined | 259,103 | 169,741 | 2,766 |
| main, scan | 258,670 | 169,350 | 2,746 |
| this PR, refined | **258,670** | **169,350** | **2,746** |
| this PR, scan | 258,670 | 169,350 | 2,746 |

The claim gates the coarse triggers only, and deliberately. A claimant not
re-woken by a coarse trigger it has already seen loses at most a round — the next
change wakes it anyway. A watch not fired against the one inference that entails
its literal is never offered that inference again.

**Cost.** Putting the watch-index test on an inference-frequency path that did
not have it is not free. Instruction counts (deterministic, `perf stat`) over the
`benchmarking.md` set, this commit alone:

| | Δ instructions |
|---|---|
| `tsp` | +1.71% |
| `magic_square --size=5` | +1.36% |
| `ortho_latin --size=6 --all` | +0.69% |
| `qap --size=12`, `langford --size=11`, `n_queens --size=14 --all` | within ±0.15% |

Hoisting an "are there any watches at all" test out of the replay loop would
remove it entirely — the index is empty for every model above — but it needs an
invariant about when the index can grow, and adding one of those to the fix for a
silently dropped wake seemed like the wrong trade. Happy to do it as a follow-up
if you'd rather have the 1.7%.

`HonourClaims_` is a template parameter so the two variants can share one body
without the shared part becoming a call. The body runs once per inference, and
factoring just the watch loop out into a lambda they both call cost a further
1.1% of `tsp`'s instructions — the compiler declines to inline it into a function
`propagate()`'s size. The template generates what writing the body out twice
generates, to within 0.01%.

**Tests.** Two unit cases in `propagators_test.cc` (a watch must fire with and
without a claimant in the round), plus a second scan-vs-refined differential in
`solve_test.cc` over a model that contains one — the existing pigeonhole is all
`NotEquals`, which never claims, which is how this survived. All three fail on the
unfixed engine; the sabotage runs are in the session log.

## 2. Watch the literal a constant-operand reified equals turns on

`ReifiedEquals` woke `on_change` on both operands. A constant operand collapses
what it reads: with `v2` pinned at `c` the undecided pass never reaches its
`domains_intersect` arm, and says MustHold exactly when `v1` is instantiated to
`c` and MustNotHold exactly when `c` leaves `v1`'s domain. Both enforce passes act
against the constant on their first wake and `DisableUntilBacktrack`.

So the propagator turns on two facts about the other operand: is it instantiated,
and is `c` still there. `on_instantiated` covers the first. The second is a
*literal*, and no coarse trigger can say it — `on_change` wakes for every removal,
so a model posting one such propagator per (variable, value) pair wakes `d` of
them per removal and `d − 1` find nothing. A refined watch on `other != c` wakes
the one whose value went.

That model is FlatZinc's `int_eq_reif` against a constant — what
`x == sum(bool2int(xs[i] == v))` flattens to. Upstream `nmseq`, same binary, same
tree, min of three:

| | nodes | failures | `Equals` calls | effectful | solveTime |
|---|---|---|---|---|---|
| n=100 main | 767 | 666 | 100,290,249 | 4.4% | 4.455 s |
| n=100 this PR | 767 | 666 | **4,429,784** (22.6×) | **98.6%** | **2.097 s** (2.12×) |
| n=200 main | 1,567 | 1,366 | 1,593,645,524 | 2.2% | 80.881 s |
| n=200 this PR | 1,567 | 1,366 | **35,420,490** (45.0×) | **99.3%** | **32.847 s** (2.46×) |

Gecode 6.3.0 from the MiniZinc 2.9.7 bundle explores the same trees on this
machine at 0.808 s and 12.394 s, so #889's gap — 5.5× and 6.5× as measured here —
becomes **2.6× at both sizes**. The effectful counts move by under 0.3%, which is
the attribution shift any wake-order change makes; the fixpoint at every node is
identical.

`magic_series --size=300` from `examples/` is the same shape in C++: identical
search (1,193 recursions, 1,181 failures), propagations 41.9M → 15.9M, **10.5%
fewer instructions**. The rest of the `benchmarking.md` set is unchanged by this
commit.

**Tests.** `equals_test` gains a lane that can actually see this. Every other lane
there posts a single constraint over its operands, so nothing ever removes an
*interior* value from one and a trigger that sees only instantiations passes. The
new lane adds a driver `g[v]` that punches `v` out of `x` on its own, making
`b[v] = 0` a pruning no other constraint can make, and checks consistency at every
node. A first attempt punched the hole with a disequality against another branched
variable and had **no teeth** — search fixed `b[v]` before it ever got round to
making the hole, which is worth knowing about this file.

## Not done

- The `bool2int` indirection #889 asks about in its third bullet is real —
  `int_eq_reif(s[j], c, b)` plus `bool2int(b, x)` is two `Equals` propagators
  where one would do — but it is a frontend question, not a propagator one, and
  the remaining `Equals` time after this change is not where `nmseq` spends
  itself.
- The residual cost is now the watch *scan*: the engine tests every watch armed
  on a variable against each inference on it, so the scan is as long as the coarse
  trigger list was and only the per-item body got cheaper. Indexing watches by
  value would need the inference replay to carry the value, which is a bigger
  engine change.

## Checks

- `ctest` 804/804 green with the default caps and with `-DGCS_TEST_CAP_DEFAULTS=OFF`.
- clang 21 build clean: no new warnings in any file touched here. (`-DGCS_WERROR=ON`
  fails on this clang for `variable_weighting.hh` and `element.cc`, both untouched
  and both pre-existing on `main`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
