### PR TITLE
Remove an unsupported run of Abs' domains in one go (#875)

### DIFF
--- a/dev_docs/large-domains.md
+++ b/dev_docs/large-domains.md
@@ -183,6 +183,81 @@ Views keep the per-value path: a view's atoms are spelled through the view and
 the lemmas have not been shown to bridge that. Same restriction, and same reason,
 as the single-support range path in the same file.
 
+### The two-lemma RUP shape does not generalise; `pol` does
+
+`Abs` (#875) is the case that shows where the shape above stops working, and it
+is worth reading before copying it into a fourth constraint.
+
+`Abs`' model is two half-reified rows, `v2 - v1 == 0` under `v1 >= 0` and
+`v2 + v1 == 0` under `v1 < 0`. That looks like `ArrayMinMax`'s guarded equality
+with a two-valued selector, so the same two ge-layer bound lemmas ought to work.
+They do not, and the reason is not the guard: it is that **unit propagation
+cannot add two PB bound constraints to a row.** Negating such a lemma leaves one
+bound on each side of the equality, and a bound over a bit-vector fixes no bit
+unless it happens to be tight enough to force one.
+
+Measured, because the failure is arithmetic rather than structural. On
+`abs_test`'s own `v1 = [-6, 8]`, `v2 = [0, 15]`, the negated lemma gives
+`v1 >= -6` — which forces `b3` through the two's-complement bound — and
+`v2 >= 7`, which forces nothing. The row then normalises to a slack of exactly
+**8** against a largest remaining coefficient of **8**, and a coefficient has to
+*exceed* the slack to propagate. One short.
+
+So why does `element.cc` verify? **Because its arithmetic lines up, not because
+the shape is sound.** A probe built for the question — `result` in `[0, 63]`,
+three entries in `{0, 40}`, so the removed run `[41, 63]` puts `result >= 41`
+against `array <= 40` with neither bound tight — verifies, and grinding through
+its propagation by hand shows why: `result >= 41` forces the top bit because 41
+exceeds what five bits can hold, which drops the row's slack below `array`'s top
+coefficient, which forces that, and so on for several rounds. Change the widths
+and that cascade stops. **Treat the guarded two-lemma RUP shape as a property of
+the instances it has been run on.**
+
+The route that does not depend on the arithmetic is `pol`, which is what every
+other helper in `abs/justify.cc` already used: the model half, plus the defining
+item of each atom whose arithmetic the step uses, summed and saturated. The
+operands cancel, the constant comes out negative, and saturation leaves a clause
+over order atoms. Two shapes come out of it, and their asymmetry is the useful
+part:
+
+* Concluding on the variable the guard is *about* (`Abs`' image direction,
+  `~[v2 in lo..hi]`) has to close both sign branches, because the conclusion's
+  negation says nothing about the sign. Four resolutions, then one clause per
+  branch whose only free literal is the sign; the two signs being a literal and
+  its negation, the conclusion follows by RUP. Six lines.
+* Concluding on the guard variable itself (the preimage direction,
+  `~[v1 in lo..hi]`) is cheaper, provided the caller **splits each run at zero**
+  first. Then `v1 >= lo >= 0` propagates `v1 >= 0` up the ge layer, so the
+  conclusion's own negation decides the sign and only the active branch is
+  needed. Three lines, and no case split left over.
+
+Neither count depends on the range's width, which is the property that matters.
+
+### Sabotaging proof lines one at a time under-reports
+
+The same work produced a methodology result worth having, because the obvious way
+to check a new justification is misleading.
+
+Dropping each of `Abs`' twelve new proof lines in turn and re-running `abs_test`
+at a pinned seed marks **eight of the twelve as droppable**; only one is
+individually load-bearing, and that one only because of a row added specifically
+to reach it. Emptying either justification wholesale is rejected, so the lines
+are jointly necessary and individually redundant — VeriPB's unit propagation has
+several routes to the same conclusion, and removing one leaves the others.
+
+Greedily minimising instead gives a four-line set that passes the pinned seed.
+It keeps only the *upper* lemma of each pair and only one of the two sign
+branches, which cannot be right by symmetry, and it is not: the same four-line
+set is **rejected on four of ten seeds**. The suite's randomised rows do not
+separate the halves of a symmetric rule at any one seed, so a minimisation run
+against one of them is fitting the fixtures.
+
+Two rules follow. **Sabotage the whole justification, not its lines** — that is
+the test that distinguishes a load-bearing derivation from a decorative one.
+And **keep a derivation you can state end to end**, rather than the subset a
+particular seed happens to need; the full set here passes ten seeds plain and
+three view-wrapped, and each of its lines has a stated role.
+
 **Two things that make an interval rewrite pay, learned on `AllEqual`.**
 
 *Keep the per-value spelling for a width-1 interval.* A range literal of one value
@@ -366,12 +441,13 @@ Two kinds of check, and the difference matters:
   `State`'s iterators are not the only way a propagator walks a domain. It can
   build an `IntervalSet` of its own and walk that, or take an interval and expand
   it with a plain `for (Integer v = lo; v <= hi; ++v)`. `State` sees neither, so
-  each such loop needs its own counter declared at the loop. Three sites carry
-  one: `element.cc`'s sweep over unsupported result values (now only on its
-  per-value view path), `all_equal.cc`'s expansion of the intersection
-  difference, and `equals.cc`'s no-overlap reason. The counter does not belong in
-  `IntervalSet::each()` itself, which is a general container used for deliberate
-  enumeration — tabulation, and the tests.
+  each such loop needs its own counter declared at the loop. Four constraints
+  carry one, over five sites: `element.cc`'s sweep over unsupported result values
+  (now only on its per-value view path), `all_equal.cc`'s expansion of the
+  intersection difference, `equals.cc`'s no-overlap reason, and `abs.cc`'s two
+  interior hole loops. The counter does not belong in `IntervalSet::each()`
+  itself, which is a general container used for deliberate enumeration —
+  tabulation, and the tests.
 
   The first two were found the same way, and it is worth naming the smell: **a
   row that starts passing when you did not fix it.** Neither site allocated a
