### PR TITLE
Correct the Theorem 2.9 claim I got wrong in #875

### DIFF
--- a/dev_docs/large-domains.md
+++ b/dev_docs/large-domains.md
@@ -183,42 +183,70 @@ Views keep the per-value path: a view's atoms are spelled through the view and
 the lemmas have not been shown to bridge that. Same restriction, and same reason,
 as the single-support range path in the same file.
 
-### The two-lemma RUP shape does not generalise; `pol` does
+### Theorem 2.9 is what makes the two-lemma shape work, and it wants a *difference*
 
-`Abs` (#875) is the case that shows where the shape above stops working, and it
-is worth reading before copying it into a fourth constraint.
+The bound-lemma shape above is not a trick that happens to work: it is an
+instance of **Theorem 2.9 (Contradictory constraints on binary sums)** in
+chapter 2 of Matthew's thesis
+(*Pseudo-Boolean Proof Logging for Constraint Propagation Algorithms*,
+Glasgow 2026, <https://theses.gla.ac.uk/86049/>; and see
+[range_literals_spec.md](range_literals_spec.md) Appendix B3). Read the theorem before adapting the
+shape to a new constraint, because its hypotheses are exactly the thing that can
+fail.
 
-`Abs`' model is two half-reified rows, `v2 - v1 == 0` under `v1 >= 0` and
-`v2 + v1 == 0` under `v1 < 0`. That looks like `ArrayMinMax`'s guarded equality
-with a two-valued selector, so the same two ge-layer bound lemmas ought to work.
-They do not, and the reason is not the guard: it is that **unit propagation
-cannot add two PB bound constraints to a row.** Negating such a lemma leaves one
-bound on each side of the equality, and a bound over a bit-vector fixes no bit
-unless it happens to be tight enough to force one.
+The theorem says: for two's-complement sums `x` and `y`, the three constraints
 
-Measured, because the failure is arithmetic rather than structural. On
-`abs_test`'s own `v1 = [-6, 8]`, `v2 = [0, 15]`, the negated lemma gives
-`v1 >= -6` — which forces `b3` through the two's-complement bound — and
-`v2 >= 7`, which forces nothing. The row then normalises to a slack of exactly
-**8** against a largest remaining coefficient of **8**, and a coefficient has to
-*exceed* the slack to propagate. One short.
+```
+y >= A            x - y >= B            x <= C
+```
 
-So why does `element.cc` verify? **Because its arithmetic lines up, not because
-the shape is sound.** A probe built for the question — `result` in `[0, 63]`,
-three entries in `{0, 40}`, so the removed run `[41, 63]` puts `result >= 41`
-against `array <= 40` with neither bound tight — verifies, and grinding through
-its propagation by hand shows why: `result >= 41` forces the top bit because 41
-exceeds what five bits can hold, which drops the row's slack below `array`'s top
-coefficient, which forces that, and so on for several rounds. Change the widths
-and that cascade stops. **Treat the guarded two-lemma RUP shape as a property of
-the instances it has been run on.**
+**always unit propagate to contradiction**, provided `A + B - C > 0` and
+`B ∈ {0, 1}`. The proof is a slack cascade, and it turns on C2 containing exactly
+the opposite literals to C1's and C3's with the same coefficients.
 
-The route that does not depend on the arithmetic is `pol`, which is what every
-other helper in `abs/justify.cc` already used: the model half, plus the defining
-item of each atom whose arithmetic the step uses, summed and saturated. The
-operands cancel, the constant comes out negative, and saturation leaves a clause
-over order atoms. Two shapes come out of it, and their asymmetry is the useful
-part:
+`justify_not_in_range_across_equality()` is that configuration with `B = 0`: the
+equality row is the difference `x - y >= 0`, and the two lemmas put a *lower*
+bound on one operand against an *upper* bound on the other. `min_max.cc` and
+`element.cc`'s guarded versions are the same thing with a selector carried
+through. So they are sound by a proven theorem, for any domain width — a probe
+built to doubt it (`result` in `[0, 63]`, entries in `{0, 40}`, so the removed
+run `[41, 63]` puts `result >= 41` against `array <= 40` with neither bound
+tight) verifies, and the cascade it verifies through is the theorem's own.
+
+**What `Abs` shows is where the hypotheses stop holding, not that the shape is
+unreliable.** `Abs`' model is two half-reified rows: `v2 - v1 == 0` under
+`v1 >= 0`, and `v2 + v1 == 0` under `v1 < 0`.
+
+* The **non-negative** branch is a difference, so it is Theorem 2.9 and the two
+  bound lemmas work. Verified by putting that branch back on the RUP shape:
+  `abs_test` passes at three seeds.
+* The **negative** branch links `v2` to `-v1`, so the row is a **sum**. The
+  lemma's negation then supplies *two lower bounds* rather than a lower and an
+  upper, and there is no assignment of the theorem's `x` and `y` to `v1` and
+  `v2` that makes the row its `x - y >= B`. Outside the hypothesis, and not
+  merely in principle: on `abs_test`'s own `v1 = [-6, 8]`, `v2 = [0, 15]` with
+  `lo = -6`, the three constraints normalise to slacks 5, 8 and 8 against largest
+  remaining coefficients 4, 8 and 8, so by **Proposition 2.1** (`C` propagates
+  `l_i` iff `slack(C) < a_i`) nothing propagates at all. Same family as the
+  thesis' own **Example 2.15**, which is the warning that generalisations of 2.9
+  do not always hold.
+
+So the rule to take away is about the *pairing*, not about `Abs`: **the two-lemma
+shape needs a lower bound on one operand and an upper bound on the other, across
+a row that is their difference.** A sign-flipped link does not qualify, and
+`justify_not_in_range.hh`'s suggestion that it just needs "the mirrored pairing"
+is too optimistic — the mirrored pairing is the non-propagating configuration
+above.
+
+`pol` is what does not care, which is why `abs/justify.cc` uses it for both
+branches: the model half, plus the defining item of each atom whose arithmetic
+the step uses, summed and saturated. The operands cancel, the constant comes out
+negative, and saturation leaves a clause over order atoms. The non-negative
+branch could use the cheaper RUP form, and does not, for uniformity — three
+resolutions against two RUP lines is not worth a second code path on a
+proof-writing path.
+
+Two shapes come out of it, and their asymmetry is the useful part:
 
 * Concluding on the variable the guard is *about* (`Abs`' image direction,
   `~[v2 in lo..hi]`) has to close both sign branches, because the conclusion's

--- a/gcs/constraints/abs/justify.hh
+++ b/gcs/constraints/abs/justify.hh
@@ -15,13 +15,15 @@ namespace gcs::innards
     //
     // The per-value form gets away with two RUP lines because `v2 == val` pins
     // every bit of v2, which pins v1's through whichever half-reified row is
-    // active. A range pins no bit, and the bounds it does give sit on *opposite
-    // sides* of the row, so closing it means adding two PB bound constraints to
-    // the row --- which unit propagation cannot do. (This is why the guarded
-    // two-lemma RUP shape min_max.cc and element.cc use does not transfer here.
-    // There the guard is falsified by the conclusion's own negation, and the
-    // remaining slack arithmetic happens to line up; measured on Abs it misses
-    // by one, see dev_docs/large-domains.md.)
+    // active. A range pins no bit, so it needs the bound lemmas min_max.cc and
+    // element.cc use -- and those are Theorem 2.9, which wants a lower bound on
+    // one operand against an upper bound on the other across their *difference*.
+    // This constraint's negative branch links v2 to -v1, so its row is a sum and
+    // the negation gives two bounds on the same side: outside the theorem, with a
+    // measured non-propagating instance. The non-negative branch *is* a
+    // difference and would take the RUP form; pol is used for both so there is
+    // one shape to read. See the Theorem 2.9 section of
+    // dev_docs/large-domains.md.
     //
     // So each branch's two bounds are derived by `pol` instead, in the same
     // resolution shape as the consequence-bound helpers below: the model half,

--- a/gcs/constraints/innards/justify_not_in_range.hh
+++ b/gcs/constraints/innards/justify_not_in_range.hh
@@ -13,16 +13,26 @@ namespace gcs::innards
     //     pruned >= lo          ->  other >= other_lo
     //     other >= other_hi + 1 ->  pruned >= hi + 1
     //
-    // each of which is RUP, because its negation supplies a pair of opposing
-    // bounds that contradict the equality at the bit level. The lemmas mention no
-    // range literal, so any literal sharing these endpoints can reuse them.
+    // each of which is RUP by Theorem 2.9 of Matthew's thesis (contradictory
+    // constraints on binary sums): its negation supplies a *lower* bound on one
+    // operand against an *upper* bound on the other, across a row that is their
+    // difference, which always unit propagates to contradiction. The lemmas
+    // mention no range literal, so any literal sharing these endpoints can reuse
+    // them.
     //
     // [other_lo, other_hi] are the bounds the range forces on `other` through the
-    // equality; for a plain `pruned = other` they are [lo, hi]. The pairing
-    // assumes a same-sign link: a sign-flipped link (such as Abs) needs the
-    // mirrored pairing. `other` must be a plain integer variable, equality-linked
-    // to `pruned` in the proof model. Pass the same reason the caller hands to
-    // infer_not_in_range.
+    // equality; for a plain `pruned = other` they are [lo, hi].
+    //
+    // **The pairing is the hypothesis, and a sign-flipped link does not satisfy
+    // it.** Against `pruned = -other` the row is a sum rather than a difference,
+    // the negation supplies two bounds on the same side, and the configuration is
+    // outside the theorem -- with a measured non-propagating instance, see the
+    // Theorem 2.9 section of dev_docs/large-domains.md. Abs' negative branch is
+    // that case and uses pol instead (abs/justify.cc); do not reach for this
+    // helper with a mirrored pairing and expect it to hold.
+    //
+    // `other` must be a plain integer variable, equality-linked to `pruned` in the
+    // proof model. Pass the same reason the caller hands to infer_not_in_range.
     auto justify_not_in_range_across_equality(ProofLogger & logger, const ReasonLiterals & reason, const SimpleIntegerVariableID & pruned, Integer lo,
         Integer hi, IntegerVariableID other, Integer other_lo, Integer other_hi) -> void;
 }


