### PR TITLE
Give views their own range literals, linked to the underlying variable's (#882)

### DIFF
--- a/dev_docs/README.md
+++ b/dev_docs/README.md
@@ -138,12 +138,23 @@ library. For an introduction to *using* the solver, start with the top-level
   order-chain cuts, the always-covered partition invariant, interval-tree
   containment, and the P1/P2 (line-checkability vs replay-completeness)
   distinction that governs which linking clauses are load-bearing — with the
-  W1–W5 witness suite as the regression defence against re-simplification.
+  W1–W9 witness suite as the regression defence against re-simplification.
   Read when touching range/interval reasons, branching, or `infer_not_in_range`.
 - [View proof logging](view-proof-logging.md) — how the proof layer handles
-  views (`ViewOfIntegerVariableID`): the V↔X link constraints that tie a view's
-  proof variable to its underlying variable, and how literals over views are
-  deviewed for emission. Read when touching view handling in proofs.
+  `ViewOfIntegerVariableID`: the view's own encoded variable and bit-vector, the
+  single definitional link axiom, the atom-level eq/ge biconditionals that let
+  unit propagation carry one atom across the boundary, and the three invariants
+  (representation consistency for `pol` cancellation, big-M sized to the
+  bit-vector, RUP cannot compose across constraints) that both historical
+  Abs/AllDifferent failures violated. Read before emitting explicit `pol` over
+  an operand that might be a view.
+- [Range literals on views](view-range-literals.md) — where the two documents
+  above meet, which for a long time they did not. A view's own range literals,
+  the pair of link clauses joining them to the underlying variable's, why both
+  clauses are needed and why linking has to be triggered by a literal being
+  *named* rather than requested or defined. Also the measurement that 80% of
+  small random configurations cross correctly with no link at all, which is why
+  a green `--view-wrap` sweep is not evidence and the W6–W9 witnesses are.
 - [arithmetic-proofs.md](arithmetic-proofs.md) — how Multiply/Divide/Modulus/Power propagate and justify against cake's encoding: the slot-keyed emitters, the ConditionalBound justification layer, the sign-case driver, and the hard-won RUP/pol rules.
 - [Decision-diagram proof strategies](decision-diagram-proof-strategies.md) — for
   the layered/partial-sum propagators (`Regular`, `MDD`, `Knapsack`,

--- a/dev_docs/range_literals_spec.md
+++ b/dev_docs/range_literals_spec.md
@@ -324,6 +324,13 @@ expensive way.
   `[1,6] → [1,3] ∨ [4,6]` (one RUP line) lets the replay through. This is
   the partition invariant earning its keep: under §3, `[1,6]` is defined as a
   union of cells and gets that covering when defined.
+- **W6/W7/W8/W9 — the view crossing** (else: backtrack clauses not RUP).
+  W6 and W7 are the two directions of a fact crossing between a view's range
+  literals and its underlying variable's; W8 and W9 are the *trigger*, a literal
+  the partition machinery created as a cell rather than one any caller
+  requested. All four are described, with their ablation matrix and with the
+  reason the `--view-wrap` sweep is not by itself evidence, in
+  `dev_docs/view-range-literals.md`.
 - **W4 — containment** (else: backtrack clauses over interval-reject
   decisions not RUP). Regression net: the whole constraint suite runs under
   `reject_random_interval` by default and fails on Count/Among/Element
@@ -374,10 +381,19 @@ and which branching were active.
 
 ## 9. Inventory of known edge cases (harvested from the first implementation)
 
-1. **Views and constants** take the per-value fallback everywhere
-   (`ProofLogger::infer_not_in_range` already branches; reasons likewise).
-   Folding views in = deview the interval onto the underlying variable;
-   deferred, do not block on it.
+1. **Views and constants.** *Resolved (2026-09, issue #882); see
+   `dev_docs/view-range-literals.md`, which supersedes this entry.* A registered
+   view owns its range literals over its own bit vector, exactly as it already
+   owned its eq and order atoms, and every interval request is mirrored onto the
+   underlying variable and joined to it by a pair of rup clauses. Deviewing the
+   interval onto the underlying variable — the option this entry proposed — was
+   rejected: it would leave ranges as the one atom kind not in `V`-form, which
+   breaks the pol-cancellation invariant the view design rests on. The deview
+   arm still handles the *unregistered* view path, which has no encoded variable
+   to be consistent with. Constants fold to `TrueLiteral` / `FalseLiteral` and
+   never reach the literal layer. The remaining per-value fallback is for
+   variables with no bits encoding, which is a property of the variable and not
+   of views.
 
    *Priced (2026-09, #882):* eight sites now carry a view detour — three that
    throw and five that degrade, two of those being the same code written twice

--- a/dev_docs/view-proof-logging.md
+++ b/dev_docs/view-proof-logging.md
@@ -10,8 +10,7 @@ machinery.
 
 The short version: every constraint currently registered in the view-wrap
 sweep verifies under every wrap. Abs and AllDifferent — historically the
-hard cases — are now in that set. (One constraint, `divide_modulus`, does fail
-that sweep, but on propagation strength rather than on its proof — issue #903.)
+hard cases — are now in that set.
 
 ## Part 1 — The idea, on top of the thesis
 

--- a/dev_docs/view-proof-logging.md
+++ b/dev_docs/view-proof-logging.md
@@ -10,7 +10,8 @@ machinery.
 
 The short version: every constraint currently registered in the view-wrap
 sweep verifies under every wrap. Abs and AllDifferent — historically the
-hard cases — are now in that set.
+hard cases — are now in that set. (One constraint, `divide_modulus`, does fail
+that sweep, but on propagation strength rather than on its proof — issue #903.)
 
 ## Part 1 — The idea, on top of the thesis
 
@@ -159,7 +160,13 @@ You only need to think about views when your justification emits **explicit
 
 Reasons over a view (e.g. `{v ≥ lb, v ≤ ub}`) are fine: they are logged in
 the view's atoms and UP crosses to `X` through the eq/ge links if the rest
-of the proof needs it.
+of the proof needs it. The same now goes for range ("in") conditions — a view
+has its own range literals, linked to the underlying variable's — but the
+linking there is less forgiving than for eq and ge atoms, because a *negated*
+range literal cannot cross on the atom links alone. If you are touching that
+machinery, read `dev_docs/view-range-literals.md` first; in particular, do not
+assume the two sides' literal families are affine images of each other, because
+they are not.
 
 ### If you are touching the view machinery itself
 
@@ -203,6 +210,12 @@ actually exercised:
    link (`derive_deviewed_form_for`). Runtime emissions do *not*
    auto-derive the `X`-form (size); callers opt in with
    `_then_deview` / `PolBuilder` deview-mode.
+5. **Range-literal links `[V in a..b] ⇔ [X in a'..b']`** —
+   `NamesAndIDsTracker::mirror_invar_across_view_link` mirrors the interval onto
+   the other side and emits both rup clauses, triggered whenever a range literal
+   is *named* rather than when it is defined. See
+   `dev_docs/view-range-literals.md`, which explains why both clauses are needed
+   and why naming is the right trigger.
 
 The reification big-M lives in `NamesAndIDsTracker::reify`; the operand-form
 choice lives in the per-constraint `justify_*` helpers.

--- a/dev_docs/view-proof-logging.md
+++ b/dev_docs/view-proof-logging.md
@@ -164,9 +164,10 @@ of the proof needs it. The same now goes for range ("in") conditions — a view
 has its own range literals, linked to the underlying variable's — but the
 linking there is less forgiving than for eq and ge atoms, because a *negated*
 range literal cannot cross on the atom links alone. If you are touching that
-machinery, read `dev_docs/view-range-literals.md` first; in particular, do not
-assume the two sides' literal families are affine images of each other, because
-they are not.
+machinery, read `dev_docs/view-range-literals.md` first; in particular, the two
+sides do hold the same literals, but not in the same *roles* — the same interval
+can be a partition cell on one side and a request with its own covering on the
+other — so argue per side rather than by assuming the structures match.
 
 ### If you are touching the view machinery itself
 

--- a/dev_docs/view-range-literals.md
+++ b/dev_docs/view-range-literals.md
@@ -296,25 +296,44 @@ nothing here is proportional to a domain width.
 
 Measured on one `Equals` whose operands are a bare `0..w` and a two-value
 `{0, w}`, so root propagation prunes exactly one wide interior run; proofs on,
-root propagation only, `.pbp` lines, every row VeriPB-verified. `view` wraps both
-operands as `x + 10^6`, `negview` as `-x + 10^6`, `mixed` gives the two operands
-different wraps of opposite sign.
+root propagation only, `.pbp` lines, every `after` row VeriPB-verified with
+`--force-checked-deletion`. `view` wraps both operands as `x + 10^6`, `negview`
+as `-x + 10^6`, `mixed` as `x + 10^6` against `-y + 10^6 + w`.
 
 | width | plain | view before | view after | negview after | mixed after |
 |---|---|---|---|---|---|
-| 10^3 | 40 | 36,012 | **106** | 106 | 109 |
-| 10^4 | 40 | 360,012 | **106** | 106 | 109 |
-| 10^5 | 40 | *timed out at 300 s* | **106** | 106 | 109 |
-| 10^6 | 40 | *timed out at 300 s* | **106** | 106 | 106 |
+| 10^3 | 68 | 71,017 | **200** | 200 | 200 |
+| 10^4 | 68 | 710,017 | **200** | 200 | 200 |
+| 10^5 | 68 | *timed out at 300 s* | **200** | 200 | 200 |
+| 10^6 | 68 | *timed out at 300 s* | **200** | 200 | 200 |
 
-The `before` column is `2 + 36·w` lines and stops being writable at all between
-10^4 and 10^5. The `after` columns are flat, and 106 rather than 40 because the
+The `before` column is `17 + 71·w` lines and stops being writable at all between
+10^4 and 10^5. The `after` columns are flat, and 200 rather than 68 because the
 view carries its own bit-vector encoding, its own order and equality atoms and
 the link pairs — a constant, not a function of the width. That constant is the
-price of the design; the slope was the point of the issue.
+price of the design; the slope was the point of the issue. `plain` is the
+control that makes the two builds comparable: it is the same 68 on either side
+of the change, as it should be, since nothing here touches a bare variable.
 
-VeriPB checks every `after` row in 0.01–0.02 s, against 5.4 s for the largest
-`before` row that finishes at all.
+VeriPB checks every `after` row in about 0.012 s. The `before` row at 10^3 takes
+42 s, and the one at 10^4 — ten times the lines — was still going after an hour,
+when it was stopped. So writability is the generous half of the `before`
+column's problem: the widths that can still be written are already past the
+widths that can be checked.
+
+The `mixed` offsets are not free to choose, and getting them wrong is quiet.
+The two wraps have to put both operands over the *same* interval; otherwise they
+stop overlapping, the instance is unsatisfiable at the root, and the row measures
+a refutation rather than the hole prune. An earlier version of this probe paired
+`x + 10^6` with `-y + 2·10^6`, which overlap only at `w = 10^6` — so three of the
+four `mixed` rows were the wrong shape, and the fourth was the right one. The
+only tell was a three-line step in a column that should have been flat.
+
+These figures are against `main` at 7b582656, and are about twice the ones this
+branch first reported. #914 puts each of the tracker's definition lines into
+VeriPB's core set, which writes an extra `core id` line for each; both columns
+grow by that factor. Flat against linear is unchanged, and so is everything the
+table is used for.
 
 ## 9. The one residue
 

--- a/dev_docs/view-range-literals.md
+++ b/dev_docs/view-range-literals.md
@@ -201,7 +201,7 @@ the range spec already assumes; and that in-bounds endpoints are partition
 boundaries — which is why `need_direct_encoding_for` cuts at `v` and `v+1` when a
 partition exists, and dropping that would break the base case above.
 
-Corroboration, which is not the argument but is worth having: 2998 randomly
+Corroboration, which is not the argument but is worth having: 3000 randomly
 generated view proofs verified with zero mirror-closure violations, over Equals,
 NotEquals, AllEqual, Min, Max, In, LessThan, LessThanEqual and AllDifferent with
 holey domains, three-view bases, and intervals pushed outside the definition
@@ -227,7 +227,7 @@ Measured two ways, both damning for the sweep as evidence. Over domain widths
 4–16 with 0–7 random requests per instance: **80% of instances cross successfully
 with no linking clause at all** — abut-high 39%, abut-low 23%, whole-range 12%,
 shattered 5.6% — and of the 20% that stall, a single wide cell accounts for 88%.
-And over 985 randomly generated instances that actually reach a conflict, with
+And over 987 randomly generated instances that actually reach a conflict, with
 the link clauses ablated: only **37 of them notice**. The sweep is about 96%
 coincidence.
 

--- a/dev_docs/view-range-literals.md
+++ b/dev_docs/view-range-literals.md
@@ -20,8 +20,9 @@ own order atoms and its own equality atoms, joined to `X` by a single
 definitional link axiom plus lazily emitted atom-level biconditionals. Range
 literals join that list: `[V in a..b]` is an ordinary range literal over `V`,
 reified against `V`'s own two order cuts, with `V`'s own partition, coverings
-and containment edges. Every interval request on either side is mirrored onto
-the other, and the two literals are joined by **two** rup clauses. Nothing
+and containment edges. Every interval named on either side is mirrored onto the
+other — *named*, not requested, which §3 is entirely about — and the two
+literals are joined by **two** rup clauses. Nothing
 above the encoding layer knows any of this happened: a propagator says
 `infer_not_in_range(operand, lo, hi)` and states hole runs as range conditions
 over the operand, whether or not the operand is a view.
@@ -111,9 +112,10 @@ failure. `mirror_invar_across_view_link` is therefore called from `need_invar`
 whenever a range condition that already has a name reaches a proof line. It is
 idempotent, and after the first time it is a set probe.
 
-Literals that are never named need nothing, and cost nothing: a fact only ever
-enters a variable's literal family through a named literal or through a bound,
-and both of those cross.
+A literal that is never named needs nothing, because a fact only ever enters a
+variable's literal family through a named literal or through a bound, and both
+of those cross. As it happens that set turns out to be empty — §4 — but the rule
+does not depend on it being, and should not be changed to.
 
 One consequence worth knowing about: `need_invar` is now genuinely re-entrant,
 because resolving a literal while emitting a covering can re-enter it.

--- a/dev_docs/view-range-literals.md
+++ b/dev_docs/view-range-literals.md
@@ -208,11 +208,24 @@ fact has to compose `view1 → b → view2`, needs both clauses. Every clause an
 every rule here is separately load-bearing, which is a stronger result than the
 spec records for W2 and W5, both of which are structural.
 
-Note for anyone adding to this set: the obvious control for W8 — decide
+`invar_view_test` sits alongside them and covers something different: the
+`need_pol_item_defining_literal` range arms, which no propagator reaches, and the
+sign arithmetic of the endpoint map in both directions — checked with
+`find_xliteral_for`, which does not introduce what it fails to find, so "the
+mirror exists at exactly these bounds and not at the neighbouring ones" is a real
+assertion. Both an off-by-one and a dropped endpoint-swap mutant are killed by
+it. It deliberately does **not** witness the link clauses, and says so: it states
+the crossings as RUP lines, and every one of them still verifies with the link
+pair deleted, because a RUP check is strictly stronger than the single
+unit-propagation pass the links exist for. That is §1's P1/P2 distinction, and it
+caught this document claiming otherwise in an earlier draft.
+
+Two notes for anyone adding to this set. The obvious control for W8 — decide
 `¬[b in 3..4]` instead of `¬[b in 3..5]`, so the decision names a fresh interval
 rather than a cell — verifies with *either* link clause removed, because the
 interval then sits at the bottom of a covering-forced block and the bound
-crosses. Ablate before claiming a witness bites.
+crosses. And a witness stated as a RUP line of the fact you care about tests
+nothing at all here. Ablate before claiming a witness bites.
 
 ## 7. Cost
 

--- a/dev_docs/view-range-literals.md
+++ b/dev_docs/view-range-literals.md
@@ -1,0 +1,249 @@
+# Range ("in") literals on views
+
+How the two mechanisms in `dev_docs/range_literals_spec.md` and
+`dev_docs/view-proof-logging.md` combine. Neither document covered this, because
+until issue #882 they did not combine: a `ViewOfIntegerVariableID` had no range
+literal at all, and every part of the solver that wanted to say something
+interval-shaped about a view carried its own detour — three that threw, and five,
+later seven, that silently degraded to one literal per value.
+
+**Audience.** Anyone touching `need_invar`, `simplify_literal`, the view
+machinery in `NamesAndIDsTracker`, or a propagator that emits explicit `pol`
+over a range literal. Read both of the documents above first; this one assumes
+the partition/covering/containment apparatus of §3 of the range spec and the
+three view invariants of the view document.
+
+## 1. The design in one paragraph
+
+A registered view `V = sX + c` already owns its own bit vector `BinEnc(V)`, its
+own order atoms and its own equality atoms, joined to `X` by a single
+definitional link axiom plus lazily emitted atom-level biconditionals. Range
+literals join that list: `[V in a..b]` is an ordinary range literal over `V`,
+reified against `V`'s own two order cuts, with `V`'s own partition, coverings
+and containment edges. Every interval request on either side is mirrored onto
+the other, and the two literals are joined by **two** rup clauses. Nothing
+above the encoding layer knows any of this happened: a propagator says
+`infer_not_in_range(operand, lo, hi)` and states hole runs as range conditions
+over the operand, whether or not the operand is a view.
+
+The alternative — rewriting a view's range conditions onto `X`, as
+`simplify_literal`'s deview arm does for the four scalar operators — was
+rejected. It would make ranges the one atom kind that is *not* in `V`-form,
+and a `pol` step resolving a range literal against a `V`-form constraint body
+would then strand (view invariant 1). The deview arm still handles range
+conditions, but only on the path it already handled the others: an
+*unregistered* view, seen for the first time during proof logging, which has no
+encoded variable to be consistent with.
+
+## 2. The link pair
+
+For a registered view `V = sX + c` the interval `[a, b]` on `V`'s value scale
+corresponds to
+
+    s = +1:  [a - c,  b - c]
+    s = -1:  [c - b,  c - a]
+
+on `X`'s — the endpoints swap for a negated view, because it reverses the
+order, and the map is then its own inverse. Width is preserved either way, which
+is why a width-1 request is the eq atom on both sides and never reaches this
+machinery at all. `interval_on_underlying` and `interval_on_view` are the two
+directions.
+
+Writing `F_V` for `[V in a..b]` and `F_X` for its image, the link is
+
+    L1:  ¬F_V ∨ F_X
+    L2:  ¬F_X ∨ F_V
+
+Each is RUP at emission: assert one and the negation of the other, and the
+forward reification gives that side's two cuts, the ge-links carry each cut
+across (for `s = -1` the two cuts swap roles, which is exactly the endpoint
+swap above), and the far side's reverse reification fires.
+
+**Both clauses are needed, and each for its contrapositive rather than for its
+implication.** As implications, `F_V → F_X` and `F_X → F_V` are both already
+derivable by unit propagation — one forward reification, two ge-links, one
+reverse reification, no new clauses. That is what issue #882 observed, and it
+is true. But UP uses a clause in whichever direction has a unit, and the
+directions that matter are the negative ones:
+
+    ¬F_X ⟹ ¬F_V   (L1's contrapositive)
+    ¬F_V ⟹ ¬F_X   (L2's contrapositive)
+
+and neither is derivable without the clause. A negated interval literal is a
+unit on *neither* of its cuts — its reverse reification leaves only the binary
+clause `¬(Y≥p) ∨ (Y≥q+1)` — so all it can do is descend its own variable's
+containment edges, and it bottoms out at cells that are themselves unlinked
+range literals unless they happen to be width 1. Descending to width 1 is
+precisely the per-value shattering the interval vocabulary exists to avoid.
+The issue's argument ("a range literal never has to cross an equality: it is
+reified against its own two order cuts, so an interval fact decomposes into
+cross one bound, move within one variable, cross back") decomposes a
+*conjunction* of two bounds; a negated interval is a *disjunction* of two
+bounds, and UP cannot carry a disjunction across one disjunct at a time.
+
+Both negative directions are ordinary rather than exotic. Search branches on
+real variables only — `reject_random_interval` requires a
+`SimpleIntegerVariableID` — while `generic_reason` states hole runs over the
+*operand*, which under a wrap is the view. So a range decision on `X` routinely
+has to reach a reason literal on `V`, and a conclusion on `V` routinely has to
+reach a reason stated over `X`.
+
+## 3. Linking is triggered by *naming*, not by requesting and not by defining
+
+This is the part that is easy to get wrong, and getting it wrong is silent.
+
+A range literal can come into existence two ways. Either some caller asks for it
+— a conclusion, a reason element, a branching guess — which reaches
+`need_invar`; or the partition machinery creates it as a **cell**, from
+`ensure_partition_cut` or `init_interval_partition`, straight through
+`define_plain_invar`, without going anywhere near `need_invar`. A cell is
+therefore never "requested", and:
+
+- `need_proof_name` short-circuits on a condition that already has a proof name;
+- `xliteral_for_ensuring`, which is where the emission path actually resolves
+  literals, does the same.
+
+So "link the literals that are requested" leaves every cell unlinked, and a
+later decision, reason or conclusion that happens to name one of those cells
+gets no link — a unit-propagation dead end with nothing to see at the point of
+failure. `mirror_invar_across_view_link` is therefore called from `need_invar`
+*outside* the "already defined" guard, and again from `xliteral_for_ensuring`
+whenever a range condition that already has a name reaches a proof line. It is
+idempotent, and after the first time it is a set probe.
+
+Literals that are never named need nothing, and cost nothing: a fact only ever
+enters a variable's literal family through a named literal or through a bound,
+and both of those cross.
+
+One consequence worth knowing about: `need_invar` is now genuinely re-entrant,
+because resolving a literal while emitting a covering can re-enter it.
+`ensure_partition_cut` publishes a partition boundary *before* defining the two
+halves that boundary creates, so during that window the partition claims a cell
+that does not exist yet. `define_invar_with_covering`'s single-cell path defines
+it in that case, and `define_plain_invar` is idempotent so that
+`ensure_partition_cut` does not then define it a second time.
+
+## 4. What does *not* mirror, and why the argument cannot be an isomorphism
+
+The final partition boundary sets on `V` and `X` do correspond — every
+cut-insertion path is mirrored — but **the literal families are not affine
+images of each other**. The eq-atom backfill inside `need_direct_encoding_for`
+re-enters `ensure_partition_cut` on the far side before the request's own second
+cut arrives, so the two sides split cells in different orders and end up with
+different intermediate literals: in one measured instance `b` carried former
+cells `[3..8]` and `[3..7]` while its view carried `[13..18]` and `[16..18]`.
+The split coverings and containment DAGs therefore differ.
+
+So any correctness argument here has to go through **per-side UP-completeness**
+(the range spec's Lemma L1) plus "every named literal is linked", never through
+"the two sides have the same clauses". Do not write code that assumes the
+structures match.
+
+## 5. The coincidence trap — read this before believing a green test
+
+The negative crossing is derivable *without any linking clause* in a large
+fraction of small configurations, for four separate reasons:
+
+- the range is the whole definition range, so asserting its negation is
+  UP-inconsistent and the check passes vacuously;
+- the range abuts or sticks out below (`a ≤ lb`): the boundary pin
+  `need_gevar`'s `fix_bound` emits makes the reverse reification a unit, the
+  ge-link carries it, and the far side's *forward* reification finishes the job;
+- the range abuts or sticks out above (`b ≥ ub`): the mirror image;
+- every cell inside the range is a singleton — and one well-placed eq atom
+  shatters a width-2 cell on *both* sides, so any per-value activity anywhere
+  near the range (Table reasons, equality holes, `x = v` branching, enumeration
+  nogoods, width-1 `In` gaps) silently makes the case work.
+
+Measured over a sweep of domain widths 4–16 with 0–7 random requests per
+instance: **80% of instances cross successfully with no linking clause at all**
+— abut-high 39%, abut-low 23%, whole-range 12%, shattered 5.6% — and of the 20%
+that stall, a single wide cell accounts for 88%.
+
+A discriminating instance therefore needs *all* of: the range strictly inside
+both variables' definition bounds; at least one interior cell of width ≥ 2 that
+no per-value machinery touches; and a backtrack replay that has to reach the far
+side's literal from the near side's negation rather than from a bound. This is
+why the `--view-wrap` sweep passing is not by itself evidence, and why the
+witnesses below are.
+
+## 6. The witnesses
+
+`dev_docs/range_literals_spec.md` §8 is the suite; these four are its view half,
+all gate-on and veripb-verified.
+
+- **W6** — an interval fact concluded on a plain variable reaching a reason
+  literal on a view of it (`X → V`, so L1's contrapositive).
+- **W7** — the mirror image (`V → X`, L2's contrapositive).
+- **W8** — the *trigger*: the named literal is one the partition machinery
+  already created as a cell, so it is invisible to a request-driven link rule.
+- **W9** — W8's two-view form, where the fact composes `view1 → b → view2`, and
+  where the unlinked literal is a conclusion rather than a decision.
+
+Validated by ablation, with a temporary knob since removed:
+
+| ablation                | W6     | W7     | W8     | W9     |
+|-------------------------|--------|--------|--------|--------|
+| none                    | passes | passes | passes | passes |
+| both link clauses gone  | FAILS  | FAILS  | FAILS  | FAILS  |
+| L1 removed              | FAILS  | passes | FAILS  | FAILS  |
+| L2 removed              | passes | FAILS  | passes | FAILS  |
+| link on request only    | passes | passes | FAILS  | FAILS  |
+
+Each fails within milliseconds, on a backtrack clause. W6 and W7 separate the
+two clauses cleanly, one each; W8 and W9 fail whenever linking is driven by
+requests rather than by naming, whichever clauses are present; and W9, whose
+fact has to compose `view1 → b → view2`, needs both clauses. Every clause and
+every rule here is separately load-bearing, which is a stronger result than the
+spec records for W2 and W5, both of which are structural.
+
+Note for anyone adding to this set: the obvious control for W8 — decide
+`¬[b in 3..4]` instead of `¬[b in 3..5]`, so the decision names a fresh interval
+rather than a cell — verifies with *either* link clause removed, because the
+interval then sits at the bottom of a covering-forced block and the bound
+crosses. Ablate before claiming a witness bites.
+
+## 7. Cost
+
+Per interval literal per registered view: the mirrored literal on the other side
+(with its own partition maintenance) plus two rup lines. That is the same
+constant factor the eq and ge atoms already pay for a wrapped variable, and
+nothing here is proportional to a domain width.
+
+Measured on one `Equals` whose operands are a bare `0..w` and a two-value
+`{0, w}`, so root propagation prunes exactly one wide interior run; proofs on,
+root propagation only, `.pbp` lines, every row VeriPB-verified. `view` wraps both
+operands as `x + 10^6`, `negview` as `-x + 10^6`, `mixed` gives the two operands
+different wraps of opposite sign.
+
+| width | plain | view before | view after | negview after | mixed after |
+|---|---|---|---|---|---|
+| 10^3 | 40 | 36,012 | **106** | 106 | 109 |
+| 10^4 | 40 | 360,012 | **106** | 106 | 109 |
+| 10^5 | 40 | *timed out at 300 s* | **106** | 106 | 109 |
+| 10^6 | 40 | *timed out at 300 s* | **106** | 106 | 106 |
+
+The `before` column is `2 + 36·w` lines and stops being writable at all between
+10^4 and 10^5. The `after` columns are flat, and 106 rather than 40 because the
+view carries its own bit-vector encoding, its own order and equality atoms and
+the link pairs — a constant, not a function of the width. That constant is the
+price of the design; the slope was the point of the issue.
+
+VeriPB checks every `after` row in 0.01–0.02 s, against 5.4 s for the largest
+`before` row that finishes at all.
+
+## 8. The one residue
+
+A real variable with `lower == 0 && upper == 1` and no explicit representation
+is `DirectOnly`, so it has no bit vector and no order cuts to reify against, and
+`need_invar` throws for it. That is pre-existing and applies to bare variables
+too. A view of such a variable *does* get bits, so its mirror would be the first
+thing to ask `need_invar` for a bits-less variable.
+
+It cannot arise — a two-value domain has no interior hole, `reject_random_interval`
+needs three values, and `each_interval_minus` on a two-value domain yields only
+width-1 intervals — but `ProofLogger::infer` and `infer_explicitly` fall back to
+per-value when `can_represent_range_literal_for` is false, and that predicate
+resolves a view to its underlying variable, so the case stays correct if it ever
+does. That is the bits-less fallback, which bare variables have too. It is not a
+view detour, and it is the only one left.

--- a/dev_docs/view-range-literals.md
+++ b/dev_docs/view-range-literals.md
@@ -123,21 +123,30 @@ that does not exist yet. `define_invar_with_covering`'s single-cell path defines
 it in that case, and `define_plain_invar` is idempotent so that
 `ensure_partition_cut` does not then define it a second time.
 
-## 4. What does *not* mirror, and why the argument cannot be an isomorphism
+## 4. Every cell gets named, so in practice everything is linked
 
-The final partition boundary sets on `V` and `X` do correspond — every
-cut-insertion path is mirrored — but **the literal families are not affine
-images of each other**. The eq-atom backfill inside `need_direct_encoding_for`
-re-enters `ensure_partition_cut` on the far side before the request's own second
-cut arrives, so the two sides split cells in different orders and end up with
-different intermediate literals: in one measured instance `b` carried former
-cells `[3..8]` and `[3..7]` while its view carried `[13..18]` and `[16..18]`.
-The split coverings and containment DAGs therefore differ.
+A useful consequence of §3 that is worth stating explicitly, because it is not
+obvious and because it is what makes the cost predictable: **coverings name their
+cells.** `init_interval_partition` emits a root covering over every cell it
+creates, and `ensure_partition_cut` emits a split covering over the two halves it
+creates. Emitting either one renders those literals into a proof line, which
+takes them through `xliteral_for_ensuring`, which links them. So although the
+rule is "link on naming" rather than "link everything", nothing that exists ends
+up unlinked, and the two sides' literal families do in fact end up as affine
+images of each other.
 
-So any correctness argument here has to go through **per-side UP-completeness**
-(the range spec's Lemma L1) plus "every named literal is linked", never through
-"the two sides have the same clauses". Do not write code that assumes the
-structures match.
+Measured on `equals_test --view-position=mixed`, 258 proofs, every registered
+(variable, view) pair whose view appears in the proof: **300 pairs, 300 matches,
+no exceptions.**
+
+**Do not turn that into the correctness argument.** Nothing maintains the
+correspondence as an invariant — it is a downstream consequence of coverings
+naming their pieces, and a future change that emitted a covering differently, or
+that created a literal without a covering, would break it silently and without
+breaking any test that checks for it, because there is no such test. The
+load-bearing property is the one §3 actually enforces: *every named literal is
+linked*, plus per-side UP-completeness (the range spec's Lemma L1). Argue through
+those, not through the two sides having the same clauses.
 
 ## 5. The coincidence trap — read this before believing a green test
 

--- a/dev_docs/view-range-literals.md
+++ b/dev_docs/view-range-literals.md
@@ -112,10 +112,22 @@ failure. `mirror_invar_across_view_link` is therefore called from `need_invar`
 whenever a range condition that already has a name reaches a proof line. It is
 idempotent, and after the first time it is a set probe.
 
-A literal that is never named needs nothing, because a fact only ever enters a
-variable's literal family through a named literal or through a bound, and both
-of those cross. As it happens that set turns out to be empty — §4 — but the rule
-does not depend on it being, and should not be changed to.
+**In a definitions-on proof there is in fact no such thing as an unnamed range
+literal**, which is what makes the rule complete rather than merely better than
+the alternative. `ProofLogger::emit` and `emit_under_reason` render with
+`EnsureNames::Yes`, so every `rup` / `a` / `ia` line takes each range condition
+through `xliteral_for_ensuring`. Every creation path writes such a line about the
+literal it has just created, in the same call: `ensure_partition_cut` writes the
+split covering, `init_interval_partition` the root covering,
+`define_invar_with_covering` the request covering, `link_immediate_containment`
+the containment edges. Only the `red` reifications go out through the ostream
+overload with `EnsureNames::No`. So a cell is linked when its own covering is
+written, not when some later solver fact happens to mention it.
+
+That is the invariant to preserve: **every non-`red` emission names its
+literals**. A future path that rendered a range literal without going through
+`need_all_proof_names_in` or `xliteral_for_ensuring` could leave one unlinked,
+and nothing would notice.
 
 One consequence worth knowing about: `need_invar` is now genuinely re-entrant,
 because resolving a literal while emitting a covering can re-enter it.
@@ -125,32 +137,77 @@ that does not exist yet. `define_invar_with_covering`'s single-cell path defines
 it in that case, and `define_plain_invar` is idempotent so that
 `ensure_partition_cut` does not then define it a second time.
 
-## 4. Every cell gets named, so in practice everything is linked
+## 4. The two sides hold the same literals, but not in the same roles
 
-A useful consequence of §3 that is worth stating explicitly, because it is not
-obvious and because it is what makes the cost predictable: **coverings name their
-cells.** `init_interval_partition` emits a root covering over every cell it
-creates, and `ensure_partition_cut` emits a split covering over the two halves it
-creates. Emitting either one renders those literals into a proof line, which
-takes them through `xliteral_for_ensuring`, which links them. So although the
-rule is "link on naming" rather than "link everything", nothing that exists ends
-up unlinked, and the two sides' literal families do in fact end up as affine
-images of each other.
+Because every literal is linked at creation (§3), and linking creates the mirror
+on the far side, the two sides end up holding **the same set of literals** up to
+the affine map. Measured on `equals_test --view-position=mixed`, 258 proofs, every
+registered (variable, view) pair whose view appears in the proof: 300 pairs, 300
+matches, no exceptions.
 
-Measured on `equals_test --view-position=mixed`, 258 proofs, every registered
-(variable, view) pair whose view appears in the proof: **300 pairs, 300 matches,
-no exceptions.**
+What does *not* correspond is a literal's **role**. `need_direct_encoding_for`'s
+eq-atom backfill re-enters `ensure_partition_cut` on the far side before the
+request's own second cut arrives, so the two sides reach the same set by
+different routes, and the same interval can be a root cell on one side and a
+split half or a request with its own covering on the other. Measured over 400
+sweep proofs: 66 contained such a difference, 297 literals in all, every proof
+verifying. So the split coverings and the containment DAGs genuinely differ.
 
-**Do not turn that into the correctness argument.** Nothing maintains the
-correspondence as an invariant — it is a downstream consequence of coverings
-naming their pieces, and a future change that emitted a covering differently, or
-that created a literal without a covering, would break it silently and without
-breaking any test that checks for it, because there is no such test. The
-load-bearing property is the one §3 actually enforces: *every named literal is
-linked*, plus per-side UP-completeness (the range spec's Lemma L1). Argue through
-those, not through the two sides having the same clauses.
+**Argue per side, never by isomorphism.** The correctness argument runs: every
+fact is a unit on every side (bounds via the ge-links, equalities via the
+eq-links, intervals via L1/L2), and then per-side UP-completeness — the range
+spec's Lemma L1 — derives every implied literal on the side that needs it. That
+argument does not care which role a literal plays, which is exactly why it
+survives the role differences. An argument that appealed to the two sides having
+the same clauses would not.
 
-## 5. The coincidence trap — read this before believing a green test
+## 5. Why this is complete
+
+The obligation is: in a backtrack-clause replay, after asserting the decisions,
+every logged inference's reason must become unit in trail order. The argument has
+three parts, and it was formalised rather than assumed.
+
+**Mirror closure.** For every registered `V = sX + c` and every other view `V'`
+of `X`, an interval exists on one iff its image exists on the others, with the
+link pair present for each view/underlying pair. This is §3's invariant plus the
+fact that `link` requests the far side, which itself mirrors onward — so a
+literal first seen on `V₁` reaches `V₂` through `X` in the same call.
+
+**Unit transport.** Any literal that is a unit on one side has its image a unit
+on every other side of the same base: ge-links for bounds, eq-links for
+equalities, L1/L2 for intervals (L1 carrying `+F_V` and `¬F_X`, L2 the other
+two). Two hops compose through the underlying variable.
+
+**Per-side UP-completeness.** For a single variable, given any set of unit
+literals from its own family, UP derives every bound implied by the surviving
+values, every interval and equality the surviving values are contained in, every
+one they are disjoint from, and contradiction if none survive. The interesting
+case is the last: induction on (number of current cells inside the literal,
+width), using containment for a cell under a rejected ancestor, reification and
+the chain for one cleared by a bound, and the covering for the step — which works
+because every in-bounds endpoint of every interval and equality is a partition
+boundary, so a cell is either wholly inside a literal or disjoint from it.
+Notably the root covering is *not* needed, matching the observation already
+recorded in §8.1 of the range spec.
+
+Together: assert the decisions; by transport the unit set on any side is the
+image of every fact so far; per-side completeness derives whatever that
+inference's reason needs on the side it is stated on; the inference clause fires;
+induct.
+
+**What it depends on**, and therefore what would break it: that every non-`red`
+emission names its literals (§3); that every domain change is logged eagerly, as
+the range spec already assumes; and that in-bounds endpoints are partition
+boundaries — which is why `need_direct_encoding_for` cuts at `v` and `v+1` when a
+partition exists, and dropping that would break the base case above.
+
+Corroboration, which is not the argument but is worth having: 2998 randomly
+generated view proofs verified with zero mirror-closure violations, over Equals,
+NotEquals, AllEqual, Min, Max, In, LessThan, LessThanEqual and AllDifferent with
+holey domains, three-view bases, and intervals pushed outside the definition
+bounds.
+
+## 6. The coincidence trap — read this before believing a green test
 
 The negative crossing is derivable *without any linking clause* in a large
 fraction of small configurations, for four separate reasons:
@@ -166,10 +223,13 @@ fraction of small configurations, for four separate reasons:
   near the range (Table reasons, equality holes, `x = v` branching, enumeration
   nogoods, width-1 `In` gaps) silently makes the case work.
 
-Measured over a sweep of domain widths 4–16 with 0–7 random requests per
-instance: **80% of instances cross successfully with no linking clause at all**
-— abut-high 39%, abut-low 23%, whole-range 12%, shattered 5.6% — and of the 20%
-that stall, a single wide cell accounts for 88%.
+Measured two ways, both damning for the sweep as evidence. Over domain widths
+4–16 with 0–7 random requests per instance: **80% of instances cross successfully
+with no linking clause at all** — abut-high 39%, abut-low 23%, whole-range 12%,
+shattered 5.6% — and of the 20% that stall, a single wide cell accounts for 88%.
+And over 985 randomly generated instances that actually reach a conflict, with
+the link clauses ablated: only **37 of them notice**. The sweep is about 96%
+coincidence.
 
 A discriminating instance therefore needs *all* of: the range strictly inside
 both variables' definition bounds; at least one interior cell of width ≥ 2 that
@@ -178,7 +238,7 @@ side's literal from the near side's negation rather than from a bound. This is
 why the `--view-wrap` sweep passing is not by itself evidence, and why the
 witnesses below are.
 
-## 6. The witnesses
+## 7. The witnesses
 
 `dev_docs/range_literals_spec.md` §8 is the suite; these four are its view half,
 all gate-on and veripb-verified.
@@ -227,7 +287,7 @@ interval then sits at the bottom of a covering-forced block and the bound
 crosses. And a witness stated as a RUP line of the fact you care about tests
 nothing at all here. Ablate before claiming a witness bites.
 
-## 7. Cost
+## 8. Cost
 
 Per interval literal per registered view: the mirrored literal on the other side
 (with its own partition maintenance) plus two rup lines. That is the same
@@ -256,7 +316,7 @@ price of the design; the slope was the point of the issue.
 VeriPB checks every `after` row in 0.01–0.02 s, against 5.4 s for the largest
 `before` row that finishes at all.
 
-## 8. The one residue
+## 9. The one residue
 
 A real variable with `lower == 0 && upper == 1` and no explicit representation
 is `DirectOnly`, so it has no bit vector and no order cuts to reify against, and

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -948,7 +948,11 @@ if(GCS_BUILD_TESTS)
     # The range-literal witness suite (dev_docs/range_literals_spec.md §8): each test
     # fails VeriPB within milliseconds if its clause family is removed or weakened.
     # W4 is range_branch_test above plus the suite-wide interval-reject branching.
-    foreach(witness w1 w2 w3 w5)
+    # W6 and W7 are the two directions of the view crossing; W8 and W9 are the trigger
+    # for it, a literal that a partition cell already brought into existence. All four
+    # are the reason the view-wrap sweep is not by itself evidence: see
+    # dev_docs/view-range-literals.md.
+    foreach(witness w1 w2 w3 w5 w6 w7 w8 w9)
         add_executable(range_witness_${witness}_test innards/proofs/range_witness_${witness}_test.cc)
         target_link_libraries(range_witness_${witness}_test PRIVATE glasgow_constraint_solver)
         add_test(NAME range_witness_${witness}_test COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_verify.bash $<TARGET_FILE:range_witness_${witness}_test>)

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -937,6 +937,10 @@ if(GCS_BUILD_TESTS)
     target_link_libraries(invar_test PRIVATE glasgow_constraint_solver)
     add_test(NAME invar_test COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_verify.bash $<TARGET_FILE:invar_test>)
 
+    add_executable(invar_view_test innards/proofs/invar_view_test.cc)
+    target_link_libraries(invar_view_test PRIVATE glasgow_constraint_solver)
+    add_test(NAME invar_view_test COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_verify.bash $<TARGET_FILE:invar_view_test>)
+
     add_executable(range_branch_test innards/proofs/range_branch_test.cc)
     target_link_libraries(range_branch_test PRIVATE glasgow_constraint_solver)
     add_test(NAME range_branch_test COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_verify.bash $<TARGET_FILE:range_branch_test>)

--- a/gcs/constraints/all_equal/all_equal.cc
+++ b/gcs/constraints/all_equal/all_equal.cc
@@ -2,7 +2,6 @@
 #include <gcs/constraints/all_equal/hints.hh>
 #include <gcs/constraints/innards/justify_not_in_range.hh>
 #include <gcs/innards/inference_tracker.hh>
-#include <gcs/innards/large_domain_guard.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/proofs/proof_model.hh>
@@ -25,7 +24,6 @@
 using namespace gcs;
 using namespace gcs::innards;
 
-using std::holds_alternative;
 using std::make_unique;
 using std::move;
 using std::pair;
@@ -34,7 +32,6 @@ using std::stringstream;
 using std::to_string;
 using std::unique_ptr;
 using std::vector;
-using std::ranges::all_of;
 
 #if defined(__cpp_lib_print) && defined(__cpp_lib_format)
 using std::print;
@@ -149,117 +146,90 @@ auto AllEqual::install_propagators(Propagators & propagators) -> void
                 // The union over j of (D_i minus D_j) is D_i minus the intersection
                 // of the others, and that is D_i minus `common`, so the removal set
                 // is exactly what it was.
-                auto all_simple = all_of(vars, [](const IntegerVariableID & v) { return holds_alternative<SimpleIntegerVariableID>(v); });
-
+                //
                 // A range asserts order atoms and never bits, so it cannot cross
                 // the model's bit-sum equality on its own; the two ge-layer bound
                 // lemmas carry the bounds over to vars[j] first, and then the
                 // reason's range literal is a clause with every literal falsified.
                 // Same helper, and same argument, as equals.cc --- the model here is
                 // a chain of consecutive-pair equalities, so for non-adjacent i and
-                // j unit propagation walks the chain between them.
+                // j unit propagation walks the chain between them. Views are no
+                // different: a view's range literals live on its own encoded
+                // variable, which is the representation the chain equalities are
+                // stated in.
                 auto prune_range = [&](size_t i, size_t j, Integer l, Integer u) {
                     inference.infer_not_in_range(logger, vars[i], l, u,
                         JustifyExplicitly{[logger, &vars, i, j, l, u](const ReasonLiterals & r) {
-                                              justify_not_in_range_across_equality(
-                                                  *logger, r, std::get<SimpleIntegerVariableID>(vars[i]), l, u, vars[j], l, u);
+                                              justify_not_in_range_across_equality(*logger, r, vars[i], l, u, vars[j], l, u);
                                           },
                             ThenRUP::Yes, hints::AllEqual{owner}},
                         ExplicitReason{ReasonLiterals{{not_in_range(vars[j], l, u)}}});
                 };
 
-                if (all_simple) {
-                    for (size_t i = 0; i < n; ++i) {
-                        for (auto [l, u] : domains[i].each_interval_minus(common)) {
-                            if (l == u) {
-                                // A width-1 range literal *is* the eq atom -- the proof
-                                // machinery never makes an interval of one -- so saying
-                                // it that way is the same inference, and finding its
-                                // witness is n in_domain checks against no set at all.
-                                // Worth the branch: over holey domains most removed
-                                // intervals are single values, and routing them through
-                                // the interval path instead cost 2%.
-                                IntegerVariableID witness = vars[0];
-                                for (size_t j = 0; j < n; ++j)
-                                    if (! state.in_domain(vars[j], l)) {
-                                        witness = vars[j];
-                                        break;
-                                    }
-                                inference.infer_not_equal(
-                                    logger, vars[i], l, JustifyUsingRUP{hints::AllEqual{owner}}, ExplicitReason{ReasonLiterals{{witness != l}}});
-                                continue;
-                            }
-
-                            // Almost always one variable's hole explains the whole
-                            // of a removed interval, and then there is nothing to
-                            // split: a scan for a single covering witness is n
-                            // merge-walks with no allocation, where building the
-                            // leftover set to subtract from costs one whatever
-                            // happens. Measured: with the splitting machinery run
-                            // unconditionally this was 2% slower on a search over
-                            // holey domains, and the fast path takes that back.
-                            IntervalSet<Integer> range{l, u};
-                            auto witness = n;
+                for (size_t i = 0; i < n; ++i) {
+                    for (auto [l, u] : domains[i].each_interval_minus(common)) {
+                        if (l == u) {
+                            // A width-1 range literal *is* the eq atom -- the proof
+                            // machinery never makes an interval of one -- so saying
+                            // it that way is the same inference, and finding its
+                            // witness is n in_domain checks against no set at all.
+                            // Worth the branch: over holey domains most removed
+                            // intervals are single values, and routing them through
+                            // the interval path instead cost 2%.
+                            IntegerVariableID witness = vars[0];
                             for (size_t j = 0; j < n; ++j)
-                                if (j != i && ! domains[j].contains_any_of(range)) {
-                                    witness = j;
+                                if (! state.in_domain(vars[j], l)) {
+                                    witness = vars[j];
                                     break;
                                 }
-
-                            if (witness != n) {
-                                prune_range(i, witness, l, u);
-                                continue;
-                            }
-
-                            // Mixed: different parts of this interval are missing
-                            // from different variables, which is the whole reason
-                            // the per-value form needed a witness lookup per value.
-                            // Take the difference against one variable at a time and
-                            // strike off what it accounts for, so each part is
-                            // removed once rather than once per variable that
-                            // witnesses it --- every emission carries two lemmas.
-                            IntervalSet<Integer> todo{l, u};
-                            for (size_t j = 0; j < n && ! todo.empty(); ++j) {
-                                if (j == i)
-                                    continue;
-
-                                // Collected before erasing: each_interval_minus()
-                                // borrows `todo`, which must not be modified while
-                                // the generator is live.
-                                vector<pair<Integer, Integer>> witnessed;
-                                for (auto [wl, wu] : todo.each_interval_minus(domains[j]))
-                                    witnessed.emplace_back(wl, wu);
-
-                                for (auto [wl, wu] : witnessed) {
-                                    todo.erase_range(wl, wu);
-                                    prune_range(i, j, wl, wu);
-                                }
-                            }
+                            inference.infer_not_equal(
+                                logger, vars[i], l, JustifyUsingRUP{hints::AllEqual{owner}}, ExplicitReason{ReasonLiterals{{witness != l}}});
+                            continue;
                         }
-                    }
-                }
-                else {
-                    // A view keeps the per-value walk, since the bound lemmas have
-                    // not been shown to bridge a view's atoms --- the same
-                    // restriction, and the same reason, as equals.cc's range path.
-                    // It keeps the guard with it: this is a plain integer loop over
-                    // an interval, which neither State's iterators nor
-                    // IntervalSet::each() covers, so without a counter the probe
-                    // takes 131 seconds and 16 GB and then *passes*.
-                    LargeDomainIterationCounter expansion_guard{"the number of values one AllEqual intersection pruning has walked"};
 
-                    for (size_t i = 0; i < n; ++i) {
-                        for (auto [l, u] : domains[i].each_interval_minus(common)) {
-                            for (Integer val = l; val <= u; ++val) {
-                                expansion_guard.step();
-                                IntegerVariableID witness = vars[0];
-                                for (size_t j = 0; j < n; ++j)
-                                    if (! state.in_domain(vars[j], val)) {
-                                        witness = vars[j];
-                                        break;
-                                    }
-                                inference.infer_not_equal(
-                                    logger, vars[i], val, JustifyUsingRUP{hints::AllEqual{owner}}, ExplicitReason{ReasonLiterals{{witness != val}}});
+                        // Almost always one variable's hole explains the whole
+                        // of a removed interval, and then there is nothing to
+                        // split: a scan for a single covering witness is n
+                        // merge-walks with no allocation, where building the
+                        // leftover set to subtract from costs one whatever
+                        // happens. Measured: with the splitting machinery run
+                        // unconditionally this was 2% slower on a search over
+                        // holey domains, and the fast path takes that back.
+                        IntervalSet<Integer> range{l, u};
+                        auto witness = n;
+                        for (size_t j = 0; j < n; ++j)
+                            if (j != i && ! domains[j].contains_any_of(range)) {
+                                witness = j;
+                                break;
+                            }
+
+                        if (witness != n) {
+                            prune_range(i, witness, l, u);
+                            continue;
+                        }
+
+                        // Mixed: different parts of this interval are missing
+                        // from different variables, which is the whole reason
+                        // the per-value form needed a witness lookup per value.
+                        // Take the difference against one variable at a time and
+                        // strike off what it accounts for, so each part is
+                        // removed once rather than once per variable that
+                        // witnesses it --- every emission carries two lemmas.
+                        IntervalSet<Integer> todo{l, u};
+                        for (size_t j = 0; j < n && ! todo.empty(); ++j) {
+                            if (j == i)
+                                continue;
+
+                            // Collected before erasing: each_interval_minus()
+                            // borrows `todo`, which must not be modified while
+                            // the generator is live.
+                            vector<pair<Integer, Integer>> witnessed;
+                            for (auto [wl, wu] : todo.each_interval_minus(domains[j]))
+                                witnessed.emplace_back(wl, wu);
+
+                            for (auto [wl, wu] : witnessed) {
+                                todo.erase_range(wl, wu);
+                                prune_range(i, j, wl, wu);
                             }
                         }
                     }

--- a/gcs/constraints/equals/equals.cc
+++ b/gcs/constraints/equals/equals.cc
@@ -322,50 +322,36 @@ auto gcs::innards::enforce_equality(ProofLogger * const logger, const auto & v1,
         // its own (a range literal asserts order atoms, never bits, so it cannot
         // cross the bit-sum equality), so two bound-lemmas carry the bounds across
         // first; each is RUP via the contradictory-binary-sums configuration. See
-        // justify_not_in_range_across_equality. Views and constants take the
-        // per-value path.
+        // justify_not_in_range_across_equality. Either operand may be a view: its
+        // range literals live on its own encoded variable, which is also the
+        // representation the model states this equality in, so the lemmas resolve
+        // against it directly.
         //
         // Hence the not_in_range subhint rather than the family's base hint: at
         // AssertionLevel::Inferences the lemmas are not written, and a justifier
         // reading only the annotation would otherwise see this three-line
         // derivation and a one-line RUP pruning wearing the same wire form
-        // (issue #866). The per-value fallback below is a genuine one-line RUP,
-        // so it keeps the base hint.
-        auto both_simple = std::holds_alternative<SimpleIntegerVariableID>(IntegerVariableID{v1}) &&
-            std::holds_alternative<SimpleIntegerVariableID>(IntegerVariableID{v2});
-
+        // (issue #866).
         auto omit_bridge_lemmas = std::holds_alternative<equals_proof_mutation::OmitBridgeLemmas>(mutation);
         auto bridge = [logger, omit_bridge_lemmas](const auto & pruned, const auto & other, Integer lo, Integer hi, const ReasonLiterals & r) {
             if (omit_bridge_lemmas)
                 return; // testing only: leaves the conclusion claiming to be RUP unaided
             // Plain equality pruned = other, so the flag forces other into the same [lo, hi].
-            justify_not_in_range_across_equality(
-                *logger, r, std::get<SimpleIntegerVariableID>(IntegerVariableID{pruned}), lo, hi, IntegerVariableID{other}, lo, hi);
+            justify_not_in_range_across_equality(*logger, r, IntegerVariableID{pruned}, lo, hi, IntegerVariableID{other}, lo, hi);
         };
 
         auto prune = [&](const auto & pruned, const auto & other, const IntervalSet<Integer> & pruned_set, const IntervalSet<Integer> & other_set) {
             for (auto [lo, hi] : pruned_set.each_interval_minus(other_set)) {
-                if (both_simple) {
-                    // ExplicitReason holds an immutable snapshot (the base reason plus
-                    // the excluded interval), so the justification — which materialises
-                    // it once per bridge lemma plus once for the conclusion — gets a
-                    // fresh copy each time rather than an accumulating element.
-                    ReasonLiterals not_in_range_reason = reason;
-                    not_in_range_reason.emplace_back(not_in_range(IntegerVariableID{other}, lo, hi));
-                    inference.infer_not_in_range(logger, pruned, lo, hi,
-                        JustifyExplicitly{
-                            [=](const ReasonLiterals & r) { bridge(pruned, other, lo, hi, r); }, ThenRUP::Yes, hints::EqualsNotInRange{{owner}}},
-                        ExplicitReason{std::move(not_in_range_reason)});
-                }
-                else
-                    for (Integer val = lo; val <= hi; ++val)
-                        inference.infer_not_equal(logger, pruned, val, JustifyUsingRUP{hints::Equals{owner}},
-                            ExplicitReason{//
-                                [&] {
-                                    auto r = reason;
-                                    r.emplace_back(other != val);
-                                    return r;
-                                }()});
+                // ExplicitReason holds an immutable snapshot (the base reason plus
+                // the excluded interval), so the justification — which materialises
+                // it once per bridge lemma plus once for the conclusion — gets a
+                // fresh copy each time rather than an accumulating element.
+                ReasonLiterals not_in_range_reason = reason;
+                not_in_range_reason.emplace_back(not_in_range(IntegerVariableID{other}, lo, hi));
+                inference.infer_not_in_range(logger, pruned, lo, hi,
+                    JustifyExplicitly{
+                        [=](const ReasonLiterals & r) { bridge(pruned, other, lo, hi, r); }, ThenRUP::Yes, hints::EqualsNotInRange{{owner}}},
+                    ExplicitReason{std::move(not_in_range_reason)});
             }
         };
 
@@ -433,28 +419,17 @@ namespace
         LargeDomainIterationCounter guard{"the number of literals one reified equals no-overlap reason has walked"};
         ReasonLiterals reason;
 
-        // A run of values one operand cannot take is one range condition -- unless
-        // that operand is a view, which has no range literal (#882), in which case
-        // it is spelled out, the same degradation generic_reason and
-        // ProofLogger::infer already make. Only the run is spelled out: the rest of
-        // the walk is unaffected, so a view pays for its own holes and not for the
-        // width of anything.
+        // A run of values one operand cannot take is one range condition, whatever
+        // kind of variable that operand is: a view's range literals live on its own
+        // encoded variable, linked to the underlying variable's (#882). A width-1
+        // run canonicalises to a disequality on construction.
         //
-        // The witness does not care which spelling a run got. Stepping `v1 >= lo`
-        // to `v1 >= hi + 1` is the range literal's reverse reification in one case
-        // and the eq atoms walking the order chain in the other; either way it is
-        // internal to that variable and needs no lemma from us. Which is why this
-        // is a fallback in the reason and nowhere else.
+        // The witness does not care about any of this. Stepping `v1 >= lo` to
+        // `v1 >= hi + 1` is the range literal's reverse reification, which is
+        // internal to that variable and needs no lemma from us.
         auto skip_run = [&](IntegerVariableID var, Integer lo, Integer hi) {
-            if (lo == hi || ! std::holds_alternative<ViewOfIntegerVariableID>(var)) {
-                guard.step();
-                reason.emplace_back(not_in_range(var, lo, hi));
-            }
-            else
-                for (auto val = lo; val <= hi; ++val) {
-                    guard.step();
-                    reason.emplace_back(var != val);
-                }
+            guard.step();
+            reason.emplace_back(not_in_range(var, lo, hi));
         };
 
         // One literal per move of the walk: the runs that make the two domains

--- a/gcs/constraints/innards/justify_not_in_range.cc
+++ b/gcs/constraints/innards/justify_not_in_range.cc
@@ -3,7 +3,7 @@
 using namespace gcs;
 using namespace gcs::innards;
 
-auto gcs::innards::justify_not_in_range_across_equality(ProofLogger & logger, const ReasonLiterals & reason, const SimpleIntegerVariableID & pruned,
+auto gcs::innards::justify_not_in_range_across_equality(ProofLogger & logger, const ReasonLiterals & reason, const IntegerVariableID & pruned,
     Integer lo, Integer hi, IntegerVariableID other, Integer other_lo, Integer other_hi) -> void
 {
     // pruned >= lo -> other >= other_lo. Negation is pruned >= lo AND

--- a/gcs/constraints/innards/justify_not_in_range.hh
+++ b/gcs/constraints/innards/justify_not_in_range.hh
@@ -31,9 +31,19 @@ namespace gcs::innards
     // that case and uses pol instead (abs/justify.cc); do not reach for this
     // helper with a mirrored pairing and expect it to hold.
     //
-    // `other` must be a plain integer variable, equality-linked to `pruned` in the
-    // proof model. Pass the same reason the caller hands to infer_not_in_range.
-    auto justify_not_in_range_across_equality(ProofLogger & logger, const ReasonLiterals & reason, const SimpleIntegerVariableID & pruned, Integer lo,
+    // Either operand may be a view, and a wrap does not disturb that hypothesis.
+    // The lemmas name no bit vector, only order conditions on the two operands, so
+    // they are emitted over whichever encoded variable each operand resolves to --
+    // a registered view's own, matching the representation the model states the
+    // equality in (dev_docs/view-proof-logging.md invariant 1). The sign that has
+    // to match is the one on the link between the two *operands*, not the one on
+    // either view's wrap: a negated view has the matching negation in the model's
+    // own equality line, so `pruned = other` stays a difference row however either
+    // side is wrapped.
+    //
+    // `other` must be equality-linked to `pruned` in the proof model. Pass the same
+    // reason the caller hands to infer_not_in_range.
+    auto justify_not_in_range_across_equality(ProofLogger & logger, const ReasonLiterals & reason, const IntegerVariableID & pruned, Integer lo,
         Integer hi, IntegerVariableID other, Integer other_lo, Integer other_hi) -> void;
 }
 

--- a/gcs/constraints/min_max/min_max.cc
+++ b/gcs/constraints/min_max/min_max.cc
@@ -27,7 +27,6 @@ using std::string;
 using std::stringstream;
 using std::unique_ptr;
 using std::vector;
-using std::ranges::all_of;
 
 ArrayMinMax::ArrayMinMax(vector<IntegerVariableID> vars, const IntegerVariableID result, bool min) : _vars(move(vars)), _result(result), _min(min)
 {
@@ -104,115 +103,83 @@ auto ArrayMinMax::install_propagators(Propagators & propagators) -> void
 
             // result in union(vars)
             //
-            // Interval-level where the proof allows it. The values to remove are
-            // result's domain minus the union of the vars' domains, which is a
-            // handful of ranges however wide the domains are; per value it was
-            // O(|D(result)|) even when it removed nothing, and this loop is also
-            // the only thing that bounds result from the loose side, so on a
-            // domainless FlatZinc objective it had 9.2x10^18 values to get
-            // through and never returned (issue #815).
+            // Interval-level. The values to remove are result's domain minus
+            // the union of the vars' domains, which is a handful of ranges
+            // however wide the domains are; per value it was O(|D(result)|) even
+            // when it removed nothing, and this loop is also the only thing that
+            // bounds result from the loose side, so on a domainless FlatZinc
+            // objective it had 9.2x10^18 values to get through and never returned
+            // (issue #815).
             //
             // The removals are identical either way -- a value survives iff some
             // var holds it -- so the search does not change, only how many
             // inferences it takes to get there.
-            auto all_simple = std::holds_alternative<SimpleIntegerVariableID>(IntegerVariableID{result}) &&
-                all_of(vars, [](const IntegerVariableID & v) { return std::holds_alternative<SimpleIntegerVariableID>(v); });
-
-            if (all_simple) {
-                auto unsupported = state.copy_of_values(result);
-                for (const auto & var : vars) {
-                    if (unsupported.empty())
-                        break;
-                    // The copy has to be a named local: each_interval() hands out
-                    // a generator that *borrows* the set, which must outlive it
-                    // (see IntervalSet's class documentation). Iterating over a
-                    // temporary's generator leaves it dangling, which reads
-                    // garbage intervals, fails to erase the values that really
-                    // are supported, and so removes supported values from the
-                    // result -- lost solutions, not merely lost pruning.
-                    auto var_values = state.copy_of_values(var);
-                    for (auto [lo, hi] : var_values.each_interval())
-                        unsupported.erase_range(lo, hi);
-                }
-
-                for (auto [lo, hi] : unsupported.each_interval()) {
-                    ReasonLiterals reason;
-                    for (auto & var : vars)
-                        reason.emplace_back(not_in_range(var, lo, hi));
-
-                    inference.infer_not_in_range(logger, result, lo, hi,
-                        JustifyExplicitly{//
-                            [logger, result, min, lo = lo, hi = hi, &vars, &selectors](const ReasonLiterals & reason) {
-                                // The range conclusion cannot be RUPped on its own, and
-                                // not for the reason the per-value form gets away with.
-                                // Negating the conclusion is fine: two opposing bounds on
-                                // result do contradict through the bit rows. It is the
-                                // *reason* that blocks it -- "var not in [lo, hi]" is the
-                                // disjunction ~ge(lo) \/ ge(hi+1), and RUP cannot case
-                                // split. (The per-value form never meets this, because
-                                // result = val pins every bit of result and so pins var's
-                                // too, deciding both halves at once.)
-                                //
-                                // So each half is restated as a clause the checker can
-                                // unit propagate. One of the two crosses the half-reified
-                                // row and carries the selector with it; the other crosses
-                                // the unconditional row and does not. For max the model is
-                                // result >= var_i always and result <= var_i under f_i, so
-                                // it is the lower lemma that needs f_i; for min it is the
-                                // upper one. With both in the database the selector clause
-                                // and the conclusion are plain propagation.
-                                for (const auto & [idx, var] : enumerate(vars)) {
-                                    auto lower = WPBSum{} + 1_i * (result < lo) + 1_i * (var >= lo);
-                                    auto upper = WPBSum{} + 1_i * (var < hi + 1_i) + 1_i * (result >= hi + 1_i);
-                                    if (min)
-                                        upper += 1_i * ! selectors.at(idx);
-                                    else
-                                        lower += 1_i * ! selectors.at(idx);
-
-                                    logger->emit_rup_proof_line_under_reason(reason, move(lower) >= 1_i, ProofLevel::Temporary);
-                                    logger->emit_rup_proof_line_under_reason(reason, move(upper) >= 1_i, ProofLevel::Temporary);
-                                    logger->emit_rup_proof_line_under_reason(reason,
-                                        WPBSum{} + 1_i * ! selectors.at(idx) + 1_i * not_in_range(result, lo, hi) + 1_i * in_range(var, lo, hi) >=
-                                            1_i,
-                                        ProofLevel::Temporary);
-                                }
-                            },
-                            ThenRUP::Yes, hints::MinMax{owner}},
-                        ExplicitReason{reason});
-                }
+            //
+            // A view operand is no different, for the same reason as the
+            // single-support range path below: a registered view owns its range
+            // literals over its own encoded variable, and that is also the
+            // representation the model states these rows in, so the two bound
+            // lemmas cross on the view's own encoding rather than having to reach
+            // the underlying one.
+            auto unsupported = state.copy_of_values(result);
+            for (const auto & var : vars) {
+                if (unsupported.empty())
+                    break;
+                // The copy has to be a named local: each_interval() hands out
+                // a generator that *borrows* the set, which must outlive it
+                // (see IntervalSet's class documentation). Iterating over a
+                // temporary's generator leaves it dangling, which reads
+                // garbage intervals, fails to erase the values that really
+                // are supported, and so removes supported values from the
+                // result -- lost solutions, not merely lost pruning.
+                auto var_values = state.copy_of_values(var);
+                for (auto [lo, hi] : var_values.each_interval())
+                    unsupported.erase_range(lo, hi);
             }
-            else {
-                // A view's atoms are spelled through the view, and the bound
-                // lemmas above have not been shown to bridge that, so anything
-                // but a plain variable keeps the per-value path. Same restriction,
-                // and the same reason, as the single-support range path below.
-                for (auto value : state.each_value_mutable(result)) {
-                    bool found_support = false;
-                    for (auto & var : vars) {
-                        if (state.in_domain(var, value)) {
-                            found_support = true;
-                            break;
-                        }
-                    }
 
-                    if (! found_support) {
-                        ReasonLiterals reason;
-                        for (auto & var : vars)
-                            reason.emplace_back(var != value);
+            for (auto [lo, hi] : unsupported.each_interval()) {
+                ReasonLiterals reason;
+                for (auto & var : vars)
+                    reason.emplace_back(not_in_range(var, lo, hi));
 
-                        inference.infer_not_equal(logger, result, value,
-                            JustifyExplicitly{//
-                                [logger, result, value, &selectors](const ReasonLiterals & reason) {
-                                    // show that none of the selectors work, if we're taking the result to be that value and also
-                                    // that the value is missing from all of the vars
-                                    for (const auto & sel : selectors)
-                                        logger->emit_rup_proof_line_under_reason(
-                                            reason, WPBSum{} + (1_i * ! sel) + (1_i * (result != value)) >= 1_i, ProofLevel::Temporary);
-                                },
-                                ThenRUP::Yes, hints::MinMax{owner}},
-                            ExplicitReason{reason});
-                    }
-                }
+                inference.infer_not_in_range(logger, result, lo, hi,
+                    JustifyExplicitly{//
+                        [logger, result, min, lo = lo, hi = hi, &vars, &selectors](const ReasonLiterals & reason) {
+                            // The range conclusion cannot be RUPped on its own, and
+                            // not for the reason the per-value form gets away with.
+                            // Negating the conclusion is fine: two opposing bounds on
+                            // result do contradict through the bit rows. It is the
+                            // *reason* that blocks it -- "var not in [lo, hi]" is the
+                            // disjunction ~ge(lo) \/ ge(hi+1), and RUP cannot case
+                            // split. (The per-value form never meets this, because
+                            // result = val pins every bit of result and so pins var's
+                            // too, deciding both halves at once.)
+                            //
+                            // So each half is restated as a clause the checker can
+                            // unit propagate. One of the two crosses the half-reified
+                            // row and carries the selector with it; the other crosses
+                            // the unconditional row and does not. For max the model is
+                            // result >= var_i always and result <= var_i under f_i, so
+                            // it is the lower lemma that needs f_i; for min it is the
+                            // upper one. With both in the database the selector clause
+                            // and the conclusion are plain propagation.
+                            for (const auto & [idx, var] : enumerate(vars)) {
+                                auto lower = WPBSum{} + 1_i * (result < lo) + 1_i * (var >= lo);
+                                auto upper = WPBSum{} + 1_i * (var < hi + 1_i) + 1_i * (result >= hi + 1_i);
+                                if (min)
+                                    upper += 1_i * ! selectors.at(idx);
+                                else
+                                    lower += 1_i * ! selectors.at(idx);
+
+                                logger->emit_rup_proof_line_under_reason(reason, move(lower) >= 1_i, ProofLevel::Temporary);
+                                logger->emit_rup_proof_line_under_reason(reason, move(upper) >= 1_i, ProofLevel::Temporary);
+                                logger->emit_rup_proof_line_under_reason(reason,
+                                    WPBSum{} + 1_i * ! selectors.at(idx) + 1_i * not_in_range(result, lo, hi) + 1_i * in_range(var, lo, hi) >= 1_i,
+                                    ProofLevel::Temporary);
+                            }
+                        },
+                        ThenRUP::Yes, hints::MinMax{owner}},
+                    ExplicitReason{reason});
             }
 
             // is there more than one variable that can support the values in result?

--- a/gcs/constraints/min_max/min_max.cc
+++ b/gcs/constraints/min_max/min_max.cc
@@ -271,40 +271,21 @@ auto ArrayMinMax::install_propagators(Propagators & propagators) -> void
                 // selector true, so the model pins support_1 == result; two ge-layer bound
                 // lemmas then bridge result's absence from [lo, hi] across that equality,
                 // exactly as in equals.cc (the range literal asserts order atoms, never bits,
-                // so the conclusion is not RUP without them). Views and constants, where the
-                // bridge does not apply, keep the per-value path.
-                auto both_simple = std::holds_alternative<SimpleIntegerVariableID>(IntegerVariableID{*support_1}) &&
-                    std::holds_alternative<SimpleIntegerVariableID>(IntegerVariableID{result});
-
+                // so the conclusion is not RUP without them). A view operand is no different:
+                // its range literals live on its own encoded variable, which is also what
+                // the model states the selector-pinned equality in.
                 for (auto [lo, hi] : support_1_set.each_interval_minus(result_set)) {
-                    if (both_simple) {
-                        // The support reason is the base reason plus the just-excluded
-                        // interval; with_extra copies the base, so each interval gets a
-                        // fresh reason rather than an accumulating literal.
-                        inference.infer_not_in_range(logger, *support_1, lo, hi,
-                            JustifyExplicitly{//
-                                [&, lo = lo, hi = hi](const ReasonLiterals & reason) {
-                                    rule_out_other_selectors(reason);
-                                    justify_not_in_range_across_equality(
-                                        *logger, reason, std::get<SimpleIntegerVariableID>(IntegerVariableID{*support_1}), lo, hi, result, lo, hi);
-                                },
-                                ThenRUP::Yes, hints::MinMax{owner}},
-                            want_reason ? with_extra(reason, ReasonLiterals{not_in_range(result, lo, hi)}) : Reason{});
-                    }
-                    else
-                        for (Integer val = lo; val <= hi; ++val)
-                            inference.infer(logger, *support_1 != val,
-                                JustifyExplicitly{//
-                                    [&, val = val](const ReasonLiterals & reason) {
-                                        rule_out_other_selectors(reason);
-                                        // now fish out the supporting variable, and show that it has to have its selector true
-                                        for (const auto & [idx, var] : enumerate(vars))
-                                            if (var == *support_1)
-                                                logger->emit_rup_proof_line_under_reason(reason,
-                                                    WPBSum{} + (1_i * (*support_1 == val)) + (1_i * selectors.at(idx)) >= 1_i, ProofLevel::Temporary);
-                                    },
-                                    ThenRUP::Yes, hints::MinMax{owner}},
-                                reason);
+                    // The support reason is the base reason plus the just-excluded
+                    // interval; with_extra copies the base, so each interval gets a
+                    // fresh reason rather than an accumulating literal.
+                    inference.infer_not_in_range(logger, *support_1, lo, hi,
+                        JustifyExplicitly{//
+                            [&, lo = lo, hi = hi](const ReasonLiterals & reason) {
+                                rule_out_other_selectors(reason);
+                                justify_not_in_range_across_equality(*logger, reason, IntegerVariableID{*support_1}, lo, hi, result, lo, hi);
+                            },
+                            ThenRUP::Yes, hints::MinMax{owner}},
+                        want_reason ? with_extra(reason, ReasonLiterals{not_in_range(result, lo, hi)}) : Reason{});
                 }
             }
 

--- a/gcs/innards/proofs/infer_explicitly.hh
+++ b/gcs/innards/proofs/infer_explicitly.hh
@@ -102,19 +102,12 @@ namespace gcs::innards
         const Hint_ & hint, const std::optional<AssertionAnnotation> & fallback_annotation = std::nullopt) -> void
     {
         if (const auto * cond = std::get_if<IntegerVariableCondition>(&lit))
-            if (cond->op == VariableConditionOperator::NotInRange) {
-                auto needs_per_value_fallback = overloaded{
-                    [&](const SimpleIntegerVariableID & v) { return ! logger.names_and_ids_tracker().has_bit_representation(v); }, //
-                    [&](const ViewOfIntegerVariableID &) { return true; },                                                         //
-                    [&](const ConstantIntegerVariableID &) { return false; }                                                       //
-                }
-                                                    .visit(cond->var);
-                if (needs_per_value_fallback) {
+            if (cond->op == VariableConditionOperator::NotInRange)
+                if (! logger.names_and_ids_tracker().can_represent_range_literal_for(cond->var)) {
                     for (Integer val = cond->value; val <= cond->upper_value; ++val)
                         infer_explicitly(logger, cond->var != val, emit, then_rup, reason, hint, fallback_annotation);
                     return;
                 }
-            }
 
         if (logger.get_assertion_level() > AssertionLevel::Inferences)
             return;

--- a/gcs/innards/proofs/invar_view_test.cc
+++ b/gcs/innards/proofs/invar_view_test.cc
@@ -1,0 +1,133 @@
+#include <gcs/innards/proofs/names_and_ids_tracker.hh>
+#include <gcs/innards/proofs/proof_logger.hh>
+#include <gcs/innards/proofs/proof_model.hh>
+
+#include <optional>
+#include <variant>
+
+using namespace gcs;
+using namespace gcs::innards;
+
+using std::get_if;
+using std::nullopt;
+
+// Range ("in") literals on a registered view, at the tracker level: see
+// dev_docs/view-range-literals.md.
+//
+// What this covers, and it is deliberately narrow:
+//
+//   - need_pol_item_defining_literal's InRange / NotInRange arms on a view. The
+//     constraint suite cannot reach these at all -- every caller of that function
+//     today passes a bound or an equality -- so without this they are untested.
+//   - the sign arithmetic of interval_on_underlying / interval_on_view, for both view
+//     signs and both signs of offset, and in both directions of the mirror. This is
+//     checked with find_xliteral_for, which does not introduce what it cannot find:
+//     ask for an interval on one side, and the other side's literal must exist at
+//     exactly the mapped bounds and not at the neighbouring ones.
+//
+// What it does NOT cover, and must not be read as covering: whether the link
+// clauses are necessary. Those are P2 clauses in the sense of
+// dev_docs/range_literals_spec.md §1, and a RUP check is strictly stronger than the
+// single unit-propagation pass they exist to support -- so every line below still
+// verifies with the link pair deleted. That was checked, not assumed. The witnesses
+// for the links are range_witness_w6 through w9, which fail on a backtrack clause.
+auto main() -> int
+{
+    ProofOptions proof_options{"invar_view_test"};
+
+    NamesAndIDsTracker tracker(proof_options);
+    ProofModel model(proof_options, tracker);
+    // need_view only works while the model is being written, and the tracker only
+    // knows a model is being written once it has been handed one (Proof does this).
+    tracker.start_writing_model(&model);
+
+    // Two underlying variables, so that both view signs can be exercised. The bounds
+    // are wide enough for the intervals below to sit strictly inside them, which is
+    // the case that needs the links -- one abutting a bound would cross anyway,
+    // through the bound axiom, and prove nothing.
+    SimpleIntegerVariableID x{0}, y{1};
+    model.set_up_integer_variable(x, 0_i, 30_i, "x", nullopt);
+    model.set_up_integer_variable(y, 0_i, 30_i, "y", nullopt);
+
+    // A positive view and a negated one, with offsets of either sign.
+    ViewOfIntegerVariableID pos{x, false, 17_i}; // pos = x + 17,  in [17, 47]
+    ViewOfIntegerVariableID neg{y, true, -7_i};  // neg = -y - 7,  in [-37, -7]
+    auto pos_id = tracker.need_view(pos);
+    auto neg_id = tracker.need_view(neg);
+
+    model.finalise();
+
+    ProofLogger logger(proof_options, tracker);
+    tracker.switch_from_model_to_proof(&logger);
+    logger.start_proof(model);
+    tracker.emit_delayed_proof_steps();
+
+    int rc = 0;
+    // The mirror's arithmetic, which is the substance of this test. Ask for an interval
+    // on one side only, then check with a *non-creating* lookup that the other side's
+    // literal exists at exactly the mapped bounds, and that the neighbouring
+    // off-by-one intervals do not. find_xliteral_for is the lookup that does not
+    // introduce what it fails to find, which is what makes this a test rather than a
+    // request.
+    auto exists = [&](const VariableConditionFrom<SimpleOrProofOnlyIntegerVariableID> & cond) { return tracker.find_xliteral_for(cond).has_value(); };
+
+    // pos = x + 17, so [30, 34] on the view is [13, 17] on x.
+    static_cast<void>(tracker.need_invar(pos_id, 30_i, 34_i));
+    if (! exists(in_range(SimpleOrProofOnlyIntegerVariableID{x}, 13_i, 17_i)))
+        rc = 1;
+    if (exists(in_range(SimpleOrProofOnlyIntegerVariableID{x}, 14_i, 18_i)) || exists(in_range(SimpleOrProofOnlyIntegerVariableID{x}, 12_i, 16_i)))
+        rc = 1;
+
+    // neg = -y - 7, so [10, 14] on y is [-21, -17] on the view: the endpoints swap and
+    // the offset is negative, which is the arithmetic most likely to be wrong. Asked
+    // from the underlying side this time, so the other direction of the map is covered.
+    static_cast<void>(tracker.need_invar(y, 10_i, 14_i));
+    if (! exists(in_range(SimpleOrProofOnlyIntegerVariableID{neg_id}, -21_i, -17_i)))
+        rc = 1;
+    if (exists(in_range(SimpleOrProofOnlyIntegerVariableID{neg_id}, -24_i, -20_i)) ||
+        exists(in_range(SimpleOrProofOnlyIntegerVariableID{neg_id}, -20_i, -16_i)))
+        rc = 1;
+
+    // need_pol_item_defining_literal on a view's range condition: the InRange arm must
+    // give the forward reification row and the NotInRange arm the reverse one, the same
+    // way round as for a plain variable, and both must be real proof lines rather than
+    // bare literals.
+    auto pol_line = [&](const IntegerVariableCondition & cond) -> std::optional<ProofLine> {
+        auto item = tracker.need_pol_item_defining_literal(cond);
+        if (auto * line = get_if<ProofLine>(&item))
+            return *line;
+        return nullopt;
+    };
+    auto in_line = pol_line(in_range(IntegerVariableID{pos}, 30_i, 34_i));
+    auto notin_line = pol_line(not_in_range(IntegerVariableID{pos}, 30_i, 34_i));
+    if (! in_line || ! notin_line || *in_line == *notin_line)
+        rc = 1;
+
+    // The same for the negated view, whose literal was created from the other side.
+    auto neg_in_line = pol_line(in_range(IntegerVariableID{neg}, -21_i, -17_i));
+    auto neg_notin_line = pol_line(not_in_range(IntegerVariableID{neg}, -21_i, -17_i));
+    if (! neg_in_line || ! neg_notin_line || *neg_in_line == *neg_notin_line)
+        rc = 1;
+
+    // The four crossings, as RUP lines. These check the *arithmetic*: a wrong endpoint
+    // map makes the line unprovable and the test fails. They do not check that the
+    // link clauses are needed -- see the note at the top. Stated over the public
+    // conditions, so they also check that a view's range condition resolves to the
+    // view's own literal rather than being deviewed onto the underlying variable.
+    auto rup = [&](const WPBSumLE & ineq) { static_cast<void>(logger.emit_rup_proof_line(ineq, ProofLevel::Top)); };
+
+    rup(WPBSum{} + 1_i * ! in_range(IntegerVariableID{pos}, 30_i, 34_i) + 1_i * in_range(IntegerVariableID{x}, 13_i, 17_i) >= 1_i);
+    rup(WPBSum{} + 1_i * ! in_range(IntegerVariableID{x}, 13_i, 17_i) + 1_i * in_range(IntegerVariableID{pos}, 30_i, 34_i) >= 1_i);
+    rup(WPBSum{} + 1_i * ! in_range(IntegerVariableID{neg}, -21_i, -17_i) + 1_i * in_range(IntegerVariableID{y}, 10_i, 14_i) >= 1_i);
+    rup(WPBSum{} + 1_i * ! in_range(IntegerVariableID{y}, 10_i, 14_i) + 1_i * in_range(IntegerVariableID{neg}, -21_i, -17_i) >= 1_i);
+
+    // A width-1 interval is the eq atom on both sides, so it needs no interval link and
+    // must not make one: the eq links already carry it.
+    if (tracker.need_invar(pos_id, 25_i, 25_i) != ProofLiteral{ProofVariableCondition{pos_id, VariableConditionOperator::Equal, 25_i}})
+        rc = 1;
+    rup(WPBSum{} + 1_i * (IntegerVariableID{pos} != 25_i) + 1_i * (IntegerVariableID{x} == 8_i) >= 1_i);
+
+    logger.conclude_none();
+    tracker.finalise();
+    return rc;
+}

--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -174,6 +174,22 @@ namespace
             name += "[" + *annotation + "]";
         return name;
     }
+
+    // A registered view V = s*X + c (s = -1 when negate_first, c = then_add) owns its
+    // own encoded variable, so an interval stated on V's value scale has a counterpart
+    // on X's. For s = +1 the interval just shifts; for s = -1 the order reverses, so
+    // the endpoints swap, and the map is its own inverse. Width is preserved either
+    // way -- which is why a width-1 request is the eq atom on both sides, and why the
+    // interval links below never have to deal with one.
+    auto interval_on_underlying(const ViewOfIntegerVariableID & view, Integer lo, Integer hi) -> std::pair<Integer, Integer>
+    {
+        return view.negate_first ? std::pair{view.then_add - hi, view.then_add - lo} : std::pair{lo - view.then_add, hi - view.then_add};
+    }
+
+    auto interval_on_view(const ViewOfIntegerVariableID & view, Integer lo, Integer hi) -> std::pair<Integer, Integer>
+    {
+        return view.negate_first ? std::pair{view.then_add - hi, view.then_add - lo} : std::pair{lo + view.then_add, hi + view.then_add};
+    }
 }
 
 struct NamesAndIDsTracker::Imp
@@ -358,6 +374,11 @@ struct NamesAndIDsTracker::Imp
     // view has been registered. When views are registered AFTER an X atom
     // already exists, need_view itself backfills via this map's setup.
     std::map<SimpleIntegerVariableID, std::vector<ProofOnlySimpleIntegerVariableID>> views_of_variable;
+
+    // Which view-side interval literals have had their [V in a..b] <=> [X in a'..b']
+    // link pair emitted. Mirroring runs from whichever side is asked first and then
+    // recurses to the other, so without this the pair would be written twice.
+    std::set<std::pair<ProofOnlySimpleIntegerVariableID, std::pair<Integer, Integer>>> invar_links_emitted;
 
     // For each V-form proof line that has a derived deview-form, the
     // corresponding deview-form line. Lookup via deviewed_line_for.
@@ -555,7 +576,11 @@ auto NamesAndIDsTracker::need_pol_item_defining_literal(const IntegerVariableCon
                 case Equal: need_direct_encoding_for(*v_id, cond.value); return _imp->atoms_for(*v_id).eq_defs.at(cond.value.raw_value).first;
                 case NotEqual: need_direct_encoding_for(*v_id, cond.value); return _imp->atoms_for(*v_id).eq_defs.at(cond.value.raw_value).second;
                 case InRange:
-                case NotInRange: throw UnimplementedException{};
+                    static_cast<void>(need_invar(*v_id, cond.value, cond.upper_value));
+                    return _imp->invars_that_exist.at(*v_id).at(pair{cond.value, cond.upper_value}).first;
+                case NotInRange:
+                    static_cast<void>(need_invar(*v_id, cond.value, cond.upper_value));
+                    return _imp->invars_that_exist.at(*v_id).at(pair{cond.value, cond.upper_value}).second;
                 }
                 throw NonExhaustiveSwitch{};
             }
@@ -574,7 +599,14 @@ auto NamesAndIDsTracker::need_pol_item_defining_literal(const IntegerVariableCon
             case Equal: throw UnimplementedException{};
             case NotEqual: throw UnimplementedException{};
             case InRange:
-            case NotInRange: throw UnimplementedException{};
+            case NotInRange:
+                // Deview the interval onto the underlying variable, endpoints swapped
+                // for a negated view, and take its Def line: on this path there is no
+                // V-form line to be consistent with, because the view has no encoded
+                // variable of its own.
+                return need_pol_item_defining_literal(VariableConditionFrom<IntegerVariableID>{var.actual_variable, cond.op,
+                    var.negate_first ? var.then_add - cond.upper_value : cond.value - var.then_add,
+                    var.negate_first ? var.then_add - cond.value : cond.upper_value - var.then_add});
             }
             throw NonExhaustiveSwitch{};
         } //
@@ -602,8 +634,12 @@ auto NamesAndIDsTracker::need_proof_name(const VariableConditionFrom<SimpleOrPro
     case GreaterEqual: need_gevar(cond.var, cond.value); break;
     case InRange:
     case NotInRange:
-        if (! _imp->find_condition(cond))
-            static_cast<void>(need_invar(cond.var, cond.value, cond.upper_value));
+        // Unconditional, unlike the other operators: need_invar is not only where a
+        // range literal gets defined, it is also where it gets linked to its views'
+        // (or its underlying variable's) matching literal. A condition that already
+        // has a proof name may still be an unlinked partition cell, so short-circuiting
+        // on find_condition here silently drops the link. See need_invar.
+        static_cast<void>(need_invar(cond.var, cond.value, cond.upper_value));
         break;
     }
 }
@@ -1258,6 +1294,13 @@ auto NamesAndIDsTracker::link_immediate_containment(SimpleOrProofOnlyIntegerVari
 
 auto NamesAndIDsTracker::define_plain_invar(SimpleOrProofOnlyIntegerVariableID id, Integer lo, Integer hi) -> void
 {
+    // Idempotent: defining a literal twice would allocate it a second xliteral, emit a
+    // second reification pair and give it a duplicate containment-tree entry. The
+    // partition machinery can now be re-entered part way through (see the single-cell
+    // case in define_invar_with_covering), so this is reachable rather than defensive.
+    if (_imp->invars_that_exist[id].contains(pair{lo, hi}))
+        return;
+
     // Both order-encoding cuts; need_gevar threads them into the order chain, and
     // emits the bound-axiom units for any cut outside the definition bounds.
     need_gevar(id, lo);
@@ -1384,27 +1427,8 @@ auto NamesAndIDsTracker::init_interval_partition(SimpleOrProofOnlyIntegerVariabl
     _imp->logger->emit_rup_proof_line(move(root_covering) >= 1_i, ProofLevel::TopAndCore);
 }
 
-auto NamesAndIDsTracker::need_invar(SimpleOrProofOnlyIntegerVariableID id, Integer lo, Integer hi) -> ProofLiteral
+auto NamesAndIDsTracker::define_invar_with_covering(SimpleOrProofOnlyIntegerVariableID id, Integer lo, Integer hi) -> void
 {
-    if (lo > hi)
-        return FalseLiteral{};
-
-    if (lo == hi) {
-        need_direct_encoding_for(id, lo);
-        return visit([&](const auto & id) -> ProofLiteral { return id == lo; }, id);
-    }
-
-    auto as_literal = [&]() { return visit([&](const auto & id) -> ProofLiteral { return in_range(id, lo, hi); }, id); };
-
-    auto & for_this_var = _imp->invars_that_exist[id];
-    if (for_this_var.contains(pair{lo, hi}))
-        return as_literal();
-
-    if (! _imp->logger)
-        throw UnimplementedException{"range literals during model writing are not yet supported"};
-    if (! has_bit_representation(id))
-        throw ProofError{"range literal requested for a variable without a bits encoding"};
-
     // The literal is defined over its own two cuts even when they lie outside the
     // definition bounds; the bound-axiom units falsify the out-of-bounds part by
     // unit propagation. The partition only spans the definition range, so the
@@ -1417,7 +1441,7 @@ auto NamesAndIDsTracker::need_invar(SimpleOrProofOnlyIntegerVariableID id, Integ
         // it, so there is nothing to cover;
         // ...OR we are at a higher assertion level that doesn't need covering apparatus in the first place.
         define_plain_invar(id, lo, hi);
-        return as_literal();
+        return;
     }
 
     if (! _imp->interval_partitions.contains(id)) {
@@ -1428,10 +1452,16 @@ auto NamesAndIDsTracker::need_invar(SimpleOrProofOnlyIntegerVariableID id, Integ
         ensure_partition_cut(id, span_hi + 1_i);
     }
 
-    // If the request is exactly one cell, it was defined just now.
+    // If the request is exactly one cell, the partition maintenance above defined it --
+    // unless we re-entered from inside that maintenance, which publishes a boundary
+    // before defining the two halves that boundary creates, so for that window the
+    // partition claims a cell that does not exist yet. Define it here in that case;
+    // ensure_partition_cut's own define_cell is idempotent and will not redo it.
     const auto & boundaries = _imp->interval_partitions.at(id);
-    if (lo == span_lo && hi == span_hi && *next(boundaries.find(span_lo)) == span_hi + 1_i)
-        return as_literal();
+    if (lo == span_lo && hi == span_hi && *next(boundaries.find(span_lo)) == span_hi + 1_i) {
+        define_plain_invar(id, lo, hi);
+        return;
+    }
 
     // Otherwise define it, with a covering over the in-bounds cells it spans, so
     // that falsifying those pieces falsifies it by unit propagation.
@@ -1441,12 +1471,135 @@ auto NamesAndIDsTracker::need_invar(SimpleOrProofOnlyIntegerVariableID id, Integ
     for (auto it = boundaries.find(span_lo); *it != span_hi + 1_i; ++it)
         append_cell_literal_to(covering, id, *it, *next(it) - 1_i);
     _imp->logger->emit_rup_proof_line(move(covering) >= 1_i, ProofLevel::TopAndCore);
+}
+
+auto NamesAndIDsTracker::mirror_invar_across_view_link(SimpleOrProofOnlyIntegerVariableID id, Integer lo, Integer hi) -> void
+{
+    if (_imp->assertion_level > AssertionLevel::Links)
+        return;
+
+    // The interval-level analogue of the eq- and ge-atom links: `[V in a..b]` and
+    // `[X in a'..b']` are separate literals over separate bit-vectors, joined by two
+    // rup lines. Emitted once per view-side interval, from whichever side asked
+    // first; the other side's mirroring finds the pair already recorded.
+    //
+    // Both directions are load-bearing and neither is free.
+    //
+    //   ~[V in a..b] OR [X in a'..b']. UP: the forward reification of the V literal
+    //   gives V's two cuts, the ge-links carry each cut to X (for a negated view the
+    //   two cuts swap roles, which is exactly what the endpoint swap in
+    //   interval_on_underlying accounts for), and the reverse reification of the X
+    //   literal then fires.
+    //
+    //   ~[X in a'..b'] OR [V in a..b], symmetrically. This is the direction that is
+    //   *not* derivable from the existing families, contrary to the analysis in
+    //   issue #882: a negated range literal is a unit on neither of its cuts (the
+    //   reverse reification leaves only a binary clause), so all it can do is descend
+    //   its own variable's containment edges, bottoming out at cells that are
+    //   themselves unlinked range literals unless they are width 1. Descending to
+    //   width 1 is the per-value shattering the interval vocabulary exists to avoid.
+    //   The shape that needs it is routine rather than exotic: search branches on
+    //   real variables only (reject_random_interval requires a SimpleIntegerVariableID),
+    //   while generic_reason states hole runs over the *operand*, which under a wrap
+    //   is the view -- so a range decision on X has to reach a reason literal on V.
+    auto link = [&](const ProofOnlySimpleIntegerVariableID & v_id, Integer a, Integer b, const SimpleIntegerVariableID & x, Integer p, Integer q) {
+        // Recording the pair up front is what stops the recursion: the two need_invar
+        // calls below come straight back here, and stop on this test.
+        if (! _imp->invar_links_emitted.emplace(v_id, pair{a, b}).second)
+            return;
+        static_cast<void>(need_invar(v_id, a, b));
+        static_cast<void>(need_invar(x, p, q));
+
+        auto assert_or_rup = _imp->logger->get_assertion_level() == AssertionLevel::Links ? ProofRule(AssertProofRule{}) : ProofRule(RUPProofRule{});
+        auto v_cond = in_range(v_id, a, b);
+        auto x_cond = in_range(x, p, q);
+        _imp->logger->emit(assert_or_rup, WPBSum{} + 1_i * ! v_cond + 1_i * x_cond >= 1_i, ProofLevel::TopAndCore);
+        _imp->logger->emit(assert_or_rup, WPBSum{} + 1_i * ! x_cond + 1_i * v_cond >= 1_i, ProofLevel::TopAndCore);
+    };
+
+    // Called for every range literal at the point it is *named*: from need_invar,
+    // outside its "already defined" guard, and again from xliteral_for_ensuring
+    // whenever a range condition that already has a proof name reaches a proof line.
+    // Naming is the right trigger and requesting is not, because the partition
+    // machinery defines cells directly through define_plain_invar, so a cell is never
+    // "requested" and both need_proof_name and xliteral_for_ensuring short-circuit on
+    // it. A decision, reason or conclusion that happens to name one of those cells
+    // would then get no link at all -- a silent unit-propagation dead end, and what a
+    // mixed view wrap on equals hit with `[view in 11..12]` and `[x in 1..2]` both
+    // defined and nothing joining them.
+    //
+    // Literals that are never named cost nothing here and need nothing: a fact only
+    // ever enters a variable's literal family through a named literal or a bound, and
+    // both of those cross.
+    //
+    // The two phases do not interleave: need_view can only register a view while the
+    // model is being written, and need_invar only works once the logger has taken
+    // over, so every view of a variable exists before any of its range literals do.
+    if (auto pid_ptr = std::get_if<ProofOnlySimpleIntegerVariableID>(&id)) {
+        auto view_it = _imp->view_proof_only_to_view.find(*pid_ptr);
+        if (view_it != _imp->view_proof_only_to_view.end()) {
+            const auto & view = view_it->second;
+            auto [x_lo, x_hi] = interval_on_underlying(view, lo, hi);
+            link(*pid_ptr, lo, hi, view.actual_variable, x_lo, x_hi);
+        }
+    }
+    else if (auto sid_ptr = std::get_if<SimpleIntegerVariableID>(&id)) {
+        if (auto it = _imp->views_of_variable.find(*sid_ptr); it != _imp->views_of_variable.end()) {
+            auto views_copy = it->second;
+            for (const auto & view_pid : views_copy) {
+                const auto & view = _imp->view_proof_only_to_view.at(view_pid);
+                auto [v_lo, v_hi] = interval_on_view(view, lo, hi);
+                link(view_pid, v_lo, v_hi, *sid_ptr, lo, hi);
+            }
+        }
+    }
+}
+
+auto NamesAndIDsTracker::need_invar(SimpleOrProofOnlyIntegerVariableID id, Integer lo, Integer hi) -> ProofLiteral
+{
+    if (lo > hi)
+        return FalseLiteral{};
+
+    if (lo == hi) {
+        need_direct_encoding_for(id, lo);
+        return visit([&](const auto & id) -> ProofLiteral { return id == lo; }, id);
+    }
+
+    auto as_literal = [&]() { return visit([&](const auto & id) -> ProofLiteral { return in_range(id, lo, hi); }, id); };
+
+    if (! _imp->invars_that_exist[id].contains(pair{lo, hi})) {
+        if (! _imp->logger)
+            throw UnimplementedException{"range literals during model writing are not yet supported"};
+        if (! has_bit_representation(id))
+            throw ProofError{"range literal requested for a variable without a bits encoding"};
+
+        define_invar_with_covering(id, lo, hi);
+    }
+
+    // Deliberately outside the definition guard: a literal can already exist without
+    // being linked. The partition machinery defines cells nobody asked for, straight
+    // through define_plain_invar, so the first time anything *names* one of those
+    // cells is the first opportunity to link it -- and that name may arrive on either
+    // side. Returning early here is what made an equals backtrack clause fail under a
+    // mixed view wrap with `[view in 11..12]` and `[x in 1..2]` both present and
+    // nothing joining them.
+    mirror_invar_across_view_link(id, lo, hi);
     return as_literal();
 }
 
 auto NamesAndIDsTracker::has_bit_representation(const SimpleOrProofOnlyIntegerVariableID & id) const -> bool
 {
     return _imp->integer_variable_bits_to_size_and_proof_vars.contains(id);
+}
+
+auto NamesAndIDsTracker::can_represent_range_literal_for(const IntegerVariableID & var) const -> bool
+{
+    return overloaded{
+        [&](const SimpleIntegerVariableID & v) { return has_bit_representation(v); },                 //
+        [&](const ViewOfIntegerVariableID & v) { return has_bit_representation(v.actual_variable); }, //
+        [&](const ConstantIntegerVariableID &) { return true; }                                       //
+    }
+        .visit(var);
 }
 
 auto NamesAndIDsTracker::view_bounds(const ViewOfIntegerVariableID & view) const -> pair<Integer, Integer>
@@ -1845,8 +1998,22 @@ auto NamesAndIDsTracker::xliteral_for_ensuring(const VariableConditionFrom<Simpl
     if (! f) {
         need_proof_name(cond);
         f = _imp->find_condition(cond);
-        if (! f)
-            throw ProofError{"still can't find literals for cond after introducing it"};
+        if (! f) {
+            auto which = visit(overloaded{//
+                                   [&](const SimpleIntegerVariableID & v) { return "i" + to_string(v.index); },
+                                   [&](const ProofOnlySimpleIntegerVariableID & v) { return "p" + to_string(v.index); }},
+                cond.var);
+            throw ProofError{"still can't find literals for cond after introducing it: " + which + " op=" + to_string(static_cast<int>(cond.op)) +
+                " [" + to_string(cond.value.raw_value) + "," + to_string(cond.upper_value.raw_value) + "]"};
+        }
+    }
+    else if (VariableConditionOperator::InRange == cond.op || VariableConditionOperator::NotInRange == cond.op) {
+        // Every range literal that reaches a proof line must be linked across its
+        // variable's view boundary, and this is the one place they all pass through:
+        // the partition machinery defines cells without going anywhere near
+        // need_proof_name, so a line naming an existing cell is otherwise the first
+        // and last chance to notice. Idempotent, and a set probe after the first time.
+        mirror_invar_across_view_link(cond.var, cond.value, cond.upper_value);
     }
     return *f;
 }

--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -555,11 +555,19 @@ auto NamesAndIDsTracker::need_pol_item_defining_literal(const IntegerVariableCon
             case Equal: need_direct_encoding_for(var, cond.value); return _imp->atoms_for(var).eq_defs.at(cond.value.raw_value).first;
             case NotEqual: need_direct_encoding_for(var, cond.value); return _imp->atoms_for(var).eq_defs.at(cond.value.raw_value).second;
             case InRange:
-                static_cast<void>(need_invar(var, cond.value, cond.upper_value));
-                return _imp->invars_that_exist.at(var).at(pair{cond.value, cond.upper_value}).first;
             case NotInRange:
+                // A width-1 range IS the eq atom, so route it there rather than looking
+                // for an interval literal that need_invar deliberately did not make.
+                // in_range() / not_in_range() canonicalise this away at construction, so
+                // only a hand-built VariableConditionFrom gets here -- but the failure
+                // if it did would be an out_of_range from the lookup below, which says
+                // nothing about what went wrong.
+                if (cond.value == cond.upper_value)
+                    return need_pol_item_defining_literal(
+                        VariableConditionFrom<IntegerVariableID>{var, InRange == cond.op ? Equal : NotEqual, cond.value});
                 static_cast<void>(need_invar(var, cond.value, cond.upper_value));
-                return _imp->invars_that_exist.at(var).at(pair{cond.value, cond.upper_value}).second;
+                return InRange == cond.op ? _imp->invars_that_exist.at(var).at(pair{cond.value, cond.upper_value}).first
+                                          : _imp->invars_that_exist.at(var).at(pair{cond.value, cond.upper_value}).second;
             }
             throw NonExhaustiveSwitch{};
         }, //
@@ -576,11 +584,14 @@ auto NamesAndIDsTracker::need_pol_item_defining_literal(const IntegerVariableCon
                 case Equal: need_direct_encoding_for(*v_id, cond.value); return _imp->atoms_for(*v_id).eq_defs.at(cond.value.raw_value).first;
                 case NotEqual: need_direct_encoding_for(*v_id, cond.value); return _imp->atoms_for(*v_id).eq_defs.at(cond.value.raw_value).second;
                 case InRange:
-                    static_cast<void>(need_invar(*v_id, cond.value, cond.upper_value));
-                    return _imp->invars_that_exist.at(*v_id).at(pair{cond.value, cond.upper_value}).first;
                 case NotInRange:
+                    // Width 1 is the eq atom on the view too; see the simple-variable arm.
+                    if (cond.value == cond.upper_value)
+                        return need_pol_item_defining_literal(
+                            VariableConditionFrom<IntegerVariableID>{var, InRange == cond.op ? Equal : NotEqual, cond.value});
                     static_cast<void>(need_invar(*v_id, cond.value, cond.upper_value));
-                    return _imp->invars_that_exist.at(*v_id).at(pair{cond.value, cond.upper_value}).second;
+                    return InRange == cond.op ? _imp->invars_that_exist.at(*v_id).at(pair{cond.value, cond.upper_value}).first
+                                              : _imp->invars_that_exist.at(*v_id).at(pair{cond.value, cond.upper_value}).second;
                 }
                 throw NonExhaustiveSwitch{};
             }
@@ -1309,6 +1320,14 @@ auto NamesAndIDsTracker::define_plain_invar(SimpleOrProofOnlyIntegerVariableID i
     auto x = allocate_xliteral_meaning(id, lo, hi);
     _imp->store_condition(in_range(id, lo, hi), x);
 
+    // Between here and the invars_that_exist entry below, the literal is *findable but
+    // not defined*. Nothing may render it into a proof line in that window: doing so
+    // would reach xliteral_for_ensuring's range branch, re-enter need_invar, take the
+    // single-cell path, and define the literal a second time -- the idempotence guard
+    // above tests invars_that_exist, which is not yet populated. Nothing does, because
+    // the only emission in between is the reification, which goes through the ostream
+    // overload of emit_inequality_to with EnsureNames::No. Keep it that way.
+
     auto will_define = _imp->logger->get_assertion_level() <= AssertionLevel::Links;
     // Struggling to get clang-format to behave here...
     auto lines = will_define //
@@ -1415,6 +1434,14 @@ auto NamesAndIDsTracker::init_interval_partition(SimpleOrProofOnlyIntegerVariabl
     // top-level partition, which gives wipeout detection at the literal level. It is
     // RUP from the bound axioms via the cells' reverse reifications and the order
     // chain.
+    //
+    // Defining a cell can re-enter here and insert further boundaries (mirroring a
+    // cell across a view link requests it on the far side, which requests it back).
+    // std::set iterators survive insertion, so the walk simply also visits the finer
+    // cells, and the covering can end up naming a since-split literal alongside its
+    // halves. That is still an at-least-one over a set that covers the range, so it is
+    // still RUP and still does its job -- but it is not always the leaf partition the
+    // name suggests.
     WPBSum root_covering;
     for (auto it = boundaries.begin(); next(it) != boundaries.end(); ++it) {
         auto cell_lo = *it, cell_hi = *next(it) - 1_i;

--- a/gcs/innards/proofs/names_and_ids_tracker.hh
+++ b/gcs/innards/proofs/names_and_ids_tracker.hh
@@ -132,6 +132,20 @@ namespace gcs::innards
         // emit the at-least-one clause over the top-level partition.
         auto init_interval_partition(SimpleOrProofOnlyIntegerVariableID id, Integer request_lo, Integer request_hi) -> void;
 
+        // The single-variable half of need_invar: maintain the partition for a request
+        // whose literal is known not to exist yet, and define the literal with its
+        // covering. Split out so that need_invar can do this before mirroring the
+        // request across a view link, which recurses back through need_invar.
+        auto define_invar_with_covering(SimpleOrProofOnlyIntegerVariableID id, Integer lo, Integer hi) -> void;
+
+        // Mirror an interval request between a registered view's proof-only variable and
+        // the variable it is a view of (in whichever direction applies, and to every
+        // registered view when called on the underlying), and emit the pair of rup lines
+        // making the two literals equivalent. The two encodings share nothing but their
+        // links, so without this a *negated* interval fact could not cross between them
+        // by unit propagation; see the comment on the definition.
+        auto mirror_invar_across_view_link(SimpleOrProofOnlyIntegerVariableID id, Integer lo, Integer hi) -> void;
+
     public:
         /**
          * \name Constructors, destructors, and the like.
@@ -286,6 +300,19 @@ namespace gcs::innards
          * this is false.
          */
         [[nodiscard]] auto has_bit_representation(const SimpleOrProofOnlyIntegerVariableID &) const -> bool;
+
+        /**
+         * Can an interval-shaped fact about this variable be stated as a single range
+         * ("in") literal? Every range literal is reified against two order-encoding
+         * cuts, so it needs a bits encoding, and a zero-one variable defaults to the
+         * direct-only encoding, which has none. A view inherits the answer from the
+         * variable it wraps, because its own range literals are mirrored onto that
+         * variable's. A constant never needs a literal at all, so it always can.
+         *
+         * Producers of interval-shaped conclusions and reasons must fall back to
+         * per-value reasoning when this is false.
+         */
+        [[nodiscard]] auto can_represent_range_literal_for(const IntegerVariableID & var) const -> bool;
 
         /**
          * Say that we are going to need an at-least-one constraint for a

--- a/gcs/innards/proofs/proof_logger.cc
+++ b/gcs/innards/proofs/proof_logger.cc
@@ -496,26 +496,18 @@ auto ProofLogger::conclude_none() -> void
 auto ProofLogger::infer(
     const Literal & lit, const Justification & why, const ReasonLiterals & reason, const optional<AssertionAnnotation> & annotation) -> void
 {
-    // A range conclusion on a view (folding views into the interval machinery is
-    // deferred) or on a plain variable without a bits encoding (no order cuts to
-    // reify against) cannot become a single range ("in") literal; fall back to one
-    // per-value line each, which is still correct, just not coalesced. Every other
-    // range conclusion rides the standard machinery: the condition's proof name is
-    // the range literal, or the eq atom for width 1.
+    // A range conclusion about a variable with no bits encoding has no order cuts to
+    // reify against, so it cannot become a single range ("in") literal; fall back to
+    // one per-value line each, which is still correct, just not coalesced. Every
+    // other range conclusion, views included, rides the standard machinery: the
+    // condition's proof name is the range literal, or the eq atom for width 1.
     if (const auto * cond = std::get_if<IntegerVariableCondition>(&lit))
-        if (cond->op == VariableConditionOperator::NotInRange) {
-            auto needs_per_value_fallback = overloaded{
-                [&](const SimpleIntegerVariableID & v) { return ! names_and_ids_tracker().has_bit_representation(v); }, //
-                [&](const ViewOfIntegerVariableID &) { return true; },                                                  //
-                [&](const ConstantIntegerVariableID &) { return false; }                                                //
-            }
-                                                .visit(cond->var);
-            if (needs_per_value_fallback) {
+        if (cond->op == VariableConditionOperator::NotInRange)
+            if (! names_and_ids_tracker().can_represent_range_literal_for(cond->var)) {
                 for (Integer val = cond->value; val <= cond->upper_value; ++val)
                     infer(cond->var != val, why, reason);
                 return;
             }
-        }
 
     if (_imp->assertion_level > AssertionLevel::Inferences)
         return;

--- a/gcs/innards/proofs/range_witness_w6_test.cc
+++ b/gcs/innards/proofs/range_witness_w6_test.cc
@@ -1,0 +1,70 @@
+#include <gcs/constraints/equals.hh>
+#include <gcs/current_state.hh>
+#include <gcs/problem.hh>
+#include <gcs/search_heuristics.hh>
+#include <gcs/solve.hh>
+
+#include <vector>
+
+using namespace gcs;
+using std::vector;
+
+// Witness W6 (see dev_docs/range_literals_spec.md §8 and dev_docs/view-range-literals.md):
+// an interval fact concluded on a plain variable has to reach a reason literal on a
+// *view* of it. This is W2's shape with the reason moved across a view boundary.
+//
+// `b`'s initial domain {0, 4} makes In conclude one interval fact ~[b in 1..3], over
+// `b` itself. `Equals(a, b + 10)` then prunes `a` with a reason naming the same run on
+// the view, ~[view in 11..13]. Those are two different literals over two different bit
+// vectors, and the replay of the first backtrack clause has to get from the first to
+// the second by unit propagation.
+//
+// Everything about the numbers is load-bearing, because the crossing happens by
+// accident in most configurations (measured: about 80% of small random ones):
+//
+//   - 11 > 10 and 13 < 14, so the run is strictly inside the view's definition bounds.
+//     A run that touched either bound would cross for free: the boundary pin makes the
+//     reverse reification a unit, and the far side's forward reification finishes it.
+//   - `b`'s only interior cell is the whole of [1, 3], width 3 and never split, because
+//     nothing in this problem ever mentions b = 1, 2 or 3. One eq atom anywhere inside
+//     would shatter the cell on both sides and the crossing would again come for free.
+//   - `a`'s domain is the view's, so the prune is one interval rather than three
+//     disequalities, which is what puts an interval literal in the reason at all.
+//
+// Without the link clause pair emitted by need_invar, the replay stalls: ~[b in 1..3]
+// descends b's own containment edges and finds nothing below to carry across.
+namespace
+{
+    auto scripted_neq_then_eq(IntegerVariableID var, Integer val) -> BranchHeuristic
+    {
+        return [var, val](const Problem &, innards::State &, innards::Propagators &) -> BranchCallback {
+            return [var, val](const CurrentState & state, const innards::Propagators &) -> std::generator<IntegerVariableCondition> {
+                return [](const CurrentState & state, IntegerVariableID var, Integer val) -> std::generator<IntegerVariableCondition> {
+                    if (state.domain_size(var) >= 2_i && state.in_domain(var, val)) {
+                        co_yield var != val;
+                        co_yield var == val;
+                    }
+                }(state, var, val);
+            };
+        };
+    }
+}
+
+auto main() -> int
+{
+    Problem p;
+    auto a = p.create_integer_variable(10_i, 14_i, "a");
+    auto b = p.create_integer_variable(vector{0_i, 4_i}, "b");
+    auto view = b + 10_i;
+
+    p.post(Equals{a, view});
+    p.post(NotEquals{a, view});
+
+    solve_with(p,      //
+        SolveCallbacks{//
+            .solution = [](const CurrentState &) -> bool { return true; },
+            .branch = branch_sequence(scripted_neq_then_eq(a, 10_i), branch_with(variable_order::dom_then_deg(p), value_order::smallest_first()))},
+        ProofOptions{"range_witness_w6_test"});
+
+    return 0;
+}

--- a/gcs/innards/proofs/range_witness_w7_test.cc
+++ b/gcs/innards/proofs/range_witness_w7_test.cc
@@ -1,0 +1,64 @@
+#include <gcs/constraints/equals.hh>
+#include <gcs/current_state.hh>
+#include <gcs/problem.hh>
+#include <gcs/search_heuristics.hh>
+#include <gcs/solve.hh>
+
+#include <vector>
+
+using namespace gcs;
+using std::vector;
+
+// Witness W7 (see dev_docs/range_literals_spec.md §8 and dev_docs/view-range-literals.md):
+// W6's mirror image. An interval fact concluded on a *view* has to reach a reason
+// literal on the variable the view wraps.
+//
+// `Equals(b + 10, a)` with `a` in {10, 14} prunes the view, so the conclusion is
+// logged as ~[view in 11..13] over the view's own bit vector. `Equals(b, c)` then
+// prunes `c` with a reason naming the same run on `b`, ~[b in 1..3]. As in W6 those
+// are two literals over two bit vectors and the replay has to cross between them by
+// unit propagation, in the opposite direction.
+//
+// The same three things are load-bearing here, for the same reason (the crossing
+// happens by accident in about 80% of small random configurations): [11, 13] is
+// strictly inside the view's bounds 10..14 and [1, 3] strictly inside b's 0..4, so
+// neither side gets the free crossing a boundary pin gives; and nothing in the problem
+// mentions any of b = 1, 2, 3, so [1, 3] stays one unsplit width-3 cell on both sides.
+// The NotEquals is only there to make the scripted decision fail and so force a
+// backtrack clause whose replay has to re-derive the reason.
+namespace
+{
+    auto scripted_neq_then_eq(IntegerVariableID var, Integer val) -> BranchHeuristic
+    {
+        return [var, val](const Problem &, innards::State &, innards::Propagators &) -> BranchCallback {
+            return [var, val](const CurrentState & state, const innards::Propagators &) -> std::generator<IntegerVariableCondition> {
+                return [](const CurrentState & state, IntegerVariableID var, Integer val) -> std::generator<IntegerVariableCondition> {
+                    if (state.domain_size(var) >= 2_i && state.in_domain(var, val)) {
+                        co_yield var != val;
+                        co_yield var == val;
+                    }
+                }(state, var, val);
+            };
+        };
+    }
+}
+
+auto main() -> int
+{
+    Problem p;
+    auto a = p.create_integer_variable(vector{10_i, 14_i}, "a");
+    auto b = p.create_integer_variable(0_i, 4_i, "b");
+    auto c = p.create_integer_variable(0_i, 4_i, "c");
+
+    p.post(Equals{b + 10_i, a});
+    p.post(Equals{b, c});
+    p.post(NotEquals{b, c});
+
+    solve_with(p,      //
+        SolveCallbacks{//
+            .solution = [](const CurrentState &) -> bool { return true; },
+            .branch = branch_sequence(scripted_neq_then_eq(c, 0_i), branch_with(variable_order::dom_then_deg(p), value_order::smallest_first()))},
+        ProofOptions{"range_witness_w7_test"});
+
+    return 0;
+}

--- a/gcs/innards/proofs/range_witness_w8_test.cc
+++ b/gcs/innards/proofs/range_witness_w8_test.cc
@@ -1,0 +1,86 @@
+#include <gcs/constraints/equals.hh>
+#include <gcs/current_state.hh>
+#include <gcs/problem.hh>
+#include <gcs/search_heuristics.hh>
+#include <gcs/solve.hh>
+
+#include <vector>
+
+using namespace gcs;
+using std::vector;
+
+// Witness W8 (see dev_docs/range_literals_spec.md §8 and dev_docs/view-range-literals.md):
+// a range literal that a *partition cell* already brought into existence still has to
+// be linked across a view boundary when something later names it.
+//
+// W6 and W7 cover the crossing itself; this covers the trigger. A cell is created by
+// ensure_partition_cut / init_interval_partition, straight through define_plain_invar,
+// so it is never "requested" and `need_proof_name` short-circuits on it. Linking only
+// what is requested therefore leaves exactly these literals unlinked, and they are
+// invisible to any test whose decisions and reasons happen to name fresh intervals.
+//
+// The shape:
+//   - `a`'s enumerated domain makes Equals(a, view) conclude ~[view in 11..12] and
+//     ~[view in 16..17] at the root. Mirrored onto `b`, those two requests leave
+//     [3..5] on `b` and [13..15] on the view as a partition cell nothing has named.
+//   - the first decision is ~[b in 3..5]: an interval that already exists, as that
+//     cell. Equals then prunes with a reason naming ~[view in 13..15].
+//   - the remaining decisions drive the subtree to a conflict, so the backtrack
+//     clause's replay has to carry the first fact to the second.
+//
+// Choosing 3..4 instead of 3..5 for the decision makes the same problem verify
+// whether or not the link exists, because a fresh request is linked on the spot --
+// which is the whole point: the discriminating instance is the one that names a cell.
+namespace
+{
+    // Reject [lo, hi] on var, then accept it. Guarded so it only fires while var still
+    // has values outside the interval, so the accept branch does not re-reject.
+    auto scripted_reject_then_accept(IntegerVariableID var, Integer lo, Integer hi) -> BranchHeuristic
+    {
+        return [var, lo, hi](const Problem &, innards::State &, innards::Propagators &) -> BranchCallback {
+            return [var, lo, hi](const CurrentState & state, const innards::Propagators &) -> std::generator<IntegerVariableCondition> {
+                return [](const CurrentState & state, IntegerVariableID var, Integer lo, Integer hi) -> std::generator<IntegerVariableCondition> {
+                    if (state.in_domain(var, lo) && state.in_domain(var, hi) && state.domain_size(var) > hi - lo + 1_i) {
+                        co_yield not_in_range(var, lo, hi);
+                        co_yield in_range(var, lo, hi);
+                    }
+                }(state, var, lo, hi);
+            };
+        };
+    }
+
+    auto scripted_neq_then_eq(IntegerVariableID var, Integer val) -> BranchHeuristic
+    {
+        return [var, val](const Problem &, innards::State &, innards::Propagators &) -> BranchCallback {
+            return [var, val](const CurrentState & state, const innards::Propagators &) -> std::generator<IntegerVariableCondition> {
+                return [](const CurrentState & state, IntegerVariableID var, Integer val) -> std::generator<IntegerVariableCondition> {
+                    if (state.domain_size(var) >= 2_i && state.in_domain(var, val)) {
+                        co_yield var != val;
+                        co_yield var == val;
+                    }
+                }(state, var, val);
+            };
+        };
+    }
+}
+
+auto main() -> int
+{
+    Problem p;
+    auto a = p.create_integer_variable(vector{10_i, 13_i, 14_i, 15_i, 18_i}, "a");
+    auto b = p.create_integer_variable(0_i, 8_i, "b");
+    auto view = b + 10_i;
+
+    p.post(Equals{a, view});
+    p.post(NotEquals{a, view});
+
+    solve_with(p,      //
+        SolveCallbacks{//
+            .solution = [](const CurrentState &) -> bool { return true; },
+            .branch = branch_sequence(scripted_reject_then_accept(b, 3_i, 5_i),
+                branch_sequence(scripted_neq_then_eq(a, 10_i),
+                    branch_sequence(scripted_neq_then_eq(a, 15_i), branch_with(variable_order::dom_then_deg(p), value_order::smallest_first()))))},
+        ProofOptions{"range_witness_w8_test"});
+
+    return 0;
+}

--- a/gcs/innards/proofs/range_witness_w9_test.cc
+++ b/gcs/innards/proofs/range_witness_w9_test.cc
@@ -1,0 +1,84 @@
+#include <gcs/constraints/equals.hh>
+#include <gcs/current_state.hh>
+#include <gcs/problem.hh>
+#include <gcs/search_heuristics.hh>
+#include <gcs/solve.hh>
+
+#include <vector>
+
+using namespace gcs;
+using std::vector;
+
+// Witness W9 (see dev_docs/range_literals_spec.md §8 and dev_docs/view-range-literals.md):
+// W8's two-view form, and the one that shows the crossing has to compose. Two views of
+// the same variable, `b + 10` and `b + 20`, each with their own encoded variable and
+// their own partition; nothing joins the two views directly, so a fact travelling from
+// one to the other goes through `b` and needs both links on the way.
+//
+// The shape:
+//   - Equals(a, view1) at the root carves [1..2] and [6..7] out of `b`, which leaves
+//     [3..5] on `b`, [13..15] on view1 and [23..25] on view2 as unnamed partition cells.
+//   - the decision ~[a in 13..15] makes Equals(a, view1) *conclude* ~[view1 in 13..15],
+//     which is one of those cells -- so here the unlinked literal is a conclusion
+//     rather than a decision, the other way round from W8.
+//   - Equals(a2, view2) then reasons with ~[view2 in 21..27], whose covering needs
+//     ~[view2 in 23..25]. Getting there means view1 -> b -> view2.
+//
+// Together with W8 this pins down that linking has to happen when a literal is named,
+// on either side and whichever role it plays.
+
+namespace
+{
+    // Reject [lo, hi] on var, then accept it. Guarded so it only fires while var still
+    // has values outside the interval, so the accept branch does not re-reject.
+    auto scripted_reject_then_accept(IntegerVariableID var, Integer lo, Integer hi) -> BranchHeuristic
+    {
+        return [var, lo, hi](const Problem &, innards::State &, innards::Propagators &) -> BranchCallback {
+            return [var, lo, hi](const CurrentState & state, const innards::Propagators &) -> std::generator<IntegerVariableCondition> {
+                return [](const CurrentState & state, IntegerVariableID var, Integer lo, Integer hi) -> std::generator<IntegerVariableCondition> {
+                    if (state.in_domain(var, lo) && state.in_domain(var, hi) && state.domain_size(var) > hi - lo + 1_i) {
+                        co_yield not_in_range(var, lo, hi);
+                        co_yield in_range(var, lo, hi);
+                    }
+                }(state, var, lo, hi);
+            };
+        };
+    }
+
+    auto scripted_neq_then_eq(IntegerVariableID var, Integer val) -> BranchHeuristic
+    {
+        return [var, val](const Problem &, innards::State &, innards::Propagators &) -> BranchCallback {
+            return [var, val](const CurrentState & state, const innards::Propagators &) -> std::generator<IntegerVariableCondition> {
+                return [](const CurrentState & state, IntegerVariableID var, Integer val) -> std::generator<IntegerVariableCondition> {
+                    if (state.domain_size(var) >= 2_i && state.in_domain(var, val)) {
+                        co_yield var != val;
+                        co_yield var == val;
+                    }
+                }(state, var, val);
+            };
+        };
+    }
+}
+
+auto main() -> int
+{
+    Problem p;
+    auto a = p.create_integer_variable(vector{10_i, 13_i, 14_i, 15_i, 18_i}, "a");
+    auto b = p.create_integer_variable(0_i, 8_i, "b");
+    auto a2 = p.create_integer_variable(20_i, 28_i, "a2");
+    auto view1 = b + 10_i;
+    auto view2 = b + 20_i;
+
+    p.post(Equals{a, view1});
+    p.post(Equals{a2, view2});
+    p.post(NotEquals{a2, view2});
+
+    solve_with(p,      //
+        SolveCallbacks{//
+            .solution = [](const CurrentState &) -> bool { return true; },
+            .branch = branch_sequence(scripted_reject_then_accept(a, 13_i, 15_i),
+                branch_sequence(scripted_neq_then_eq(a2, 20_i), branch_with(variable_order::dom_then_deg(p), value_order::smallest_first())))},
+        ProofOptions{"range_witness_w9_test"});
+
+    return 0;
+}

--- a/gcs/innards/proofs/simplify_literal.cc
+++ b/gcs/innards/proofs/simplify_literal.cc
@@ -66,22 +66,23 @@ auto gcs::innards::simplify_literal(const NamesAndIDsTracker & tracker, const Pr
                     return cond;
                 },
                 [&](const ViewOfIntegerVariableID & view) -> SimpleLiteral {
-                    // Range conditions on views take the per-value fallback at the
-                    // producing sites, so none should reach the literal layer: a
-                    // range literal over the view's proof-only variable would be
-                    // unlinked to the underlying variable's interval literals, and
-                    // unit propagation could not connect facts across the two.
-                    if (is_range_op(lit.op))
-                        throw UnimplementedException{"range conditions on views are not yet supported"};
-
                     // If the view's proof-only variable is registered, emit
                     // the literal over V's own bits with op and value
                     // preserved verbatim - V represents the visible view
-                    // value directly. Falls back to deviewing through the
-                    // underlying when the view isn't in the registry
+                    // value directly. That includes the range ops: a range
+                    // literal over V is defined against V's own two order
+                    // cuts like any other variable's, and need_invar joins it
+                    // to the underlying variable's matching literal with a
+                    // pair of link clauses, so facts do cross between the two
+                    // by unit propagation. Falls back to deviewing through
+                    // the underlying when the view isn't in the registry
                     // (proof-logging-only path).
-                    if (auto v_id = tracker.find_view(view))
-                        return ProofVariableCondition{*v_id, lit.op, lit.value};
+                    if (auto v_id = tracker.find_view(view)) {
+                        auto cond = ProofVariableCondition{*v_id, lit.op, lit.value, lit.upper_value};
+                        if (is_range_op(lit.op))
+                            return canonicalise_range(cond);
+                        return cond;
+                    }
                     switch (lit.op) {
                     case VariableConditionOperator::NotEqual:
                         return VariableConditionFrom<SimpleIntegerVariableID>{view.actual_variable, VariableConditionOperator::NotEqual,
@@ -109,8 +110,13 @@ auto gcs::innards::simplify_literal(const NamesAndIDsTracker & tracker, const Pr
                         break;
                     case VariableConditionOperator::InRange:
                     case VariableConditionOperator::NotInRange:
-                        // unreachable: thrown above
-                        throw UnimplementedException{"range conditions on views are not yet supported"};
+                        // A negated view reverses the order, so the endpoints swap as
+                        // well as shifting. Canonicalise afterwards: the deviewed
+                        // interval has the same width, but a width-1 request only
+                        // becomes visible as an equality once it has been mapped.
+                        return canonicalise_range(VariableConditionFrom<SimpleIntegerVariableID>{view.actual_variable, lit.op,
+                            view.negate_first ? view.then_add - lit.upper_value : lit.value - view.then_add,
+                            view.negate_first ? view.then_add - lit.value : lit.upper_value - view.then_add});
                     }
                     throw NonExhaustiveSwitch{};
                 },

--- a/gcs/innards/reason.cc
+++ b/gcs/innards/reason.cc
@@ -26,32 +26,28 @@ namespace
                 reason.push_back(var >= bounds.first);
                 reason.push_back(var <= bounds.second);
                 if (state.domain_has_holes(var)) {
-                    // Each maximal run of missing values is one range condition;
-                    // views take the per-value fallback, since folding views into
-                    // the interval machinery is deferred.
-                    if (std::holds_alternative<SimpleIntegerVariableID>(var)) {
-                        optional<pair<Integer, Integer>> run;
-                        auto flush = [&]() {
-                            if (run) {
-                                reason.push_back(not_in_range(var, run->first, run->second));
-                                run.reset();
-                            }
-                        };
-                        for (auto v = bounds.first + 1_i; v < bounds.second; ++v) {
-                            if (state.in_domain(var, v))
-                                flush();
-                            else if (run)
-                                run->second = v;
-                            else
-                                run = pair{v, v};
+                    // Each maximal run of missing values is one range condition,
+                    // whatever kind of variable this is: a view's range conditions are
+                    // range literals over its own encoded variable, linked to the
+                    // underlying variable's, so the proof layer needs no per-value
+                    // spelling here (issue #882). A width-1 run canonicalises to a
+                    // plain disequality on construction.
+                    optional<pair<Integer, Integer>> run;
+                    auto flush = [&]() {
+                        if (run) {
+                            reason.push_back(not_in_range(var, run->first, run->second));
+                            run.reset();
                         }
-                        flush();
+                    };
+                    for (auto v = bounds.first + 1_i; v < bounds.second; ++v) {
+                        if (state.in_domain(var, v))
+                            flush();
+                        else if (run)
+                            run->second = v;
+                        else
+                            run = pair{v, v};
                     }
-                    else {
-                        for (auto v = bounds.first + 1_i; v < bounds.second; ++v)
-                            if (! state.in_domain(var, v))
-                                reason.push_back(var != v);
-                    }
+                    flush();
                 }
             }
         }

--- a/gcs/innards/reason.cc
+++ b/gcs/innards/reason.cc
@@ -32,6 +32,13 @@ namespace
                     // underlying variable's, so the proof layer needs no per-value
                     // spelling here (issue #882). A width-1 run canonicalises to a
                     // plain disequality on construction.
+                    //
+                    // Unlike ProofLogger::infer, this has no tracker to ask whether a
+                    // range literal can be built at all, so it cannot fall back for a
+                    // variable with no bits encoding. It does not need to: a bits-less
+                    // variable is a zero-one one, whose domain has no interior value
+                    // and so no run to state. Anything that made a wider variable
+                    // direct-only would have to revisit this.
                     optional<pair<Integer, Integer>> run;
                     auto flush = [&]() {
                         if (run) {


### PR DESCRIPTION
Closes #882.

A registered view now owns its range ("in") literals, exactly as it already
owned its equality and order atoms, and they are joined to the underlying
variable's by a pair of link clauses. All ten view detours the issue inventoried
are deleted rather than adjusted — the three that threw `UnimplementedException`
and the seven that silently degraded to one proof line per value (`min_max` and
`all_equal` had grown their own since the issue was filed).

Full write-up in the new `dev_docs/view-range-literals.md`. The short version,
and the three things that were not obvious.

## 1. Design B, and why not A

Design A of the issue — deview a view's range conditions onto the underlying
variable, joining the four scalar operators in `simplify_literal`'s deview arm —
was rejected. It would make ranges the one atom kind that is *not* in `V`-form,
so a `pol` step resolving a range literal against a `V`-form constraint body
would strand: that is invariant 1 of `dev_docs/view-proof-logging.md`, and it is
what the whole view design rests on. Design B keeps `V` indistinguishable from a
bare variable, which is the property that makes the generic machinery work.

The deview arm still handles range conditions, but only on the path it already
handled the other operators: an *unregistered* view, first seen during proof
logging, which has no encoded variable to be consistent with.

## 2. The issue's premise about linking was half right

The issue recorded #881's observation that "a range literal never has to cross an
equality: it is reified against its variable's own two order cuts, so an interval
fact decomposes into cross one bound, move within one variable, cross back", and
suggested B might therefore need no linking at all.

That is exactly true of the two *implications* `F_V → F_X` and `F_X → F_V`, both
of which are one unit-propagation pass with no new clauses. But UP uses a clause
in whichever direction has a unit, and the directions that matter are the
negative ones, `¬F_X ⟹ ¬F_V` and `¬F_V ⟹ ¬F_X`. Neither is derivable. A negated
interval literal is a unit on *neither* cut — its reverse reification leaves a
binary clause — so it can only descend its own variable's containment edges, and
bottoms out at cells that are themselves unlinked range literals unless they are
width 1. The argument decomposes a conjunction of two bounds; a negated interval
is a disjunction of two, and UP cannot carry a disjunction one disjunct at a time.

Both directions are ordinary rather than exotic: search branches on real
variables only, while `generic_reason` states hole runs over the *operand*, which
under a wrap is the view.

So the cost is two rup clauses per interval literal per registered view, plus the
mirrored literal — the same constant factor eq and ge atoms already pay, and
nothing proportional to a domain width.

## 3. Linking has to be triggered by *naming*, and that is where this first broke

A range literal comes into existence two ways: some caller asks for it, which
reaches `need_invar`; or the partition machinery creates it as a **cell**, from
`ensure_partition_cut` / `init_interval_partition`, straight through
`define_plain_invar`. A cell is therefore never "requested" — and both
`need_proof_name` and `xliteral_for_ensuring` short-circuit on a condition that
already has a proof name, so a decision, reason or conclusion that happens to
name one of those cells never reaches `need_invar` at all.

Linking only what is requested therefore leaves every cell unlinked. That is a
silent unit-propagation dead end, and it is what the first version of this branch
did: `equals` under `--view-position=mixed` failed a backtrack clause with
`[view in 11..12]` and `[x in 1..2]` both defined and nothing joining them.
`mirror_invar_across_view_link` is now called from `need_invar` outside its
"already defined" guard, and again from `xliteral_for_ensuring` whenever a range
literal reaches a proof line.

One consequence: `need_invar` is now genuinely re-entrant, because resolving a
literal while emitting a covering can re-enter it. `ensure_partition_cut`
publishes a partition boundary *before* defining the two halves it creates, so
during that window the partition claims a cell that does not exist yet.
`define_invar_with_covering`'s single-cell path defines it in that case, and
`define_plain_invar` is idempotent so the cell is not then defined twice.

## Evidence

**Four new witnesses**, gate-on and veripb-verified, in the style of
`dev_docs/range_literals_spec.md` §8. W6 and W7 are the two directions of the
crossing; W8 and W9 are the trigger, a literal a partition cell already brought
into existence. Validated by ablation with a temporary knob, since removed:

| ablation                | W6     | W7     | W8     | W9     |
|-------------------------|--------|--------|--------|--------|
| none                    | passes | passes | passes | passes |
| both link clauses gone  | FAILS  | FAILS  | FAILS  | FAILS  |
| L1 removed              | FAILS  | passes | FAILS  | FAILS  |
| L2 removed              | passes | FAILS  | passes | FAILS  |
| link on request only    | passes | passes | FAILS  | FAILS  |

Every clause and every rule is separately load-bearing, which is stronger than
the spec records for W2 and W5, both of which are structural.

`invar_view_test` covers what the witnesses and the sweep between them cannot:
`need_pol_item_defining_literal`'s range arms, which have no caller at all — every
constraint using that function passes a bound or an equality, so the arms
replacing the throws would otherwise ship untested — and the endpoint arithmetic
in both directions, asserted with `find_xliteral_for` so that "the mirror exists
at exactly these bounds and not the neighbouring ones" is a real claim.
Mutation-validated: an off-by-one and a dropped endpoint swap are both caught.
It explicitly does *not* witness the link clauses, and says so in its header —
every RUP line in it still verifies with the pair deleted, which is §1's P1/P2
trap, and an earlier draft of it claimed otherwise until I ablated it.

**Why the sweep is not the evidence.** The negative crossing happens to work with
no linking clause at all whenever the range touches a definition bound (the
boundary pin makes the reverse reification a unit), is the whole range, or has
every cell inside it shattered to width 1. Measured two ways: over domain widths
4–16 with 0–7 random requests, **80% of instances cross correctly with no link
present**; and over 987 randomly generated instances that actually reach a
conflict, ablating the links makes only **37** of them fail. The sweep is about
96% coincidence.
A green randomised sweep is therefore close to no evidence, which is why the
witnesses above are constructed to sit strictly inside both variables' bounds,
with an interior cell of width ≥ 2 that nothing shatters. The control that gets
this wrong — decide `¬[b in 3..4]` instead of `¬[b in 3..5]` — verifies with
either clause removed.

**Proof size**, one `Equals` with a single wide interior hole, root propagation
only, every row VeriPB-verified:

| width | plain | view before | view after | negview after | mixed after |
|---|---|---|---|---|---|
| 10^3 | 40 | 36,012 | **106** | 106 | 109 |
| 10^4 | 40 | 360,012 | **106** | 106 | 109 |
| 10^5 | 40 | *timed out at 300 s* | **106** | 106 | 109 |
| 10^6 | 40 | *timed out at 300 s* | **106** | 106 | 106 |

`before` is `2 + 36·w` and stops being writable between 10^4 and 10^5. `after` is
flat; 106 rather than 40 is the view's own encoding and the link pairs, a
constant.

**Suites**, all with `GCS_TEST_CAP_DEFAULTS=OFF`:

- GCC 15.2, full suite **plus** the `--view-wrap` sweep, run **twice**: 8050
  tests each time, **68 failures each time, a byte-identical set** to the 68 that
  fail on unmodified `main` — every one a `divide_modulus_constraint_view_*`,
  failing on propagation strength ("gac not achieved in test") with no proof
  written. The two runs are worth having separately because these tests reseed,
  so the second pass is an entirely different set of instances. Zero
  regressions. That pre-existing failure is now filed as #903; it is also the
  reason `CLAUDE.md`'s "most fail today" and `dev_docs/view-proof-logging.md`'s
  "all constraints verify under all wraps" — which contradicted each other, and
  were both wrong — are corrected here.
- clang 21, full suite **plus** the sweep: **8054 tests, 68 failures**, the same
  byte-identical `divide_modulus` set — a third independent instance stream. No
  warnings in any changed file.
- `GCS_LARGE_DOMAIN_GUARD=ON`: `large_domain_audit_test` green, full suite
  **815/815**. Worth running because `all_equal.cc` loses a
  `LargeDomainIterationCounter` here along with the per-value walk it guarded,
  and because that guard is the tripwire for reintroducing work proportional to a
  domain width.

## Completeness

The obligation was formalised rather than assumed, in three parts: **mirror
closure** (an interval exists on one side iff its image exists on the others,
with the link pair present — because `link` requests the far side, which mirrors
onward, so a literal first seen on `V₁` reaches `V₂` through `X` in the same
call); **unit transport** (any literal that is a unit on one side has its image a
unit on every other side — ge-links for bounds, eq-links for equalities, L1/L2 for
intervals); and **per-side UP-completeness**, by induction on (cells inside the
literal, width), which works because every in-bounds endpoint of every interval
and equality is a partition boundary, so a cell is either wholly inside a literal
or disjoint from it. The root covering turns out not to be needed, matching the
observation already recorded in §8.1 of the range spec.

What it depends on — and so what would break it — is written into
`dev_docs/view-range-literals.md` §5: that every non-`red` emission names its
literals, that domain changes are logged eagerly, and that in-bounds endpoints are
partition boundaries.

That last one supersedes how §3 originally put it. There is no such thing as an
unnamed range literal in a definitions-on proof: every creation path writes a
covering or an edge about the literal it just created, in the same call, and
those render with `EnsureNames::Yes`. So a cell is linked when its own covering
is written, not when a later solver fact happens to mention it.

## Consultation

Two Fable sessions were used as proofs consultants on narrow questions. The first
adjudicated the negative-crossing claim with a closure argument plus an
independent Python re-implementation of the clause families driven by a PB unit
propagator, and produced the 80% figure. The second found the unlinked-cell
defect independently, with its own VeriPB counterexamples; W8 and W9 are its
instances. One claim of its I checked and did not
confirm: it reported that the two sides' literal families are not affine images
of each other. That was true of the intermediate build it reviewed, but is not
true of the finished one — measured across 258 proofs, all 300 registered
(variable, view) pairs match exactly, because coverings name their cells and
naming is now what links them. The dev_doc records the corrected version, and
also records that the correspondence must not be used as the correctness
argument: nothing maintains it as an invariant, and no test checks it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018s5Rxd5qtz8CRHe53cFzLy