@@ -397,6 +473,23 @@ Two kinds of check, and the difference matters:
   And a reason is a place to look that a search for pruning loops will not reach:
   guard the assembly on `InferenceTrackerBase::want_reasons()` first, then count
   the walk that survives it.
+
+  `abs.cc`'s two loops (#875) put a number on the first half. Its 10^9 shapes
+  were reported as surviving in 129 s on a 2 TB box; re-measured here, the image
+  shape takes 42 s and **16.4 GB**, and the preimage shape does not finish at
+  all — `bad_alloc` after 45 s and 23.7 GB under a cap. So the same two rows
+  would have come out one `Clean` and one `KnownTrip` on this 30 GB machine, and
+  both `Clean` on the big one, from the identical code. That is the argument for
+  instrumenting a loop rather than leaving it to the fallback, made concrete:
+  neither reading was a fact about `Abs`.
+
+  It also took two probes rather than a sharpened one. The `Abs` row posts two
+  bare wide variables, which never *reach* either loop: the image of `v1`'s whole
+  domain is the whole of `v2`'s, so `each_interval_minus()` yields nothing. One
+  row per loop, because a probe that reaches one reaches neither the other (a
+  contiguous `v2` has a contiguous preimage). Checked one at a time that each row
+  trips its own counter and not the other's — with two counters in one propagator,
+  a row that trips *a* guard proves nothing about which loop it exercised.
 
   What the counter at that site now counts is *moves of an interval walk*, not
   values (#867). A reason that says "these two domains do not overlap" one value
@@ -453,14 +546,14 @@ is the part worth reading carefully:
 
 ### Where we stand
 
-71 constraint probes, plus 20 heuristic ones in the second table. The lane
+73 constraint probes, plus 20 heuristic ones in the second table. The lane
 itself is the authority — run it rather than trusting this table, which is a
 snapshot for orientation.
 
 | | constraints |
 |---|---|
 | **KnownTrip** (19) | `Power`, `PowerTable`, `AllDifferent`, `AllDifferentExcept`, `Count`, `NValue`, `AtMostOne`, `AtMostOneSmartTable`, `GlobalCardinality/hall`, `ArrayMinMax`, `LexSmartTable`, `SmartTable`, `Regular`, `RegularLegacy`, `RegularBacchus`, `MDD`, `Cumulative`, `Disjunctive`, `Knapsack` |
-| **Clean** (38) | the arithmetic family, comparison, equality, linear, `AllDifferent` under `VC`, `Element` in both arms and with a holey entry, `AllEqual` with holes and without, `Among`, `In`, `GlobalCardinality`, `Table` (both shapes), `ValuePrecede`, `SeqPrecedeChain`, `IncreasingChain`, `Lex`, `Sort`, `ArgSort`, `NegativeTable`, `Disjunctive2D`, `BinPacking`, `MinDistance`, `DifferenceConstraints`, `Nogoods` |
+| **Clean** (40) | the arithmetic family (with two rows of its own for `Abs`' interior holes), comparison, equality, linear, `AllDifferent` under `VC`, `Element` in both arms and with a holey entry, `AllEqual` with holes and without, `Among`, `In`, `GlobalCardinality`, `Table` (both shapes), `ValuePrecede`, `SeqPrecedeChain`, `IncreasingChain`, `Lex`, `Sort`, `ArgSort`, `NegativeTable`, `Disjunctive2D`, `BinPacking`, `MinDistance`, `DifferenceConstraints`, `Nogoods` |
 | **NoWidePosition** (14) | the graph and permutation family, and the Boolean constraints |
 
 `Among`, `In`, `AllEqual/holes`, `GlobalCardinality`, `Table` and `Element` started
@@ -667,11 +760,12 @@ separately, because they mean different things:
 
 ### Results at 10^3 → 10^4
 
-Re-measured over all 71 probes after the interval rewrites landed for
+Re-measured over all 73 probes after the interval rewrites landed for
 `ArrayMinMax`, `Table`, `Among`, `Element`, `In`, `GlobalCardinality` and
-`AllEqual/holes`, and again after #878 — which moved nothing: `Element/holey` is
-a new row at a flat 41 rows and 51 steps, and the rewrite behind it changes which
-values get removed not at all, so no other row could have moved either. The
+`AllEqual/holes`, and again after #878 and #875 — which moved nothing but their
+own rows: `Element/holey` is flat at 41 rows and 51 steps, `Abs/hole` at 30 and
+46, `Abs/hole-preimage` at 26 and 64, and none of the three rewrites changes
+which values get removed, so no other row could have moved either. The
 figures move, so re-run the survey rather than quoting this table after touching
 any propagator's removal loop — that is how the previous version of it went
 stale, see below.
@@ -681,7 +775,7 @@ stale, see below.
 | **Both** grow | 10x / 10x | `Power`, `PowerTable`, `NValue`, `Regular`, `RegularLegacy`, `RegularBacchus`, `MDD` |
 | **OPB only** | 10x / 1.0x | `Cumulative` (19046 → 190046 rows; one capacity line per time point, so it is H3 on the encoding side) |
 | **Steps only** | 1.0x / 10x | `GlobalCardinality/hall` (34-row OPB fixed, 33984 → 339984 steps) |
-| neither | 1.0x / 1.0x | everything else, 62 of 71 |
+| neither | 1.0x / 1.0x | everything else, 64 of 73 |
 
 The last row means "does not grow with the width", not "identical at both widths",
 and three entries in it are worth naming so nobody reads them as a promise.
@@ -743,7 +837,7 @@ whose steps grow at a fixed encoding is a propagator that has an interval and
 spells it out. That is a real conclusion rather than a gap in the survey, and it
 should be re-tested after stage 4 rather than assumed to stay true — a genuine
 candidate would be a growing row whose removed set provably is not an interval,
-and none of the 71 probes produces one today.
+and none of the 73 probes produces one today.
 
 Two things kept this table wrong for longer than it should have been. The probe
 sharpening of PR #849 turned exactly these three rows from `HazardNotReached` into

--- a/gcs/constraints/abs/abs.cc
+++ b/gcs/constraints/abs/abs.cc
@@ -3,6 +3,7 @@
 #include <gcs/constraints/abs/justify.hh>
 #include <gcs/innards/assertion_hints.hh>
 #include <gcs/innards/inference_tracker.hh>
+#include <gcs/innards/large_domain_guard.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/proofs/proof_model.hh>
@@ -239,11 +240,21 @@ auto Abs::install_propagators(Propagators & propagators) -> void
             }
             auto image_set = pieces_to_set(image_pieces);
 
+            // Both interior loops expand an interval by hand, which State's
+            // iterators never see, so each carries its own counter -- the same
+            // reason element.cc and all_equal.cc do (issues #855, #875). Without
+            // one the audit lane's Abs rows report Clean however wide the domain
+            // is, since nothing here allocates and nothing crashes: the 10^9
+            // shape simply runs for a couple of minutes.
+            LargeDomainIterationCounter image_guard{"the number of values one Abs image pruning has walked"};
+            LargeDomainIterationCounter preimage_guard{"the number of values one Abs preimage pruning has walked"};
+
             auto [post_v2_lb, post_v2_ub] = state.bounds(v2);
             for (auto [lo, hi] : v2_set.each_interval_minus(image_set)) {
                 auto clipped_lo = max(lo, post_v2_lb);
                 auto clipped_hi = min(hi, post_v2_ub);
                 for (Integer val = clipped_lo; val <= clipped_hi; ++val) {
+                    image_guard.step();
                     if (! state.in_domain(v2, val))
                         continue;
                     inference.infer_not_equal(logger, v2, val,
@@ -269,6 +280,7 @@ auto Abs::install_propagators(Propagators & propagators) -> void
                 auto clipped_lo = max(lo, post_v1_lb);
                 auto clipped_hi = min(hi, post_v1_ub);
                 for (Integer val = clipped_lo; val <= clipped_hi; ++val) {
+                    preimage_guard.step();
                     if (! state.in_domain(v1, val))
                         continue;
                     inference.infer_not_equal(

--- a/gcs/constraints/abs/abs.cc
+++ b/gcs/constraints/abs/abs.cc
@@ -30,6 +30,7 @@
 using namespace gcs;
 using namespace gcs::innards;
 
+using std::get;
 using std::holds_alternative;
 using std::max;
 using std::min;
@@ -249,10 +250,41 @@ auto Abs::install_propagators(Propagators & propagators) -> void
             LargeDomainIterationCounter image_guard{"the number of values one Abs image pruning has walked"};
             LargeDomainIterationCounter preimage_guard{"the number of values one Abs preimage pruning has walked"};
 
+            // A range removal needs a range literal in its reason, and a view has
+            // none (issue #882), so anything but two plain variables keeps the
+            // per-value path. A constant v2 keeps it too, which is not merely the
+            // same restriction: the range lemmas below resolve against v2's
+            // order-encoding flags, and a constant has none.
+            auto both_simple = holds_alternative<SimpleIntegerVariableID>(v1) && holds_alternative<SimpleIntegerVariableID>(v2);
+
             auto [post_v2_lb, post_v2_ub] = state.bounds(v2);
             for (auto [lo, hi] : v2_set.each_interval_minus(image_set)) {
                 auto clipped_lo = max(lo, post_v2_lb);
                 auto clipped_hi = min(hi, post_v2_ub);
+                if (clipped_lo > clipped_hi)
+                    continue;
+
+                // Removing the run in one go. The values removed are the same
+                // either way -- a v2 value survives iff v1 holds it or its
+                // negation -- so the search does not change, only how many
+                // inferences it takes to get there.
+                if (both_simple && clipped_lo < clipped_hi) {
+                    inference.infer_not_in_range(logger, v2, clipped_lo, clipped_hi,
+                        JustifyExplicitly{
+                            [logger, v1s = get<SimpleIntegerVariableID>(v1), v2s = get<SimpleIntegerVariableID>(v2), clipped_lo = clipped_lo,
+                                clipped_hi = clipped_hi, abs_nonneg_le, abs_nonneg_ge, abs_neg_le, abs_neg_ge](const ReasonLiterals & r) {
+                                // The four halves stay optional in the capture and are
+                                // dereferenced here: define_proof_model does not run at
+                                // all with proofs off, so a capture-list dereference is
+                                // reading an empty optional on every call.
+                                justify_abs_hole_range(
+                                    *logger, r, v1s, v2s, clipped_lo, clipped_hi, *abs_nonneg_le, *abs_nonneg_ge, *abs_neg_le, *abs_neg_ge);
+                            },
+                            ThenRUP::Yes, hints::Abs{originator}},
+                        ExplicitReason{ReasonLiterals{{not_in_range(v1, clipped_lo, clipped_hi), not_in_range(v1, -clipped_hi, -clipped_lo)}}});
+                    continue;
+                }
+
                 for (Integer val = clipped_lo; val <= clipped_hi; ++val) {
                     image_guard.step();
                     if (! state.in_domain(v2, val))
@@ -279,6 +311,43 @@ auto Abs::install_propagators(Propagators & propagators) -> void
             for (auto [lo, hi] : v1_set.each_interval_minus(preimage_set)) {
                 auto clipped_lo = max(lo, post_v1_lb);
                 auto clipped_hi = min(hi, post_v1_ub);
+                if (clipped_lo > clipped_hi)
+                    continue;
+
+                if (both_simple) {
+                    // Split at zero. A run that straddles it does have a single
+                    // image to name -- abs([lo, hi]) is [0, max(-lo, hi)] -- but
+                    // its own negation then decides nothing about v1's sign, and
+                    // the justification would need the two-branch treatment the
+                    // other direction uses. One split instead, and each piece
+                    // proves itself.
+                    for (auto [piece_lo, piece_hi] : {pair{clipped_lo, min(clipped_hi, -1_i)}, pair{max(clipped_lo, 0_i), clipped_hi}}) {
+                        if (piece_lo > piece_hi)
+                            continue;
+
+                        if (piece_lo < piece_hi) {
+                            auto image_lo = piece_lo >= 0_i ? piece_lo : -piece_hi;
+                            auto image_hi = piece_lo >= 0_i ? piece_hi : -piece_lo;
+                            inference.infer_not_in_range(logger, v1, piece_lo, piece_hi,
+                                JustifyExplicitly{
+                                    [logger, v1s = get<SimpleIntegerVariableID>(v1), v2s = get<SimpleIntegerVariableID>(v2), piece_lo = piece_lo,
+                                        piece_hi = piece_hi, abs_nonneg_le, abs_nonneg_ge, abs_neg_le, abs_neg_ge](const ReasonLiterals &) {
+                                        justify_abs_preimage_range(
+                                            *logger, v1s, v2s, piece_lo, piece_hi, *abs_nonneg_le, *abs_nonneg_ge, *abs_neg_le, *abs_neg_ge);
+                                    },
+                                    ThenRUP::Yes, hints::Abs{originator}},
+                                ExplicitReason{ReasonLiterals{not_in_range(v2, image_lo, image_hi)}});
+                            continue;
+                        }
+
+                        preimage_guard.step();
+                        if (state.in_domain(v1, piece_lo))
+                            inference.infer_not_equal(
+                                logger, v1, piece_lo, JustifyUsingRUP{hints::Abs{originator}}, ExplicitReason{ReasonLiterals{v2 != abs(piece_lo)}});
+                    }
+                    continue;
+                }
+
                 for (Integer val = clipped_lo; val <= clipped_hi; ++val) {
                     preimage_guard.step();
                     if (! state.in_domain(v1, val))

--- a/gcs/constraints/abs/abs_test.cc
+++ b/gcs/constraints/abs/abs_test.cc
@@ -89,6 +89,49 @@ auto run_dup_abs_test(bool proofs, pair<int, int> x_range) -> void
     check_results(proof_name, expected, actual);
 }
 
+// Interior hole pruning over sparse domains (issue #875). The interval removals
+// live only on this path, and nothing in the data table can reach it: every row
+// there is a contiguous range or a constant, and a contiguous domain has no
+// interior hole to remove.
+//
+// The two loops need different shapes, which is why this takes both domains as
+// value lists. The preimage loop wants a hole in v2, and the random rows above
+// do reach that one. The *image* loop wants v1's image under abs to skip a run
+// that v2 contains, which takes a hole in v1 -- and before this existed, no test
+// in the suite reached it at all.
+auto run_abs_hole_test(bool proofs, const string & label, const vector<int> & v1_values, const vector<int> & v2_values) -> void
+{
+    // Sizes and extremes rather than the lists: preimage_far's v1 is 101 values
+    // wide and dumping it buries every other line of the run.
+    print(cerr, "abs holes [{}] v1={} values in [{},{}] v2={} values in [{},{}]{}", label, v1_values.size(), v1_values.front(), v1_values.back(),
+        v2_values.size(), v2_values.front(), v2_values.back(), proofs ? " with proofs:" : ":");
+    cerr << flush;
+
+    set<pair<int, int>> expected, actual;
+    for (auto a : v1_values)
+        for (auto b : v2_values)
+            if (b == abs(a))
+                expected.emplace(a, b);
+    println(cerr, " expecting {} solutions", expected.size());
+
+    auto to_integers = [](const vector<int> & values) {
+        vector<Integer> result;
+        for (auto v : values)
+            result.push_back(Integer{v});
+        return result;
+    };
+
+    Problem p;
+    auto v1 = p.create_integer_variable(to_integers(v1_values));
+    auto v2 = p.create_integer_variable(to_integers(v2_values));
+    p.post(Abs{v1, v2});
+
+    auto proof_name = proofs ? make_optional("abs_test_holes_" + label) : nullopt;
+    solve_for_tests_checking_gac(p, proof_name, expected, actual, tuple{IntegerVariableID{v1}, IntegerVariableID{v2}});
+
+    check_results(proof_name, expected, actual);
+}
+
 // Targeted tests for the proofs Abs::prepare emits for its four consequence
 // bounds. Domains are picked so that one specific bound is non-trivial, so a
 // proof failure points unambiguously at that bound. Uses
@@ -200,6 +243,33 @@ auto main(int argc, char * argv[]) -> int
         run_abs_initialiser_test("wide_asym_ub_dominant", {-5, 50}, {0, 80});
     }
 
+    // Sparse-domain hole rows, keyed to the two interior loops. Bare handles
+    // only: the interval path needs plain variables (a view has no range
+    // literal, #882), so a view-wrapped run takes the per-value path instead and
+    // these rows would say nothing about it.
+    auto contiguous = [](int lo, int hi) {
+        vector<int> result;
+        for (int v = lo; v <= hi; ++v)
+            result.push_back(v);
+        return result;
+    };
+    vector<tuple<string, vector<int>, vector<int>>> hole_data = {// Image loop. v1's image is {0, 1} u [8, 10], so [2, 7] has no preimage
+        // and is removed as one run of six. Nothing clips it first: v1 spans
+        // zero, so neither lower bound moves, and the two upper bounds coincide.
+        {"image_gap", {-1, 0, 1, 8, 9, 10}, contiguous(0, 10)},
+        // The same image reached from below zero, so the reason's live literal
+        // is the mirrored ~[v1 in -7..-2] rather than ~[v1 in 2..7].
+        {"image_gap_neg", {-10, -9, -8, 0, 1}, contiguous(0, 10)},
+        // An image run starting at zero, where the removed range and its mirror
+        // overlap at zero. v1 keeps a negative value so that v2's lower bound is
+        // not lifted past the run before the loop sees it.
+        {"image_gap_from_zero", {-3, 3, 4, 5}, contiguous(0, 5)},
+        // Preimage loop, with a run whose distance from zero is the point: the
+        // sign the justification needs is 31 order atoms away from the bound the
+        // conclusion's negation gives it. The random rows all leave runs
+        // adjacent to zero, where that step is free.
+        {"preimage_far", contiguous(-50, 50), {30, 40}}};
+
     // Bare-handle dup ranges. Skipped under the view-wrap sweep.
     vector<pair<int, int>> dup_data = {
         {-3, 3}, {-5, 0}, {0, 5}, {-1, 1}, {2, 5} //
@@ -210,9 +280,12 @@ auto main(int argc, char * argv[]) -> int
             continue;
         for (auto & [r1, r2] : data)
             run_abs_test(proofs, view_cfg, r1, r2);
-        if (view_wrap_config_is_effectively_bare(view_cfg, n_positions))
+        if (view_wrap_config_is_effectively_bare(view_cfg, n_positions)) {
             for (auto & x_range : dup_data)
                 run_dup_abs_test(proofs, x_range);
+            for (auto & [label, v1_values, v2_values] : hole_data)
+                run_abs_hole_test(proofs, label, v1_values, v2_values);
+        }
     }
 
     return EXIT_SUCCESS;

--- a/gcs/constraints/abs/justify.cc
+++ b/gcs/constraints/abs/justify.cc
@@ -65,6 +65,67 @@ auto gcs::innards::justify_abs_hole(ProofLogger & logger, const ReasonLiterals &
     // rest follows by RUP
 }
 
+auto gcs::innards::justify_abs_hole_range(ProofLogger & logger, const ReasonLiterals & reason, const SimpleIntegerVariableID & v1,
+    const SimpleIntegerVariableID & v2, Integer lo, Integer hi, ProofLine abs_nonneg_le, ProofLine abs_nonneg_ge, ProofLine abs_neg_le,
+    ProofLine abs_neg_ge) -> void
+{
+    auto & ids = logger.names_and_ids_tracker();
+
+    // Each resolution is the model half plus the defining item of the two atoms
+    // whose arithmetic it uses; the halves' bit coefficients are the operands'
+    // own, so v1's and v2's terms cancel and saturation leaves a clause.
+    //
+    // v1 >= 0 branch, where abs_nonneg_le is v2 <= v1 and abs_nonneg_ge is
+    // v2 >= v1. v2 >= lo carries to v1 >= lo, and v2 <= hi to v1 <= hi.
+    emit_resolution(logger, abs_nonneg_le, ids.need_pol_item_defining_literal(v2 >= lo), ids.need_pol_item_defining_literal(v1 < lo));
+    emit_resolution(logger, abs_nonneg_ge, ids.need_pol_item_defining_literal(v2 < hi + 1_i), ids.need_pol_item_defining_literal(v1 >= hi + 1_i));
+
+    // v1 < 0 branch, where abs_neg_le is v2 <= -v1 and abs_neg_ge is v2 >= -v1,
+    // so the range is mirrored: v2 >= lo carries to v1 <= -lo, and v2 <= hi to
+    // v1 >= -hi.
+    emit_resolution(logger, abs_neg_le, ids.need_pol_item_defining_literal(v2 >= lo), ids.need_pol_item_defining_literal(v1 >= -lo + 1_i));
+    emit_resolution(logger, abs_neg_ge, ids.need_pol_item_defining_literal(v2 < hi + 1_i), ids.need_pol_item_defining_literal(v1 < -hi));
+
+    // With each branch's pair in the database, v2 inside [lo, hi] falsifies
+    // every literal of that branch's reason literal, leaving the sign. Spelled
+    // with the two order atoms rather than the range literal, so no range flag
+    // has to be defined for this line.
+    logger.emit_rup_proof_line_under_reason(
+        reason, WPBSum{} + 1_i * (v1 < 0_i) + 1_i * (v2 < lo) + 1_i * (v2 >= hi + 1_i) >= 1_i, ProofLevel::Temporary);
+    logger.emit_rup_proof_line_under_reason(
+        reason, WPBSum{} + 1_i * (v1 >= 0_i) + 1_i * (v2 < lo) + 1_i * (v2 >= hi + 1_i) >= 1_i, ProofLevel::Temporary);
+
+    // The two signs being a literal and its negation, the rest follows by RUP.
+}
+
+auto gcs::innards::justify_abs_preimage_range(ProofLogger & logger, const SimpleIntegerVariableID & v1, const SimpleIntegerVariableID & v2,
+    Integer lo, Integer hi, ProofLine abs_nonneg_le, ProofLine abs_nonneg_ge, ProofLine abs_neg_le, ProofLine abs_neg_ge) -> void
+{
+    auto & ids = logger.names_and_ids_tracker();
+
+    if (lo >= 0_i) {
+        // v1 inside [lo, hi] with lo >= 0 forces the sign, and that is the first
+        // resolution: v1 >= lo and v1 <= -1 are contradictory arithmetic, so
+        // saturation leaves `v1 < lo \/ v1 >= 0`.
+        emit_resolution(logger, ids.need_pol_item_defining_literal(v1 >= lo), ids.need_pol_item_defining_literal(v1 < 0_i));
+
+        // Then the two bounds the nonneg row licenses, in the other direction to
+        // the image case: v1 >= lo carries to v2 >= lo, v1 <= hi to v2 <= hi.
+        emit_resolution(logger, abs_nonneg_ge, ids.need_pol_item_defining_literal(v1 >= lo), ids.need_pol_item_defining_literal(v2 < lo));
+        emit_resolution(logger, abs_nonneg_le, ids.need_pol_item_defining_literal(v1 < hi + 1_i), ids.need_pol_item_defining_literal(v2 >= hi + 1_i));
+    }
+    else {
+        // hi < 0, so v1 <= hi forces the sign the other way, and the mirror runs
+        // through the neg row: v1 >= lo gives v2 <= -lo, v1 <= hi gives
+        // v2 >= -hi.
+        emit_resolution(logger, ids.need_pol_item_defining_literal(v1 < hi + 1_i), ids.need_pol_item_defining_literal(v1 >= 0_i));
+        emit_resolution(logger, abs_neg_le, ids.need_pol_item_defining_literal(v1 >= lo), ids.need_pol_item_defining_literal(v2 >= -lo + 1_i));
+        emit_resolution(logger, abs_neg_ge, ids.need_pol_item_defining_literal(v1 < hi + 1_i), ids.need_pol_item_defining_literal(v2 < -hi));
+    }
+
+    // rest follows by RUP
+}
+
 auto gcs::innards::justify_abs_v2_ge_zero(ProofLogger & logger, IntegerVariableID v1, IntegerVariableID v2, ProofLine abs_nonneg_ge) -> void
 {
     if (holds_alternative<ConstantIntegerVariableID>(v1))

--- a/gcs/constraints/abs/justify.hh
+++ b/gcs/constraints/abs/justify.hh
@@ -10,6 +10,49 @@ namespace gcs::innards
     // from dom(v1).
     auto justify_abs_hole(ProofLogger & logger, const ReasonLiterals & reason, IntegerVariableID v1, IntegerVariableID v2, Integer val) -> void;
 
+    // The range form of the same removal: justifies `~[v2 in lo..hi]` from a
+    // reason saying v1 holds nothing in [lo, hi] and nothing in [-hi, -lo].
+    //
+    // The per-value form gets away with two RUP lines because `v2 == val` pins
+    // every bit of v2, which pins v1's through whichever half-reified row is
+    // active. A range pins no bit, and the bounds it does give sit on *opposite
+    // sides* of the row, so closing it means adding two PB bound constraints to
+    // the row --- which unit propagation cannot do. (This is why the guarded
+    // two-lemma RUP shape min_max.cc and element.cc use does not transfer here.
+    // There the guard is falsified by the conclusion's own negation, and the
+    // remaining slack arithmetic happens to line up; measured on Abs it misses
+    // by one, see dev_docs/large-domains.md.)
+    //
+    // So each branch's two bounds are derived by `pol` instead, in the same
+    // resolution shape as the consequence-bound helpers below: the model half,
+    // plus the defining item of each atom whose arithmetic is used. That leaves
+    // one clause per branch whose only free literal is the sign, and the two
+    // signs being a literal and its negation, the conclusion follows by RUP.
+    //
+    // Four resolutions and two RUP lines per removed range, independent of its
+    // width, which is the property that matters. Both variables must be plain:
+    // a range literal on a view is not available (issue #882), and a constant
+    // has no order-encoding atoms to resolve against. Width-1 ranges are left
+    // to justify_abs_hole, which is what they canonicalise to anyway.
+    auto justify_abs_hole_range(ProofLogger & logger, const ReasonLiterals & reason, const SimpleIntegerVariableID & v1,
+        const SimpleIntegerVariableID & v2, Integer lo, Integer hi, ProofLine abs_nonneg_le, ProofLine abs_nonneg_ge, ProofLine abs_neg_le,
+        ProofLine abs_neg_ge) -> void;
+
+    // The mirrored direction: justifies `~[v1 in lo..hi]` where the caller's
+    // reason says v2 holds nothing in abs([lo, hi]). Takes no ReasonLiterals: all
+    // three of its lines are pol consequences of the model alone, so unlike the
+    // image direction none of them has to be stated under the reason.
+    //
+    // Cheaper than the above, and the asymmetry is the interesting part. [lo, hi]
+    // must lie wholly on one side of zero, which the caller arranges by splitting
+    // at zero; the conclusion's own negation then decides v1's sign, so only the
+    // active branch is needed and there is no case split left to close. Three
+    // resolutions: the sign, and the two bounds it licenses.
+    //
+    // Same plain-variable requirement as above.
+    auto justify_abs_preimage_range(ProofLogger & logger, const SimpleIntegerVariableID & v1, const SimpleIntegerVariableID & v2, Integer lo,
+        Integer hi, ProofLine abs_nonneg_le, ProofLine abs_nonneg_ge, ProofLine abs_neg_le, ProofLine abs_neg_ge) -> void;
+
     // The bound proofs below share their resolution shape between the
     // prepare-time initialiser and the run-time propagator. The initialiser
     // calls them with empty ReasonLiterals (the operand bound RUPs from

--- a/gcs/large_domain_audit_test.cc
+++ b/gcs/large_domain_audit_test.cc
@@ -188,8 +188,31 @@ namespace
         // --- Arithmetic. These are the six that already implement the policy
         // #833 asks for, as consistency::Auto: tabulate within a budget, else BC.
         add("Abs", Expect::Clean, [](Problem & p) {
+            // Two bare wide variables never reach the interior pruning: the
+            // image of v1's domain is then the whole of v2's, so
+            // each_interval_minus yields nothing and both hole loops are
+            // skipped. The two rows below are the ones that reach them.
             auto v = wide(p, 2);
             p.post(Abs{v[0], v[1]});
+        });
+        add("Abs/hole", Expect::KnownTrip, [](Problem & p) {
+            // H1: the image loop, abs.cc. The removed values have to be a hole
+            // in the *image* rather than merely outside v2's bounds, because
+            // bounds propagation clips the latter first -- which is exactly what
+            // the loop's clipped_lo / clipped_hi are for. So v1's image is
+            // {0, w} and everything strictly between is left for the loop.
+            auto v1 = p.create_integer_variable(vector<Integer>{-probe_width, 0_i, probe_width});
+            auto v2 = wide_var(p);
+            p.post(Abs{v1, v2});
+        });
+        add("Abs/hole-preimage", Expect::KnownTrip, [](Problem & p) {
+            // H1: the mirrored preimage loop, which the row above does not
+            // reach -- v2 contiguous makes its preimage contiguous, so that
+            // difference is empty. Hole in v2 instead, and the two halves of
+            // v1 either side of zero are what is left over.
+            auto v2 = p.create_integer_variable(vector<Integer>{0_i, probe_width});
+            auto v1 = p.create_integer_variable(-probe_width, probe_width);
+            p.post(Abs{v1, v2});
         });
         add("Plus", Expect::Clean, [](Problem & p) {
             auto v = wide(p, 3);

--- a/gcs/large_domain_audit_test.cc
+++ b/gcs/large_domain_audit_test.cc
@@ -195,21 +195,22 @@ namespace
             auto v = wide(p, 2);
             p.post(Abs{v[0], v[1]});
         });
-        add("Abs/hole", Expect::KnownTrip, [](Problem & p) {
-            // H1: the image loop, abs.cc. The removed values have to be a hole
-            // in the *image* rather than merely outside v2's bounds, because
-            // bounds propagation clips the latter first -- which is exactly what
-            // the loop's clipped_lo / clipped_hi are for. So v1's image is
-            // {0, w} and everything strictly between is left for the loop.
+        add("Abs/hole", Expect::Clean, [](Problem & p) {
+            // The image loop, abs.cc. The removed values have to be a hole in
+            // the *image* rather than merely outside v2's bounds, because bounds
+            // propagation clips the latter first -- which is exactly what the
+            // loop's clipped_lo / clipped_hi are for. So v1's image is {0, w}
+            // and everything strictly between is left for the loop, which now
+            // removes it as the one run it is.
             auto v1 = p.create_integer_variable(vector<Integer>{-probe_width, 0_i, probe_width});
             auto v2 = wide_var(p);
             p.post(Abs{v1, v2});
         });
-        add("Abs/hole-preimage", Expect::KnownTrip, [](Problem & p) {
-            // H1: the mirrored preimage loop, which the row above does not
-            // reach -- v2 contiguous makes its preimage contiguous, so that
-            // difference is empty. Hole in v2 instead, and the two halves of
-            // v1 either side of zero are what is left over.
+        add("Abs/hole-preimage", Expect::Clean, [](Problem & p) {
+            // The mirrored preimage loop, which the row above does not reach --
+            // v2 contiguous makes its preimage contiguous, so that difference is
+            // empty. Hole in v2 instead, and the two halves of v1 either side of
+            // zero are what is left over: two runs, and two removals.
             auto v2 = p.create_integer_variable(vector<Integer>{0_i, probe_width});
             auto v1 = p.create_integer_variable(-probe_width, probe_width);
             p.post(Abs{v1, v2});


### PR DESCRIPTION
Part of #833 (stage 4, interval-level rewrites). Fixes #875.

Written stacked on #897 (#878), since both touch `gcs/large_domain_audit_test.cc`
and `dev_docs/large-domains.md`; #897 merged while this was in progress, so it
sits directly on `main` with no rebase needed.

`Abs`' two interior hole loops already had their difference as intervals —
`each_interval_minus()` hands them one — and then walked each interval a value at
a time, in a plain `for (Integer val = ...)` loop that `State` never sees. So
neither the guard nor the audit lane could see either loop, and the `Abs` row
never even *reached* them: two bare wide variables make the image of `v1`'s whole
domain the whole of `v2`'s, so the difference is empty.

## The hazard

Root propagation only, pinned to one core, guard off:

| `w` | `Abs/hole` before | `Abs/hole-preimage` before | after (both) |
|---|---|---|---|
| 10⁶ | 38 ms, 20 MB | 73 ms, 37 MB | **0 ms, ~4.9 MB** |
| 10⁷ | 424 ms, 168 MB | 818 ms, 331 MB | **0 ms, ~4.9 MB** |
| 10⁸ | 3832 ms, 1.64 GB | 7460 ms, 3.28 GB | **0 ms, ~4.9 MB** |
| 10⁹ | 41853 ms, **16.4 GB** | `bad_alloc`, 45 s, **23.7 GB** | **0 ms, ~4.9 MB** |

**Unlike #878's, this hazard allocates**, and that is worth stating because it
settles an argument the doc was making abstractly. The issue reports both shapes
as *surviving* in ~120 s on a 2 TB box. On this 30 GB one, the identical code
gives one `Clean` and one `KnownTrip`. Neither reading is a fact about `Abs` — it
is a fact about the machine, which is exactly why the loops needed instrumenting
rather than being left to the lane's `bad_alloc` fallback.

Two rows, not one sharpened row, because a probe that reaches one loop reaches
neither the other: a contiguous `v2` has a contiguous preimage. Checked one at a
time that each row trips **its own** counter and not the other's — with two
counters in one propagator, tripping *a* guard proves nothing about which loop
ran.

## The proof side, and a finding about `element.cc`

`Abs`' model is two half-reified rows (`v2 - v1 == 0` under `v1 >= 0`,
`v2 + v1 == 0` under `v1 < 0`), which is `ArrayMinMax`'s guarded equality with a
two-valued selector. So `min_max.cc`/`element.cc`'s two ge-layer bound lemmas
ought to work here. **They do not, and the obstacle is not the guard:** unit
propagation cannot *add* two PB bound constraints to a row, and a bound over a
bit-vector fixes no bit unless it happens to be tight enough to force one.

I measured the miss rather than hand-waving it. On `abs_test`'s own
`v1 = [-6, 8]`, `v2 = [0, 15]`, negating the lemma gives `v1 >= -6` (which forces
`b3` through the two's-complement bound) and `v2 >= 7` (which forces nothing); the
row's normalised slack is then exactly **8** against a largest remaining
coefficient of **8**, and a coefficient has to *exceed* the slack to propagate.
One short.

**Which raises why `element.cc` verifies, and the answer is that its arithmetic
lines up.** I built a probe for the question — `result` in `[0, 63]`, three
entries in `{0, 40}`, so the removed run `[41, 63]` puts `result >= 41` against
`array <= 40` with neither bound tight — and it *does* verify, via a cascade that
starts because 41 exceeds what five bits hold and so drops the row's slack below
`array`'s top coefficient. Change the widths and that cascade stops. I have not
turned this into a failing case for `element.cc`, and I am not claiming it is a
bug today; but the shape should be read as a property of the instances it has
been run on, and the doc now says so. Happy to file it if you want it tracked.

The route that does not depend on the arithmetic is `pol`, which is what every
other helper in `abs/justify.cc` already used. Two shapes come out, and the
asymmetry is the useful part:

* Concluding on the variable the guard is *about* (the image direction,
  `~[v2 in lo..hi]`) must close **both** sign branches, because the conclusion's
  negation says nothing about the sign: four resolutions, then one clause per
  branch whose only free literal is the sign. Six lines.
* Concluding on the **guard variable itself** (the preimage direction) is three
  lines — *provided the caller splits each run at zero* first, so `v1 >= lo >= 0`
  propagates `v1 >= 0` up the ge layer and the conclusion's own negation decides
  the sign. No case split left over.

Neither count depends on the range's width.

## Sabotage, and why the obvious check misleads

The interesting negative result. Dropping each of the twelve new proof lines in
turn and re-running `abs_test` at a pinned seed:

| | result |
|---|---|
| any one of 8 of the 12 lines | **passes** — individually not load-bearing |
| `P5` (preimage, neg branch, upper) | rejected, on the `preimage_far` row added for it |
| `I2`, `I6`, `P3` | rejected |
| either justification body emptied | **rejected** |

So the lines are jointly necessary and individually redundant — UP has several
routes to the same conclusion. Greedy minimisation then offers a four-line set
that passes the pinned seed, keeps only the *upper* lemma of each pair and one of
the two sign branches (which cannot be right by symmetry), and is **rejected on
four of ten seeds**. The suite's randomised rows do not separate the halves of a
symmetric rule at any one seed, so minimising against one of them is fitting the
fixtures. Two rules, now in the doc: **sabotage the whole justification, not its
lines**, and **keep a derivation you can state end to end**.

## A coverage gap this uncovered

`abs_test`'s seed is fresh per run, and the image justification's coverage was a
coin toss: reached from 3 instances at seed 1, 8 at seed 2, 3 at seed 3, and
**none at all** on the first unseeded run I traced. The data table can only
express contiguous ranges and constants, and a contiguous domain has no interior
hole to remove.

Four sparse-domain rows fix that deterministically: `image_gap`,
`image_gap_neg`, `image_gap_from_zero` (a run starting at zero, where the removed
range and its mirror overlap there), and `preimage_far` — v1 contiguous
`[-50, 50]` against `v2 = {30, 40}`, leaving a run 31 order atoms from zero,
where every random row leaves runs adjacent to it. That last one is the row that
makes `P5` load-bearing.

## Restrictions, each for its own reason

A view has no range literal (#882); a constant `v2` has no order-encoding atoms
to resolve against; a width-1 run stays on the per-value path, which is what
`not_in_range()` canonicalises it to anyway. Each keeps the existing per-value
loop, so nothing is weakened.

## Testing

* `ctest` **810/810** on GCC (`-DGCS_WERROR=ON`), **815/815** on clang.
* clang 21 tree-wide: **36 warnings, all of them the three pre-existing
  `-Wunused-lambda-capture` sites in `element.cc`** — unchanged baseline, none
  from `abs.cc`.
* `abs_test` **uncapped** across **ten pinned seeds** plain and **three**
  `--view-position=mixed`, all passing; 74 VeriPB verifications at seed 1.
* Large-domain audit lane green on both compilers: **73 rows**, 146 assertions,
  0.55 s, 28 MB peak.
* Proof-scaling survey re-run over all 73 probes: `Abs/hole` flat at 30 OPB rows
  and 46 steps, `Abs/hole-preimage` at 26 and 64, and **nothing else moved**.
* One bug caught in passing by the non-proof run: the four half-line
  `optional<ProofLine>`s were dereferenced in a lambda's *capture list*, which
  runs whether or not proofs are on — `define_proof_model` never runs with proofs
  off, so that was reading empty optionals on every call (double-free in tcache).
  They stay optional in the capture and are dereferenced in the body, as the rest
  of the file does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