### PR DESCRIPTION
Corrects a claim I got wrong in #899 (#875). Documentation and comments only;
no behaviour change.

## What I got wrong

#899's write-up says `element.cc`'s and `min_max.cc`'s bound-lemma shape
"verifies because its arithmetic lines up", and that it should be read as a
property of the instances it has been run on. **The correction goes the other
way: the shape is an instance of a proven theorem.** I noticed the failure for
`Abs`, could not close it by RUP, and reached for a cause instead of chasing the
citation that was sitting in `justify_not_in_range.cc`'s own comment ("the
Theorem 2.9 configuration"). Thanks for pushing back on it.

## What is actually true

**Theorem 2.9 (Contradictory constraints on binary sums)**, chapter 2 of
Matthew's thesis — for two's-complement sums `x` and `y`, the constraints

```
y >= A            x - y >= B            x <= C
```

**always unit propagate to contradiction**, provided `A + B - C > 0` and
`B ∈ {0, 1}`. The proof is a slack cascade, turning on C2 holding exactly the
opposite literals to C1's and C3's at the same coefficients.

`justify_not_in_range_across_equality()` is that configuration with `B = 0`: the
equality row is the *difference*, and the two lemmas put a **lower** bound on one
operand against an **upper** bound on the other. `min_max.cc` and `element.cc`'s
guarded versions are the same thing with a selector carried through. Sound at any
domain width — and the probe I built to doubt it verifies *through the theorem's
own cascade*, which is what I mistook for luck.

