### PR TITLE
Subtract a holey Element array entry as runs, not values (#878)

### DIFF
--- a/dev_docs/large-domains.md
+++ b/dev_docs/large-domains.md
@@ -202,6 +202,52 @@ Together these take a rewrite that was 2.5% slower on holey-domain search back t
 level, while keeping the wide case (200 ms of work, and 131 seconds in the audit
 probe) at nothing.
 
+**A third, learned on `Element` (#878): a domain's runs are not free to read.**
+Not every H1a site is an inference at all. `Element`'s GAC sweep subtracts each
+array entry's domain from the result's still-unsupported set, which is internal
+bookkeeping — the set of values removed from `result` is identical either way, so
+the proof does not change and there is nothing to get past the checker. What is
+left is purely a question of cost, and the run-level form of that subtraction has
+to get the runs from somewhere.
+
+Four shapes were measured on `langford --size=11`, whose 25.7M `element` calls
+are the only variable-array `Element` in a hot loop in the benchmark set (`qap`,
+`tsp`, `table_layout` and `p_dispersion` all post the constant-array form, which
+takes a different branch, and `hitori` and `seat_moving` post the variable one
+but finish in under a tenth of a second). Instructions retired and cycles,
+median of five pinned runs, with the search identical in all five:
+
+| how the entry's domain is subtracted | instructions | cycles |
+|---|---|---|
+| a run of `erase()` per value — before (#515's fallback) | 47.587e9 | 19.789e9 |
+| **contiguity test, else `copy_of_values()` + `for_each_interval()`** | **47.170e9 (−0.88%)** | **19.734e9 (−0.28%)** |
+| `copy_of_values()` + `for_each_interval()`, unconditionally | 47.640e9 (+0.11%) | 19.821e9 (+0.16%) |
+| a new zero-copy `State::for_each_interval_immutable()`, unconditionally | 47.324e9 (−0.55%) | 20.220e9 (+2.18%) |
+| the same, in the holey branch only | 47.581e9 (−0.01%) | 20.440e9 (+3.29%) |
+
+All four fix the hazard — none of them walks a value — so what separates them is
+what the *contiguous* entry pays, which is most entries here. Two things in that
+table are worth carrying forward.
+
+Dropping the contiguity test and materialising every entry costs 0.1% of the
+instructions, which is the `small_vector` copy, so the test earns its keep. And
+the shape that avoids the copy altogether is the one that loses: both zero-copy
+variants retire no more instructions than the per-value fallback and burn 2–3%
+more cycles than anything else in the table. Nothing in `branch-misses` or
+`L1-icache-load-misses` accounts for that (three more pinned runs, medians): all
+four sit at 0.167–0.168e9 branch misses, and the variant with the *best* icache
+figure — 0.125e9, against 0.142e9 for the per-value fallback — has the
+second-worst cycles. So the extra cycles are stall this measurement does not
+explain, and chasing it further was not worth doing once the answer was "don't".
+**Do not reach for a new `State` iteration primitive for a per-entry inner loop
+on the strength of the copy it saves; measure it, because the copy is not what
+costs.**
+
+Instructions retired is the metric that settles a comparison like this one, and
+worth reaching for before wall time: identical search makes it reproducible to
+0.002% here, where wall time and cycles move ±1% between batches and about 3%
+between one hour and the next.
+
 **Where the equality is guarded by a conjunction, the same lemmas take a longer
 guard.** `Element`'s model is `result - array[i] == 0` half-reified on the
 conjunction of index conditions, so it is `ArrayMinMax`'s shape with the selector
@@ -407,14 +453,14 @@ is the part worth reading carefully:
 
 ### Where we stand
 
-70 constraint probes, plus 20 heuristic ones in the second table. The lane
+71 constraint probes, plus 20 heuristic ones in the second table. The lane
 itself is the authority — run it rather than trusting this table, which is a
 snapshot for orientation.
 
 | | constraints |
 |---|---|
 | **KnownTrip** (19) | `Power`, `PowerTable`, `AllDifferent`, `AllDifferentExcept`, `Count`, `NValue`, `AtMostOne`, `AtMostOneSmartTable`, `GlobalCardinality/hall`, `ArrayMinMax`, `LexSmartTable`, `SmartTable`, `Regular`, `RegularLegacy`, `RegularBacchus`, `MDD`, `Cumulative`, `Disjunctive`, `Knapsack` |
-| **Clean** (37) | the arithmetic family, comparison, equality, linear, `AllDifferent` under `VC`, `Element` in both arms, `AllEqual` with holes and without, `Among`, `In`, `GlobalCardinality`, `Table` (both shapes), `ValuePrecede`, `SeqPrecedeChain`, `IncreasingChain`, `Lex`, `Sort`, `ArgSort`, `NegativeTable`, `Disjunctive2D`, `BinPacking`, `MinDistance`, `DifferenceConstraints`, `Nogoods` |
+| **Clean** (38) | the arithmetic family, comparison, equality, linear, `AllDifferent` under `VC`, `Element` in both arms and with a holey entry, `AllEqual` with holes and without, `Among`, `In`, `GlobalCardinality`, `Table` (both shapes), `ValuePrecede`, `SeqPrecedeChain`, `IncreasingChain`, `Lex`, `Sort`, `ArgSort`, `NegativeTable`, `Disjunctive2D`, `BinPacking`, `MinDistance`, `DifferenceConstraints`, `Nogoods` |
 | **NoWidePosition** (14) | the graph and permutation family, and the Boolean constraints |
 
 `Among`, `In`, `AllEqual/holes`, `GlobalCardinality`, `Table` and `Element` started
@@ -474,7 +520,8 @@ now a `KnownTrip`:
 * `Element` needs the array entries to be **narrow**. The GAC sweep erases each
   entry's domain from the result's still-unsupported set, so a *wide* entry
   erases everything in one `erase_range` and leaves no remainder — the original
-  probe made the hazard disappear by being too wide.
+  probe made the hazard disappear by being too wide. (And a narrow entry reaches
+  only half of that sweep; see below.)
 * `AllEqual` needs holes *and* a large difference. Bounds propagation runs first
   (`all_equal.cc:95`) and collapses a merely narrow partner, so the hole has to
   be spread across the full width: a two-value domain at the extremes leaves the
@@ -496,6 +543,20 @@ The moral for anyone adding a row: **a probe that survives has proved nothing
 until you have checked it reached the code you meant to test.** Two of the three
 real hazards above were hidden by the probe being *more* extreme than necessary,
 which is not the direction one expects to have to correct.
+
+**And bracketing an axis with two probes is not the same as covering it.** The
+`Element` bullet above is the case to learn this from, because sharpening it
+once was not enough. The row it produced makes the array entries narrow, which
+reaches the sweep's remainder; the row it replaced made them wide, which reaches
+the `erase_range` that leaves no remainder. Between the two sits the shape that
+reaches neither: an entry that is wide *and* has a hole in it. Both rows said
+`Clean` while that shape walked a 10^9-value entry one value at a time (#878):
+4.2 s of root propagation at that width, and 0 ms after the fix. The branch is
+not selected by the width at all — it is selected by
+`domain_size(entry) == hi - lo + 1`, which a narrow entry satisfies and a wide
+contiguous one satisfies too. Before adding a row, read the *condition* on the
+branch and pick the probe from that, rather than reasoning about the axis the
+issue is named after. `Element/holey` is that row.
 
 One deliberate non-axis: the lane runs **without proof logging**. `NValue`'s
 H2′ is caught anyway, because its per-value work is in `prepare()`, but a
@@ -606,18 +667,21 @@ separately, because they mean different things:
 
 ### Results at 10^3 → 10^4
 
-Re-measured over all 70 probes after the interval rewrites landed for
+Re-measured over all 71 probes after the interval rewrites landed for
 `ArrayMinMax`, `Table`, `Among`, `Element`, `In`, `GlobalCardinality` and
-`AllEqual/holes`. The figures move, so re-run the survey rather than
-quoting this table after touching any propagator's removal loop — that is how the
-previous version of it went stale, see below.
+`AllEqual/holes`, and again after #878 — which moved nothing: `Element/holey` is
+a new row at a flat 41 rows and 51 steps, and the rewrite behind it changes which
+values get removed not at all, so no other row could have moved either. The
+figures move, so re-run the survey rather than quoting this table after touching
+any propagator's removal loop — that is how the previous version of it went
+stale, see below.
 
 | | growth (opb / steps) | constraints |
 |---|---|---|
 | **Both** grow | 10x / 10x | `Power`, `PowerTable`, `NValue`, `Regular`, `RegularLegacy`, `RegularBacchus`, `MDD` |
 | **OPB only** | 10x / 1.0x | `Cumulative` (19046 → 190046 rows; one capacity line per time point, so it is H3 on the encoding side) |
 | **Steps only** | 1.0x / 10x | `GlobalCardinality/hall` (34-row OPB fixed, 33984 → 339984 steps) |
-| neither | 1.0x / 1.0x | everything else, 61 of 70 |
+| neither | 1.0x / 1.0x | everything else, 62 of 71 |
 
 The last row means "does not grow with the width", not "identical at both widths",
 and three entries in it are worth naming so nobody reads them as a promise.
@@ -679,7 +743,7 @@ whose steps grow at a fixed encoding is a propagator that has an interval and
 spells it out. That is a real conclusion rather than a gap in the survey, and it
 should be re-tested after stage 4 rather than assumed to stay true — a genuine
 candidate would be a growing row whose removed set provably is not an interval,
-and none of the 70 probes produces one today.
+and none of the 71 probes produces one today.
 
 Two things kept this table wrong for longer than it should have been. The probe
 sharpening of PR #849 turned exactly these three rows from `HazardNotReached` into

--- a/gcs/constraints/element/element.cc
+++ b/gcs/constraints/element/element.cc
@@ -600,17 +600,30 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators_impl(Prop
                                 if (array_has_nonconstants)
                                     considered_vars.push_back(array_var);
                                 // Subtract array_var's domain from the still-unsupported
-                                // set. When that domain is a single contiguous run (the
-                                // common case) this is one erase_range rather than one
-                                // erase per value — the dominant cost of the GAC support
-                                // sweep (issue #515). A holey domain must still go value
-                                // by value: erase_range would also drop values in the
-                                // holes, which this array entry does not support.
+                                // set. A contiguous domain goes in as one erase_range
+                                // however wide it is, which was the point of issue #515
+                                // — but the fallback it left for a domain with holes
+                                // in it went value by value, and one hole is all it
+                                // takes to stop the size matching the span, so a
+                                // 10^9-wide entry missing a single value got walked a
+                                // billion times (issue #878). A hole changes nothing
+                                // about the shape of the answer: the domain is a set of
+                                // runs either way, and each run is one erase_range.
+                                //
+                                // The contiguity test stays rather than the run path
+                                // subsuming it, because reading the runs needs the
+                                // domain materialised and paying for that on every entry
+                                // of every call is not free. Four shapes were measured
+                                // and all four fix #878; this is the only one that is
+                                // also faster than what it replaces, and
+                                // dev_docs/large-domains.md has the numbers.
                                 auto [lo, hi] = state.bounds(array_var);
                                 if (state.domain_size(array_var) == hi - lo + 1_i)
                                     still_to_find_support_for.erase_range(lo, hi);
-                                else
-                                    state.for_each_value_immutable(array_var, [&](Integer v) { still_to_find_support_for.erase(v); });
+                                else {
+                                    auto entry_values = state.copy_of_values(array_var);
+                                    entry_values.for_each_interval([&](Integer l, Integer h) { still_to_find_support_for.erase_range(l, h); });
+                                }
                             }
                         }
                         else {

--- a/gcs/interval_set.hh
+++ b/gcs/interval_set.hh
@@ -586,6 +586,36 @@ namespace gcs
         }
 
         /**
+         * \brief Calls \p f(lower, upper) for each stored interval, in ascending
+         * order.
+         *
+         * Non-coroutine alternative to each_interval(), and the interval-level
+         * mirror of for_each(): no heap-allocated generator frame, the
+         * iteration inlines into the caller. Prefer this over each_interval()
+         * in hot loops, for the same reason for_each() exists -- a propagator
+         * subtracting one variable's domain from a set runs one of these per
+         * array entry per call (element.cc, issue #878).
+         *
+         * If \p f returns \c bool, returning \c false stops iteration early.
+         * If \p f returns \c void, iteration always runs to completion.
+         *
+         * \sa each_interval(), for_each()
+         */
+        template <typename F_>
+        auto for_each_interval(F_ && f) const -> void
+        {
+            if constexpr (std::is_void_v<std::invoke_result_t<F_ &, Int_, Int_>>) {
+                for (const auto & [l, u] : intervals)
+                    f(l, u);
+            }
+            else {
+                for (const auto & [l, u] : intervals)
+                    if (! f(l, u))
+                        return;
+            }
+        }
+
+        /**
          * \brief Returns a generator that yields each integer strictly between lower()
          * and upper() that is not a member of the set, in ascending order.
          *

--- a/gcs/interval_set_test.cc
+++ b/gcs/interval_set_test.cc
@@ -1131,3 +1131,65 @@ TEST_CASE("for_each_reversed stops early when the callback says so")
     set.for_each_reversed([&](int v) -> void { all.push_back(v); });
     CHECK(all == vector<int>{10, 9, 8, 3, 2, 1});
 }
+
+TEST_CASE("for_each_interval matches each_interval")
+{
+    // The non-coroutine mirror of each_interval(), for callers that run it once
+    // per array entry per propagation (element.cc's GAC support sweep, issue
+    // #878). It has to agree with each_interval() exactly.
+    IntervalSet<int> s1(5, 9), s2, s3;
+    s2.insert_at_end(1, 2);
+    s2.insert_at_end(7, 7);
+    s2.insert_at_end(10, 13);
+    // s3 stays empty.
+
+    for (const auto & set : {s1, s2, s3}) {
+        vector<pair<int, int>> from_generator, from_callback;
+        for (auto i : set.each_interval())
+            from_generator.push_back(i);
+        set.for_each_interval([&](int l, int u) { from_callback.emplace_back(l, u); });
+        CHECK(from_callback == from_generator);
+
+        // And the values it describes are the values the set has.
+        vector<int> expanded;
+        for (auto [l, u] : from_callback)
+            for (int v = l; v <= u; ++v)
+                expanded.push_back(v);
+        vector<int> values;
+        set.for_each([&](int v) { values.push_back(v); });
+        CHECK(expanded == values);
+    }
+}
+
+TEST_CASE("for_each_interval stops early when the callback says so")
+{
+    IntervalSet<int> set;
+    set.insert_at_end(1, 3);
+    set.insert_at_end(8, 10);
+    set.insert_at_end(20, 20);
+
+    vector<pair<int, int>> seen;
+    set.for_each_interval([&](int l, int u) {
+        seen.emplace_back(l, u);
+        return seen.size() < 2;
+    });
+    CHECK(seen == vector<pair<int, int>>{{1, 3}, {8, 10}});
+
+    // A void callback runs to completion, as for_each() does.
+    vector<pair<int, int>> all;
+    set.for_each_interval([&](int l, int u) -> void { all.emplace_back(l, u); });
+    CHECK(all == vector<pair<int, int>>{{1, 3}, {8, 10}, {20, 20}});
+}
+
+TEST_CASE("for_each_interval over a set no walk of values could cross")
+{
+    // The property the #878 rewrite needs: the cost is the number of runs, not
+    // the number of values. Two runs a billion values wide, and a test that
+    // returns at all is the evidence.
+    IntervalSet<long long> holey(0, 1000000000LL);
+    holey.erase(5);
+
+    vector<pair<long long, long long>> runs;
+    holey.for_each_interval([&](long long l, long long u) { runs.emplace_back(l, u); });
+    CHECK(runs == vector<pair<long long, long long>>{{0, 4}, {6, 1000000000LL}});
+}

--- a/gcs/large_domain_audit_test.cc
+++ b/gcs/large_domain_audit_test.cc
@@ -417,6 +417,27 @@ namespace
             auto result = wide_var(p);
             p.post(Element{result, p.create_integer_variable(0_i, 2_i), narrow(p, 3, 1_i, 3_i)}.with_consistency(consistency::BC{}));
         });
+        add("Element/holey", Expect::Clean, [](Problem & p) {
+            // Neither row above reaches the sweep's other half. They erase each
+            // entry's domain from the result's still-unsupported set, and an
+            // entry that is one contiguous run goes in as a single erase_range
+            // however wide it is -- so a narrow entry exercises the remainder
+            // and a wide entry exercises the fast path, and nothing exercises an
+            // entry that is wide *and* has a hole in it, which is the shape that
+            // used to be walked a value at a time (#878). One value knocked out
+            // of a full-width entry is enough: domain_size stops matching
+            // hi - lo + 1 while the domain is still 10^9 wide.
+            //
+            // Three entries and a free index on purpose. With the index fixed
+            // the equality propagator takes over instead, which is a different
+            // path with its own holey handling and would have made this row
+            // about that one.
+            auto result = wide_var(p);
+            auto entries = wide(p, 3);
+            for (const auto & e : entries)
+                p.post(NotEquals{e, ConstantIntegerVariableID{5_i}});
+            p.post(Element{result, p.create_integer_variable(0_i, 2_i), entries});
+        });
 
         // --- Ordering.
         add("IncreasingChain", Expect::Clean, [](Problem & p) { p.post(Increasing{wide(p, 4)}); });


### PR DESCRIPTION
Part of #833 (stage 4, interval-level rewrites). Fixes #878.

`Element`'s GAC support sweep subtracts each array entry's domain from the set of
result values still needing support. A contiguous entry goes in as one
`erase_range` however wide it is — that was #515 — but the fallback it left for an
entry with holes in it went value by value, and **one hole is all it takes** to
stop `domain_size()` matching the span. So a 10^9-wide entry missing a single
value got walked a billion times.

The comment at the site was right that `erase_range(lo, hi)` is wrong for a holey
domain, and wrong that a holey domain therefore forces per-value: the domain is a
set of runs either way, and each run is one `erase_range`.

**No inference and no proof change.** The subtraction is internal bookkeeping —
the set of values removed from `result` is identical, and the removals themselves
still go through #858's range path unchanged. That is what makes this a much
smaller change than #858 was: no lemmas, no views restriction, nothing to get
past the checker. The proof-scaling survey confirms it: nothing moved.

## The hazard

Root propagation only, three entries `0..w` with one value knocked out, pinned to
one core:

| `w` | before | after |
|---|---|---|
| 10^6 | 10 ms | **0 ms** |
| 10^7 | 48 ms | **0 ms** |
| 10^8 | 422 ms | **0 ms** |
| 10^9 | 4238 ms | **0 ms** |

Memory is flat at ~5.5 MB throughout, both ways: this one does not die, it just
stops. So the audit row would have said `Clean` on any machine — which is why it
needed the guard build to catch, and why the lane's fallback `std::bad_alloc`
detector would never have found it.

## Which shape to keep, and the one that surprised me

The contiguity test **stays**, and that was worth measuring rather than guessing.
`langford --size=11` is the only variable-array `Element` in a hot loop in the
benchmark set at 25.7M `element` calls (`qap`, `tsp`, `table_layout` and
`p_dispersion` all post the constant-array form, which takes a different branch;
`hitori` and `seat_moving` post the variable one but finish in under a tenth of a
second). Medians of five pinned interleaved runs, search identical in all five:

| how the entry's domain is subtracted | instructions | cycles |
|---|---|---|
| a run of `erase()` per value — before | 47.587e9 | 19.789e9 |
| **contiguity test, else `copy_of_values()` + `for_each_interval()`** | **47.170e9 (−0.88%)** | **19.734e9 (−0.28%)** |
| `copy_of_values()` + `for_each_interval()`, unconditionally | 47.640e9 (+0.11%) | 19.821e9 (+0.16%) |
| a new zero-copy `State::for_each_interval_immutable()`, unconditionally | 47.324e9 (−0.55%) | 20.220e9 (+2.18%) |
| the same, in the holey branch only | 47.581e9 (−0.01%) | 20.440e9 (+3.29%) |

All four fix the hazard — none of them walks a value — so what separates them is
what a *contiguous* entry pays, which is most entries there.

**The surprise is that avoiding the copy is what loses.** The obvious "right"
answer was a `State::for_each_interval_immutable()` sibling of
`for_each_value_immutable()`: zero copy, one dispatch instead of two, unified
code, and the primitive #874/#875/#877 would all want. It retires *fewer*
instructions than the per-value fallback and burns **2–3% more cycles than
anything else in the table**, in both placements. Branch misses are flat across
all four (0.167–0.168e9) and the variant with the *best* L1i figure has the
second-worst cycles, so the counters do not explain it and I stopped chasing once
the answer was "don't". It is not in this PR, and `dev_docs/large-domains.md`
records why so the next person does not re-derive it.

Also recorded: instructions retired is the metric that settles a comparison like
this one — reproducible to 0.002% here where wall time and cycles move ±1% within
a batch and ~3% between one hour and the next. The first wall-time batch I ran
said the unified shape was 0.8% *slower*; it is not.

## The audit row, and the lesson behind it

Both existing `Element` rows post `narrow(p, 3, 1_i, 3_i)` entries — narrow *and*
contiguous — so neither reaches the holey branch. **That is a probe sharpened once
in the right direction and stopped.** The row these replaced made the entries
wide, which reaches the `erase_range` that leaves no remainder; narrowing them
reached the remainder instead. Between the two sits the shape that reaches
neither, and both rows said `Clean` while it walked a billion values. The branch
is not selected by the width at all — it is selected by `domain_size(entry) == hi
- lo + 1`, which a narrow entry satisfies and a wide contiguous one satisfies
too. **Bracketing an axis with two probes is not the same as covering it**; read
the condition on the branch and pick the probe from that.

**Checked by negative control, not assumed.** With the entries wide and holey and
`element.cc` as it was, the lane reports

```
Element/holey   Clean   trips   <-- MISMATCH
detail: Large domain guard tripped: the number of values one
for_each_value_immutable() call has visited is 100001, over the limit of 100000
```

which is the site the issue names, at the width the issue names, and no other row
moves.

Three entries and a free index on purpose: with the index fixed the equality
propagator takes over instead, which is a different path with its own holey
handling, and the row would have been about that one.

## Testing

* `ctest` 810/810 on GCC, 815/815 on clang (the extra five are the guard build's
  own lanes), both `-DGCS_WERROR=ON` on GCC.
* clang 21 over the whole tree: **36 warnings, all of them the three
  pre-existing `-Wunused-lambda-capture` sites in `element.cc`** (lines 334, 470,
  582), none on new code — the same baseline as before.
* `element_test` **uncapped**, all five modes × plain and `--view-position=mixed`,
  all exiting 0 with **188 VeriPB verifications** between them (seed announced,
  `--seed=358178437`).
* Large-domain audit lane green on both compilers: 71 rows, 142 assertions, 0.6 s
  and 27 MB peak. `Element/holey` is the new row.
* Proof-scaling survey re-run over all 71 probes: `Element/holey` is 41 OPB rows
  and 51 steps at both 10^3 and 10^4, and **nothing else moved**, which is what a
  rewrite that changes no inference has to look like.
* `interval_set_test`: 545 assertions, three new cases for `for_each_interval()`
  (agreement with `each_interval()`, early exit, and a two-run set a billion
  values wide that no value walk could cross).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