## What `Abs` actually shows

Where the hypothesis stops holding, which is a much narrower and more useful
statement:

| branch | row | pairing the negation gives | Theorem 2.9? |
|---|---|---|---|
| `v1 >= 0` | `v2 - v1 == 0`, a **difference** | lower on one, upper on the other | **yes** |
| `v1 < 0` | `v2 + v1 == 0`, a **sum** | two bounds on the *same* side | **no** |

* The non-negative branch does work under the two bound lemmas. **Checked**, by
  putting that branch back on the RUP shape: `abs_test` passes at three seeds. My
  "does not transfer here" covered this case too, and should not have.
* The negative branch links `v2` to `-v1`, so no assignment of the theorem's `x`
  and `y` makes the row its `x - y >= B`. Outside the hypothesis, and measurably
  so rather than just in principle: on `abs_test`'s own `v1 = [-6, 8]`,
  `v2 = [0, 15]` with `lo = -6`, the three constraints normalise to slacks
  **5, 8, 8** against largest remaining coefficients **4, 8, 8**, so by
  **Proposition 2.1** (`C` propagates `l_i` iff `slack(C) < a_i`) nothing
  propagates at all. Same family as the thesis' own **Example 2.15**.

So the rule is about the **pairing**, not about `Abs`: the shape needs a lower
bound on one operand and an upper bound on the other, across a row that is their
difference.

**The merged code is unaffected** — `pol` is correct for both branches — but the
reason it was needed is the sign flip, not a general unreliability of the shape.
The doc now also records that the non-negative branch could take the cheaper RUP
form and deliberately does not, so there is one shape to read on a proof-writing
path.

## Comments corrected too

Both would have sent the next reader the way I went:

* `justify_not_in_range.hh` said a sign-flipped link "needs the mirrored
  pairing" — too optimistic, since the mirrored pairing *is* the non-propagating
  configuration. It now names Theorem 2.9, states the pairing as the hypothesis,
  and says not to reach for the helper with a sign-flipped link.
* `abs/justify.hh` repeated the "slack arithmetic happens to line up" reasoning.

## Testing

Comment-and-doc only, so this is a check that nothing was mangled rather than a
behaviour test: `abs_test` uncapped at seed 1 (74 VeriPB verifications) and
`min_max_test` (88) both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
