### PR TITLE
Unify the literal layer's theory into one document (#882)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,15 @@ Doxyfile
 # ... and the committed VeriPB smoke fixture used by the Windows CI lane:
 !.github/veripb_smoke/*.opb
 !.github/veripb_smoke/*.pbp
+# LaTeX intermediates and output from dev_docs (.log is already covered above).
+# The built .pdf is not checked in: it is a binary that changes on every edit,
+# so build it when you want to read it.
+*.aux
+*.fdb_latexmk
+*.fls
+*.toc
+/dev_docs/*.out
+/dev_docs/*.pdf
 *~
 XCSP3-CPP-Parser
 generator

--- a/dev_docs/README.md
+++ b/dev_docs/README.md
@@ -133,28 +133,35 @@ library. For an introduction to *using* the solver, start with the top-level
   the root" belongs to the paper's root simplification stage rather than to its
   propagator), and what is deferred (incrementality, `IncImp`, root
   simplification).
-- [Range ("in") literals](range_literals_spec.md) — the design specification
-  for the interval-literal proof layer: reifying `[X∈[a,b]]` to its
-  order-chain cuts, the always-covered partition invariant, interval-tree
-  containment, and the P1/P2 (line-checkability vs replay-completeness)
-  distinction that governs which linking clauses are load-bearing — with the
-  W1–W9 witness suite as the regression defence against re-simplification.
-  Read when touching range/interval reasons, branching, or `infer_not_in_range`.
-- [View proof logging](view-proof-logging.md) — how the proof layer handles
-  `ViewOfIntegerVariableID`: the view's own encoded variable and bit-vector, the
-  single definitional link axiom, the atom-level eq/ge biconditionals that let
-  unit propagation carry one atom across the boundary, and the three invariants
+- [What a literal is](literals.md) — the index page for the literal layer, and
+  the map from each invariant to the function that maintains it. It points at
+  **[literal-encodings.tex](literal-encodings.tex)**, which is the single
+  authoritative account: a revised and extended version of §3.2 and §3.3 of
+  Matthew McIlree's thesis, covering the two things the thesis does not —
+  interval literals, and several representations of one variable — with the
+  encoding procedure, the nine invariants, the reproved completeness theorems,
+  a table of every way a fact can cross from one literal to another, and the
+  witness suite, coincidence trap and refuted designs that keep it from being
+  simplified back. **Read this before changing anything about atoms, coverings
+  or view links.** The three documents below are its implementation companions.
+- [Range ("in") literals](range_literals_spec.md) — the implementation record
+  for the interval-literal layer: the vocabulary propagator authors see
+  (`infer_not_in_range` and interval reason elements), what was built and in
+  what order, the W1–W9 witness suite as checked in with its ablation notes, and
+  the inventory of edge cases. Read when touching range/interval reasons,
+  branching, or `infer_not_in_range`.
+- [View proof logging](view-proof-logging.md) — working with
+  `ViewOfIntegerVariableID` as a propagator author: the three invariants
   (representation consistency for `pol` cancellation, big-M sized to the
   bit-vector, RUP cannot compose across constraints) that both historical
-  Abs/AllDifferent failures violated. Read before emitting explicit `pol` over
-  an operand that might be a view.
-- [Range literals on views](view-range-literals.md) — where the two documents
-  above meet, which for a long time they did not. A view's own range literals,
-  the pair of link clauses joining them to the underlying variable's, why both
-  clauses are needed and why linking has to be triggered by a literal being
-  *named* rather than requested or defined. Also the measurement that 80% of
-  small random configurations cross correctly with no link at all, which is why
-  a green `--view-wrap` sweep is not evidence and the W6–W9 witnesses are.
+  Abs/AllDifferent failures violated, how the machinery is laid out, and the
+  `--view-wrap` / `--view-position` test harness. Read before emitting explicit
+  `pol` over an operand that might be a view.
+- [Range literals on views](view-range-literals.md) — issue #882's record: the
+  ten view detours it deleted, why linking has to be triggered by a literal
+  being *named* rather than requested or defined, the W6–W9 ablation table, and
+  the measurement that 80% of small random configurations cross correctly with
+  no link at all — which is why a green `--view-wrap` sweep is not evidence.
 - [arithmetic-proofs.md](arithmetic-proofs.md) — how Multiply/Divide/Modulus/Power propagate and justify against cake's encoding: the slot-keyed emitters, the ConditionalBound justification layer, the sign-case driver, and the hard-won RUP/pol rules.
 - [Decision-diagram proof strategies](decision-diagram-proof-strategies.md) — for
   the layered/partial-sum propagators (`Regular`, `MDD`, `Knapsack`,
@@ -344,3 +351,16 @@ library. For an introduction to *using* the solver, start with the top-level
 
 More documents will be added here as we build up coverage of other parts of
 the codebase.
+
+## Further reading
+
+- Matthew McIlree, *Proof Logging for Constraint Programming*, PhD thesis,
+  University of Glasgow, 2026. <https://theses.gla.ac.uk/86049/> — the
+  foundations most of the proof-logging documents here build on: the PB proof
+  system and its rules (chapter 2, including Theorems 2.7–2.9 on binary sums,
+  which several documents cite by number), the encoding procedure and proof
+  logging framework (chapter 3), and justification procedures for individual
+  propagators (§3.4 and chapters 4 onwards). Where a document here says
+  "the thesis", this is it. §3.2 and §3.3 have been revised and extended in
+  [literal-encodings.tex](literal-encodings.tex) to cover interval literals and
+  views; the rest stands as written.

--- a/dev_docs/README.md
+++ b/dev_docs/README.md
@@ -140,9 +140,9 @@ library. For an introduction to *using* the solver, start with the top-level
   Matthew McIlree's thesis, covering the two things the thesis does not —
   interval literals, and several representations of one variable — with the
   encoding procedure, the nine invariants, the reproved completeness theorems,
-  a table of every way a fact can cross from one literal to another, and the
-  witness suite, coincidence trap and refuted designs that keep it from being
-  simplified back. **Read this before changing anything about atoms, coverings
+  a table of every way a fact can cross from one literal to another, the design
+  rationale for the choices that are not forced, and the witness suite,
+  coincidence trap and refuted designs that keep it from being simplified back. **Read this before changing anything about atoms, coverings
   or view links.** The three documents below are its implementation companions.
 - [Range ("in") literals](range_literals_spec.md) — the implementation record
   for the interval-literal layer: the vocabulary propagator authors see

--- a/dev_docs/README.md
+++ b/dev_docs/README.md
@@ -355,8 +355,10 @@ the codebase.
 
 ## Further reading
 
-- Matthew McIlree, *Proof Logging for Constraint Programming*, PhD thesis,
-  University of Glasgow, 2026. <https://theses.gla.ac.uk/86049/> — the
+- Matthew McIlree, *Pseudo-Boolean Proof Logging for Constraint Propagation
+  Algorithms*, PhD thesis, University of Glasgow, 2026.
+  <https://theses.gla.ac.uk/86049/> — that is the exact title, and not "Proof
+  Logging for Constraint Programming", which is the title of its chapter 3. The
   foundations most of the proof-logging documents here build on: the PB proof
   system and its rules (chapter 2, including Theorems 2.7–2.9 on binary sums,
   which several documents cite by number), the encoding procedure and proof

--- a/dev_docs/README.md
+++ b/dev_docs/README.md
@@ -147,9 +147,10 @@ library. For an introduction to *using* the solver, start with the top-level
 - [Range ("in") literals](range_literals_spec.md) — the implementation record
   for the interval-literal layer: the vocabulary propagator authors see
   (`infer_not_in_range` and interval reason elements), what was built and in
-  what order, the W1–W9 witness suite as checked in with its ablation notes, and
-  the inventory of edge cases. Read when touching range/interval reasons,
-  branching, or `infer_not_in_range`.
+  what order, which witness test guards what and how each was validated, and the
+  inventory of edge cases. The theory it used to carry is now in
+  `literal-encodings.tex`; this is what the code does. Its section numbers are
+  cited from nine tests and `gcs/CMakeLists.txt`, so do not renumber them.
 - [View proof logging](view-proof-logging.md) — working with
   `ViewOfIntegerVariableID` as a propagator author: the three invariants
   (representation consistency for `pol` cancellation, big-M sized to the
@@ -158,10 +159,10 @@ library. For an introduction to *using* the solver, start with the top-level
   `--view-wrap` / `--view-position` test harness. Read before emitting explicit
   `pol` over an operand that might be a view.
 - [Range literals on views](view-range-literals.md) — issue #882's record: the
-  ten view detours it deleted, why linking has to be triggered by a literal
-  being *named* rather than requested or defined, the W6–W9 ablation table, and
-  the measurement that 80% of small random configurations cross correctly with
-  no link at all — which is why a green `--view-wrap` sweep is not evidence.
+  view detours it deleted, where in the code the *naming* trigger lives and why
+  a request-driven one silently fails, the measured divergence between the two
+  sides' roles, and the residue. Two corrections are recorded here rather than
+  quietly fixed, because both were believed and written down first.
 - [arithmetic-proofs.md](arithmetic-proofs.md) — how Multiply/Divide/Modulus/Power propagate and justify against cake's encoding: the slot-keyed emitters, the ConditionalBound justification layer, the sign-case driver, and the hard-won RUP/pol rules.
 - [Decision-diagram proof strategies](decision-diagram-proof-strategies.md) — for
   the layered/partial-sum propagators (`Regular`, `MDD`, `Knapsack`,

--- a/dev_docs/literal-encodings.tex
+++ b/dev_docs/literal-encodings.tex
@@ -150,14 +150,14 @@ neither of which the thesis covers.
     may be wrapped by several views at once.  Each registered view is given its
     own encoded variable, its own bit vector, and its own complete family of
     atomic literals, joined to $X$'s by a definitional link and by atom-level
-    linking clauses.
+    linking constraints.
 \end{itemize}
 
 Neither addition is conservative over the thesis's propagation results.
 Inequality and equality atoms are complete under unit propagation given the
 order chain alone; interval literals are not, and need two further families of
 state-independent clause.  Facts move between two representations of the same
-variable only through linking clauses, and --- for interval literals --- the
+variable only through linking constraints, and --- for interval literals --- the
 direction that a proof actually needs is the one that is \emph{not} derivable
 from the others.  The theorems below are therefore restated over a
 \emph{representation family} and over all three literal kinds, and reproved.
@@ -878,7 +878,7 @@ $t$ in the proof.
 \item[\invRep{}: representation closure and linking.]
   For every $W,W'\in\Rep(X)$: if an atomic variable of $W$ is defined, then so is
   the corresponding atomic variable of $W'$ (\cref{def:image} below); and for
-  every defined atomic variable of a proper $W$, the two clauses linking it to
+  every defined atomic variable of a proper $W$, the two constraints linking it to
   the corresponding atomic variable of the base $X$ appear in $F_t$.
 
 \item[\invName{}: cells are named.]
@@ -953,7 +953,7 @@ a width-one case on either side.  Second, a sign flip converts a positive bound
 literal into a negative one, but leaves the polarity of equality and interval
 literals alone --- an interval is order-agnostic, a half-line is not.
 
-The linking clauses are exactly the clausal form of the biconditional
+The atom-level linking constraints are exactly the clausal form of the biconditional
 $\ell \Leftrightarrow \ell^{X}$, for each defined atom of each proper
 representation:
 \begin{align}
@@ -1536,6 +1536,12 @@ $\atge{w}{v}$, either polarity & its image on $X$ & ge-links,
 $\ateq{w}{v}$, either polarity & its image on $X$ & eq-links, \cref{eq:eqlink} \\
 $\atin{w}{a}{b}$, either polarity & its image on $X$ & in-links,
   \cref{eq:inlink}; \emph{both} clauses needed, see \cref{rem:bothlinks} \\
+every bit of $X$ fixed & every bit of $W$ fixed & $\ViewLink(W)$ and
+  thesis Theorem~2.8; the crossing the completion argument of
+  \cref{sec:optimality} needs.  Partial assignments cross too --- for $W=X+8$
+  over a three-bit base, $\ViewLink(W)$ forces $w_3$ from the empty assignment
+  --- but an atomic literal is not carried across this way in general; see
+  \nsec{sec:notprovided} \\
 anything on $W_1$ & its image on $W_2$ & two hops through the base
   (\cref{lem:transport}) \\[4pt]
 \multicolumn{3}{@{}l}{\emph{Between different variables}}\\[2pt]
@@ -1874,7 +1880,7 @@ by \cref{eq:rootbounds}.  Hence \invDomain{} is initially respected.
     (\invPart{}, \invCover{}, \invCont{}).
   \item Every defined atomic literal on a proper representation, and every one
     on a base that has proper representations, must be mirrored onto the others
-    and joined to them by the linking clauses of
+    and joined to them by the linking constraints of
     \cref{eq:gelink,eq:eqlink,eq:inlink} --- for interval literals, triggered at
     the point the literal is \emph{named} (\invRep{}, \invName{}).
 \end{enumerate}
@@ -1883,7 +1889,7 @@ Steps~1 to~6 are the thesis's framework; steps~7 to~9 are the literal-layer
 invariants stated as obligations.  Despite requiring a delicate set-up in terms
 of variable encodings and propagation properties, the resulting proof has a
 relatively intuitive structure: other than the definition, chain, covering,
-containment and linking clauses, it is essentially the solver writing down all
+containment and linking constraints, it is essentially the solver writing down all
 the facts that it learned, at the points that it learned them.
 
 \subsubsection{Optimality Proofs from Solution-Improving Search}
@@ -1944,7 +1950,8 @@ extended encoding, and each extends the same recursion by one step.
     do.
 \end{enumerate}
 
-None of the linking clauses of \cref{eq:gelink,eq:eqlink,eq:inlink} is needed
+None of the atom-level linking constraints of
+\cref{eq:gelink,eq:eqlink,eq:inlink} is needed
 for this argument, and none of the covering or containment clauses is either;
 they are implied clauses over variables that already propagate, and cannot
 block a propagation that would otherwise occur.
@@ -2130,7 +2137,7 @@ A randomised sweep over views is close to no evidence about the in-links, and it
 is worth knowing by how much, because the natural reaction to
 \cref{rem:bothlinks} is to test it rather than to prove it.
 
-The negative crossing of \cref{eq:inlink} succeeds \emph{with no linking clause
+The negative crossing of \cref{eq:inlink} succeeds \emph{with no linking constraint
 at all} whenever any of four things happens:
 
 \begin{itemize}[itemsep=1pt]
@@ -2147,10 +2154,10 @@ at all} whenever any of four things happens:
 
 Measured over domain widths $4$ to $16$ with zero to seven random interval
 requests per instance: \textbf{80\% of instances cross successfully with no
-linking clause at all} --- abutting above $39\%$, abutting below $23\%$, whole
+linking constraint at all} --- abutting above $39\%$, abutting below $23\%$, whole
 range $12\%$, fully shattered $5.6\%$ --- and of the $20\%$ that stall, a single
 wide cell accounts for $88\%$.  Measured the other way, over $987$ randomly
-generated instances that actually reach a conflict, ablating the link clauses
+generated instances that actually reach a conflict, ablating the link constraints
 makes only $37$ of them notice.  The sweep is about $96\%$ coincidence.
 
 A discriminating instance therefore needs \emph{all} of: an interval strictly
@@ -2216,7 +2223,7 @@ $10^6$ & 40 & \emph{timed out} & \textbf{106} & 106 & 106 \\
 The third column is the per-value fallback a view had before it owned interval
 literals: $2+36w$ lines, unwritable past $10^4$.  The remaining columns are flat.
 They are $106$ rather than $40$ because the view carries its own bit vector, its
-own atoms and the link clauses --- a constant, not a function of the width.  That
+own atoms and the link constraints --- a constant, not a function of the width.  That
 constant is the price of the design; the slope was the point.
 
 \appendix
@@ -2325,7 +2332,7 @@ built on unsplit cells for exactly this reason.
 
 \paragraph{Why a nearby instance proves nothing.}
 Take instead the decision $\natin{x}{1}{15}$, whose interval abuts the lower
-bound.  Now no link clause is needed at all.  \cref{eq:din2} for it is
+bound.  Now no link constraint is needed at all.  \cref{eq:din2} for it is
 $\atin{x}{1}{15}\vee\natge{x}{1}\vee\atge{x}{16}$; the boundary pin
 $\atge{x}{1}$ of \inv{Bound} is a unit, so $\atge{x}{16}$ propagates.  The
 ge-link carries that to $\natge{v}{15}$, since $X\geq 16$ is $V\leq 14$, and the
@@ -2366,7 +2373,7 @@ where 80\% of small random instances turn out to be one of them.
   of the proof rather than derive them, on a scale running
   \textsc{Off} $<$ \textsc{Definitions} $<$ \textsc{Links} $<$
   \textsc{Inferences} $<$ \textsc{Backtracking}.  At \textsc{Links} the atom
-  definitions and the linking clauses are asserted, but the covering and
+  definitions and the linking constraints are asserted, but the covering and
   containment apparatus is still emitted, as ordinary RUP lines: the guards on
   it are all ``above \textsc{Links}''.  Above \textsc{Links} the interval
   machinery is skipped entirely, and no cells exist.  So there is no setting in

--- a/dev_docs/literal-encodings.tex
+++ b/dev_docs/literal-encodings.tex
@@ -1,5 +1,5 @@
 % Pseudo-Boolean encodings and proof logging for integer variables with
-% multiple representations.
+% several views.
 %
 % Build with: latexmk -pdf literal-encodings.tex
 %
@@ -76,7 +76,7 @@
 \newcommand{\Lin}{\fname{Lin}}
 \newcommand{\Aux}{\fname{Aux}}
 \newcommand{\Vars}{\fname{Vars}}
-\newcommand{\Rep}{\fname{Rep}}
+\newcommand{\ViewVars}{\fname{ViewVars}}
 \newcommand{\ViewLink}{\fname{ViewLink}}
 \newcommand{\Cells}{\fname{Cells}}
 \newcommand{\Bdry}{\fname{Bd}}
@@ -84,7 +84,7 @@
 \newcommand{\ImpLits}{\fname{ImpLits}}
 \newcommand{\Standardise}{\fname{Standardise}}
 \newcommand{\Linearise}{\fname{Linearise}}
-\newcommand{\NeededReps}{\fname{NeededRepresentations}}
+\newcommand{\NeededViews}{\fname{NeededViews}}
 \newcommand{\NeededAtomicVariables}{\fname{NeededAtomicVariables}}
 \newcommand{\atge}[2]{#1_{\geq #2}}
 \newcommand{\ateq}[2]{#1_{= #2}}
@@ -111,13 +111,13 @@
 \newcommand{\invPart}{\inv{Part}}
 \newcommand{\invCover}{\inv{Cover}}
 \newcommand{\invCont}{\inv{Cont}}
-\newcommand{\invRep}{\inv{Rep}}
+\newcommand{\invView}{\inv{View}}
 \newcommand{\invName}{\inv{Name}}
 \newcommand{\invConflict}{\inv{Conflict}}
 \newcommand{\invDomain}{\inv{Domain}}
 
 \title{Representing Problems for Proofs, and a Proof Logging Framework,\\
-  for Integer Variables with Several Representations}
+  for Integer Variables with Several Views}
 \author{Matthew McIlree \and Ciaran McCreesh}
 \date{}
 
@@ -149,10 +149,10 @@ neither of which the thesis covers.
     holes, at constant rather than linear cost in the width of the run.  A
     width-one interval literal \emph{is} the equality atom, not a separate
     Boolean.
-  \item \textbf{Several representations of one variable.}  A constraint may be
+  \item \textbf{Several views of one variable.}  A constraint may be
     posted over an affine \emph{view} $V = sX+c$ of a variable $X$, and one $X$
     may be wrapped by several views at once.  Each registered view is given its
-    own encoded variable, its own bit vector, and its own complete family of
+    own \emph{view variable}, its own bit vector, and its own complete family of
     atomic literals, joined to $X$'s by a definitional link and by atom-level
     linking constraints.
 \end{itemize}
@@ -160,11 +160,11 @@ neither of which the thesis covers.
 Neither addition is conservative over the thesis's propagation results.
 Inequality and equality atoms are complete under unit propagation given the
 order chain alone; interval literals are not, and need two further families of
-state-independent clause.  Facts move between two representations of the same
+state-independent clause.  Facts move between two view variables of the same
 variable only through linking constraints, and --- for interval literals --- the
 direction that a proof actually needs is the one that is \emph{not} derivable
 from the others.  The theorems below are therefore restated over a
-\emph{representation family} and over all three literal kinds, and reproved.
+\emph{view family} and over all three literal kinds, and reproved.
 
 \paragraph{Numbering.}  Results that correspond to results of the thesis keep
 the thesis's numbers, so that citations from the thesis and from our earlier
@@ -248,7 +248,7 @@ definition of equivalence is: ``the PB problem is the result of applying
 
 The one substantive change to this section from the thesis is that the encoding
 now admits two further \emph{shared} classes of introduced variable, beyond the
-atomic constraint variables: \emph{representation variables} for affine views,
+atomic constraint variables: \emph{view variables} for affine views,
 and a third kind of atomic variable for intervals.  Both are still uniquely
 determined, semantically, by an assignment to the original variables: their
 definition constraints and their links leave no freedom.  That is what keeps P1
@@ -270,9 +270,9 @@ rather than private to one, and each is uniquely determined by an assignment to
 the original variables:
 
 \begin{itemize}
-  \item \textbf{Representation variables} name affine views $sX+c$ of an
+  \item \textbf{View variables} name affine views $sX+c$ of an
     original variable.  A constraint posted over a view of $X$ is linearised
-    over the corresponding representation variable.
+    over the corresponding view variable.
   \item \textbf{Atomic constraint variables} (or simply \emph{atomic
     variables}) are $0$--$1$ variables denoting basic relationships between a
     variable and a value or an interval of values.
@@ -304,15 +304,15 @@ higher-level modelling language.
 For a CSP with variables $\mathcal V$, initial domain state (without holes)
 $\dm_0$, and constraints $\mathcal C$, we can produce a PB formula as follows.
 \begin{enumerate}[label=\arabic*:,leftmargin=2.6em,itemsep=1pt]
-  \item $\mathcal W \leftarrow \bigcup_{X\in\mathcal V}\{X\}
-        \cup \bigcup_{C\in\mathcal C}\NeededReps(C)$
-  \item $\ViewLink(\mathcal W) \leftarrow \bigcup_{W\in\mathcal W}\ViewLink(W)$
+  \item $\mathcal W \leftarrow \bigcup_{X\in\mathcal V}\ViewVars(X)$
+  \item $\ViewLink(\mathcal W\setminus\mathcal V) \leftarrow
+        \bigcup_{W\in\mathcal W\setminus\mathcal V}\ViewLink(W)$
   \item $\Bnd(\mathcal W) \leftarrow \bigcup_{W\in\mathcal W}\Bnd(W,\dm_0)$
   \item $\mathcal A \leftarrow \bigcup_{C\in\mathcal C}
         \NeededAtomicVariables(C,\dm_0)$
   \item $\Def(\mathcal A) \leftarrow \bigcup_{y\in\mathcal A}\Def(y)$
   \item $\Lin(\mathcal C) \leftarrow \bigcup_{C\in\mathcal C}\Linearise(C,\dm_0)$
-  \item $F \leftarrow \BinEnc\bigl(\Bnd(\mathcal W)\cup\ViewLink(\mathcal W)
+  \item $F \leftarrow \BinEnc\bigl(\Bnd(\mathcal W)\cup\ViewLink(\mathcal W\setminus\mathcal V)
         \cup\Def(\mathcal A)\cup\Lin(\mathcal C)\bigr)$
   \item $F \leftarrow \Standardise(F)$
 \end{enumerate}
@@ -322,48 +322,56 @@ Steps~1 and~2 are new; step~5 now has a third case.  The remainder of this
 section gives more detail on each stage along with soundness arguments, and
 introduces notation used throughout.
 
-\paragraph{Steps 1 and 2: representations and their links.}
+\paragraph{Steps 1 and 2: views and their links.}
 
-\begin{definitionT}[Representation]
-\label{def:rep}
-A \emph{representation} of a CP variable $X$ is an integer variable $W$
-together with a sign $s_W\in\{+1,-1\}$ and an offset $c_W\in\mathbb Z$, subject
-to $W = s_W X + c_W$.  Write
+\begin{definitionT}[View and view variable]
+\label{def:view}
+A \emph{view} of a CP variable $X$ is an affine expression $sX+c$ with
+$s\in\{+1,-1\}$ and $c\in\mathbb Z$, and it is \emph{proper} when it is not $X$
+itself.  The encoding gives each view its own \emph{view variable}: an integer
+variable $W$ with a sign $s_W\in\{+1,-1\}$ and an offset $c_W\in\mathbb Z$,
+subject to $W = s_W X + c_W$.  Write
 \[
   \varphi_W(k) = s_W k + c_W, \qquad
   \psi_W(v) = \varphi_W^{-1}(v) = s_W(v - c_W),
 \]
 so that $\varphi_W$ is an order-preserving bijection $\mathbb Z\to\mathbb Z$
-when $s_W=+1$ and an order-reversing one when $s_W=-1$.  Every CP variable is a
-representation of itself, with $\varphi_X$ the identity function.  We write
-$\Rep(X)$ for the set of representations of $X$ occurring in the encoding, and
-$\mathcal W = \bigcup_{X\in\mathcal V}\Rep(X)$.  A representation $W\neq X$ is
-\emph{proper}, and $X$ is its \emph{base}; $\Rep$ is a partition of $\mathcal
-W$ by base.
+when $s_W=+1$ and an order-reversing one when $s_W=-1$.  Every CP variable is
+the view variable of the trivial view of itself, with $\varphi_X$ the identity
+function.  A view variable $W\neq X$ is \emph{proper}, and $X$ is its
+\emph{base}.
+
+Write $\NeededViews(C)$ for the views occurring in a constraint $C$, and
+$\ViewVars(X)$ --- the \emph{view family} of $X$ --- for $X$ together with the
+view variable of each proper view of $X$ in
+$\bigcup_{C\in\mathcal C}\NeededViews(C)$.  Then
+$\mathcal W = \bigcup_{X\in\mathcal V}\ViewVars(X)$, so $\ViewVars$ is a
+partition of $\mathcal W$ by base, and $\mathcal W\setminus\mathcal V$ is the
+set of proper view variables.
 \end{definitionT}
 
-For each proper $W\in\Rep(X)$, $\ViewLink(W)$ is the single linear equality
+For each proper $W\in\ViewVars(X)$, $\ViewLink(W)$ is the single linear equality
 \begin{equation}
   \ViewLink(W) \;:=\; W - s_W X = c_W ,
   \label{eq:link}
 \end{equation}
-which \Standardise{} will split into a $\geq$ and a $\leq$ row.  For a base
-variable, $\ViewLink(X)$ is empty.
+which \Standardise{} will split into a $\geq$ and a $\leq$ row.  It is stated
+only for proper view variables: a base variable has nothing to link to.
 
-Representation variables arise because constraints are posted over
-\emph{operands}, and an operand may be a view.  A modelling layer that writes
+View variables arise because constraints are posted over \emph{operands}, and an
+operand may be a view.  A modelling layer that writes
 $\globalcon{AllDifferent}(X_1, X_2+1, X_3+2)$ is naming three operands, two of
-which are proper representations of $X_2$ and $X_3$.  Two different
-constraints may name the same view, and one variable may be named through
-several different views at once, which is precisely why representation
-variables have to be shared rather than private to a linearisation.
+which are proper views of $X_2$ and $X_3$.  Two different constraints may name
+the same view, and one variable may be named through several different views at
+once, which is precisely why view variables have to be shared rather than
+private to a linearisation.
 
 A view therefore gets a variable of its own, at the cost of one linear equality.
 \Cref{sec:rationale} says why, and what the alternative --- substituting
 $sX+c$ wherever the view occurs --- would cost.
 
 \paragraph{Step 3: domain bound constraints.}
-For a representation $W$ of $X$ and domain state $\dm_0$, let $\Bnd(W,\dm_0)$
+For a view variable $W$ of $X$ and domain state $\dm_0$, let $\Bnd(W,\dm_0)$
 be the two linear constraints
 \begin{equation}
   W \geq \min \varphi_W(\dm_0(X)) \qquad\text{and}\qquad
@@ -383,10 +391,10 @@ together, and several later arguments need $W$'s own bounds to be available as
 units on $W$'s own atoms.
 
 Clearly, if we construct a CSP with variables $\mathcal W$, constraints
-$\mathcal C \cup \Bnd(\mathcal W)\cup\ViewLink(\mathcal W)$, and unrestricted
+$\mathcal C \cup \Bnd(\mathcal W)\cup\ViewLink(\mathcal W\setminus\mathcal V)$, and unrestricted
 integer domains, then its solution set has the same cardinality as our original
 CSP's, and is identical to it under projection onto $\mathcal V$: every proper
-representation is determined by its base through \cref{eq:link}, so the
+view variable is determined by its base through \cref{eq:link}, so the
 projection is a bijection and not merely a surjection.
 
 \paragraph{Steps 4 and 5: atomic constraint variables.}
@@ -398,10 +406,10 @@ definition of $\Linearise(C,\dm_0)$.
 
 Each atomic variable $y$ requires a fully reified linear definition constraint
 $\Def(y)$ of the form $y\Leftrightarrow C$.  We allow three types of atomic
-variable definition, each associated with a \emph{representation}
+variable definition, each associated with a \emph{view variable}
 $W\in\mathcal W$ --- not merely with a CP variable --- and with one or two
 integers.  For clarity we always use subscripted names suggestive of the
-definition, writing $w$ for the PB name of the representation $W$.
+definition, writing $w$ for the PB name of the view variable $W$.
 
 \begin{enumerate}[leftmargin=2.2em]
   \item A \textbf{bound variable} $\atge{w}{v}$ represents whether $W$ must be
@@ -452,7 +460,7 @@ entirely redundant: the values of the atomic variables are uniquely determined
 for any solution.  This means the solution set projected onto the original
 variables remains exactly the same, and in particular adding them cannot
 possibly change satisfiability or the objective value.  The same is true of
-representation variables, by \cref{eq:link}.
+view variables, by \cref{eq:link}.
 
 Recalling $0$--$1$ literals, we can represent $W$ being at most $v$, not equal
 to $v$, or outside $[a,b]$ by negating the corresponding variables.
@@ -464,7 +472,7 @@ literals}.
 \paragraph{Step 6: linearise constraints.}
 For each constraint $C$ we require a function $\Linearise(C,\dm_0)$ turning it
 into a set of reified linear constraints $\Lin(C)$.  This can use
-representation variables, atomic literals, and further auxiliary variables.
+view variables, atomic literals, and further auxiliary variables.
 Write $\Vars(\Lin(C))$ for the set of variables appearing in the
 linearisation, and let $\Aux(C) = \Vars(\Lin(C))\setminus(\mathcal W\cup
 \mathcal A)$ be the auxiliary variables introduced.  We require:
@@ -486,18 +494,18 @@ linearisation, and let $\Aux(C) = \Vars(\Lin(C))\setminus(\mathcal W\cup
     bounded with corresponding bound constraints $\Bnd(V_j)$, considered part of
     the linearisation.
   \item[L3.] Auxiliary variables must not be shared between linearisations:
-    $\Aux(C_1)\cap\Aux(C_2)=\emptyset$ for all $C_1\neq C_2$.  Representation
+    $\Aux(C_1)\cap\Aux(C_2)=\emptyset$ for all $C_1\neq C_2$.  View variable
     variables and atomic variables are \emph{not} auxiliary variables and may be
     shared freely.
-  \item[L4.] Most importantly, $\Lin(C)\cup\Def(\mathcal A)\cup\ViewLink(\mathcal W)$
+  \item[L4.] Most importantly, $\Lin(C)\cup\Def(\mathcal A)\cup\ViewLink(\mathcal W\setminus\mathcal V)$
     must enforce the same restriction as $C$ on the variables in $\mathcal V$.
     That is, a valid assignment $\sigma:\mathcal V\to\mathbb Z$ satisfies $C$ if
     and only if it can be extended to a valid assignment
-    $\sigma^+:\Vars(\Lin(C)\cup\Def(\mathcal A)\cup\ViewLink(\mathcal W))\to\mathbb Z$
-    satisfying $\Lin(C)\cup\Def(\mathcal A)\cup\ViewLink(\mathcal W)$.
+    $\sigma^+:\Vars(\Lin(C)\cup\Def(\mathcal A)\cup\ViewLink(\mathcal W\setminus\mathcal V))\to\mathbb Z$
+    satisfying $\Lin(C)\cup\Def(\mathcal A)\cup\ViewLink(\mathcal W\setminus\mathcal V)$.
 \end{description}
 
-L3 is where representation variables differ from the thesis's presentation:
+L3 is where view variables differ from the thesis's presentation:
 they are shared, and they are shared for the same reason atomic variables are.
 The proof of \cref{lem:composing} shows that this is safe precisely because
 \cref{eq:link}, like \cref{eq:defge,eq:defeq,eq:defin}, determines the shared
@@ -508,7 +516,7 @@ variable's value uniquely from the assignment to $\mathcal V$.
 Let $P$ be a CSP with variables $\mathcal V$ and constraints $\mathcal C$,
 where all domains are integer ranges.  After executing steps~1 to~6 of
 \cref{proc:encoding} let $P'$ be the CSP with constraints
-$\mathcal C' := \Lin(\mathcal C)\cup\Bnd(\mathcal W)\cup\ViewLink(\mathcal W)
+$\mathcal C' := \Lin(\mathcal C)\cup\Bnd(\mathcal W)\cup\ViewLink(\mathcal W\setminus\mathcal V)
 \cup\Def(\mathcal A)$, whose variables are precisely those occurring in
 $\mathcal C'$, and whose domain for every non-$0$--$1$ variable is $\mathbb Z$.
 Then:
@@ -523,11 +531,11 @@ Then:
 \begin{proof}
 Call a variable of $P'$ \emph{determined} if its value is a function of the
 restriction of an assignment to $\mathcal V$ alone.  Every variable in
-$\mathcal W\cup\mathcal A$ is determined: a proper representation by
+$\mathcal W\cup\mathcal A$ is determined: a proper view variable by
 \cref{eq:link}, and an atomic variable by its definition constraint, which is a
 fully reified constraint over $\mathcal W$ (for $\atge{w}{v}$) or over
 previously determined atomic variables (for $\ateq{w}{v}$ and $\atin{w}{a}{b}$,
-whose definitions mention only bound variables of the same representation).
+whose definitions mention only bound variables of the same view variable).
 The determination is well founded because the dependency order is
 $\mathcal V \to \mathcal W \to \{\text{bound}\} \to
 \{\text{equality},\text{interval}\}$, with no cycles.
@@ -535,14 +543,14 @@ $\mathcal V \to \mathcal W \to \{\text{bound}\} \to
 \emph{Part 1.}  Let $\sigma$ be a solution to $P$ and $C_1,\dots,C_n$ the
 constraints of $P$.  By validity, $\sigma$ satisfies $\Bnd(\mathcal V)$, and
 extending it by the determined values satisfies $\Bnd(\mathcal
-W)\cup\ViewLink(\mathcal W)$.  By L4, $\sigma$ can be extended to a solution
-$\sigma_1$ of $\Bnd(\mathcal W)\cup\ViewLink(\mathcal W)\cup\Def(\mathcal
+W)\cup\ViewLink(\mathcal W\setminus\mathcal V)$.  By L4, $\sigma$ can be extended to a solution
+$\sigma_1$ of $\Bnd(\mathcal W)\cup\ViewLink(\mathcal W\setminus\mathcal V)\cup\Def(\mathcal
 A)\cup\Lin(C_1)$.
 
 Now assume we have extended $\sigma$ to a solution $\sigma_{k-1}$ of
-$\Bnd(\mathcal W)\cup\ViewLink(\mathcal W)\cup\Def(\mathcal A)\cup
+$\Bnd(\mathcal W)\cup\ViewLink(\mathcal W\setminus\mathcal V)\cup\Def(\mathcal A)\cup
 \bigcup_{i<k}\Lin(C_i)$.  By L4 again, $\sigma$ can be extended to a solution
-$\sigma'_k$ of $\Bnd(\mathcal W)\cup\ViewLink(\mathcal W)\cup\Def(\mathcal
+$\sigma'_k$ of $\Bnd(\mathcal W)\cup\ViewLink(\mathcal W\setminus\mathcal V)\cup\Def(\mathcal
 A)\cup\Lin(C_k)$.  Define $\sigma_k$ by
 \begin{align}
   \sigma_k(V) &= \sigma(V) && \text{if } V\in\mathcal V; \\
@@ -552,7 +560,7 @@ A)\cup\Lin(C_k)$.  Define $\sigma_k$ by
   \sigma_k(V) &= \sigma'_k(V) && \text{if otherwise } V\in\Vars(\Lin(C_k)).
 \end{align}
 This is an extension of $\sigma$, and it satisfies both $\Lin(C_k)$ and
-$\Bnd(\mathcal W)\cup\ViewLink(\mathcal W)\cup\Def(\mathcal A)\cup
+$\Bnd(\mathcal W)\cup\ViewLink(\mathcal W\setminus\mathcal V)\cup\Def(\mathcal A)\cup
 \bigcup_{i<k}\Lin(C_i)$, because
 $\sigma_k(V)=\sigma_{k-1}(V)=\sigma'_k(V)$ for every $V\in\mathcal
 V\cup\mathcal W\cup\mathcal A$ --- each such $V$ being determined by $\sigma$,
@@ -564,7 +572,7 @@ both $\sigma_{k-1}$ and $\sigma'_k$.  The claim follows by induction.
 \emph{Part 2.}  Let $\sigma'$ be a solution to $P'$.  There is only one
 possible restriction of $\sigma'$ to a valid assignment to $\mathcal V$; and by
 L4, since $\sigma'$ satisfies $\Lin(C_i)\cup\Def(\mathcal A)\cup\ViewLink(\mathcal
-W)$ for each $i$, that restriction must satisfy each $C_i$ and hence $P$.
+W\setminus\mathcal V)$ for each $i$, that restriction must satisfy each $C_i$ and hence $P$.
 \end{proof}
 
 We refer to the result of steps~1 to~6 as the \emph{intermediate ILP}.  In the
@@ -592,7 +600,7 @@ occurrence of a non-Boolean variable with a binary exponential sum.  This may
 be a poor encoding from a solving perspective, but it maintains the form of the
 ILP, letting us ``pretend'' we have integer variables while working honestly
 with native PB constraints.  Every variable in $\mathcal W$ --- proper
-representations included --- is replaced, and each gets its \emph{own} bit
+view variables included --- is replaced, and each gets its \emph{own} bit
 vector: $\BinEnc(W)$ and $\BinEnc(X)$ share no PB variables, and are related
 only by the encoded form of $\ViewLink(W)$.
 
@@ -612,7 +620,7 @@ the encoding.
 
 \begin{remark}
 Two width details matter in practice and neither affects the argument.  First,
-the bit vector of a proper representation is sized from $[l_W,u_W]$, and can be
+the bit vector of a proper view variable is sized from $[l_W,u_W]$, and can be
 \emph{wider} than that of its base: a view of a variable with range $[1,8]$ has
 range $[1,8]$ too but a bit vector spanning $[0,15]$, and a view $X+10^6$ has a
 much wider one.  Any coefficient bound or big-$M$ computed for a line mentioning
@@ -653,7 +661,7 @@ of assignments to $\mathcal V$ (projected from full assignments) that satisfy
 $P'$.  Let $F^*$ be the $0$--$1$ linear CSP obtained after step~7.  Every
 solution to $P'$ corresponds to a solution of $F^*$, by assigning to each
 non-$0$--$1$ variable $W$ the unique $h$-bit vector representing its value ---
-note that this is well defined for a proper representation exactly as for a
+note that this is well defined for a proper view variable exactly as for a
 base one, since $\ViewLink(W)$ and $\Bnd(W)$ force $W$'s value into $[l_W,u_W]$,
 which its bit width covers.  Conversely, every solution to $F^*$ corresponds to
 a solution of $P'$ by decoding each bit vector.  The final formula $F$ obtained
@@ -669,7 +677,7 @@ P2 holds.
 
 \begin{remark}
 The projection in \cref{thm:p1p2} is onto the bits of the \emph{base} variables
-only.  The bits of proper representations, and all atomic variables, are
+only.  The bits of proper view variables, and all atomic variables, are
 determined but not projected onto.  This matters for enumeration; see
 \cref{sec:enumeration}.
 \end{remark}
@@ -686,8 +694,8 @@ satisfy L1 to L4 by inspection.
 
 Two remarks are needed in the extended setting.
 
-First, a constraint's operands may be representations rather than base
-variables, and its linearisation is written over the operands.  Thus
+First, a constraint's operands may be views rather than base variables, and its
+linearisation is written over their view variables.  Thus
 $\globalcon{AllDifferent}(W_1,\dots,W_n)$ linearises to
 $u_{ij}\Rightarrow W_i - W_j > 0$ and $\bar u_{ij} \Rightarrow W_j - W_i > 0$
 over exactly the operands it was given, with no reference to their bases.  This
@@ -707,8 +715,8 @@ an open decision recorded in \cref{sec:open}.
 We begin from the assumption that we have used an encoding method following
 \cref{proc:encoding}.  So before logging anything in the proof, we have a
 correct PB representation of an input CP problem in terms of binary-encoded
-representations of the CP variables, atomic literals defined for certain
-representations and values, and some other auxiliary variables.
+view variables of the CP variables, atomic literals defined for certain view
+variables and values, and some other auxiliary variables.
 
 Based on this encoding method, we formulate a proof logging framework based on
 maintaining invariants relating the solver's explored domain states to the
@@ -729,7 +737,7 @@ $F\!\restriction_R$ sets $\ell$.
 We can always freely introduce in the proof further atomic variables with
 definitions corresponding to \cref{eq:defge,eq:defeq,eq:defin}, by
 redundance-based strengthening.  After binary encoding and standardisation
-these amount, for a representation $W$ of $X$, to the PB constraints
+these amount, for a view variable $W$ of $X$, to the PB constraints
 \begin{align}
   \Def^{\Rightarrow}(\atge{w}{v}) &:= \atge{w}{v} \Rightarrow \BinEnc(W)\geq v;
     \label{eq:dge1}\\
@@ -792,7 +800,7 @@ place of the atom, and we have not done that.
 \begin{lemmaT}[Propagation of contradictory bound literals]
 \label{lem:contra-bounds}
 Suppose two bound variables $\atge{w}{v}$ and $\atge{w}{v'}$ are defined for
-some representation $W$ and values $v\geq v'$.  Then if $\atge{w}{v}$ and
+some view variable $W$ and values $v\geq v'$.  Then if $\atge{w}{v}$ and
 $\natge{w}{v'}$ propagate, further unit propagation will result in a
 conflict.
 \end{lemmaT}
@@ -803,14 +811,14 @@ two's-complement encoding, the definition constraints
 $\Def^{\Rightarrow}(\atge{w}{v})$ and $\Def^{\Leftarrow}(\atge{w}{v'})$ are in
 the required form after substituting $\atge{w}{v}\mapsto 1$,
 $\atge{w}{v'}\mapsto 0$.  Note that both constraints are over the \emph{same}
-bit vector $\BinEnc(W)$; this is why a representation is given its own bit
+bit vector $\BinEnc(W)$; this is why a view variable is given its own bit
 vector rather than being unfolded into its base's.
 \end{proof}
 
 \begin{corollaryT}[RUP properties of atomic literals]
 \label{cor:chainrup}
 For two bound variables $\atge{w}{v}$ and $\atge{w}{v'}$ defined on the same
-representation $W$ with $v\geq v'$, the constraint
+view variable $W$ with $v\geq v'$, the constraint
 \begin{equation}
   \atge{w}{v} \Rightarrow \atge{w}{v'} \geq 1
   \label{eq:chainlink}
@@ -832,7 +840,7 @@ $t$ in the proof.
 
 \item[\invChain{} (thesis Inv1): the order chain.]
   For any two bound variables $\atge{w}{v}$, $\atge{w}{v'}$ on the same
-  representation $W$ with $v<v'$, if $\Def(\atge{w}{v})$ and
+  view variable $W$ with $v<v'$, if $\Def(\atge{w}{v})$ and
   $\Def(\atge{w}{v'})$ appear in $F_t$, then either a bound variable is defined
   for some value strictly between $v$ and $v'$, or the constraint
   $\atge{w}{v'}\Rightarrow\atge{w}{v}\geq 1$ appears in $F_t$.
@@ -840,7 +848,7 @@ $t$ in the proof.
 \item[\inv{Bound}: boundary pins.]
   For every defined $\atge{w}{v}$ with $v\leq l_W$, the unit $\atge{w}{v}$
   appears in $F_t$; for every defined $\atge{w}{v}$ with $v>u_W$, the unit
-  $\natge{w}{v}$ appears in $F_t$.  A representation whose bounds are not a
+  $\natge{w}{v}$ appears in $F_t$.  A view variable whose bounds are not a
   consequence of the model --- a free bit-sum introduced inside the proof ---
   is exempt, and its owner derives the bounds explicitly instead; no interval
   literal is defined over such a variable today.
@@ -877,7 +885,7 @@ $t$ in the proof.
   \emph{(iii) The root covering.}  If $\Bdry(W)$ exists, $F_t$ contains a clause
   $\atset{w}{C_1}\vee\cdots\vee\atset{w}{C_m}\geq 1$ where every
   $\atset{w}{C_i}$ is defined, each $C_i$ is a union of adjacent cells, and
-  $\bigcup_i C_i = [l_W,u_W]$.  A representation
+  $\bigcup_i C_i = [l_W,u_W]$.  A view variable
   with no interval literal, or with only out-of-bounds ones, has no partition and
   no root covering, and this clause holds vacuously --- which is what lets
   \cref{lem:covering} and \cref{thm:complete} still say something about a plain
@@ -885,13 +893,13 @@ $t$ in the proof.
 
 \item[\invCont{}: containment.]
   For any two defined two-cut atoms $\atset{w}{E}$ and $\atset{w}{E'}$ of the
-  same representation $W$ with $E\subsetneq E'$, there is a chain
+  same view variable $W$ with $E\subsetneq E'$, there is a chain
   $E=E_0\subsetneq E_1\subsetneq\cdots\subsetneq E_m=E'$ with every
   $\atset{w}{E_j}$ defined, such that each clause
   $\natset{w}{E_j}\vee\atset{w}{E_{j+1}}$ appears in $F_t$.
 
-\item[\invRep{}: representation closure and linking.]
-  For every $W,W'\in\Rep(X)$: if an atomic variable of $W$ is defined, then so is
+\item[\invView{}: view closure and linking.]
+  For every $W,W'\in\ViewVars(X)$: if an atomic variable of $W$ is defined, then so is
   the corresponding atomic variable of $W'$ (\cref{def:image} below); and for
   every defined atomic variable of a proper $W$, the two constraints linking it to
   the corresponding atomic variable of the base $X$ appear in $F_t$.
@@ -902,18 +910,18 @@ $t$ in the proof.
 
   Deliberately about cells, not about every interval literal.  A literal whose
   in-bounds part is empty is defined with no partition, no covering and no
-  containment edge, and nothing names it; \invRep{} does not suffer, because such
+  containment edge, and nothing names it; \invView{} does not suffer, because such
   a literal can only arise from an explicit request, and the request path
-  establishes \invRep{} for itself.  \cref{rem:naming} says why the trigger is
+  establishes \invView{} for itself.  \cref{rem:naming} says why the trigger is
   naming rather than requesting, which is what this invariant is for.
 
 \end{description}
 
 \invChain{} and \inv{Bound} come from the thesis, generalised only by being
-stated per representation.  \invCut{} is implicit there; we make it explicit
+stated per view variable.  \invCut{} is implicit there; we make it explicit
 because both new literal kinds depend on it.  \invPart{}, \invCover{} and
-\invCont{} are the interval apparatus.  \invRep{} is the multi-representation
-apparatus.  \invName{} is a hygiene condition that \invRep{} needs for the
+\invCont{} are the interval apparatus.  \invView{} is the multi-view
+apparatus.  \invName{} is a hygiene condition that \invView{} needs for the
 interval literals created as cells, and only for those --- see
 \cref{rem:naming}.
 
@@ -928,11 +936,11 @@ encoding layer.  It was implemented, and rejected for complexity rather than for
 soundness.
 \end{remark}
 
-\paragraph{Correspondence between representations.}
+\paragraph{Correspondence between view variables.}
 
 \begin{definitionT}[Image of a literal]
 \label{def:image}
-Let $W,W'\in\Rep(X)$ and let $\theta = \varphi_{W'}\circ\psi_W$, an affine
+Let $W,W'\in\ViewVars(X)$ and let $\theta = \varphi_{W'}\circ\psi_W$, an affine
 bijection $\mathbb Z\to\mathbb Z$ with $\theta(v) = s v + d$ where
 $s = s_W s_{W'}$ and $d = c_{W'} - s\,c_W$.  The \emph{image} on $W'$ of a
 literal $\ell$ over an atomic variable of $W$, written $\ell^{W'}$, is the
@@ -971,7 +979,7 @@ literals alone --- an interval is order-agnostic, a half-line is not.
 
 The atom-level linking constraints are exactly the clausal form of the biconditional
 $\ell \Leftrightarrow \ell^{X}$, for each defined atom of each proper
-representation:
+view variable:
 \begin{align}
   \text{ge-link:}\quad
     &\natge{w}{v}\vee (\atge{w}{v})^{X}, \qquad
@@ -1030,7 +1038,7 @@ contrapositives,
 \]
 and neither is derivable without its clause.  A negated interval literal is a
 unit on \emph{neither} of its cuts, by the asymmetry noted after
-\cref{eq:din2}; all it can do is descend its own representation's containment
+\cref{eq:din2}; all it can do is descend its own view variable's containment
 edges, and it bottoms out at cells that are themselves unlinked interval
 literals unless they happen to have width one.  Descending to width one is
 precisely the per-value shattering that interval literals exist to avoid.  The
@@ -1044,11 +1052,11 @@ exactly the same way; the interval case is not special in needing two clauses,
 only in that the shortcut is tempting.
 \end{remarkN}
 
-\paragraph{Defined domains over a representation family.}
-Any set of atomic literals $L$ defined over representations of the same base
+\paragraph{Defined domains over a view family.}
+Any set of atomic literals $L$ defined over view variables of the same base
 $X$ represents a restriction of $X$ to some feasible set of values.  We call
 the values allowed the \emph{defined domain}, stated on the base's value scale,
-so that literals over different representations can be intersected directly:
+so that literals over different view variables can be intersected directly:
 \begin{multline}
   \dm_L(X) := \{k : \forall\,\atge{w}{v}\in L .\ \varphi_W(k)\geq v\}
       \cap \{k : \forall\,\natge{w}{v}\in L .\ \varphi_W(k)< v\} \\
@@ -1060,27 +1068,26 @@ so that literals over different representations can be intersected directly:
   \label{eq:domL}
 \end{multline}
 This set may be empty, or infinite, since $\dm_{\emptyset}(X)=\mathbb Z$.  When
-$\Rep(X)=\{X\}$ and no interval literal is defined, \cref{eq:domL} is exactly
+$\ViewVars(X)=\{X\}$ and no interval literal is defined, \cref{eq:domL} is exactly
 the thesis's definition.  We write $\dm_L(W) := \varphi_W(\dm_L(X))$ for the
 same set on $W$'s scale.
 
 Conversely, the complete (potentially infinite) set of atomic literals over
-\emph{every} representation of $X$ that should be true for a domain
+\emph{every} view variable of $X$ that should be true for a domain
 $\dm_t(X)$ is
 \begin{align}
-  \ImpLits(\dm_t(X)) := \bigcup_{W\in\Rep(X)}\Bigl(
-    &\{\ateq{w}{v} : \dm_t(W)=\{v\}\}
-    \cup \{\nateq{w}{v} : v\notin\dm_t(W)\} \notag\\
-    {}\cup{}&\{\atge{w}{v} : \forall\,v'<v .\ v'\notin\dm_t(W)\}
-    \cup \{\natge{w}{v} : \forall\,v'\geq v .\ v'\notin\dm_t(W)\}
-      \notag\\
-    {}\cup{}&\{\atin{w}{a}{b} : \dm_t(W)\subseteq[a,b]\}
-    \cup \{\natin{w}{a}{b} : \dm_t(W)\cap[a,b]=\emptyset\}\Bigr).
+  \ImpLits(\dm_t(X)) := \bigcup_{W\in\ViewVars(X)}\Bigl(
+    &\{\ateq{w}{v} : \dm_t(W)=\{v\}\} \notag\\
+    {}\cup{}&\{\nateq{w}{v} : v\notin\dm_t(W)\} \notag\\
+    {}\cup{}&\{\atge{w}{v} : \forall\,v'<v .\ v'\notin\dm_t(W)\} \notag\\
+    {}\cup{}&\{\natge{w}{v} : \forall\,v'\geq v .\ v'\notin\dm_t(W)\} \notag\\
+    {}\cup{}&\{\atin{w}{a}{b} : \dm_t(W)\subseteq[a,b]\} \notag\\
+    {}\cup{}&\{\natin{w}{a}{b} : \dm_t(W)\cap[a,b]=\emptyset\}\Bigr).
   \label{eq:implits}
 \end{align}
 
-\paragraph{Propagation results, one representation at a time.}
-We first establish everything for a single representation $W$, writing $L^W$ for
+\paragraph{Propagation results, one view variable at a time.}
+We first establish everything for a single view variable $W$, writing $L^W$ for
 the atomic literals over atomic variables of $W$ defined in $F_t$, and $[l,u]$
 for $[l_W,u_W]$.  \cref{lem:transport} then lifts the results to a family.
 
@@ -1269,7 +1276,7 @@ that happen to have been written: the induction descends through whatever
 coverings exist now, not through the order in which they were emitted.
 
 The distinction matters for one specific reason.  An equality atom created
-before its representation has any partition is not covered by any clause at
+before its view variable has any partition is not covered by any clause at
 that point; when the partition is later created it becomes a width-one cell,
 and a width-one cell can never be split, so it never needs a covering.  A
 formulation of \invCover{} in terms of ``was a cell when defined'' would have to
@@ -1280,7 +1287,7 @@ special-case it; the structural form does not.
 \label{thm:wipeout}
 Let $F_t$ be a set of PB constraints either in the encoding of a CP problem, as
 produced by \cref{proc:encoding}, or derived from it, and suppose \invChain{}
-and \invCut{} are respected.  Let $W$ be a representation, and let $U\subseteq
+and \invCut{} are respected.  Let $W$ be a view variable, and let $U\subseteq
 L^W$ be a set of literals each of which propagates under some $R$.  If
 $\dm_U(W)=\emptyset$ then $F_t\!\restriction_R$ propagates to conflict.
 \end{theoremT}
@@ -1340,7 +1347,7 @@ before in this design --- see \nsec{sec:loadbearing}.
 \label{thm:complete}
 Let $F_t$ be as in \cref{thm:wipeout}, and suppose \invChain{}, \inv{Bound},
 \invCut{}, \invPart{}, \invCover{} and \invCont{} are respected.  Let $W$ be a
-representation and $U\subseteq L^W$ a set of literals each of which propagates
+view variable and $U\subseteq L^W$ a set of literals each of which propagates
 under some $R$.  If $F_t\!\restriction_R$ does not propagate to contradiction,
 then every literal in $\ImpLits(\dm_U(X))\cap L^W$ propagates under $R$.
 \end{theoremT}
@@ -1420,11 +1427,11 @@ The reader should simply not read ``complete propagation'' as ``everything the
 solver's domain implies''.
 \end{remark}
 
-\paragraph{Lifting to a representation family.}
+\paragraph{Lifting to a view family.}
 
 \begin{lemmaN}[Unit transport]
 \label{lem:transport}
-Assume \invRep{}.  Let $W,W'\in\Rep(X)$ and let $\ell$ be a literal over an
+Assume \invView{}.  Let $W,W'\in\ViewVars(X)$ and let $\ell$ be a literal over an
 atomic variable of $W$ defined in $F_t$.  If $\ell$ propagates under $R$, then
 $\ell^{W'}$ propagates under $R$.
 \end{lemmaN}
@@ -1434,7 +1441,7 @@ It suffices to show that a literal crosses a single link pair, in either
 direction and either polarity; a general $W\to W'$ transport is then at most two
 such crossings, through the base, because images compose:
 $(\ell^{X})^{W'} = \ell^{W'}$.  So take $W$ proper and consider its link to the
-base.  By \invRep{} the atomic variable underlying $\ell^{X}$ is defined and the
+base.  By \invView{} the atomic variable underlying $\ell^{X}$ is defined and the
 two linking clauses
 \cref{eq:gelink}, \cref{eq:eqlink} or \cref{eq:inlink} appear in $F_t$.  Those
 two clauses are $\overline{p}\vee q$ and $\overline{q}\vee p$ for
@@ -1447,9 +1454,9 @@ combinations are therefore covered.
 
 \begin{remarkN}[Why naming, not requesting, is the trigger]
 \label{rem:naming}
-\cref{lem:transport} is only as good as \invRep{}, and \invRep{} is the
+\cref{lem:transport} is only as good as \invView{}, and \invView{} is the
 invariant that is easiest to break silently.  Inequality and equality atoms are
-mirrored eagerly at the moment they are defined, so for them \invRep{} is
+mirrored eagerly at the moment they are defined, so for them \invView{} is
 maintained by construction.  Interval literals are not, because they come into
 existence two ways: because some consumer asked for one --- a conclusion, a
 reason element, a branching decision --- or because the partition machinery
@@ -1475,16 +1482,16 @@ one unlinked, and nothing would notice.
 \begin{theoremP}[Empty defined domain, family version]
 \label{thm:wipeout-family}
 Let $F_t$ be as in \cref{thm:wipeout}, and suppose \invChain{}, \invCut{} and
-\invRep{} are respected.  Let $L$ be the atomic literals defined in $F_t$ for
-any representation of $X$, and let $U\subseteq L$ be a set of literals each of
+\invView{} are respected.  Let $L$ be the atomic literals defined in $F_t$ for
+any view variable of $X$, and let $U\subseteq L$ be a set of literals each of
 which propagates under $R$.  If $\dm_U(X)=\emptyset$ then
 $F_t\!\restriction_R$ propagates to conflict.
 \end{theoremP}
 
 \begin{proof}
-Fix any $W\in\Rep(X)$ and let $U^W = \{\ell^{W} : \ell\in U\}$.  By
+Fix any $W\in\ViewVars(X)$ and let $U^W = \{\ell^{W} : \ell\in U\}$.  By
 \cref{lem:transport} every literal of $U^{W}$ propagates under $R$, and
-$U^W\subseteq L^W$ by \invRep{}.  Images preserve satisfaction by base values,
+$U^W\subseteq L^W$ by \invView{}.  Images preserve satisfaction by base values,
 so $\dm_{U^W}(X)=\dm_U(X)=\emptyset$.  \cref{thm:wipeout} applied to $U^W$ gives
 the conflict.
 \end{proof}
@@ -1493,13 +1500,13 @@ the conflict.
 \label{thm:complete-family}
 Let $F_t$, $L$ and $U$ be as in \cref{thm:wipeout-family}, and suppose in
 addition that \inv{Bound}, \invPart{}, \invCover{} and \invCont{} are respected
-for every representation of $X$.  If $F_t\!\restriction_R$ does not propagate to
+for every view variable of $X$.  If $F_t\!\restriction_R$ does not propagate to
 contradiction, then every literal in $\ImpLits(\dm_U(X))\cap L$ propagates
 under $R$.
 \end{theoremP}
 
 \begin{proof}
-Let $\ell\in\ImpLits(\dm_U(X))\cap L$ be a literal over the representation $W$.
+Let $\ell\in\ImpLits(\dm_U(X))\cap L$ be a literal over the view variable $W$.
 Transport $U$ to $U^{W}$ as in the previous proof; every literal of $U^W$
 propagates and $\dm_{U^W}(X)=\dm_U(X)$.  Then \cref{thm:complete} applied on
 $W$ gives that $\ell$ propagates.
@@ -1507,13 +1514,13 @@ $W$ gives that $\ell$ propagates.
 
 The shape of this argument is worth stating explicitly, because it is what makes
 the design maintainable: \textbf{transport, then argue on one side}.  Two
-representations of one variable end up holding the same literals, by \invRep{},
+view variables of one variable end up holding the same literals, by \invView{},
 but there is no reason for them to hold those literals in the same \emph{roles},
 and in practice they do not always: we have observed proofs in which an interval
-is a partition cell on one representation and a request with its own covering on
+is a partition cell on one view variable and a request with its own covering on
 its image, and in which the two containment DAGs are not isomorphic.
 \cref{thm:complete-family} does not care, because \cref{thm:complete} is proved
-per representation from invariants that each side satisfies independently.  That
+per view variable from invariants that each side satisfies independently.  That
 is deliberate, and it is worth being explicit about why: an argument that
 appealed to the two sides having corresponding clause sets would be unsound
 reasoning \emph{even in the runs where the correspondence happens to hold},
@@ -1534,7 +1541,7 @@ deletion --- correctly or, as has happened three times, incorrectly.
 \toprule
 \textbf{Fact} & \textbf{Becomes} & \textbf{Carried by} \\
 \midrule
-\multicolumn{3}{@{}l}{\emph{Within one representation}}\\[2pt]
+\multicolumn{3}{@{}l}{\emph{Within one view variable}}\\[2pt]
 $\atge{w}{v}$ & $\atge{w}{v'}$, $v'<v$ & order chain, \invChain{}
   (\cref{lem:chain}) \\
 $\natge{w}{v}$ & $\natge{w}{v'}$, $v'>v$ & the same clauses,
@@ -1556,7 +1563,7 @@ $\atset{w}{E}$ and all but one piece excluded & the surviving piece & covering \
 every cell excluded & conflict & reverse reifications and the chain
   (\cref{thm:wipeout}); the root covering is redundant here, see
   \cref{rem:rootcovering} \\[4pt]
-\multicolumn{3}{@{}l}{\emph{Between two representations of the same variable}}\\[2pt]
+\multicolumn{3}{@{}l}{\emph{Between two view variables of the same variable}}\\[2pt]
 $\atge{w}{v}$, either polarity & its image on $X$ & ge-links,
   \cref{eq:gelink}; polarity flips when $s_W=-1$ \\
 $\ateq{w}{v}$, either polarity & its image on $X$ & eq-links, \cref{eq:eqlink} \\
@@ -1586,7 +1593,7 @@ Two limits are worth stating plainly, because misreading either of them has
 cost time.
 
 \paragraph{A lone bound does not cross a constraint.}
-The results above are entirely about one CP variable and its representations.
+The results above are entirely about one CP variable and its view variables.
 Nothing here lets unit propagation move a bound literal on $X$ to a bound
 literal on $Y$ across a constraint such as $\BinEnc(X)=\BinEnc(Y)$: doing so
 would require adding two constraints together, which unit propagation never
@@ -1666,7 +1673,7 @@ The extended vocabulary widens what may appear as a $d_i$ in two ways, and both
 are used.  A decision may be an interval literal, so that interval splitting
 (``$X\in[a,b]$'' versus ``$X\notin[a,b]$'') is a two-way branch over one atomic
 literal rather than a pair of bounds; and a decision may be stated over any
-representation, though in practice a solver branches on the variables it has
+view variable, though in practice a solver branches on the variables it has
 state for, which are the base variables.  Neither changes \cref{eq:bt}.
 
 When the solver backtracks from the root decision level, the sequence of
@@ -1688,16 +1695,16 @@ encoding or derived in the proof up to $t$.  We must have logged enough that:
   then $F_t\cup\{\neg B_t\}$ must unit propagate to contradiction.
 \item[\invDomain{} (thesis Inv3).]
   For every base variable $X$, if $L$ is the set of atomic literals defined for
-  \emph{any representation of} $X$ that would propagate during unit propagation
+  \emph{any view variable of} $X$ that would propagate during unit propagation
   of $F_t\cup\{\neg B_t\}$, then unless contradiction is reached beforehand, we
   must have $\dm_L(X)\subseteq\dm_t(X)$.
 \end{description}
 
-\invDomain{} is where the multi-representation setting shows up in the search
+\invDomain{} is where the multi-view setting shows up in the search
 invariants, and it shows up in exactly the way one would want.  The solver holds
 one domain per base variable; a view has no domain of its own, only an affine
 window onto its base's.  Correspondingly, $\dm_L(X)$ in \cref{eq:domL} is an
-intersection over the literals of \emph{all} representations, stated on the
+intersection over the literals of \emph{all} view variables, stated on the
 base's value scale.  A fact learned about a view therefore constrains the same
 object the solver's domain constrains, and the containment
 $\dm_L(X)\subseteq\dm_t(X)$ is between two subsets of the same set of integers.
@@ -1705,7 +1712,7 @@ $\dm_L(X)\subseteq\dm_t(X)$ is between two subsets of the same set of integers.
 \begin{theoremT}
 \label{thm:btrup}
 If \invConflict{} and \invDomain{} are respected, the literal-layer invariants
-\cref{thm:wipeout-family} needs hold --- \invChain{}, \invCut{} and \invRep{} ---
+\cref{thm:wipeout-family} needs hold --- \invChain{}, \invCut{} and \invView{} ---
 and a complete solver always logs backtracking justifications, then every
 backtracking justification $B_t$ follows by RUP.
 \end{theoremT}
@@ -1720,7 +1727,7 @@ implies $B_t$ is RUP.
 \emph{Case 2: a propagator has removed all remaining values from the domain of
 some base variable $X$.}  Then \invDomain{} implies that unit propagation on
 $F_t\cup\{\neg B_t\}$ either obtains a contradiction, or propagates a set of
-literals $L$ over representations of $X$ with $\dm_L(X)=\emptyset$.  In the
+literals $L$ over view variables of $X$ with $\dm_L(X)=\emptyset$.  In the
 latter case \cref{thm:wipeout-family} implies that further unit propagation must
 still result in contradiction.
 
@@ -1734,14 +1741,14 @@ level and $d_i$ is the $i$th branching decision on $X$; so each
 $\overline{d}_i$ propagates under $F_t\cup\{\neg B_t\}$.
 
 Now suppose $F_t\cup\{\neg B_t\}$ does not propagate to contradiction, and let
-$L$ be the set of atomic literals over representations of $X$ that propagate
+$L$ be the set of atomic literals over view variables of $X$ that propagate
 under unit propagation to fixpoint.  We must have $\dm_L(X)\neq\emptyset$, since
 otherwise \cref{thm:wipeout-family} gives a conflict; so pick $v\in\dm_L(X)$.
 By \invDomain{}, $v\in\dm_t(X)$, so some branch decision $d_i$ is satisfied by
 $v$, the branches being a partition of $\dm_t(X)$.  But $\overline{d}_i\in L$,
 and $v\in\dm_L(X)$ means $v$ satisfies every literal of $L$, so $v$ does not
 satisfy $d_i$ --- a contradiction.  Note that $d_i$ may be stated over any
-representation of $X$, and that $\dm_L$ is computed over all of them, so no
+view variable of $X$, and that $\dm_L$ is computed over all of them, so no
 transport step is needed here beyond the one inside
 \cref{thm:wipeout-family}.
 \end{proof}
@@ -1778,25 +1785,25 @@ Two things about \cref{eq:propjust} are new.  First, $\ell$ may be a negated
 interval literal: a propagator that removes a run of values from a domain states
 that as one conclusion $\natin{w}{a}{b}$, not as $b-a+1$ conclusions.
 Second, $\ell$ and the literals of $R$ need not be stated over the same
-representation, and routinely are not.  A propagator whose operand is a view
+view variable, and routinely are not.  A propagator whose operand is a view
 concludes over the view; a reason derived from the solver's domains is stated
-over whichever representation the propagator holds; and a branching decision was
+over whichever view variable the propagator holds; and a branching decision was
 taken on the base.  All three meet only through \cref{lem:transport}.
 
 \begin{lemmaT}
 \label{lem:reasons}
 If $R$ is a finite set of literals defined in $F_t$ with
 $R\subseteq\bigcup_i\ImpLits(\dm_t(X_i))$, and \invChain{}, \inv{Bound},
-\invCut{}, \invPart{}, \invCover{}, \invCont{}, \invRep{} and \invDomain{} are
+\invCut{}, \invPart{}, \invCover{}, \invCont{}, \invView{} and \invDomain{} are
 respected, then $F_t\cup\{\neg B_t\}$ either propagates to contradiction or
 propagates every literal in $R$.
 \end{lemmaT}
 
 \begin{proof}
-Let $\ell\in R$ be a literal over a representation $W$ of the base variable
+Let $\ell\in R$ be a literal over a view variable $W$ of the base variable
 $X_i$, so $\ell\in\ImpLits(\dm_t(X_i))$.  Suppose $F_t\cup\{\neg B_t\}$ does not
 propagate to contradiction, and let $L$ be the atomic literals over
-representations of $X_i$ that propagate, as guaranteed by \invDomain{}.  Since
+view variables of $X_i$ that propagate, as guaranteed by \invDomain{}.  Since
 we do not reach conflict, $\dm_L(X_i)\neq\emptyset$ by
 \cref{thm:wipeout-family}.  Then $\dm_L(X_i)\subseteq\dm_t(X_i)$, so
 $\ImpLits(\dm_L(X_i))\supseteq\ImpLits(\dm_t(X_i))$ by \cref{eq:implits}, and
@@ -1825,7 +1832,7 @@ $X$ with initial bounds $l$ and $u$, these are
   \label{eq:rootbounds}
 \end{equation}
 These follow by RUP by the same argument as \cref{cor:chainrup}, since the bound
-constraints $\Bnd(X)$ are present, and likewise for every representation, proper
+constraints $\Bnd(X)$ are present, and likewise for every view variable, proper
 ones included, because $\Bnd(W)$ is asserted for each.
 
 \begin{remark}[The eager introduction is load-bearing, and the solver is lazier]
@@ -1867,10 +1874,10 @@ Either way a contradiction is reached, so \invConflict{} is respected.
 Suppose instead a propagator has just made an inference that changed a domain,
 and logged $R\Rightarrow\ell\geq 1$.  The reason is valid at the point directly
 before the inference, so every literal of $R$, and hence $\ell$, propagates under
-$F_t\cup\{\neg B_t\}$.  If $\ell$ is stated over a proper representation $W$ of
+$F_t\cup\{\neg B_t\}$.  If $\ell$ is stated over a proper view variable $W$ of
 $X$, then by \cref{lem:transport} its image on $X$ propagates too; either way the
 domain restriction $\ell$ encodes is incorporated into $\dm_L(X)$ for the
-propagated set $L$, since $\dm_L$ is computed over all representations.  Hence
+propagated set $L$, since $\dm_L$ is computed over all view variables.  Hence
 \invDomain{} continues to be respected.
 
 It remains to argue that there is a starting point at which \invDomain{} holds.
@@ -1885,10 +1892,10 @@ by \cref{eq:rootbounds}.  Hence \invDomain{} is initially respected.
 \begin{enumerate}[itemsep=1pt]
   \item Encode the problem using \cref{proc:encoding}, giving every operand
     --- base variable or view --- its own bit vector, and every proper
-    representation its definitional link \cref{eq:link}.
+    view variable its definitional link \cref{eq:link}.
   \item At the start of the proof, derive by RUP $\atge{x}{l}\geq 1$ and
     $\natge{x}{u+1}\geq 1$ for the bounds $l..u$ on each variable, and
-    likewise for any out-of-range cut subsequently created on any representation.
+    likewise for any out-of-range cut subsequently created on any view variable.
   \item Any time the solver backtracks, derive by RUP a backtracking
     justification $G\Rightarrow 0\geq 1$, where $G$ is the sequence of decisions
     prior to backtracking.
@@ -1899,16 +1906,16 @@ by \cref{eq:rootbounds}.  Hence \invDomain{} is initially respected.
   \item Any atomic variables needed for the above must be defined in the proof,
     if not already in the input model, with the corresponding definition
     constraints \cref{eq:defge,eq:defeq,eq:defin}.
-  \item Every defined bound literal must be threaded into its representation's
+  \item Every defined bound literal must be threaded into its view variable's
     order chain (\invChain{}).
   \item Every defined interval literal must be maintained within its
-    representation's partition, with its covering and its containment edges
+    view variable's partition, with its covering and its containment edges
     (\invPart{}, \invCover{}, \invCont{}).
-  \item Every defined atomic literal on a proper representation, and every one
-    on a base that has proper representations, must be mirrored onto the others
+  \item Every defined atomic literal on a proper view variable, and every one
+    on a base that has proper view variables, must be mirrored onto the others
     and joined to them by the linking constraints of
     \cref{eq:gelink,eq:eqlink,eq:inlink} --- for interval literals, triggered at
-    the point the literal is \emph{named} (\invRep{}, \invName{}).
+    the point the literal is \emph{named} (\invView{}, \invName{}).
 \end{enumerate}
 
 Steps~1 to~6 are the thesis's framework; steps~7 to~9 are the literal-layer
@@ -1941,7 +1948,7 @@ constraint derived after a solution is found is simply a propagation
 justification with $R=\emptyset$, as if the objective-improving constraint had
 always been part of the model.  It has the effect of maintaining \invDomain{} by
 ensuring the bound restriction on the objective variable's domain propagates ---
-and, by \cref{lem:transport}, on every representation of it.
+and, by \cref{lem:transport}, on every view variable of it.
 
 \paragraph{A requirement for partial solution witnessing.}
 For solution witnessing to be compact and user-friendly, we would like to
@@ -1962,17 +1969,17 @@ variables already known to propagate.  Three additions have to be checked in the
 extended encoding, and each extends the same recursion by one step.
 
 \begin{enumerate}[itemsep=1pt]
-  \item \textbf{Proper representations.}  Fixing $\BinEnc(X)$ reduces
+  \item \textbf{Proper view variables.}  Fixing $\BinEnc(X)$ reduces
     $\ViewLink(W)$, that is $\BinEnc(W) - s_W\BinEnc(X) = c_W$, to a pair of
     constraints of the form $\BinEnc(W)\geq A$ and $\BinEnc(W)\leq A$ for a
     constant $A$.  By Theorem~2.8 of the thesis these unit propagate to a fixed
     consistent assignment of every bit of $\BinEnc(W)$.  So the bits of every
-    proper representation propagate as soon as the base's bits are set.
-  \item \textbf{Inequality and equality atoms} on any representation are fully
-    reified over that representation's bits, or over its inequality atoms, so
+    proper view variable propagate as soon as the base's bits are set.
+  \item \textbf{Inequality and equality atoms} on any view variable are fully
+    reified over that view variable's bits, or over its inequality atoms, so
     they propagate by the existing recursion once step~1 has fired.
   \item \textbf{Interval atoms} are fully reified, by \cref{eq:defin}, over two
-    inequality atoms of the same representation, so they propagate once those
+    inequality atoms of the same view variable, so they propagate once those
     do.
 \end{enumerate}
 
@@ -2007,8 +2014,8 @@ The required property of the encoding is then:
 
 The extended encoding makes the choice of preserved set more delicate than it
 looks, and we state it explicitly: \textbf{the preserved set is the bits of the
-base variables only}.  It does not include the bits of proper representations,
-nor any atomic variable of any representation.  This is the right choice, and
+base variables only}.  It does not include the bits of proper view variables,
+nor the atomic variables of any view variable, proper or not.  This is the right choice, and
 the only workable one, for three reasons.
 
 \begin{itemize}[itemsep=1pt]
@@ -2020,9 +2027,9 @@ the only workable one, for three reasons.
     solver happened to do.  A preserved set that grew as the proof ran would make
     the conclusion depend on the search, which is exactly what a preserved set
     exists to prevent.
-  \item It is stable under adding a representation.  Two runs of the same solver
+  \item It is stable under adding a view variable.  Two runs of the same solver
     that wrap the same variable in different views have different sets of
-    proper representations and therefore different encodings, but the same
+    proper view variables and therefore different encodings, but the same
     preserved set and the same enumeration conclusion.
 \end{itemize}
 
@@ -2030,9 +2037,9 @@ One consequence deserves care.  A solution witness \emph{is} written over atomic
 variables --- one base equality literal per variable --- even though atomic
 variables are not preserved.  That is sound only because unit propagation
 completes such a witness to the preserved bits, and onward --- through
-\cref{sec:optimality}'s step~1 --- to the bits of every proper representation.
+\cref{sec:optimality}'s step~1 --- to the bits of every proper view variable.
 The completion argument is therefore load-bearing for enumeration in a way it is
-not for optimality, and a representation whose bits did not propagate from the
+not for optimality, and a view variable whose bits did not propagate from the
 base's would break P3 rather than merely making a witness verbose.
 
 There is a second, quieter interaction.  Some of the units this framework pins
@@ -2066,7 +2073,7 @@ incorrectly three times on the strength of tests that stayed green.
 
 Everything in \cref{sec:atomprops} beyond the definitions themselves guards
 against P2.  \invChain{}, \invCut{}, \invPart{}, \invCover{}, \invCont{},
-\invRep{} and \invName{} contribute nothing to the validity of any individual
+\invView{} and \invName{} contribute nothing to the validity of any individual
 line; they exist so that \cref{thm:complete-family} holds, and
 \cref{thm:complete-family} exists so that \cref{lem:reasons} holds, and
 \cref{lem:reasons} exists so that a backtracking justification three thousand
@@ -2187,7 +2194,7 @@ generated instances that actually reach a conflict, ablating the link constraint
 makes only $37$ of them notice.  The sweep is about $96\%$ coincidence.
 
 A discriminating instance therefore needs \emph{all} of: an interval strictly
-inside both representations' definition ranges; at least one interior cell of
+inside both view variables' definition ranges; at least one interior cell of
 width at least two that no per-value machinery touches; and a replay that has to
 reach the far side's literal from the near side's negation rather than from a
 bound.  W6 to W9 are constructed against exactly this.
@@ -2201,7 +2208,7 @@ The following are not proofs, and are recorded only for calibration.
     no verifier failures, once the width-one gap of \cref{def:widthone} was
     closed.  Every failure class encountered before that was reproduced and then
     eliminated by exactly the clauses \cref{sec:atomprops} mandates.
-  \item $3{,}000$ randomly generated view proofs with zero \invRep{} violations,
+  \item $3{,}000$ randomly generated view proofs with zero \invView{} violations,
     over nine constraint families with holey domains, three-view bases, and
     intervals pushed outside the definition bounds.
   \item Over $8{,}000$ constraint tests under every view wrap and position,
@@ -2216,7 +2223,7 @@ which gates and which branching were active.
 \subsubsection*{Cost}
 \phantomsection\addcontentsline{toc}{subsubsection}{Cost}\label{sec:cost}
 
-Per distinct interval literal requested on a representation: at most two cell
+Per distinct interval literal requested on a view variable: at most two cell
 splits, hence at most four new literals of which any width-one piece is an
 equality atom, plus the requested literal; two redundance lines per literal;
 binary coverings for each split; one covering for the request, as wide as the
@@ -2226,7 +2233,7 @@ point.  The known growth mode is a wide request over a heavily fragmented
 region, whose covering is as wide as the number of prior boundaries inside it,
 bounded by the request count rather than by the domain size.
 
-Per interval literal per proper representation: the mirrored literal on the
+Per interval literal per proper view variable: the mirrored literal on the
 other side, with its own partition maintenance, plus two clauses.  This is the
 same constant factor that inequality and equality atoms already pay for a
 wrapped variable.  Measured on a constraint over a bare variable of width $w$
@@ -2431,7 +2438,7 @@ where 80\% of small random instances turn out to be one of them.
   witness suite.
 
 \item \textbf{Unregistered views.}  A view first encountered during proof
-  logging, after the model is closed, cannot be given a representation variable,
+  logging, after the model is closed, cannot be given a view variable,
   because \cref{eq:link} is a model constraint.  Such a view is instead rewritten
   onto its base: a bound becomes a bound (with the polarity flip of
   \cref{def:image}), an equality becomes an equality, and an interval becomes
@@ -2443,7 +2450,7 @@ where 80\% of small random instances turn out to be one of them.
   the Boolean constants and never reach the literal layer at all.
 
 \item \textbf{Re-entrancy.}  Mirroring an interval literal onto another
-  representation can, in the same call, cause that representation's partition to
+  view variable can, in the same call, cause that view variable's partition to
   split, which can mirror back and split this one.  The machinery is therefore
   re-entrant: a boundary is published before the two halves it creates are
   defined, so for that window the partition claims a cell that does not yet
@@ -2453,9 +2460,9 @@ where 80\% of small random instances turn out to be one of them.
   structural condition is checkable at any quiescent point.
 
 \item \textbf{Do the two sides really differ?}  We have observed proofs in which
-  an interval is a partition cell on one representation and a request with its
-  own covering on its image, and in which the containment DAGs of two
-  representations are not isomorphic.  We have not characterised when this
+  an interval is a partition cell on one view variable and a request with its
+  own covering on its image, and in which the containment DAGs of the two view
+  variables are not isomorphic.  We have not characterised when this
   happens.  It does not matter for any result here, and that is deliberate:
   \cref{thm:complete-family} is proved by transporting to one side and then
   arguing there, so it never appeals to a correspondence between the two sides'
@@ -2544,7 +2551,7 @@ becomes visible in \cref{sec:framework}: it makes the atoms appearing in the
 encoding of a constraint depend on \emph{which} wrapper the constraint happened
 to be handed, so a generic constraint-logging procedure can no longer treat every
 operand identically, and a cutting-planes step that resolves an operand against a
-constraint body has to know which representation that body is stated in.  Giving
+constraint body has to know which view variable that body is stated over.  Giving
 the view a variable of its own costs one linear equality and makes every operand
 look the same.  The narrower version of the same question --- keep the view's
 variable, but state its \emph{intervals} on the base --- is the ``deviewing''
@@ -2599,8 +2606,8 @@ than the design we have, rather than wrong, are under \cref{sec:rationale}.
 
 \item \textbf{Rewriting a view's interval conditions onto its base}
   (``deviewing''), instead of giving the view its own interval literals.  This
-  would leave intervals as the one atom kind not stated in the view's own
-  representation, so a cutting-planes step resolving an interval literal against
+  would leave intervals as the one atom kind not stated over the view's own
+  variable, so a cutting-planes step resolving an interval literal against
   a constraint body would find nothing to cancel against.  It is the right
   answer only for the unregistered-view path of \cref{sec:open}, which has no
   encoded variable to be consistent with.

--- a/dev_docs/literal-encodings.tex
+++ b/dev_docs/literal-encodings.tex
@@ -897,10 +897,11 @@ $t$ in the proof.
 
 \item[\invCont{}: containment.]
   For any two defined two-cut atoms $\atset{w}{E}$ and $\atset{w}{E'}$ of the
-  same view variable $W$ with $E\subsetneq E'$, there is a chain
-  $E=E_0\subsetneq E_1\subsetneq\cdots\subsetneq E_m=E'$ with every
-  $\atset{w}{E_j}$ defined, such that each clause
-  $\natset{w}{E_j}\vee\atset{w}{E_{j+1}}$ appears in $F_t$.
+  same view variable $W$ with $E\subsetneq E'$: if no defined two-cut atom
+  $\atset{w}{D}$ of $W$ has $E\subsetneq D\subsetneq E'$, then the clause
+  $\natset{w}{E}\vee\atset{w}{E'}$ appears in $F_t$.  The arguments below use
+  chains of these clauses rather than single edges; \cref{lem:contclosure}
+  supplies them.
 
 \item[\invView{}: view closure and linking.]
   For every $W,W'\in\ViewVars(X)$: if an atomic variable of $W$ is defined, then so is
@@ -1138,37 +1139,51 @@ present are negative.  This is where the asymmetry bites: normalisation cannot b
 a negative two-cut literal, and there is nothing else to do with one except
 propagate through the machinery of \invCover{} and \invCont{}.
 
-\begin{lemmaN}[Containment closure]
+\begin{lemmaN}[Containment chains]
 \label{lem:contclosure}
-Suppose that whenever a two-cut atom $\atset{w}{E}$ of $W$ is defined, the clause
-$\natset{w}{E}\vee\atset{w}{E'}$ is emitted for every \emph{minimal}
-$E'\supsetneq E$ whose atom is defined, and the clause
-$\natset{w}{E''}\vee\atset{w}{E}$ for every \emph{maximal} $E''\subsetneq E$
-whose atom is defined.  Then \invCont{} holds.
+Assume \invCont{}.  Then for any two defined two-cut atoms $\atset{w}{E}$ and
+$\atset{w}{E'}$ of $W$ with $E\subsetneq E'$, there is a chain
+$E=E_0\subsetneq E_1\subsetneq\cdots\subsetneq E_m=E'$ with every
+$\atset{w}{E_j}$ defined and every clause
+$\natset{w}{E_j}\vee\atset{w}{E_{j+1}}$ in $F_t$.
 \end{lemmaN}
 
 \begin{proof}
-By induction on the number of defined atoms.  Let $\atset{w}{E}$ and
-$\atset{w}{E'}$ both be defined with $E\subsetneq E'$, and consider the later of
-the two to be defined, say at step $n$; by the inductive hypothesis \invCont{}
-held over the atoms defined before step $n$.
+By induction on the number of defined two-cut atoms $\atset{w}{D}$ of $W$ with
+$E\subsetneq D\subsetneq E'$.  If there are none, \invCont{} puts
+$\natset{w}{E}\vee\atset{w}{E'}$ in $F_t$, and the chain is that single edge.
 
-If $\atset{w}{E'}$ is the later, then $\atset{w}{E}$ was already defined, so $E$
-is contained in some maximal $E''\subsetneq E'$ with $E\subseteq E''$ and
-$\atset{w}{E''}$ defined.  If $E=E''$ the edge
-$\natset{w}{E}\vee\atset{w}{E'}$ is emitted directly; otherwise $E\subsetneq
-E''$, so the inductive hypothesis gives a chain from $E$ to $E''$, which the
-emitted edge $\natset{w}{E''}\vee\atset{w}{E'}$ extends.  The case where
-$\atset{w}{E}$ is the later is symmetric, using a minimal container.  Emitting
-an edge never invalidates a chain, so \invCont{} continues to hold.
+Otherwise, choose $C$ minimal among the sets $D$ with $E\subsetneq D\subseteq
+E'$ whose atom is defined; this collection is non-empty, since $E'$ belongs to
+it.  Nothing defined lies strictly between $E$ and $C$: such a $D$ would satisfy
+$E\subsetneq D\subsetneq C\subseteq E'$ and contradict the minimality of $C$.
+So \invCont{} puts $\natset{w}{E}\vee\atset{w}{C}$ in $F_t$.  If $C=E'$ we are
+done.  Otherwise every defined atom strictly between $C$ and $E'$ is also
+strictly between $E$ and $E'$, and $C$ is strictly between $E$ and $E'$ but not
+strictly between $C$ and $E'$, so the induction applies to the pair $C,E'$ and
+the edge just obtained extends the chain it gives.
 \end{proof}
 
 \begin{remark}
+\invCont{} is maintained by emitting, whenever a two-cut atom $\atset{w}{E}$ is
+defined, the clause $\natset{w}{E}\vee\atset{w}{E'}$ for every \emph{minimal}
+$E'\supsetneq E$ whose atom is defined, and $\natset{w}{E''}\vee\atset{w}{E}$
+for every \emph{maximal} $E''\subsetneq E$ whose atom is defined --- which is
+exactly what \code{link\_immediate\_containment} does.  Nothing is re-emitted
+later, and nothing needs to be: defining a new atom never makes a pair of
+already-defined atoms newly required.  A pair $(E,E')$ stops being required as
+soon as something is defined between them, and since definitions are never
+withdrawn, requirements are only ever lost that way; the only newly required
+pairs are those involving the new atom, which are the edges just emitted.  As with
+\invCover{}, then, the invariant is stated over the current structure and the
+emission discipline keeps up with it, which is what lets both be state
+independent.
+
 Interval requests may overlap without nesting --- $[7,15]$ after $[5,10]$ ---
 so the containment relation is a DAG, not a tree, and a set may have several
-incomparable minimal containers.  \cref{lem:contclosure} does not care.  Note
-also that it needs \emph{minimal} and \emph{maximal} to be computed over all
-sets whose atoms are currently defined for $W$, not merely over the cells.
+incomparable minimal containers.  Neither \invCont{} nor \cref{lem:contclosure}
+cares.  Note that \emph{minimal} and \emph{maximal} are computed over all sets
+whose atoms are currently defined for $W$, not merely over the cells.
 \end{remark}
 
 \begin{lemmaN}[Cell exclusion]
@@ -1191,8 +1206,8 @@ the direction used below.
 
 \emph{Case 1: some negative two-cut literal of $U$ names a set containing $C$.}
 That is, $\natset{w}{E}\in U$ for a defined $\atset{w}{E}$ with $C\subseteq E$.
-If $E=C$ we are done.  Otherwise $C\subsetneq E$, and \invCont{} gives a chain of
-binary clauses $\natset{w}{C}\vee\atset{w}{E_1}$,
+If $E=C$ we are done.  Otherwise $C\subsetneq E$, and \cref{lem:contclosure}
+gives a chain of binary clauses $\natset{w}{C}\vee\atset{w}{E_1}$,
 $\natset{w}{E_1}\vee\atset{w}{E_2}$, \dots,
 $\natset{w}{E_{m-1}}\vee\atset{w}{E}$; reading each contrapositive in turn from
 $\natset{w}{E}$ propagates $\natset{w}{C}$.
@@ -1393,8 +1408,8 @@ two-cut literal.  If a bound literal does, then either $\atge{w}{v+1}$ or
 $\natge{w}{v}$ propagates by \cref{lem:chain}, and \cref{eq:deq1} then
 propagates $\ell$ from whichever it is.  If instead a negative two-cut
 literal $\natset{w}{E}\in U$ with $v\in E$ does, then $\{v\}\subseteq E$; if
-$E=\{v\}$ then $\ell\in U$, and otherwise \invCont{} gives a chain of binary
-clauses whose contrapositives propagate $\ell$ from $\natset{w}{E}$.  If a
+$E=\{v\}$ then $\ell\in U$, and otherwise \cref{lem:contclosure} gives a chain of
+binary clauses whose contrapositives propagate $\ell$ from $\natset{w}{E}$.  If a
 positive two-cut literal excludes $v$, cut normalisation has already replaced it
 by bound literals, so this is the first case.
 

--- a/dev_docs/literal-encodings.tex
+++ b/dev_docs/literal-encodings.tex
@@ -846,9 +846,13 @@ $t$ in the proof.
   $\atge{w}{v'}\Rightarrow\atge{w}{v}\geq 1$ appears in $F_t$.
 
 \item[\inv{Bound}: boundary pins.]
-  For every defined $\atge{w}{v}$ with $v\leq l_W$, the unit $\atge{w}{v}$
-  appears in $F_t$; for every defined $\atge{w}{v}$ with $v>u_W$, the unit
-  $\natge{w}{v}$ appears in $F_t$.  A view variable whose bounds are not a
+  If any $\atge{w}{v}$ with $v\leq l_W$ is defined, then for the largest such
+  $v$ the unit $\atge{w}{v}$ appears in $F_t$; if any $\atge{w}{v}$ with
+  $v>u_W$ is defined, then for the smallest such $v$ the unit $\natge{w}{v}$
+  appears in $F_t$.  One pin a side is enough: every other out-of-range cut
+  follows from it by \invChain{}, through \cref{lem:chain}, which is why the
+  arguments that use \inv{Bound} assume \invChain{} as well.  A view variable
+  whose bounds are not a
   consequence of the model --- a free bit-sum introduced inside the proof ---
   is exempt, and its owner derives the bounds explicitly instead; no interval
   literal is defined over such a variable today.
@@ -1222,8 +1226,8 @@ disjoint from the interval $C$, and $C$ lies wholly on one side of it.
 
 \begin{lemmaN}[Covering completeness]
 \label{lem:covering}
-Assume \inv{Bound}, \invCut{}, \invPart{} and \invCover{}.  Let $\atset{w}{E}$ be
-a defined two-cut atom of $W$ and let $S=E\cap[l,u]$.
+Assume \invChain{}, \inv{Bound}, \invCut{}, \invPart{} and \invCover{}.  Let
+$\atset{w}{E}$ be a defined two-cut atom of $W$ and let $S=E\cap[l,u]$.
 \begin{enumerate}[label=(\alph*),itemsep=1pt]
   \item If $S=\emptyset$ then $\natset{w}{E}$ propagates under any $R$.
   \item If $S\neq\emptyset$, $E$ is not currently a cell, and $\natset{w}{C}$
@@ -1233,9 +1237,11 @@ a defined two-cut atom of $W$ and let $S=E\cap[l,u]$.
 
 \begin{proof}
 \emph{(a)}  Write $E=[a,b]$.  If $b<l$ then $\atge{w}{b+1}$ is defined by
-\invCut{} with $b+1\leq l$, so it is a unit by \inv{Bound}, and
+\invCut{} with $b+1\leq l$, so \inv{Bound} makes $\atge{w}{v}$ a unit for some
+$b+1\leq v\leq l$, \cref{lem:chain} propagates $\atge{w}{b+1}$ from it, and
 \cref{eq:deq1,eq:din1} propagate $\natset{w}{E}$.  If $a>u$ then $\atge{w}{a}$
-is defined with $a>u$, so $\natge{w}{a}$ is a unit by \inv{Bound}, and
+is defined with $a>u$, so \inv{Bound} makes $\natge{w}{v}$ a unit for some
+$u<v\leq a$, \cref{lem:chain} propagates $\natge{w}{a}$ from it, and
 \cref{eq:deq1,eq:din1} propagate $\natset{w}{E}$ through the other cut.
 
 \emph{(b)}  For a set that is a union of adjacent cells, define its \emph{rank}
@@ -1841,15 +1847,28 @@ ones included, because $\Bnd(W)$ is asserted for each.
 $L=\emptyset$, \cref{eq:domL} gives $\dm_L(X)=\mathbb Z$, which is not contained
 in $\dm_t(X)$, so the base case of \cref{thm:maintain} fails without it.
 
-The implementation does not introduce these eagerly.  \inv{Bound} as stated ---
-a unit for each defined out-of-range cut --- is what it maintains, and atoms are
-created only when a proof line needs them, so a variable no proof line has
-mentioned has no atoms at all.  This is not known to cause trouble: a variable
-with no defined literal appears in no reason and no conclusion, so \invDomain{}
-is never appealed to for it.  But it is a real difference between the framework
-as stated here and the framework as implemented, we have not worked the lazy
+The implementation does not introduce these eagerly.  Atoms are created only
+when a proof line needs them, so a variable no proof line has mentioned has no
+atoms at all.  This is not known to cause trouble: a variable with no defined
+literal appears in no reason and no conclusion, so \invDomain{} is never
+appealed to for it.  But it is a real difference between the framework as
+stated here and the framework as implemented, we have not worked the lazy
 variant through, and the honest position is that the results below are proved
 for \cref{eq:rootbounds} as written.
+
+In the other direction the implementation is \emph{stronger} than \inv{Bound}
+asks, and this one costs measurable proof.  \code{fix\_bound} emits a pin for
+every out-of-range cut it creates, not one a side, so a variable can accumulate
+hundreds of top-of-proof units that \cref{lem:chain} would supply from one.  On
+the TSP example this is $2{,}258$ pins over $68$ distinct variable-and-side
+pairs, the worst single variable carrying $255$ --- a cost variable with lower
+bound $0$ whose cuts run from $\atge{w}{-482}$ up to $\atge{w}{0}$, each pinned
+separately.  Weakening the emission to match the invariant is not quite as
+simple as pinning the extreme cut, because the cuts are created one at a time
+and in no particular order, and the pin has to be a persistent top-of-proof line
+rather than one re-derived per use; the workable version pins the cut at the
+definition bound once, on the first out-of-range request for the variable, and
+nothing after that.
 \end{remark}
 
 \begin{theoremT}
@@ -2177,8 +2196,9 @@ at all} whenever any of four things happens:
   \item the interval is the whole definition range, so asserting its negation is
     already inconsistent under unit propagation and the check passes vacuously;
   \item the interval abuts or extends below the lower bound, so that the
-    boundary pin of \inv{Bound} makes \cref{eq:din2} a unit, the ge-link carries
-    it, and the far side's \emph{forward} reification finishes the job;
+    boundary pin of \inv{Bound} --- through the order chain, if the pin is not
+    at the cut itself --- makes \cref{eq:din2} a unit, the ge-link carries it,
+    and the far side's \emph{forward} reification finishes the job;
   \item the interval abuts or extends above the upper bound, the mirror image;
   \item every cell inside the interval is a singleton --- and one well-placed
     equality atom shatters a width-two cell on \emph{both} sides, so any

--- a/dev_docs/literal-encodings.tex
+++ b/dev_docs/literal-encodings.tex
@@ -82,6 +82,11 @@
 \newcommand{\atge}[2]{#1_{\geq #2}}
 \newcommand{\ateq}[2]{#1_{= #2}}
 \newcommand{\atin}[3]{#1_{\in[#2,#3]}}
+% Negated forms: the bar sits over the variable name only, never over the
+% subscript, which otherwise stretches it unpleasantly.
+\newcommand{\natge}[2]{\overline{#1}_{\geq #2}}
+\newcommand{\nateq}[2]{\overline{#1}_{= #2}}
+\newcommand{\natin}[3]{\overline{#1}_{\in[#2,#3]}}
 \newcommand{\inv}[1]{\textnormal{\textsc{Inv-#1}}}
 \newcommand{\code}[1]{\texttt{#1}}
 % Unnumbered sections are referred to by title, so that the numbered ones
@@ -392,14 +397,14 @@ definition, writing $w$ for the PB name of the representation $W$.
     equal $v$:
     \begin{equation}
       \Def(\ateq{w}{v}) := \ateq{w}{v} \Leftrightarrow
-        \atge{w}{v} + \overline{\atge{w}{v+1}} \geq 2 .
+        \atge{w}{v} + \natge{w}{v+1} \geq 2 .
       \label{eq:defeq}
     \end{equation}
   \item An \textbf{interval variable} $\atin{w}{a}{b}$, for $a<b$, represents
     whether $W$ must take a value in the closed interval $[a,b]$:
     \begin{equation}
       \Def(\atin{w}{a}{b}) := \atin{w}{a}{b} \Leftrightarrow
-        \atge{w}{a} + \overline{\atge{w}{b+1}} \geq 2 .
+        \atge{w}{a} + \natge{w}{b+1} \geq 2 .
       \label{eq:defin}
     \end{equation}
 \end{enumerate}
@@ -435,8 +440,8 @@ representation variables, by \cref{eq:link}.
 Recalling $0$--$1$ literals, we can represent $W$ being at most $v$, not equal
 to $v$, or outside $[a,b]$ by negating the corresponding variables.
 Collectively we refer to literals of the form $\atge{w}{v}$,
-$\overline{\atge{w}{v}}$, $\ateq{w}{v}$, $\overline{\ateq{w}{v}}$,
-$\atin{w}{a}{b}$ and $\overline{\atin{w}{a}{b}}$ as \emph{atomic (constraint)
+$\natge{w}{v}$, $\ateq{w}{v}$, $\nateq{w}{v}$,
+$\atin{w}{a}{b}$ and $\natin{w}{a}{b}$ as \emph{atomic (constraint)
 literals}.
 
 \paragraph{Step 6: linearise constraints.}
@@ -669,7 +674,7 @@ Second, no linearisation mentions interval variables.  Interval literals do not
 appear in the model at all: they are introduced inside the proof, by redundance,
 as the proof needs them.  The one place where the question arises --- whether
 holes in an initial domain should be stated in the model as
-$\overline{\atin{x}{a}{b}}$ rather than derived at the root of the proof --- is
+$\natin{x}{a}{b}$ rather than derived at the root of the proof --- is
 an open decision recorded in \cref{sec:open}.
 
 \subsection{A Proof Logging Framework}
@@ -704,16 +709,16 @@ these amount, for a representation $W$ of $X$, to the PB constraints
 \begin{align}
   \Def^{\Rightarrow}(\atge{w}{v}) &:= \atge{w}{v} \Rightarrow \BinEnc(W)\geq v;
     \label{eq:dge1}\\
-  \Def^{\Leftarrow}(\atge{w}{v}) &:= \overline{\atge{w}{v}} \Rightarrow
+  \Def^{\Leftarrow}(\atge{w}{v}) &:= \natge{w}{v} \Rightarrow
     -\BinEnc(W)\geq -v+1; \label{eq:dge2}\\
   \Def^{\Rightarrow}(\ateq{w}{v}) &:= \ateq{w}{v} \Rightarrow
-    \atge{w}{v} + \overline{\atge{w}{v+1}} \geq 2; \label{eq:deq1}\\
-  \Def^{\Leftarrow}(\ateq{w}{v}) &:= \overline{\ateq{w}{v}} \Rightarrow
-    \overline{\atge{w}{v}} + \atge{w}{v+1} \geq 1; \label{eq:deq2}\\
+    \atge{w}{v} + \natge{w}{v+1} \geq 2; \label{eq:deq1}\\
+  \Def^{\Leftarrow}(\ateq{w}{v}) &:= \nateq{w}{v} \Rightarrow
+    \natge{w}{v} + \atge{w}{v+1} \geq 1; \label{eq:deq2}\\
   \Def^{\Rightarrow}(\atin{w}{a}{b}) &:= \atin{w}{a}{b} \Rightarrow
-    \atge{w}{a} + \overline{\atge{w}{b+1}} \geq 2; \label{eq:din1}\\
-  \Def^{\Leftarrow}(\atin{w}{a}{b}) &:= \overline{\atin{w}{a}{b}} \Rightarrow
-    \overline{\atge{w}{a}} + \atge{w}{b+1} \geq 1. \label{eq:din2}
+    \atge{w}{a} + \natge{w}{b+1} \geq 2; \label{eq:din1}\\
+  \Def^{\Leftarrow}(\atin{w}{a}{b}) &:= \natin{w}{a}{b} \Rightarrow
+    \natge{w}{a} + \atge{w}{b+1} \geq 1. \label{eq:din2}
 \end{align}
 
 We assume in what follows that any PB literal appearing in a derivation with
@@ -728,7 +733,7 @@ Note the asymmetry between $\Def^{\Rightarrow}$ and $\Def^{\Leftarrow}$ for the
 two-cut atoms, \cref{eq:deq1,eq:deq2,eq:din1,eq:din2}.  The forward direction is
 a \emph{conjunction}: asserting $\ateq{w}{v}$ or $\atin{w}{a}{b}$ makes both
 cuts units.  The reverse direction is a \emph{disjunction}: asserting
-$\overline{\ateq{w}{v}}$ or $\overline{\atin{w}{a}{b}}$ makes neither cut a
+$\nateq{w}{v}$ or $\natin{w}{a}{b}$ makes neither cut a
 unit; \cref{eq:deq2,eq:din2} become binary clauses that fire only when one of
 the two cuts is already known.  Almost everything in this section that is not
 already in the thesis exists because of that asymmetry.
@@ -736,7 +741,7 @@ already in the thesis exists because of that asymmetry.
 \begin{remark}
 The solver optionally uses a compact encoding in which an equality atom at a
 definition bound is defined by its one non-trivial cut only
-($\ateq{w}{l_W}\Leftrightarrow\overline{\atge{w}{l_W+1}}$, and dually at
+($\ateq{w}{l_W}\Leftrightarrow\natge{w}{l_W+1}$, and dually at
 $u_W$).  This is off by default, because the eager form matches
 \code{cake\_pb\_cp}'s.  Every argument below survives it, because the dropped
 cut is a pinned unit by \invCut{} and \inv{Bound}, but the reader checking the
@@ -747,7 +752,7 @@ proofs against an implementation should be aware of the variation.
 \label{lem:contra-bounds}
 Suppose two bound variables $\atge{w}{v}$ and $\atge{w}{v'}$ are defined for
 some representation $W$ and values $v\geq v'$.  Then if $\atge{w}{v}$ and
-$\overline{\atge{w}{v'}}$ propagate, further unit propagation will result in a
+$\natge{w}{v'}$ propagate, further unit propagation will result in a
 conflict.
 \end{lemmaT}
 
@@ -794,7 +799,7 @@ $t$ in the proof.
 \item[\inv{Bound}: boundary pins.]
   For every defined $\atge{w}{v}$ with $v\leq l_W$, the unit $\atge{w}{v}$
   appears in $F_t$; for every defined $\atge{w}{v}$ with $v>u_W$, the unit
-  $\overline{\atge{w}{v}}$ appears in $F_t$.
+  $\natge{w}{v}$ appears in $F_t$.
 
 \item[\invCut{}: cuts exist.]
   Whenever $\ateq{w}{v}$ is defined, so are $\atge{w}{v}$ and $\atge{w}{v+1}$;
@@ -831,7 +836,7 @@ $t$ in the proof.
   For any two defined equality or interval literals $E\subsetneq E'$ of the same
   representation $W$, there is a chain
   $E=E_0\subsetneq E_1\subsetneq\cdots\subsetneq E_m=E'$ of defined literals
-  such that each clause $\overline{E_j}\vee E_{j+1}$ appears in $F_t$.
+  such that each clause $\overline{E}_j\vee E_{j+1}$ appears in $F_t$.
 
 \item[\invRep{}: representation closure and linking.]
   For every $W,W'\in\Rep(X)$: if an atomic variable of $W$ is defined, then so is
@@ -875,22 +880,24 @@ literal satisfied by exactly the same values of $X$:
   \begin{array}{llll}
     (\atge{w}{v})^{W'} &=
       \begin{cases}
-        \atge{w'}{\theta(v)} & s=+1\\
-        \overline{\atge{w'}{\theta(v)+1}} & s=-1
+        \atge{w'}{\theta(v)} & s=+1\\[7pt]
+        \natge{w'}{\theta(v)+1} & s=-1
       \end{cases}
     &\qquad
-    (\ateq{w}{v})^{W'} &= \ateq{w'}{\theta(v)}\\[2.2ex]
+    (\ateq{w}{v})^{W'} &= \ateq{w'}{\theta(v)}\\[2.6ex]
     (\atin{w}{a}{b})^{W'} &=
       \begin{cases}
-        \atin{w'}{\theta(a)}{\theta(b)} & s=+1\\
+        \atin{w'}{\theta(a)}{\theta(b)} & s=+1\\[2pt]
         \atin{w'}{\theta(b)}{\theta(a)} & s=-1
       \end{cases}
     &\qquad
-    (\overline{\ell})^{W'} &= \overline{\ell^{W'}}
+    (\natin{w}{a}{b})^{W'} &= \overline{(\atin{w}{a}{b})^{W'}}
   \end{array}
 \]
-Taking images is functorial: $(\ell^{W'})^{W''} = \ell^{W''}$, and
-$\ell^{W}=\ell$.
+Negation commutes with taking images --- the last entry above, and likewise for
+the other two kinds --- so the negated image of an atom may be written by barring
+the atom inside, which is what \cref{eq:gelink,eq:eqlink,eq:inlink} do.  Taking
+images is functorial: $(\ell^{W'})^{W''} = \ell^{W''}$, and $\ell^{W}=\ell$.
 \end{definitionT}
 
 Two facts about \cref{def:image} are worth stating because they are what make
@@ -906,16 +913,16 @@ $\ell \Leftrightarrow \ell^{X}$, for each defined atom of each derived
 representation:
 \begin{align}
   \text{ge-link:}\quad
-    &\overline{\atge{w}{v}}\vee (\atge{w}{v})^{X}, \qquad
-     \overline{(\atge{w}{v})^{X}}\vee \atge{w}{v};
+    &\natge{w}{v}\vee (\atge{w}{v})^{X}, \qquad
+     (\natge{w}{v})^{X}\vee \atge{w}{v};
      \label{eq:gelink}\\
   \text{eq-link:}\quad
-    &\overline{\ateq{w}{v}}\vee \ateq{x}{\psi_W(v)}, \qquad
-     \overline{\ateq{x}{\psi_W(v)}}\vee \ateq{w}{v};
+    &\nateq{w}{v}\vee \ateq{x}{\psi_W(v)}, \qquad
+     \nateq{x}{\psi_W(v)}\vee \ateq{w}{v};
      \label{eq:eqlink}\\
   \text{in-link:}\quad
-    &\overline{\atin{w}{a}{b}}\vee (\atin{w}{a}{b})^{X}, \qquad
-     \overline{(\atin{w}{a}{b})^{X}}\vee \atin{w}{a}{b}.
+    &\natin{w}{a}{b}\vee (\atin{w}{a}{b})^{X}, \qquad
+     (\natin{w}{a}{b})^{X}\vee \atin{w}{a}{b}.
      \label{eq:inlink}
 \end{align}
 
@@ -941,9 +948,9 @@ correct and it is beside the point.  Unit propagation uses a clause in whichever
 direction has a unit, and the directions that matter here are the
 contrapositives,
 \[
-  \overline{(\atin{w}{a}{b})^X} \implies \overline{\atin{w}{a}{b}}
+  (\natin{w}{a}{b})^{X} \implies \natin{w}{a}{b}
   \qquad\text{and}\qquad
-  \overline{\atin{w}{a}{b}} \implies \overline{(\atin{w}{a}{b})^X},
+  \natin{w}{a}{b} \implies (\natin{w}{a}{b})^{X},
 \]
 and neither is derivable without its clause.  A negated interval literal is a
 unit on \emph{neither} of its cuts, by the asymmetry noted after
@@ -968,11 +975,11 @@ the values allowed the \emph{defined domain}, stated on the base's value scale,
 so that literals over different representations can be intersected directly:
 \begin{multline}
   \dm_L(X) := \{k : \forall\,\atge{w}{v}\in L .\ \varphi_W(k)\geq v\}
-      \cap \{k : \forall\,\overline{\atge{w}{v}}\in L .\ \varphi_W(k)< v\} \\
+      \cap \{k : \forall\,\natge{w}{v}\in L .\ \varphi_W(k)< v\} \\
     {}\cap \{k : \forall\,\ateq{w}{v}\in L .\ \varphi_W(k) = v\}
-      \cap \{k : \forall\,\overline{\ateq{w}{v}}\in L .\ \varphi_W(k)\neq v\} \\
+      \cap \{k : \forall\,\nateq{w}{v}\in L .\ \varphi_W(k)\neq v\} \\
     {}\cap \{k : \forall\,\atin{w}{a}{b}\in L .\ a\leq\varphi_W(k)\leq b\}
-      \cap \{k : \forall\,\overline{\atin{w}{a}{b}}\in L .\
+      \cap \{k : \forall\,\natin{w}{a}{b}\in L .\
         \varphi_W(k)<a \text{ or } \varphi_W(k)>b\}.
   \label{eq:domL}
 \end{multline}
@@ -987,12 +994,12 @@ $\dm_t(X)$ is
 \begin{align}
   \ImpLits(\dm_t(X)) := \bigcup_{W\in\Rep(X)}\Bigl(
     &\{\ateq{w}{v} : \dm_t(W)=\{v\}\}
-    \cup \{\overline{\ateq{w}{v}} : v\notin\dm_t(W)\} \notag\\
+    \cup \{\nateq{w}{v} : v\notin\dm_t(W)\} \notag\\
     {}\cup{}&\{\atge{w}{v} : \forall\,v'<v .\ v'\notin\dm_t(W)\}
-    \cup \{\overline{\atge{w}{v}} : \forall\,v'\geq v .\ v'\notin\dm_t(W)\}
+    \cup \{\natge{w}{v} : \forall\,v'\geq v .\ v'\notin\dm_t(W)\}
       \notag\\
     {}\cup{}&\{\atin{w}{a}{b} : \dm_t(W)\subseteq[a,b]\}
-    \cup \{\overline{\atin{w}{a}{b}} : \dm_t(W)\cap[a,b]=\emptyset\}\Bigr).
+    \cup \{\natin{w}{a}{b} : \dm_t(W)\cap[a,b]=\emptyset\}\Bigr).
   \label{eq:implits}
 \end{align}
 
@@ -1007,8 +1014,8 @@ It is convenient to normalise away positive two-cut literals once and for all.
 \label{lem:chain}
 If \invChain{} is respected, then for any $W$, if $\atge{w}{v}$ and
 $\atge{w}{v'}$ are both defined in $F_t$ for $v>v'$, then if $\atge{w}{v}$
-propagates so does $\atge{w}{v'}$, and if $\overline{\atge{w}{v'}}$ propagates
-so does $\overline{\atge{w}{v}}$.
+propagates so does $\atge{w}{v'}$, and if $\natge{w}{v'}$ propagates
+so does $\natge{w}{v}$.
 \end{lemmaT}
 
 \begin{proof}
@@ -1018,15 +1025,15 @@ consecutive terms.  Since only finitely many bound literals are defined in a
 finite formula, this sequence exists.  \invChain{} puts
 $\atge{w}{v_j}\Rightarrow\atge{w}{v_{j+1}}\geq 1$ in $F_t$ for each $j$, and each
 is a binary clause, so it propagates in one direction from $\atge{w}{v_j}$ and
-in the other from $\overline{\atge{w}{v_{j+1}}}$.  Chaining gives both claims.
+in the other from $\natge{w}{v_{j+1}}$.  Chaining gives both claims.
 \end{proof}
 
 \begin{lemmaN}[Cut normalisation]
 \label{lem:normalise}
 Let $R\subseteq L^W$ and let $R'$ be obtained from $R$ by replacing each
-positive literal $\ateq{w}{v}$ by $\{\atge{w}{v},\overline{\atge{w}{v+1}}\}$ and
+positive literal $\ateq{w}{v}$ by $\{\atge{w}{v},\natge{w}{v+1}\}$ and
 each positive literal $\atin{w}{a}{b}$ by
-$\{\atge{w}{a},\overline{\atge{w}{b+1}}\}$.  Then every literal of $R'$
+$\{\atge{w}{a},\natge{w}{b+1}\}$.  Then every literal of $R'$
 propagates under $R$, and $\dm_{R'}(W)=\dm_R(W)$.
 \end{lemmaN}
 
@@ -1087,13 +1094,13 @@ Then $\overline{C}$ propagates under $R$.
 Write $C=[p,q]$, so that $C$ is the literal $\atin{w}{p}{q}$ if $p<q$ and
 $\ateq{w}{p}$ if $p=q$; in either case \cref{eq:din1,eq:deq1} give the two
 clauses $\overline{C}\vee\atge{w}{p}$ and
-$\overline{C}\vee\overline{\atge{w}{q+1}}$, and both cuts are defined by
+$\overline{C}\vee\natge{w}{q+1}$, and both cuts are defined by
 \invCut{}.
 
 \emph{Case 1: some negative two-cut literal of $U$ contains $C$.}  That is,
 $\overline{E}\in U$ for a defined $E$ with $C\subseteq E$.  If $E=C$ we are
 done.  Otherwise $C\subsetneq E$, and \invCont{} gives a chain of binary clauses
-$\overline{C}\vee E_1$, $\overline{E_1}\vee E_2$, \dots, $\overline{E_{m-1}}\vee
+$\overline{C}\vee E_1$, $\overline{E}_1\vee E_2$, \dots, $\overline{E}_{m-1}\vee
 E$; reading each contrapositive in turn from $\overline{E}$ propagates
 $\overline{C}$.
 
@@ -1106,18 +1113,18 @@ $C\cap E=\emptyset$.
 
 So every value of $C$ is excluded by a bound literal of $U$.  Put
 $v^{+}=\max\{v : \atge{w}{v}\in U\}$ (with $v^{+}=-\infty$ if there is none)
-and $v^{-}=\min\{v : \overline{\atge{w}{v}}\in U\}$ (with $v^{-}=+\infty$ if
+and $v^{-}=\min\{v : \natge{w}{v}\in U\}$ (with $v^{-}=+\infty$ if
 there is none).  The values \emph{not} excluded by bounds of $U$ are exactly
 $[v^{+},v^{-}-1]$.  If $v^{-}\leq v^{+}$ then $\atge{w}{v^{+}}$ and
-$\overline{\atge{w}{v^{-}}}$ propagate and \cref{lem:contra-bounds} gives a
+$\natge{w}{v^{-}}$ propagate and \cref{lem:contra-bounds} gives a
 conflict, contrary to assumption.  So $[v^{+},v^{-}-1]$ is a non-empty interval
 disjoint from the interval $C$, and $C$ lies wholly on one side of it.
 \begin{itemize}[itemsep=1pt]
   \item If $q<v^{+}$: then $q+1\leq v^{+}$, and $\atge{w}{q+1}$ is defined, so
     \cref{lem:chain} propagates it from $\atge{w}{v^{+}}$.  The clause
-    $\overline{C}\vee\overline{\atge{w}{q+1}}$ then propagates $\overline{C}$.
+    $\overline{C}\vee\natge{w}{q+1}$ then propagates $\overline{C}$.
   \item If $p\geq v^{-}$: then $\atge{w}{p}$ is defined and \cref{lem:chain}
-    propagates $\overline{\atge{w}{p}}$ from $\overline{\atge{w}{v^{-}}}$.  The
+    propagates $\natge{w}{p}$ from $\natge{w}{v^{-}}$.  The
     clause $\overline{C}\vee\atge{w}{p}$ then propagates $\overline{C}$.
     \qedhere
 \end{itemize}
@@ -1137,8 +1144,8 @@ equality or interval literal of $W$ and let $S=E\cap[l,u]$.
 \begin{proof}
 \emph{(a)}  Write $E=[a,b]$.  If $b<l$ then $\atge{w}{b+1}$ is defined by
 \invCut{} with $b+1\leq l$, so it is a unit by \inv{Bound}, and
-$\overline{E}\vee\overline{\atge{w}{b+1}}$ propagates $\overline{E}$.  If $a>u$
-then $\atge{w}{a}$ is defined with $a>u$, so $\overline{\atge{w}{a}}$ is a unit
+$\overline{E}\vee\natge{w}{b+1}$ propagates $\overline{E}$.  If $a>u$
+then $\atge{w}{a}$ is defined with $a>u$, so $\natge{w}{a}$ is a unit
 by \inv{Bound}, and $\overline{E}\vee\atge{w}{a}$ propagates $\overline{E}$.
 
 \emph{(b)}  For a set that is a union of adjacent cells, define its \emph{rank}
@@ -1152,13 +1159,13 @@ propagates by hypothesis.  If $G$ has rank at least two then $G$ is not a cell,
 so \invCover{}(i) puts $\overline{G}\vee C_1\vee\cdots\vee C_k$ in $F_t$ with
 each $C_i$ a defined literal, a union of adjacent cells, properly contained in
 $G$ --- hence of strictly smaller rank --- and contained in $S$.  By induction
-each $\overline{C_i}$ propagates, so the covering propagates $\overline{G}$.
+each $\overline{C}_i$ propagates, so the covering propagates $\overline{G}$.
 
 Now for $E$ itself.  If $E\subseteq[l,u]$ then $E=S$, which is a union of
 adjacent cells by \invPart{}, and the claim applies directly.  Otherwise
 $E\neq S$, and \invCover{}(ii) puts $\overline{E}\vee C_1\vee\cdots\vee C_k$ in
 $F_t$ with each $C_i$ a defined literal that is a union of adjacent cells and
-$\bigcup_i C_i=S$; each $C_i\subseteq S$, so $\overline{C_i}$ propagates by the
+$\bigcup_i C_i=S$; each $C_i\subseteq S$, so $\overline{C}_i$ propagates by the
 claim, and the covering propagates $\overline{E}$.
 \end{proof}
 
@@ -1198,26 +1205,26 @@ both the defined domain and the property of propagating under $R$.
 
 Since $\dm_U(W)=\emptyset$, every integer is excluded by $U$ somehow.  In
 particular the values below any fixed point must be excluded, and no negative
-two-cut literal and no literal $\overline{\atge{w}{v}}$ excludes a value below
+two-cut literal and no literal $\natge{w}{v}$ excludes a value below
 $v$; so $U$ contains at least one literal $\atge{w}{v}$.  Let $v^{+}$ be the
 largest value such that $\atge{w}{v^{+}}$ propagates under $R$; this exists
 because only finitely many bound variables are defined in a finite formula.
 Symmetrically, let $v^{-}$ be the smallest value such that
-$\overline{\atge{w}{v^{-}}}$ propagates; this exists for the mirrored reason.
+$\natge{w}{v^{-}}$ propagates; this exists for the mirrored reason.
 
 If $v^{+}\geq v^{-}$ then \cref{lem:contra-bounds} gives a conflict.  So
 $v^{+}<v^{-}$, and in particular the value $v^{+}$ is not excluded by any bound
 literal of $U$.  It must therefore be excluded by a negative two-cut literal of
 $U$, and there are two cases.
 \begin{itemize}[itemsep=1pt]
-  \item $\overline{\ateq{w}{v^{+}}}\in U$.  Then $\atge{w}{v^{+}}$ propagates,
+  \item $\nateq{w}{v^{+}}\in U$.  Then $\atge{w}{v^{+}}$ propagates,
     and \cref{eq:deq2} --- the clause
-    $\ateq{w}{v^{+}}\vee\overline{\atge{w}{v^{+}}}\vee\atge{w}{v^{+}+1}$ ---
+    $\ateq{w}{v^{+}}\vee\natge{w}{v^{+}}\vee\atge{w}{v^{+}+1}$ ---
     propagates $\atge{w}{v^{+}+1}$, contradicting the maximality of $v^{+}$.
-  \item $\overline{\atin{w}{a}{b}}\in U$ with $a\leq v^{+}\leq b$.  By
+  \item $\natin{w}{a}{b}\in U$ with $a\leq v^{+}\leq b$.  By
     \invCut{}, $\atge{w}{a}$ is defined, and $a\leq v^{+}$, so
     \cref{lem:chain} propagates it.  Then \cref{eq:din2} --- the clause
-    $\atin{w}{a}{b}\vee\overline{\atge{w}{a}}\vee\atge{w}{b+1}$ --- propagates
+    $\atin{w}{a}{b}\vee\natge{w}{a}\vee\atge{w}{b+1}$ --- propagates
     $\atge{w}{b+1}$, and $b+1>v^{+}$, again contradicting maximality.
     \qedhere
 \end{itemize}
@@ -1263,24 +1270,24 @@ If $v^{+}>v$ then $\ell$ propagates by \cref{lem:chain}.  If $v^{+}=v$ then
 $\ell$ propagates by definition of $v^{+}$.  Otherwise $v^{+}<v$, so
 $v^{+}\notin D$, and $v^{+}$ is not excluded by any bound literal of $U$ (by
 maximality of $v^{+}$ and, on the other side, because
-$\overline{\atge{w}{v'}}\in U$ with $v'\leq v^{+}$ would give a conflict by
+$\natge{w}{v'}\in U$ with $v'\leq v^{+}$ would give a conflict by
 \cref{lem:contra-bounds}).  So $v^{+}$ is excluded by a negative two-cut
 literal, and exactly as in the two bullets of \cref{thm:wipeout} we derive
 $\atge{w}{v''}$ for some $v''>v^{+}$, contradicting maximality.
 
-\emph{Case 2: $\ell=\overline{\atge{w}{v}}$.}  Symmetric to Case 1, taking
-$v^{-}$ the smallest value with $\overline{\atge{w}{v^{-}}}$ propagating and
+\emph{Case 2: $\ell=\natge{w}{v}$.}  Symmetric to Case 1, taking
+$v^{-}$ the smallest value with $\natge{w}{v^{-}}$ propagating and
 using the other cut in each reverse reification.
 
 \emph{Case 3: $\ell=\ateq{w}{v}$, so $D=\{v\}$.}  Since $\ell$ is defined, so
 are $\atge{w}{v}$ and $\atge{w}{v+1}$ by \invCut{}; both
-$\atge{w}{v}\in\ImpLits$ and $\overline{\atge{w}{v+1}}\in\ImpLits$, so they
+$\atge{w}{v}\in\ImpLits$ and $\natge{w}{v+1}\in\ImpLits$, so they
 propagate by Cases 1 and 2, and \cref{eq:deq2} then propagates $\ell$.
 
-\emph{Case 4: $\ell=\overline{\ateq{w}{v}}$, so $v\notin D$.}  If
+\emph{Case 4: $\ell=\nateq{w}{v}$, so $v\notin D$.}  If
 $\ateq{w}{v}\in U$ then $D=\{v\}$, contradiction; so consider what excludes $v$.
 If a bound literal does, then either $\atge{w}{v+1}$ or
-$\overline{\atge{w}{v}}$ propagates by \cref{lem:chain}, and the corresponding
+$\natge{w}{v}$ propagates by \cref{lem:chain}, and the corresponding
 clause of \cref{eq:deq1} propagates $\ell$.  If instead a negative two-cut
 literal $\overline{E}\in U$ with $v\in E$ does, then $\{v\}\subseteq E$; if
 $E=\{v\}$ then $\ell\in U$, and otherwise \invCont{} gives a chain of binary
@@ -1291,11 +1298,11 @@ by bound literals, so this is the first case.
 \emph{Case 5: $\ell=\atin{w}{a}{b}$, with $D\subseteq[a,b]$.}  Since $\ell$ is
 defined, $\atge{w}{a}$ and $\atge{w}{b+1}$ are defined by \invCut{}.  Every
 $v<a$ is outside $D$ and every $v\geq b+1$ is outside $D$, so
-$\atge{w}{a}$ and $\overline{\atge{w}{b+1}}$ are in
+$\atge{w}{a}$ and $\natge{w}{b+1}$ are in
 $\ImpLits(\dm_U(X))\cap L^W$ and propagate by Cases 1 and 2.  \cref{eq:din2}
 then propagates $\ell$.
 
-\emph{Case 6: $\ell=\overline{\atin{w}{a}{b}}$, with $D\cap[a,b]=\emptyset$.}
+\emph{Case 6: $\ell=\natin{w}{a}{b}$, with $D\cap[a,b]=\emptyset$.}
 Write $E=[a,b]$ and $S=E\cap[l,u]$.  If $S=\emptyset$ then $\ell$ propagates by
 \cref{lem:covering}(a).  Otherwise, $S$ is a union of cells by \invPart{}, and
 every cell $C\subseteq S$ satisfies $D\cap C=\emptyset$, so $\overline{C}$
@@ -1417,20 +1424,20 @@ deletion --- correctly or, as has happened three times, incorrectly.
 \multicolumn{3}{@{}l}{\emph{Within one representation}}\\[2pt]
 $\atge{w}{v}$ & $\atge{w}{v'}$, $v'<v$ & order chain, \invChain{}
   (\cref{lem:chain}) \\
-$\overline{\atge{w}{v}}$ & $\overline{\atge{w}{v'}}$, $v'>v$ & the same clauses,
+$\natge{w}{v}$ & $\natge{w}{v'}$, $v'>v$ & the same clauses,
   read the other way \\
 $\ateq{w}{v}$ or $\atin{w}{a}{b}$ & its two cuts & $\Def^{\Rightarrow}$,
   \cref{eq:deq1,eq:din1} \\
 both cuts & $\ateq{w}{v}$ or $\atin{w}{a}{b}$ & $\Def^{\Leftarrow}$,
   \cref{eq:deq2,eq:din2} \\
-one cut crossing the literal & $\overline{\ateq{w}{v}}$ or
-  $\overline{\atin{w}{a}{b}}$ & $\Def^{\Rightarrow}$, contrapositive \\
-$\overline{\ateq{w}{v}}$ or $\overline{\atin{w}{a}{b}}$ & a bound stepping over
+one cut crossing the literal & $\nateq{w}{v}$ or
+  $\natin{w}{a}{b}$ & $\Def^{\Rightarrow}$, contrapositive \\
+$\nateq{w}{v}$ or $\natin{w}{a}{b}$ & a bound stepping over
   it & $\Def^{\Leftarrow}$: this is the hole jump, and the reason
   \cref{thm:wipeout} needs no covering \\
 $\overline{E'}$, $E\subsetneq E'$ & $\overline{E}$ & containment, \invCont{}
   (\cref{lem:contclosure}) \\
-$\overline{C_1},\dots,\overline{C_k}$ & $\overline{E}$ & covering, \invCover{}
+$\overline{C}_1,\dots,\overline{C}_k$ & $\overline{E}$ & covering, \invCover{}
   (\cref{lem:covering}) \\
 $E$ and all but one piece excluded & the surviving piece & covering \\
 every cell excluded & conflict & reverse reifications and the chain
@@ -1525,7 +1532,7 @@ decision variable all assignments are somehow partitioned by the branches.  In
 general, if there are $k$ decisions before a particular backtrack, the required
 backtracking justification is
 \begin{equation}
-  B_t := \sum_{i=0}^{k-1}\overline{d_i} \geq 1
+  B_t := \sum_{i=0}^{k-1}\overline{d}_i \geq 1
   \label{eq:bt}
 \end{equation}
 where each $d_i$ is an atomic literal representing the branching decision at
@@ -1597,16 +1604,16 @@ current branching variable $X$.}  Let $\dm_t(X)$ be the domain of $X$ after
 propagation at the current decision level.  The branching choices partition
 $\dm_t(X)$.  Since this is not a leaf node, backtracking justifications have
 already been logged for each of the $k$ child branches, each of the form
-$G\Rightarrow \overline{d_i}\geq 1$ where $G$ encodes the decisions above this
+$G\Rightarrow \overline{d}_i\geq 1$ where $G$ encodes the decisions above this
 level and $d_i$ is the $i$th branching decision on $X$; so each
-$\overline{d_i}$ propagates under $F_t\cup\{\neg B_t\}$.
+$\overline{d}_i$ propagates under $F_t\cup\{\neg B_t\}$.
 
 Now suppose $F_t\cup\{\neg B_t\}$ does not propagate to contradiction, and let
 $L$ be the set of atomic literals over representations of $X$ that propagate
 under unit propagation to fixpoint.  We must have $\dm_L(X)\neq\emptyset$, since
 otherwise \cref{thm:wipeout-family} gives a conflict; so pick $v\in\dm_L(X)$.
 By \invDomain{}, $v\in\dm_t(X)$, so some branch decision $d_i$ is satisfied by
-$v$, the branches being a partition of $\dm_t(X)$.  But $\overline{d_i}\in L$,
+$v$, the branches being a partition of $\dm_t(X)$.  But $\overline{d}_i\in L$,
 and $v\in\dm_L(X)$ means $v$ satisfies every literal of $L$, so $v$ does not
 satisfy $d_i$ --- a contradiction.  Note that $d_i$ may be stated over any
 representation of $X$, and that $\dm_L$ is computed over all of them, so no
@@ -1644,7 +1651,7 @@ valid immediately before the domain change.
 
 Two things about \cref{eq:propjust} are new.  First, $\ell$ may be a negated
 interval literal: a propagator that removes a run of values from a domain states
-that as one conclusion $\overline{\atin{w}{a}{b}}$, not as $b-a+1$ conclusions.
+that as one conclusion $\natin{w}{a}{b}$, not as $b-a+1$ conclusions.
 Second, $\ell$ and the literals of $R$ need not be stated over the same
 representation, and routinely are not.  A propagator whose operand is a view
 concludes over the view; a reason derived from the solver's domains is stated
@@ -1689,7 +1696,7 @@ initial bounds at the start of the proof, if not already present, and derive by
 RUP the units stating that they hold at the root decision level: for a variable
 $X$ with initial bounds $l$ and $u$, these are
 \begin{equation}
-  \atge{x}{l}\geq 1 \qquad\text{and}\qquad \overline{\atge{x}{u+1}}\geq 1 .
+  \atge{x}{l}\geq 1 \qquad\text{and}\qquad \natge{x}{u+1}\geq 1 .
   \label{eq:rootbounds}
 \end{equation}
 These follow by RUP by the same argument as \cref{cor:chainrup}, since the bound
@@ -1740,7 +1747,7 @@ by \cref{eq:rootbounds}.  Hence \invDomain{} is initially respected.
     --- base variable or view --- its own bit vector, and every derived
     representation its definitional link \cref{eq:link}.
   \item At the start of the proof, derive by RUP $\atge{x}{l}\geq 1$ and
-    $\overline{\atge{x}{u+1}}\geq 1$ for the bounds $l..u$ on each variable, and
+    $\natge{x}{u+1}\geq 1$ for the bounds $l..u$ on each variable, and
     likewise for any out-of-range cut subsequently created on any representation.
   \item Any time the solver backtracks, derive by RUP a backtracking
     justification $G\Rightarrow 0\geq 1$, where $G$ is the sequence of decisions
@@ -1789,7 +1796,7 @@ solution witness introduces
   -\BinEnc(W) \geq -o-1 \quad\text{for minimisation,}
 \]
 followed by a literal definition and the RUP constraint $\atge{w}{o+1}\geq 1$ or
-$\overline{\atge{w}{o}}\geq 1$.  This fits neatly into the framework, as the RUP
+$\natge{w}{o}\geq 1$.  This fits neatly into the framework, as the RUP
 constraint derived after a solution is found is simply a propagation
 justification with $R=\emptyset$, as if the objective-improving constraint had
 always been part of the model.  It has the effect of maintaining \invDomain{} by
@@ -2132,9 +2139,9 @@ and $30-10=20$, $30-5=25$.  On $V$ the partition is created in turn, with
 boundaries $\{10,20,26,30\}$, cells $[10,19]$, $[20,25]$, $[26,29]$, and its own
 root covering.  Finally the two clauses
 \[
-  \overline{\atin{x}{5}{10}}\vee\atin{v}{20}{25}
+  \natin{x}{5}{10}\vee\atin{v}{20}{25}
   \qquad\text{and}\qquad
-  \overline{\atin{v}{20}{25}}\vee\atin{x}{5}{10}
+  \natin{v}{20}{25}\vee\atin{x}{5}{10}
 \]
 are emitted.  The recursion terminates because the pair is recorded before the
 two \code{need} calls are made.
@@ -2143,14 +2150,14 @@ two \code{need} calls are made.
 Both endpoints fall strictly inside existing cells, so both cells split first:
 \begin{itemize}[itemsep=0pt]
   \item $[5,10]$ splits at $7$ into $[5,6]$ and $[7,10]$, with the split covering
-    $\overline{\atin{x}{5}{10}}\vee\atin{x}{5}{6}\vee\atin{x}{7}{10}$;
+    $\natin{x}{5}{10}\vee\atin{x}{5}{6}\vee\atin{x}{7}{10}$;
   \item $[11,20]$ splits at $16$ into $[11,15]$ and $[16,20]$, with its split
     covering.
 \end{itemize}
 Then $[7,15]$ is defined, with the covering
-$\overline{\atin{x}{7}{15}}\vee\atin{x}{7}{10}\vee\atin{x}{11}{15}$ and the two
-containment edges $\overline{\atin{x}{7}{10}}\vee\atin{x}{7}{15}$ and
-$\overline{\atin{x}{11}{15}}\vee\atin{x}{7}{15}$.  The root covering is
+$\natin{x}{7}{15}\vee\atin{x}{7}{10}\vee\atin{x}{11}{15}$ and the two
+containment edges $\natin{x}{7}{10}\vee\atin{x}{7}{15}$ and
+$\natin{x}{11}{15}\vee\atin{x}{7}{15}$.  The root covering is
 \emph{not} touched: to falsify $[5,10]$ later, unit propagation goes through its
 own split covering.  The same sequence then happens on $V$ for the image
 $[V\in 15..23]$, and the link pair joins the two.
@@ -2163,15 +2170,15 @@ with their images.
 \paragraph{A negative crossing.}
 Suppose the solver now decides $\neg[X\in 7..15]$ and, deeper in the subtree, a
 propagator's reason names $[V\in 15..23]$, which is the image.  In the replay,
-$\overline{\atin{x}{7}{15}}$ is asserted.  It is a unit on neither of its cuts:
+$\natin{x}{7}{15}$ is asserted.  It is a unit on neither of its cuts:
 \cref{eq:din2} for it is the ternary clause
-$\atin{x}{7}{15}\vee\overline{\atge{x}{7}}\vee\atge{x}{16}$, and with the first
+$\atin{x}{7}{15}\vee\natge{x}{7}\vee\atge{x}{16}$, and with the first
 literal false and neither bound known, nothing propagates.  Its containment
-edges point the wrong way --- they carry $\overline{\atin{x}{7}{15}}$ \emph{down}
+edges point the wrong way --- they carry $\natin{x}{7}{15}$ \emph{down}
 to $[7,10]$ and $[11,15]$, not across.  The only thing that carries the fact to
 $V$ is the \emph{first} clause of the link pair,
-$\overline{\atin{v}{15}{23}}\vee\atin{x}{7}{15}$: with $\atin{x}{7}{15}$ false it
-propagates $\overline{\atin{v}{15}{23}}$ in one step.  Read as an implication that
+$\natin{v}{15}{23}\vee\atin{x}{7}{15}$: with $\atin{x}{7}{15}$ false it
+propagates $\natin{v}{15}{23}$ in one step.  Read as an implication that
 clause says $\atin{v}{15}{23}\to\atin{x}{7}{15}$, which is not the direction
 anything needs; it is here for its contrapositive.  Delete it and the
 backtracking justification fails, while every individual line of the proof still
@@ -2181,9 +2188,9 @@ decided on $V$ and needed on $X$ --- and it needs the other clause.
 \paragraph{Why a nearby instance proves nothing.}
 Replace the decision by $\neg[X\in 1..15]$, whose interval abuts the lower bound.
 Now no link clause is needed at all.  \cref{eq:din2} for it is
-$\atin{x}{1}{15}\vee\overline{\atge{x}{1}}\vee\atge{x}{16}$; the boundary pin
+$\atin{x}{1}{15}\vee\natge{x}{1}\vee\atge{x}{16}$; the boundary pin
 $\atge{x}{1}$ of \inv{Bound} is a unit, so $\atge{x}{16}$ propagates.  The ge-link
-carries that to $\overline{\atge{v}{15}}$, since $X\geq 16$ is $V\leq 14$, and the
+carries that to $\natge{v}{15}$, since $X\geq 16$ is $V\leq 14$, and the
 \emph{forward} reification of the image literal $\atin{v}{15}{29}$ then falsifies
 it.  A green result on this instance says nothing whatever about the link pair,
 and three further shapes have the same property --- see \nsec{sec:coincidence},
@@ -2208,7 +2215,7 @@ where 80\% of small random instances turn out to be one of them.
 \item \textbf{Initial-domain gaps.}  Holes in an initial domain are currently
   derived at the root of the proof, by root propagation of the constraint that
   posts the domain.  They could instead be stated in the model, as
-  $\overline{\atin{x}{a}{b}}\geq 1$ rows forming part of the domain definition.
+  $\natin{x}{a}{b}\geq 1$ rows forming part of the domain definition.
   That formulation is equally definitional and slightly more direct, but it
   requires interval literals to exist during model writing, and it changes the
   OPB surface that a verified encoder conforms against.  The decision is open

--- a/dev_docs/literal-encodings.tex
+++ b/dev_docs/literal-encodings.tex
@@ -600,11 +600,17 @@ the bit vector of a derived representation is sized from $[l_W,u_W]$, and can be
 range $[1,8]$ too but a bit vector spanning $[0,15]$, and a view $X+10^6$ has a
 much wider one.  Any coefficient bound or big-$M$ computed for a line mentioning
 $W$ must be measured against $\BinEnc(W)$, not against the value range of $X$.
-Second, the solver's implementation allocates no magnitude bit that cannot reach
-a value of the domain, so a variable with range $[0,0]$ has the empty sum,
-identically zero; the thesis's ``least strictly positive $h$'' would give it one
-bit.  This is a deliberate divergence, for conformance with the verified
-encoder \code{cake\_pb\_cp}.
+Second, the implementation's width rule diverges from Step~7 in two places, both
+deliberate and both for conformance with the verified encoder
+\code{cake\_pb\_cp}.  It allocates no magnitude bit that cannot reach a value of
+the domain, so a variable with range $[0,0]$ has the empty sum, identically zero,
+where the thesis's ``least strictly positive $h$'' gives it one bit.  And it
+sizes from the \emph{signed} upper bound, $\max\{|l_W|,\,u_W+1\}$ rather than
+$\max\{|u_W|+1,\,|l_W|\}$, which differs exactly for a wholly-negative singleton
+at a power of two: $\{-2\}$ gets two bits rather than three, $\{-8\}$ four rather
+than five.  Both encodings cover the definition range, so \cref{thm:p1p2} is
+indifferent; but a view $-X$ of a variable fixed at a power of two meets the
+second one.
 \end{remark}
 
 \paragraph{Step 8: standardise constraints.}
@@ -743,9 +749,14 @@ The solver optionally uses a compact encoding in which an equality atom at a
 definition bound is defined by its one non-trivial cut only
 ($\ateq{w}{l_W}\Leftrightarrow\natge{w}{l_W+1}$, and dually at
 $u_W$).  This is off by default, because the eager form matches
-\code{cake\_pb\_cp}'s.  Every argument below survives it, because the dropped
-cut is a pinned unit by \invCut{} and \inv{Bound}, but the reader checking the
-proofs against an implementation should be aware of the variation.
+\code{cake\_pb\_cp}'s.  Under that variant \invCut{} \emph{fails} at the
+definition bounds: the dropped cut is not a pinned atom but no atom at all ---
+for $X\in[3,9]$ the equality atom at $3$ is defined and $\atge{x}{3}$ is never
+created.  Everything below is therefore stated for the default encoding.  The
+compact variant should be sound, the dropped cut being a constant of the
+encoding rather than a fact, but making the results unconditional would mean
+rereading every appeal to \invCut{} at a definition bound with a constant in
+place of the atom, and we have not done that.
 \end{remark}
 
 \begin{lemmaT}[Propagation of contradictory bound literals]
@@ -794,7 +805,10 @@ $t$ in the proof.
   representation $W$ with $v<v'$, if $\Def(\atge{w}{v})$ and
   $\Def(\atge{w}{v'})$ appear in $F_t$, then either $\atge{w}{v''}$ is defined
   for some $v<v''<v'$, or the constraint
-  $\atge{w}{v'}\Rightarrow\atge{w}{v}\geq 1$ appears in $F_t$.
+  $\natge{w}{v}$ appears in $F_t$.  A representation whose bounds are not a
+  consequence of the model --- a free bit-sum introduced inside the proof ---
+  is exempt, and its owner derives the bounds explicitly instead; no interval
+  literal is defined over such a variable today.
 
 \item[\inv{Bound}: boundary pins.]
   For every defined $\atge{w}{v}$ with $v\leq l_W$, the unit $\atge{w}{v}$
@@ -807,8 +821,8 @@ $t$ in the proof.
   $\atge{w}{b+1}$.
 
 \item[\invPart{}: the partition.]
-  If any interval literal is defined for $W$, then there is a finite set of
-  \emph{boundaries} $\Bdry(W)\subseteq[l_W,u_W+1]$ with
+  If any interval literal with non-empty in-bounds part is defined for $W$, then
+  there is a finite set of \emph{boundaries} $\Bdry(W)\subseteq[l_W,u_W+1]$ with
   $l_W,u_W+1\in\Bdry(W)$.  The \emph{cells} $\Cells(W)$ are the intervals
   $[p,p'-1]$ for consecutive $p<p'$ in $\Bdry(W)$; they partition $[l_W,u_W]$.
   Every cell is a defined literal --- an equality atom if it has width one, an
@@ -828,9 +842,13 @@ $t$ in the proof.
   $F_t$ contains a clause $\overline{E}\vee C_1\vee\cdots\vee C_k$ where each
   $C_i$ is a defined literal that is a union of adjacent cells, and
   $\bigcup_i C_i = S$.
-  \emph{(iii) The root covering.}  $F_t$ contains a clause
+  \emph{(iii) The root covering.}  If $\Bdry(W)$ exists, $F_t$ contains a clause
   $C_1\vee\cdots\vee C_m\geq 1$ where the $C_i$ are defined literals that are
-  unions of adjacent cells with $\bigcup_i C_i = [l_W,u_W]$.
+  unions of adjacent cells with $\bigcup_i C_i = [l_W,u_W]$.  A representation
+  with no interval literal, or with only out-of-bounds ones, has no partition and
+  no root covering, and this clause holds vacuously --- which is what lets
+  \cref{lem:covering} and \cref{thm:complete} still say something about a plain
+  order/equality variable, the entire setting of the thesis.
 
 \item[\invCont{}: containment.]
   For any two defined equality or interval literals $E\subsetneq E'$ of the same
@@ -844,13 +862,20 @@ $t$ in the proof.
   every defined atomic variable of a derived $W$, the two clauses linking it to
   the corresponding atomic variable of the base $X$ appear in $F_t$.
 
-\item[\invName{}: everything is named.]
-  Every defined interval literal has appeared in some emitted proof line other
-  than its own reification.
+\item[\invName{}: cells are named.]
+  Every cell has appeared in some emitted proof line other than its own
+  reification.
+
+  Deliberately about cells, not about every interval literal.  A literal whose
+  in-bounds part is empty is defined with no partition, no covering and no
+  containment edge, and nothing names it; \invRep{} does not suffer, because such
+  a literal can only arise from an explicit request, and the request path
+  establishes \invRep{} for itself.  See the remark after \cref{lem:transport}.
 
 \end{description}
-
-\invChain{} and \inv{Bound} come from the thesis, generalised only by being
+apparatus.  \invName{} is a hygiene condition that \invRep{} needs for the
+interval literals created as cells, and only for those --- see the remark after
+\cref{lem:transport}.
 stated per representation.  \invCut{} is implicit there; we make it explicit
 because both new literal kinds depend on it.  \invPart{}, \invCover{} and
 \invCont{} are the interval apparatus.  \invRep{} is the multi-representation
@@ -859,8 +884,9 @@ literals, and only for them --- see the remark after \cref{lem:transport}.
 
 \begin{remark}
 Nothing above depends on the search state.  Every clause named is a tautology of
-the encoding, RUP at the moment it is emitted, and is emitted at the top proof
-level.  The alternative --- emitting a covering over whatever facts currently
+the encoding, emitted at the top proof level, and derivable there from what
+precedes it --- by RUP, except for the ge-links, which are cutting-planes steps
+(see the discussion after \cref{eq:inlink}).  The alternative --- emitting a covering over whatever facts currently
 witness an exclusion --- is also sound, but makes the invariant depend on what
 was live when, and drags a level-aware registry of live conclusions into the
 encoding layer.  It was implemented, and rejected for complexity rather than for
@@ -926,13 +952,28 @@ representation:
      \label{eq:inlink}
 \end{align}
 
-Each is RUP at the point it is emitted.  For the ge-link this is Theorem~2.9 of
-the thesis applied to $\Def(\atge{w}{v})$, $\Link(W)$ and the corresponding half
-of $\Def((\atge{w}{v})^X)$, whose $\BinEnc$ terms cancel exactly; in the solver
-it is emitted as an explicit cutting-planes step rather than as a RUP line, so
-that the derivation is checkable in one pass.  For the eq-link, asserting one
-side and the negation of the other propagates both cuts through
-\cref{eq:deq1}, carries each across by the ge-links, and closes on
+The eq-link and the in-link are RUP at the point they are emitted.  \textbf{The
+ge-link is not}, and this is worth being precise about, because the natural
+assumption is that it is.  Summing $\Def(\atge{w}{v})$, $\Link(W)$ and the
+corresponding half of $\Def((\atge{w}{v})^X)$ does make the $\BinEnc$ terms
+cancel exactly, and saturating leaves the clause --- but that is a
+\emph{cutting-planes} derivation, not a unit-propagation one.  What would make
+the configuration RUP is Theorem~2.9 of the thesis, and it requires the middle
+constraint's right-hand side to lie in $\{0,1\}$; here that constraint is a half
+of $\Link(W)$, so the right-hand side is $\pm c_W$, and the theorem does not
+apply once $|c_W|>1$.  Example~2.15 of the thesis is a counterexample of exactly
+this shape.
+
+Nor is this a corner case.  Checking the clause as a RUP line with a verifier
+over a three-bit base, only $c_W = 0$ succeeds at every threshold; $X\in[0,7]$
+with $W = X+1$ and $v=6$ is a concrete rejection, and other offsets fail at some
+thresholds and not others.  The solver is unaffected, because
+\code{need\_gevar} emits these by \code{pol}; but a future simplification of that
+emission to a RUP line would fail on the first view with a nonzero offset, and
+would fail intermittently, which is worse.
+
+For the eq-link, asserting one side and the negation of the other propagates both
+cuts through \cref{eq:deq1}, carries each across by the ge-links, and closes on
 \cref{eq:deq2} of the far side.  For the in-link, the same argument with
 \cref{eq:din1,eq:din2}, noting that for $s=-1$ the two cuts exchange roles ---
 which is exactly the endpoint swap in \cref{def:image}.
@@ -1083,7 +1124,7 @@ currently defined literals of $W$, not merely over the cells.
 
 \begin{lemmaN}[Cell exclusion]
 \label{lem:cell}
-Assume \invChain{}, \inv{Bound}, \invCut{}, \invPart{} and \invCont{}.  Let
+Assume \invChain{}, \invCut{}, \invPart{} and \invCont{}.  Let
 $U\subseteq L^W$ be a cut-normalised set of literals each of which propagates
 under $R$, suppose $F_t\!\restriction_R$ does not propagate to conflict, and
 write $D=\dm_U(W)$.  Let $C\in\Cells(W)$ be a cell with $D\cap C=\emptyset$.
@@ -1204,11 +1245,13 @@ Suppose not, and cut-normalise $U$ using \cref{lem:normalise}, which preserves
 both the defined domain and the property of propagating under $R$.
 
 Since $\dm_U(W)=\emptyset$, every integer is excluded by $U$ somehow.  In
-particular the values below any fixed point must be excluded, and no negative
-two-cut literal and no literal $\natge{w}{v}$ excludes a value below
-$v$; so $U$ contains at least one literal $\atge{w}{v}$.  Let $v^{+}$ be the
-largest value such that $\atge{w}{v^{+}}$ propagates under $R$; this exists
-because only finitely many bound variables are defined in a finite formula.
+particular the values below any fixed point must be excluded.  No literal
+$\natge{w}{v}$ excludes anything below $v$, and $U$ is finite --- it is a subset
+of $L^W$, and only finitely many atomic variables are defined in a finite
+formula --- so its negative two-cut literals between them exclude only a bounded
+set.  Hence $U$ contains at least one literal $\atge{w}{v}$.  Let $v^{+}$ be the
+largest value such that $\atge{w}{v^{+}}$ propagates under $R$; this exists for
+the same reason.
 Symmetrically, let $v^{-}$ be the smallest value such that
 $\natge{w}{v^{-}}$ propagates; this exists for the mirrored reason.
 
@@ -1264,8 +1307,10 @@ Consider a literal $\ell\in\ImpLits(\dm_U(X))\cap L^W$.  By \cref{eq:implits}
 there are six cases.
 
 \emph{Case 1: $\ell=\atge{w}{v}$, with $v'\notin D$ for all $v'<v$.}  In
-particular $D$ is bounded from below, so $U$ contains a positive bound literal,
-and we may let $v^{+}$ be the largest value with $\atge{w}{v^{+}}$ propagating.
+particular $D$ is bounded from below.  Since $U$ is finite, its negative two-cut
+literals exclude only a bounded set, so $U$ must contain a positive bound
+literal, and we may let $v^{+}$ be the largest value with $\atge{w}{v^{+}}$
+propagating.
 If $v^{+}>v$ then $\ell$ propagates by \cref{lem:chain}.  If $v^{+}=v$ then
 $\ell$ propagates by definition of $v^{+}$.  Otherwise $v^{+}<v$, so
 $v^{+}\notin D$, and $v^{+}$ is not excluded by any bound literal of $U$ (by
@@ -1284,9 +1329,9 @@ are $\atge{w}{v}$ and $\atge{w}{v+1}$ by \invCut{}; both
 $\atge{w}{v}\in\ImpLits$ and $\natge{w}{v+1}\in\ImpLits$, so they
 propagate by Cases 1 and 2, and \cref{eq:deq2} then propagates $\ell$.
 
-\emph{Case 4: $\ell=\nateq{w}{v}$, so $v\notin D$.}  If
-$\ateq{w}{v}\in U$ then $D=\{v\}$, contradiction; so consider what excludes $v$.
-If a bound literal does, then either $\atge{w}{v+1}$ or
+\emph{Case 4: $\ell=\nateq{w}{v}$, so $v\notin D$.}  Consider what excludes $v$;
+after cut normalisation the candidates are a bound literal and a negative
+two-cut literal.  If a bound literal does, then either $\atge{w}{v+1}$ or
 $\natge{w}{v}$ propagates by \cref{lem:chain}, and the corresponding
 clause of \cref{eq:deq1} propagates $\ell$.  If instead a negative two-cut
 literal $\overline{E}\in U$ with $v\in E$ does, then $\{v\}\subseteq E$; if
@@ -1310,6 +1355,26 @@ propagates by \cref{lem:cell}.  If $E$ is itself a current cell we are done; if
 not, \cref{lem:covering}(b) propagates $\ell$.
 \end{proof}
 
+\begin{remark}[What ``complete'' does and does not mean]
+\label{rem:domlimits}
+\cref{eq:domL} takes no account of $\Bnd(W)$, so $\dm_U(W)$ can contain values
+the variable's own bounds exclude, and \cref{thm:complete} is correspondingly
+narrower than its name suggests.  With cells $[1,3]$, $[4,6]$, $[7,10]$ on
+$[1,10]$ and $U = \{\overline{[1,3]}, \overline{[4,6]}\}$, unit propagation does
+derive $\atge{w}{7}$ --- through the root covering and the surviving cell --- but
+$\atge{w}{7}\notin\ImpLits(\dm_U)$, so the theorem does not claim it.  With
+$U$ extended by $\overline{[7,10]}$, unit propagation reaches a conflict while
+$\dm_U(W)$ is still non-empty, so \cref{thm:wipeout}'s hypothesis does not hold
+either.  Neither is a counterexample to anything stated; both are consequences of
+$\dm_U$ being computed from $U$ alone.
+
+This is the thesis's convention and we keep it, because it is what makes the
+theorems compose: \cref{sec:unsat} puts the root bound literals into the
+propagated set, at which point $\dm_U(W)\subseteq[l_W,u_W]$ and the gap closes.
+The reader should simply not read ``complete propagation'' as ``everything the
+solver's domain implies''.
+\end{remark}
+
 \paragraph{Lifting to a representation family.}
 
 \begin{lemmaN}[Unit transport]
@@ -1320,9 +1385,12 @@ $\ell^{W'}$ propagates under $R$.
 \end{lemmaN}
 
 \begin{proof}
-Images compose, $(\ell^{X})^{W'} = \ell^{W'}$, so it suffices to prove the claim
-for $W'=X$ and for $W$ derived, and then apply it twice.  By \invRep{} the
-atomic variable underlying $\ell^{X}$ is defined and the two linking clauses
+It suffices to show that a literal crosses a single link pair, in either
+direction and either polarity; a general $W\to W'$ transport is then at most two
+such crossings, through the base, because images compose:
+$(\ell^{X})^{W'} = \ell^{W'}$.  So take $W$ derived and consider its link to the
+base.  By \invRep{} the atomic variable underlying $\ell^{X}$ is defined and the
+two linking clauses
 \cref{eq:gelink}, \cref{eq:eqlink} or \cref{eq:inlink} appear in $F_t$.  Those
 two clauses are $\overline{p}\vee q$ and $\overline{q}\vee p$ for
 $p$ the positive literal of $W$'s atom and $q$ its image; a binary clause
@@ -1487,8 +1555,13 @@ the pair
   \qquad\text{and}\qquad
   \atge{y}{b'+1}\Rightarrow\atge{x}{b+1},
 \]
-each RUP by the Theorem~2.9 configuration, mentioning no interval literal and
-therefore reusable by any literal sharing those endpoints.  This is
+each RUP by the Theorem~2.9 configuration --- which does apply here, the middle
+constraint being an equality between two bit-sums, so its right-hand side is
+zero.  The lemmas' \emph{conclusions} mention only order atoms, which is what
+lets them be shared by any interval literal with those endpoints; they are
+nevertheless emitted under the propagator's reason, which does contain the
+interval literal, and are deleted with the scaffolding level rather than
+persisting.  This is
 \S3.4 material and we do not develop it here; we note only that the interval
 vocabulary does not change the situation, because an interval literal asserts
 only order atoms, never bits.
@@ -1580,9 +1653,10 @@ $\dm_L(X)\subseteq\dm_t(X)$ is between two subsets of the same set of integers.
 
 \begin{theoremT}
 \label{thm:btrup}
-If \invConflict{} and \invDomain{} are respected, and a complete solver always
-logs backtracking justifications, then every backtracking justification $B_t$
-follows by RUP.
+If \invConflict{} and \invDomain{} are respected, the literal-layer invariants
+\cref{thm:wipeout-family} needs hold --- \invChain{}, \invCut{} and \invRep{} ---
+and a complete solver always logs backtracking justifications, then every
+backtracking justification $B_t$ follows by RUP.
 \end{theoremT}
 
 \begin{proof}
@@ -1700,10 +1774,25 @@ $X$ with initial bounds $l$ and $u$, these are
   \label{eq:rootbounds}
 \end{equation}
 These follow by RUP by the same argument as \cref{cor:chainrup}, since the bound
-constraints $\Bnd(X)$ are present.  \inv{Bound} is the lazy generalisation
-actually implemented: the unit is emitted for whichever out-of-range cut is
-first created, and the same argument applies, because $\Bnd(W)$ is asserted for
-every representation, derived ones included.
+constraints $\Bnd(X)$ are present, and likewise for every representation, derived
+ones included, because $\Bnd(W)$ is asserted for each.
+
+\begin{remark}[The eager introduction is load-bearing, and the solver is lazier]
+\label{rem:lazypins}
+\invDomain{} needs \cref{eq:rootbounds} to be present from the start.  With
+$L=\emptyset$, \cref{eq:domL} gives $\dm_L(X)=\mathbb Z$, which is not contained
+in $\dm_t(X)$, so the base case of \cref{thm:maintain} fails without it.
+
+The implementation does not introduce these eagerly.  \inv{Bound} as stated ---
+a unit for each defined out-of-range cut --- is what it maintains, and atoms are
+created only when a proof line needs them, so a variable no proof line has
+mentioned has no atoms at all.  This is not known to cause trouble: a variable
+with no defined literal appears in no reason and no conclusion, so \invDomain{}
+is never appealed to for it.  But it is a real difference between the framework
+as stated here and the framework as implemented, we have not worked the lazy
+variant through, and the honest position is that the results below are proved
+for \cref{eq:rootbounds} as written.
+\end{remark}
 
 \begin{theoremT}
 \label{thm:maintain}
@@ -1884,9 +1973,10 @@ the only workable one, for three reasons.
     preserved set and the same enumeration conclusion.
 \end{itemize}
 
-One consequence deserves care.  Because atomic variables are not preserved, a
-solution witness must not be stated purely in terms of them.  It is stated over
-base equality literals, and unit propagation completes it --- through
+One consequence deserves care.  A solution witness \emph{is} written over atomic
+variables --- one base equality literal per variable --- even though atomic
+variables are not preserved.  That is sound only because unit propagation
+completes such a witness to the preserved bits, and onward --- through
 \cref{sec:optimality}'s step~1 --- to the bits of every derived representation.
 The completion argument is therefore load-bearing for enumeration in a way it is
 not for optimality, and a representation whose bits did not propagate from the
@@ -1947,9 +2037,11 @@ checked by RUP after the decisions have been asserted, discriminates.
 
 \subsubsection*{The witness suite}
 
-Each clause family has a deterministic counterexample that fails within
-milliseconds if the family is removed or weakened.  These are checked in as
-gate-on, verifier-checked tests, and any change to the clause set must run them.
+Each clause family has a counterexample that fails quickly if the family is
+removed or weakened.  All but one are deterministic tests, checked in as gate-on
+and verifier-checked; W4 is instead a standing regression net, the whole
+constraint suite run under interval-rejecting branching, and it is random rather
+than deterministic.  Any change to the clause set must run them all.
 
 \begin{center}
 \small
@@ -2133,11 +2225,16 @@ decision.  On $X$:
   \item there is no containment yet, nothing being nested.
 \end{itemize}
 Because the literal has now been \emph{named} --- by the root covering, if
-nothing else --- the mirroring hook fires, and $[X\in 5..10]$ maps to
-$[V\in 20..25]$: the endpoints swap because $\varphi_V$ reverses the order,
-and $30-10=20$, $30-5=25$.  On $V$ the partition is created in turn, with
-boundaries $\{10,20,26,30\}$, cells $[10,19]$, $[20,25]$, $[26,29]$, and its own
-root covering.  Finally the two clauses
+nothing else --- the mirroring hook fires for each cell in turn, and the images
+join $V$'s side.  It is worth following the order, because it is not the order
+one would guess.  The first literal the root covering names is $[1,4]$, whose
+image $[26,29]$ is what creates $V$'s partition, with boundaries
+$\{10,26,30\}$ and cells $[10,25]$, $[26,29]$; $V$'s own root covering is
+therefore $\atin{v}{10}{25}\vee\atin{v}{26}{29}\geq 1$, and rendering \emph{that}
+names $[10,25]$, whose image is a fresh request $[X\in 5..20]$ back on $X$.  Only
+then does $[5,10]$'s own image $[20,25]$ arrive and split $[10,25]$ at $20$.  The
+endpoints swap because $\varphi_V$ reverses the order: $30-10=20$, $30-5=25$.
+Finally the two clauses
 \[
   \natin{x}{5}{10}\vee\atin{v}{20}{25}
   \qquad\text{and}\qquad
@@ -2164,33 +2261,54 @@ $[V\in 15..23]$, and the link pair joins the two.
 
 The state now is: boundaries $\{1,5,7,11,16,21\}$ on $X$ and
 $\{10,15,20,24,26,30\}$ on $V$; five cells each, in bijection under $\varphi_V$;
-and defined non-cell literals $[X\in 5..10]$, $[X\in 11..20]$, $[X\in 7..15]$
-with their images.
+and non-cell literals $[X\in 5..10]$, $[X\in 11..20]$, $[X\in 7..15]$ and
+$[X\in 5..20]$, with their images.  The last of those is not something any
+caller asked for: it is the image of $V$'s first root covering, as above.  This
+is the general phenomenon of \cref{sec:open} item~6 --- the two sides hold the
+same literals, but arrive at them by different routes and hold them in different
+roles.
 
 \paragraph{A negative crossing.}
-Suppose the solver now decides $\neg[X\in 7..15]$ and, deeper in the subtree, a
-propagator's reason names $[V\in 15..23]$, which is the image.  In the replay,
-$\natin{x}{7}{15}$ is asserted.  It is a unit on neither of its cuts:
+Suppose the solver now decides $\natin{x}{7}{10}$ --- the \emph{cell} $[7,10]$,
+not the request $[7,15]$ --- and, deeper in the subtree, a propagator's reason
+names $[V\in 20..23]$, which is its image.  In the replay,
+$\natin{x}{7}{10}$ is asserted.  It is a unit on neither of its cuts:
 \cref{eq:din2} for it is the ternary clause
-$\atin{x}{7}{15}\vee\natge{x}{7}\vee\atge{x}{16}$, and with the first
-literal false and neither bound known, nothing propagates.  Its containment
-edges point the wrong way --- they carry $\natin{x}{7}{15}$ \emph{down}
-to $[7,10]$ and $[11,15]$, not across.  The only thing that carries the fact to
-$V$ is the \emph{first} clause of the link pair,
-$\natin{v}{15}{23}\vee\atin{x}{7}{15}$: with $\atin{x}{7}{15}$ false it
-propagates $\natin{v}{15}{23}$ in one step.  Read as an implication that
-clause says $\atin{v}{15}{23}\to\atin{x}{7}{15}$, which is not the direction
-anything needs; it is here for its contrapositive.  Delete it and the
-backtracking justification fails, while every individual line of the proof still
-verifies.  This is witness W6 in miniature; W7 is the mirror image --- a fact
-decided on $V$ and needed on $X$ --- and it needs the other clause.
+$\atin{x}{7}{10}\vee\natge{x}{7}\vee\atge{x}{11}$, and with the first literal
+false and neither bound known, nothing propagates.  Its containment edges are no
+help either: they run $\natin{x}{7}{10}\vee\atin{x}{5}{10}$ and
+$\natin{x}{7}{10}\vee\atin{x}{7}{15}$, both already satisfied by the decision, so
+neither propagates anything.  And there is nothing below to descend to: a cell
+has no covering, and no defined literal lies strictly inside it.  The only thing
+that
+carries the fact to $V$ is the first clause of its link pair,
+$\natin{v}{20}{23}\vee\atin{x}{7}{10}$: with $\atin{x}{7}{10}$ false it
+propagates $\natin{v}{20}{23}$ in one step.  Read as an implication that clause
+says $\atin{v}{20}{23}\to\atin{x}{7}{10}$, which is not the direction anything
+needs; it is here for its contrapositive.  Delete it and the backtracking
+justification fails, while every individual line of the proof still verifies.
+This is witness W6 in miniature; W7 is the mirror image --- a fact decided on
+$V$ and needed on $X$ --- and it needs the other clause.
+
+\paragraph{Why it has to be a cell.}
+Run the same argument on the \emph{request} $[7,15]$ instead and the conclusion
+is false: deleting that literal's first link clause leaves the proof verifying.
+The reason is that $[7,15]$ is a union of two cells, so the invariants supply a
+second route. Containment carries $\natin{x}{7}{15}$ \emph{down} to
+$\natin{x}{7}{10}$ and $\natin{x}{11}{15}$; those cells have link pairs of their
+own, which carry them to $\natin{v}{20}{23}$ and $\natin{v}{15}{19}$; and $V$'s
+request covering
+$\natin{v}{15}{23}\vee\atin{v}{15}{19}\vee\atin{v}{20}{23}$ lifts them back up.
+So it is the \emph{family} of first clauses that is load-bearing, and no single
+member of it, for any literal that is not a cell on both sides.  W6 to W9 are
+built on unsplit cells for exactly this reason.
 
 \paragraph{Why a nearby instance proves nothing.}
-Replace the decision by $\neg[X\in 1..15]$, whose interval abuts the lower bound.
-Now no link clause is needed at all.  \cref{eq:din2} for it is
+Take instead the decision $\natin{x}{1}{15}$, whose interval abuts the lower
+bound.  Now no link clause is needed at all.  \cref{eq:din2} for it is
 $\atin{x}{1}{15}\vee\natge{x}{1}\vee\atge{x}{16}$; the boundary pin
-$\atge{x}{1}$ of \inv{Bound} is a unit, so $\atge{x}{16}$ propagates.  The ge-link
-carries that to $\natge{v}{15}$, since $X\geq 16$ is $V\leq 14$, and the
+$\atge{x}{1}$ of \inv{Bound} is a unit, so $\atge{x}{16}$ propagates.  The
+ge-link carries that to $\natge{v}{15}$, since $X\geq 16$ is $V\leq 14$, and the
 \emph{forward} reification of the image literal $\atin{v}{15}{29}$ then falsifies
 it.  A green result on this instance says nothing whatever about the link pair,
 and three further shapes have the same property --- see \nsec{sec:coincidence},
@@ -2204,10 +2322,13 @@ where 80\% of small random instances turn out to be one of them.
 \item \textbf{Variables with no bit vector.}  As noted in
   \nsec{sec:notprovided}, interval literals need cuts to reify against.  The
   gate is whether the variable has a registered bit vector, not what its domain
-  looks like: a two-valued variable given a purely direct encoding is registered
-  with a one-element bit vector, and is therefore \emph{not} the failing case,
-  even though it has no order atoms until they are built lazily.  The failing
-  case is a direct-only variable of width three or more.  Consumers guard on the
+  looks like: a variable with domain exactly $\{0,1\}$, given a purely direct
+  encoding, is registered with a one-element bit vector, and is therefore
+  \emph{not} the failing case, even though it has no order atoms until they are
+  built lazily.  Note that the test is on the two \emph{values}, not on the
+  width: a direct-only variable with domain $\{5,6\}$ has no bit vector and does
+  throw.  So the failing case is any direct-only variable other than a
+  $\{0,1\}$ one.  Consumers guard on the
   same predicate, which resolves a view to its base --- correctly, since a view
   of a bit-vector-less variable would have to mirror onto a variable that cannot
   hold the mirror.
@@ -2221,13 +2342,18 @@ where 80\% of small random instances turn out to be one of them.
   OPB surface that a verified encoder conforms against.  The decision is open
   and should be taken alongside that work.
 
-\item \textbf{Assertion levels.}  Where the checker is asked to take the
-  definitional layer on trust rather than checking it, the linking clauses are
-  asserted rather than derived, and the covering and containment apparatus is
-  omitted entirely.  This is consistent --- if the definitions are not present,
-  neither are the facts they would let unit propagation derive --- but the
-  theorems above are stated for the fully-derived setting, and the trusted
-  settings are not separately exercised by the witness suite.
+\item \textbf{Assertion levels.}  The solver can be asked to \emph{assert} parts
+  of the proof rather than derive them, on a scale running
+  \textsc{Off} $<$ \textsc{Definitions} $<$ \textsc{Links} $<$
+  \textsc{Inferences} $<$ \textsc{Backtracking}.  At \textsc{Links} the atom
+  definitions and the linking clauses are asserted, but the covering and
+  containment apparatus is still emitted, as ordinary RUP lines: the guards on
+  it are all ``above \textsc{Links}''.  Above \textsc{Links} the interval
+  machinery is skipped entirely, and no cells exist.  So there is no setting in
+  which the links are asserted and the apparatus is dropped, which is what an
+  earlier draft of this entry claimed.  The theorems above are stated for the
+  fully-derived setting; the asserting levels are not separately exercised by the
+  witness suite.
 
 \item \textbf{Unregistered views.}  A view first encountered during proof
   logging, after the model is closed, cannot be given a representation variable,

--- a/dev_docs/literal-encodings.tex
+++ b/dev_docs/literal-encodings.tex
@@ -65,20 +65,27 @@
 \crefname{remarkN}{Remark}{Remarks}
 
 % ---------------------------------------------------------------------- macros
-\newcommand{\BinEnc}{\ensuremath{\operatorname{BinEnc}}}
-\newcommand{\Bnd}{\ensuremath{\operatorname{Bnd}}}
-\newcommand{\Def}{\ensuremath{\operatorname{Def}}}
-\newcommand{\Lin}{\ensuremath{\operatorname{Lin}}}
-\newcommand{\Aux}{\ensuremath{\operatorname{Aux}}}
-\newcommand{\Vars}{\ensuremath{\operatorname{Vars}}}
-\newcommand{\Rep}{\ensuremath{\operatorname{Rep}}}
-\newcommand{\Link}{\ensuremath{\operatorname{Link}}}
-\newcommand{\Cells}{\ensuremath{\operatorname{Cells}}}
-\newcommand{\Bdry}{\ensuremath{\operatorname{Bd}}}
-\newcommand{\dm}{\ensuremath{\operatorname{dom}}}
-\newcommand{\ImpLits}{\ensuremath{\operatorname{ImpLits}}}
-\newcommand{\Standardise}{\ensuremath{\operatorname{Standardise}}}
-\newcommand{\Linearise}{\ensuremath{\operatorname{Linearise}}}
+% Every function, set and procedure name goes through \fname, and every
+% constraint name through \globalcon, so that their fonts can be changed in one
+% place rather than hunted for.
+\newcommand{\fname}[1]{\ensuremath{\operatorname{#1}}}
+\newcommand{\globalcon}[1]{\ensuremath{\mathrm{#1}}}
+\newcommand{\BinEnc}{\fname{BinEnc}}
+\newcommand{\Bnd}{\fname{Bnd}}
+\newcommand{\Def}{\fname{Def}}
+\newcommand{\Lin}{\fname{Lin}}
+\newcommand{\Aux}{\fname{Aux}}
+\newcommand{\Vars}{\fname{Vars}}
+\newcommand{\Rep}{\fname{Rep}}
+\newcommand{\ViewLink}{\fname{ViewLink}}
+\newcommand{\Cells}{\fname{Cells}}
+\newcommand{\Bdry}{\fname{Bd}}
+\newcommand{\dm}{\fname{dom}}
+\newcommand{\ImpLits}{\fname{ImpLits}}
+\newcommand{\Standardise}{\fname{Standardise}}
+\newcommand{\Linearise}{\fname{Linearise}}
+\newcommand{\NeededReps}{\fname{NeededRepresentations}}
+\newcommand{\NeededAtomicVariables}{\fname{NeededAtomicVariables}}
 \newcommand{\atge}[2]{#1_{\geq #2}}
 \newcommand{\ateq}[2]{#1_{= #2}}
 \newcommand{\atin}[3]{#1_{\in[#2,#3]}}
@@ -116,19 +123,20 @@
 \section*{About this document}
 
 This is a revised and extended version of Sections~3.2 and~3.3 of the first
-author's PhD thesis, \emph{Proof Logging for Constraint Programming}
-(University of Glasgow, 2026), adapted and reused with substantial additions.
-It exists for three reasons: as the basis of a journal treatment of
-pseudo-Boolean proof logging for constraint programming; as the single
-authoritative account, for the Glasgow Constraint Solver's developers, of what
-a literal is and what makes the literal layer work; and as a target for
-adversarial review, since a subtle defect in this design is much cheaper to
-find now than to diagnose later from an incomprehensible verifier rejection.
+author's PhD thesis, \emph{Pseudo-Boolean Proof Logging for Constraint
+Propagation Algorithms} (University of Glasgow, 2026), adapted and reused with
+substantial additions.  It exists for three reasons: as the basis of a journal
+treatment of pseudo-Boolean proof logging for constraint programming; as the
+single authoritative account, for the Glasgow Constraint Solver's developers, of
+what a literal is and what makes the literal layer work; and as a target for
+adversarial review.  A subtle defect in this design is much cheaper to find now
+than to diagnose later from an incomprehensible verifier rejection.
 
-The thesis presents a single integer variable represented one way (a
-two's-complement bit vector) and carrying two families of atomic literal (order
-atoms $\atge{x}{v}$ and equality atoms $\ateq{x}{v}$).  Two things have changed
-in the solver since.
+The thesis presents a canonical pseudo-Boolean representation of integer
+variables using two's complement bit-vectors.  Additionally, there are two
+families of ``atomic literals'': inequality atoms $\atge{x}{v}$ and equality
+atoms $\ateq{x}{v}$.  The solver has since gained interval literals and views,
+neither of which the thesis covers.
 
 \begin{itemize}
   \item \textbf{Interval literals.}  There is now a third family, $\atin{x}{a}{b}$,
@@ -145,9 +153,9 @@ in the solver since.
     linking clauses.
 \end{itemize}
 
-Neither addition is conservative over the thesis's propagation results.  Order
-and equality atoms are complete under unit propagation given the order chain
-alone; interval literals are not, and need two further families of
+Neither addition is conservative over the thesis's propagation results.
+Inequality and equality atoms are complete under unit propagation given the
+order chain alone; interval literals are not, and need two further families of
 state-independent clause.  Facts move between two representations of the same
 variable only through linking clauses, and --- for interval literals --- the
 direction that a proof actually needs is the one that is \emph{not} derivable
@@ -212,7 +220,7 @@ equivalent to an input CSP, at least for some generalised definition of the
 word ``obvious''.  For clarity, we will talk about transforming a ``CP
 problem'' into a ``PB problem''.
 
-\subsubsection{The Difficulty of Equivalence}
+\subsubsection{Defining Equivalence for Proofs}
 
 The ultimate goal of encoding for proof logging purposes is to trust that the
 process preserves the integrity of the proof with respect to the original
@@ -226,19 +234,20 @@ So at one level, the only guarantees we really need are:
     objective is equal to the optimal value of the PB objective.
 \end{description}
 
-To make it easier to obtain these guarantees, we employ very restricted
-transformations with minimal reformulation --- much less than one might use if
-encoding in order to solve the problem with a PB or SAT system.  We want our
-encodings to be as ``dumb'' as possible, because we want to be extremely
-certain that the two properties hold.  So in practice, our working definition
-of equivalence is: ``the PB problem is the result of applying
-\cref{proc:encoding} to the CP problem''.
+However, to make it easier to obtain these guarantees, we should employ very
+restricted transformations with minimal reformulation, much less than one might
+use if encoding in order to use a PB or SAT system to solve the problem.  To put
+it simply, we want our encodings to be as ``dumb'' as possible because we want to
+be extremely certain the two properties hold.  So in practice, our working
+definition of equivalence is: ``the PB problem is the result of applying
+\cref{proc:encoding} to the CP problem''.  We will define this procedure shortly.
 
 The one substantive change to this section from the thesis is that the encoding
 now admits two further \emph{shared} classes of introduced variable, beyond the
 atomic constraint variables: \emph{representation variables} for affine views,
-and a third kind of atomic variable for intervals.  Both are still fully
-determined by an assignment to the original variables, which is what keeps P1
+and a third kind of atomic variable for intervals.  Both are still uniquely
+determined, semantically, by an assignment to the original variables: their
+definition constraints and their links leave no freedom.  That is what keeps P1
 and P2 easy to argue.
 
 \subsubsection{A Transformation Procedure}
@@ -252,55 +261,64 @@ the variables' values in exactly the same way as the original CP constraints.
 We have the freedom to introduce auxiliary variables at this stage to assist in
 the linearisation (such as the $u$ flag in \cref{ex:pbenc}).
 
-Three classes of introduced variable are \emph{shared} between linearisations
-rather than private to one, and each is fully determined by an assignment to
+Two classes of introduced variable are \emph{shared} between linearisations
+rather than private to one, and each is uniquely determined by an assignment to
 the original variables:
 
 \begin{itemize}
-  \item \textbf{Representation variables} name affine images $sX+c$ of an
-    original variable.  A constraint posted over a \emph{view} of $X$ is
-    linearised over the corresponding representation variable.
-  \item \textbf{Atomic constraint variables} are $0$--$1$ variables denoting
-    basic relationships between a variable and a value or an interval of values.
-  \item Both come with \emph{definition constraints}, which are fully reified
-    and hence entirely redundant.
+  \item \textbf{Representation variables} name affine views $sX+c$ of an
+    original variable.  A constraint posted over a view of $X$ is linearised
+    over the corresponding representation variable.
+  \item \textbf{Atomic constraint variables} (or simply \emph{atomic
+    variables}) are $0$--$1$ variables denoting basic relationships between a
+    variable and a value or an interval of values.
 \end{itemize}
 
-Everything else introduced by a linearisation is private to it.  The soundness
-of concatenating linearisations rests on exactly that division; see
-\cref{lem:composing}.
+Both come with \emph{definition constraints}, which are fully reified on fresh
+variables.  That makes them redundant in one specific sense: the values of the
+introduced variables are uniquely determined for any solution, so the solution
+set projected onto the original variables is unchanged, and in particular
+adding them cannot change satisfiability or the objective value.  It does not
+make them dispensable, since they are what the proof reasons with; nor does it
+mean that solutions can be counted without regard to them, which is what the
+preserved set of \cref{sec:enumeration} is for.
+
+All other variables introduced as part of a linearisation should not appear in
+other linearisations.  The soundness of concatenating linearisations rests on
+exactly that division; see \cref{lem:composing}.
 
 We assume we start with a general constraint satisfaction problem, with
 variable set $\mathcal V$, finite domains $\dm_0(X_i)$ for $X_i\in\mathcal V$,
 and constraints $\mathcal C$.  All domains can be assumed to be ranges of
 integers without holes, since any missing values can be modelled with
 additional constraints if necessary.  We also assume that the constraints are a
-flat list.
+flat list, without constructs such as loops that might be found in a
+higher-level modelling language.
 
 \begin{procedureT}
 \label{proc:encoding}
 For a CSP with variables $\mathcal V$, initial domain state (without holes)
 $\dm_0$, and constraints $\mathcal C$, we can produce a PB formula as follows.
 \begin{enumerate}[label=\arabic*:,leftmargin=2.6em,itemsep=1pt]
-  \item $\mathcal R \leftarrow \bigcup_{X\in\mathcal V}\{X\}
-        \cup \bigcup_{C\in\mathcal C}\text{NeededRepresentations}(C)$
-  \item $\Bnd(\mathcal R) \leftarrow \bigcup_{W\in\mathcal R}\Bnd(W,\dm_0)$
-  \item $\Link(\mathcal R) \leftarrow \bigcup_{W\in\mathcal R}\Link(W)$
+  \item $\mathcal W \leftarrow \bigcup_{X\in\mathcal V}\{X\}
+        \cup \bigcup_{C\in\mathcal C}\NeededReps(C)$
+  \item $\ViewLink(\mathcal W) \leftarrow \bigcup_{W\in\mathcal W}\ViewLink(W)$
+  \item $\Bnd(\mathcal W) \leftarrow \bigcup_{W\in\mathcal W}\Bnd(W,\dm_0)$
   \item $\mathcal A \leftarrow \bigcup_{C\in\mathcal C}
-        \text{NeededAtomicVariables}(C,\dm_0)$
+        \NeededAtomicVariables(C,\dm_0)$
   \item $\Def(\mathcal A) \leftarrow \bigcup_{y\in\mathcal A}\Def(y)$
   \item $\Lin(\mathcal C) \leftarrow \bigcup_{C\in\mathcal C}\Linearise(C,\dm_0)$
-  \item $F \leftarrow \BinEnc\bigl(\Bnd(\mathcal R)\cup\Link(\mathcal R)
+  \item $F \leftarrow \BinEnc\bigl(\Bnd(\mathcal W)\cup\ViewLink(\mathcal W)
         \cup\Def(\mathcal A)\cup\Lin(\mathcal C)\bigr)$
   \item $F \leftarrow \Standardise(F)$
 \end{enumerate}
 \end{procedureT}
 
-Steps~1 and~3 are new; step~5 now has a third case.  The remainder of this
+Steps~1 and~2 are new; step~5 now has a third case.  The remainder of this
 section gives more detail on each stage along with soundness arguments, and
 introduces notation used throughout.
 
-\paragraph{Step 1 and 3: representations and their links.}
+\paragraph{Steps 1 and 2: representations and their links.}
 
 \begin{definitionT}[Representation]
 \label{def:rep}
@@ -313,40 +331,40 @@ to $W = s_W X + c_W$.  Write
 \]
 so that $\varphi_W$ is an order-preserving bijection $\mathbb Z\to\mathbb Z$
 when $s_W=+1$ and an order-reversing one when $s_W=-1$.  Every CP variable is a
-representation of itself, with $\varphi_X=\mathrm{id}$.  We write $\Rep(X)$ for
-the set of representations of $X$ occurring in the encoding, and
-$\mathcal R = \bigcup_{X\in\mathcal V}\Rep(X)$.  A representation $W\neq X$ is
-\emph{derived}, and $X$ is its \emph{base}; $\Rep$ is a partition of $\mathcal
-R$ by base.
+representation of itself, with $\varphi_X$ the identity function.  We write
+$\Rep(X)$ for the set of representations of $X$ occurring in the encoding, and
+$\mathcal W = \bigcup_{X\in\mathcal V}\Rep(X)$.  A representation $W\neq X$ is
+\emph{proper}, and $X$ is its \emph{base}; $\Rep$ is a partition of $\mathcal
+W$ by base.
 \end{definitionT}
 
-For each derived $W\in\Rep(X)$, $\Link(W)$ is the single linear equality
+For each proper $W\in\Rep(X)$, $\ViewLink(W)$ is the single linear equality
 \begin{equation}
-  \Link(W) \;:=\; W - s_W X = c_W ,
+  \ViewLink(W) \;:=\; W - s_W X = c_W ,
   \label{eq:link}
 \end{equation}
 which \Standardise{} will split into a $\geq$ and a $\leq$ row.  For a base
-variable, $\Link(X)$ is empty.
+variable, $\ViewLink(X)$ is empty.
 
 Representation variables arise because constraints are posted over
 \emph{operands}, and an operand may be a view.  A modelling layer that writes
-$\mathrm{AllDifferent}(X_1, X_2+1, X_3+2)$ is naming three operands, two of
-which are derived representations of $X_2$ and $X_3$.  Two different
+$\globalcon{AllDifferent}(X_1, X_2+1, X_3+2)$ is naming three operands, two of
+which are proper representations of $X_2$ and $X_3$.  Two different
 constraints may name the same view, and one variable may be named through
 several different views at once, which is precisely why representation
 variables have to be shared rather than private to a linearisation.
 
-The alternative --- substituting $s X + c$ for the view wherever it occurs, and
-stating everything in $X$'s atoms --- is rejected, for a reason that only
-becomes visible in \cref{sec:framework}: it makes the atoms appearing in the
-encoding of a constraint depend on \emph{which} wrapper the constraint happened
-to be handed, so a generic constraint-logging procedure can no longer treat
-every operand identically, and a cutting-planes step that resolves an operand
-against a constraint body has to know which representation that body is stated
-in.  Giving the view its own variable costs one linear equality and makes every
-operand look the same.
+We reject the alternative --- substituting $s X + c$ for the view wherever it
+occurs, and stating everything in $X$'s atoms --- for a reason that only becomes
+visible in \cref{sec:framework}.  It makes the atoms appearing in the encoding of
+a constraint depend on \emph{which} wrapper the constraint happened to be handed,
+so a generic constraint-logging procedure can no longer treat every operand
+identically, and a cutting-planes step that resolves an operand against a
+constraint body has to know which representation that body is stated in.  Giving
+the view a variable of its own costs one linear equality, and makes every operand
+look the same.
 
-\paragraph{Step 2: domain bound constraints.}
+\paragraph{Step 3: domain bound constraints.}
 For a representation $W$ of $X$ and domain state $\dm_0$, let $\Bnd(W,\dm_0)$
 be the two linear constraints
 \begin{equation}
@@ -360,29 +378,29 @@ When it is clear from context we omit $\dm_0$ and write $\Bnd(W)$.  We call
 $[\,\min\varphi_W(\dm_0(X)),\ \max\varphi_W(\dm_0(X))\,]$ the \emph{definition
 range} of $W$ and denote it $[l_W,u_W]$.
 
-Note that $\Bnd(W)$ for a derived $W$ is implied by $\Bnd(X)$ together with
-$\Link(W)$ (it is their sum, up to sign), so asserting it changes nothing.  It
+Note that $\Bnd(W)$ for a proper $W$ is implied by $\Bnd(X)$ together with
+$\ViewLink(W)$ (it is their sum, up to sign), so asserting it changes nothing.  It
 is asserted anyway, because unit propagation cannot add two constraints
 together, and several later arguments need $W$'s own bounds to be available as
 units on $W$'s own atoms.
 
-Clearly, if we construct a CSP with variables $\mathcal R$, constraints
-$\mathcal C \cup \Bnd(\mathcal R)\cup\Link(\mathcal R)$, and unrestricted
+Clearly, if we construct a CSP with variables $\mathcal W$, constraints
+$\mathcal C \cup \Bnd(\mathcal W)\cup\ViewLink(\mathcal W)$, and unrestricted
 integer domains, then this has exactly the same solution set as our original
-CSP, projected onto $\mathcal V$: every derived representation is determined by
+CSP, projected onto $\mathcal V$: every proper representation is determined by
 its base through \cref{eq:link}.
 
 \paragraph{Steps 4 and 5: atomic constraint variables.}
 These are fresh $0$--$1$ variables that can be shared between linearisations
 and have a special meaning.  For each supported constraint type $C$ we need to
-know which atomic variables it requires, so $\text{NeededAtomicVariables}$ is
+know which atomic variables it requires, so $\NeededAtomicVariables$ is
 defined on a per-constraint basis; usually this is immediately clear from the
 definition of $\Linearise(C,\dm_0)$.
 
 Each atomic variable $y$ requires a fully reified linear definition constraint
 $\Def(y)$ of the form $y\Leftrightarrow C$.  We allow three types of atomic
 variable definition, each associated with a \emph{representation}
-$W\in\mathcal R$ --- not merely with a CP variable --- and with one or two
+$W\in\mathcal W$ --- not merely with a CP variable --- and with one or two
 integers.  For clarity we always use subscripted names suggestive of the
 definition, writing $w$ for the PB name of the representation $W$.
 
@@ -449,7 +467,7 @@ For each constraint $C$ we require a function $\Linearise(C,\dm_0)$ turning it
 into a set of reified linear constraints $\Lin(C)$.  This can use
 representation variables, atomic literals, and further auxiliary variables.
 Write $\Vars(\Lin(C))$ for the set of variables appearing in the
-linearisation, and let $\Aux(C) = \Vars(\Lin(C))\setminus(\mathcal R\cup
+linearisation, and let $\Aux(C) = \Vars(\Lin(C))\setminus(\mathcal W\cup
 \mathcal A)$ be the auxiliary variables introduced.  We require:
 
 \begin{description}[font=\normalfont\bfseries,leftmargin=2.4em]
@@ -472,12 +490,12 @@ linearisation, and let $\Aux(C) = \Vars(\Lin(C))\setminus(\mathcal R\cup
     $\Aux(C_1)\cap\Aux(C_2)=\emptyset$ for all $C_1\neq C_2$.  Representation
     variables and atomic variables are \emph{not} auxiliary variables and may be
     shared freely.
-  \item[L4.] Most importantly, $\Lin(C)\cup\Def(\mathcal A)\cup\Link(\mathcal R)$
+  \item[L4.] Most importantly, $\Lin(C)\cup\Def(\mathcal A)\cup\ViewLink(\mathcal W)$
     must enforce the same restriction as $C$ on the variables in $\mathcal V$.
     That is, a valid assignment $\sigma:\mathcal V\to\mathbb Z$ satisfies $C$ if
     and only if it can be extended to a valid assignment
-    $\sigma^+:\Vars(\Lin(C)\cup\Def(\mathcal A)\cup\Link(\mathcal R))\to\mathbb Z$
-    satisfying $\Lin(C)\cup\Def(\mathcal A)\cup\Link(\mathcal R)$.
+    $\sigma^+:\Vars(\Lin(C)\cup\Def(\mathcal A)\cup\ViewLink(\mathcal W))\to\mathbb Z$
+    satisfying $\Lin(C)\cup\Def(\mathcal A)\cup\ViewLink(\mathcal W)$.
 \end{description}
 
 L3 is where representation variables differ from the thesis's presentation:
@@ -491,7 +509,7 @@ variable's value uniquely from the assignment to $\mathcal V$.
 Let $P$ be a CSP with variables $\mathcal V$ and constraints $\mathcal C$,
 where all domains are integer ranges.  After executing steps~1 to~6 of
 \cref{proc:encoding} let $P'$ be the CSP with constraints
-$\mathcal C' := \Lin(\mathcal C)\cup\Bnd(\mathcal R)\cup\Link(\mathcal R)
+$\mathcal C' := \Lin(\mathcal C)\cup\Bnd(\mathcal W)\cup\ViewLink(\mathcal W)
 \cup\Def(\mathcal A)$, whose variables are precisely those occurring in
 $\mathcal C'$, and whose domain for every non-$0$--$1$ variable is $\mathbb Z$.
 Then:
@@ -506,48 +524,48 @@ Then:
 \begin{proof}
 Call a variable of $P'$ \emph{determined} if its value is a function of the
 restriction of an assignment to $\mathcal V$ alone.  Every variable in
-$\mathcal R\cup\mathcal A$ is determined: a derived representation by
+$\mathcal W\cup\mathcal A$ is determined: a proper representation by
 \cref{eq:link}, and an atomic variable by its definition constraint, which is a
-fully reified constraint over $\mathcal R$ (for $\atge{w}{v}$) or over
+fully reified constraint over $\mathcal W$ (for $\atge{w}{v}$) or over
 previously determined atomic variables (for $\ateq{w}{v}$ and $\atin{w}{a}{b}$,
 whose definitions mention only bound variables of the same representation).
 The determination is well founded because the dependency order is
-$\mathcal V \to \mathcal R \to \{\text{bound}\} \to
+$\mathcal V \to \mathcal W \to \{\text{bound}\} \to
 \{\text{equality},\text{interval}\}$, with no cycles.
 
 \emph{Part 1.}  Let $\sigma$ be a solution to $P$ and $C_1,\dots,C_n$ the
 constraints of $P$.  By validity, $\sigma$ satisfies $\Bnd(\mathcal V)$, and
 extending it by the determined values satisfies $\Bnd(\mathcal
-R)\cup\Link(\mathcal R)$.  By L4, $\sigma$ can be extended to a solution
-$\sigma_1$ of $\Bnd(\mathcal R)\cup\Link(\mathcal R)\cup\Def(\mathcal
+W)\cup\ViewLink(\mathcal W)$.  By L4, $\sigma$ can be extended to a solution
+$\sigma_1$ of $\Bnd(\mathcal W)\cup\ViewLink(\mathcal W)\cup\Def(\mathcal
 A)\cup\Lin(C_1)$.
 
 Now assume we have extended $\sigma$ to a solution $\sigma_{k-1}$ of
-$\Bnd(\mathcal R)\cup\Link(\mathcal R)\cup\Def(\mathcal A)\cup
+$\Bnd(\mathcal W)\cup\ViewLink(\mathcal W)\cup\Def(\mathcal A)\cup
 \bigcup_{i<k}\Lin(C_i)$.  By L4 again, $\sigma$ can be extended to a solution
-$\sigma'_k$ of $\Bnd(\mathcal R)\cup\Link(\mathcal R)\cup\Def(\mathcal
+$\sigma'_k$ of $\Bnd(\mathcal W)\cup\ViewLink(\mathcal W)\cup\Def(\mathcal
 A)\cup\Lin(C_k)$.  Define $\sigma_k$ by
 \begin{align}
   \sigma_k(V) &= \sigma(V) && \text{if } V\in\mathcal V; \\
-  \sigma_k(V) &= \sigma_{k-1}(V) && \text{if } V\in\mathcal R\cup\mathcal A; \\
+  \sigma_k(V) &= \sigma_{k-1}(V) && \text{if } V\in\mathcal W\cup\mathcal A; \\
   \sigma_k(V) &= \sigma_{k-1}(V) && \text{if otherwise }
      V\in\Vars\bigl(\bigcup_{i<k}\Lin(C_i)\bigr); \\
   \sigma_k(V) &= \sigma'_k(V) && \text{if otherwise } V\in\Vars(\Lin(C_k)).
 \end{align}
 This is an extension of $\sigma$, and it satisfies both $\Lin(C_k)$ and
-$\Bnd(\mathcal R)\cup\Link(\mathcal R)\cup\Def(\mathcal A)\cup
+$\Bnd(\mathcal W)\cup\ViewLink(\mathcal W)\cup\Def(\mathcal A)\cup
 \bigcup_{i<k}\Lin(C_i)$, because
 $\sigma_k(V)=\sigma_{k-1}(V)=\sigma'_k(V)$ for every $V\in\mathcal
-V\cup\mathcal R\cup\mathcal A$ --- each such $V$ being determined by $\sigma$,
+V\cup\mathcal W\cup\mathcal A$ --- each such $V$ being determined by $\sigma$,
 which all three assignments extend --- while
 $\Vars(\bigcup_{i<k}\Lin(C_i))\cap\Vars(\Lin(C_k))\subseteq
-\mathcal V\cup\mathcal R\cup\mathcal A$ by L3, so $\sigma_k$ is an extension of
+\mathcal V\cup\mathcal W\cup\mathcal A$ by L3, so $\sigma_k$ is an extension of
 both $\sigma_{k-1}$ and $\sigma'_k$.  The claim follows by induction.
 
 \emph{Part 2.}  Let $\sigma'$ be a solution to $P'$.  There is only one
 possible restriction of $\sigma'$ to a valid assignment to $\mathcal V$; and by
-L4, since $\sigma'$ satisfies $\Lin(C_i)\cup\Def(\mathcal A)\cup\Link(\mathcal
-R)$ for each $i$, that restriction must satisfy each $C_i$ and hence $P$.
+L4, since $\sigma'$ satisfies $\Lin(C_i)\cup\Def(\mathcal A)\cup\ViewLink(\mathcal
+W)$ for each $i$, that restriction must satisfy each $C_i$ and hence $P$.
 \end{proof}
 
 We refer to the result of steps~1 to~6 as the \emph{intermediate ILP}.  In the
@@ -565,7 +583,7 @@ is posted over the view $Z' = -Z + 7$ as $X - Z' \geq -4$, could be
   &u \Rightarrow X - Y > 0; \qquad \bar u \Rightarrow Y - X > 0;\\
   &X - Z' \geq -4 .
 \end{align}
-Line \cref{eq:exlink} is $\Link(Z')$, and $\Bnd(Z')$ is the image of
+Line \cref{eq:exlink} is $\ViewLink(Z')$, and $\Bnd(Z')$ is the image of
 $\Bnd(Z)$ under $\varphi_{Z'}(k) = -k+7$.
 \end{exampleT}
 
@@ -574,10 +592,10 @@ $\BinEnc$ turns the intermediate ILP into a $0$--$1$ ILP by replacing each
 occurrence of a non-Boolean variable with a binary exponential sum.  This may
 be a poor encoding from a solving perspective, but it maintains the form of the
 ILP, letting us ``pretend'' we have integer variables while working honestly
-with native PB constraints.  Every variable in $\mathcal R$ --- derived
+with native PB constraints.  Every variable in $\mathcal W$ --- proper
 representations included --- is replaced, and each gets its \emph{own} bit
 vector: $\BinEnc(W)$ and $\BinEnc(X)$ share no PB variables, and are related
-only by the encoded form of $\Link(W)$.
+only by the encoded form of $\ViewLink(W)$.
 
 Specifically, for any non-$0$--$1$ variable $W$ with definition range
 $[l_W,u_W]$: if $l_W\geq 0$, let $h$ be least with $2^h\geq u_W+1$ and define
@@ -595,7 +613,7 @@ the encoding.
 
 \begin{remark}
 Two width details matter in practice and neither affects the argument.  First,
-the bit vector of a derived representation is sized from $[l_W,u_W]$, and can be
+the bit vector of a proper representation is sized from $[l_W,u_W]$, and can be
 \emph{wider} than that of its base: a view of a variable with range $[1,8]$ has
 range $[1,8]$ too but a bit vector spanning $[0,15]$, and a view $X+10^6$ has a
 much wider one.  Any coefficient bound or big-$M$ computed for a line mentioning
@@ -636,8 +654,8 @@ of assignments to $\mathcal V$ (projected from full assignments) that satisfy
 $P'$.  Let $F^*$ be the $0$--$1$ linear CSP obtained after step~7.  Every
 solution to $P'$ corresponds to a solution of $F^*$, by assigning to each
 non-$0$--$1$ variable $W$ the unique $h$-bit vector representing its value ---
-note that this is well defined for a derived representation exactly as for a
-base one, since $\Link(W)$ and $\Bnd(W)$ force $W$'s value into $[l_W,u_W]$,
+note that this is well defined for a proper representation exactly as for a
+base one, since $\ViewLink(W)$ and $\Bnd(W)$ force $W$'s value into $[l_W,u_W]$,
 which its bit width covers.  Conversely, every solution to $F^*$ corresponds to
 a solution of $P'$ by decoding each bit vector.  The final formula $F$ obtained
 after step~8 has exactly the same solutions as $F^*$.
@@ -652,7 +670,7 @@ P2 holds.
 
 \begin{remark}
 The projection in \cref{thm:p1p2} is onto the bits of the \emph{base} variables
-only.  The bits of derived representations, and all atomic variables, are
+only.  The bits of proper representations, and all atomic variables, are
 determined but not projected onto.  This matters for enumeration; see
 \cref{sec:enumeration}.
 \end{remark}
@@ -662,15 +680,16 @@ determined but not projected onto.  This matters for enumeration; see
 To instantiate the encoding method for concrete CSPs we exhibit ``sufficiently
 obvious'' linearisations for all supported non-linear constraints.  These are
 unchanged from the thesis, and are not reproduced here; the encodings for
-$\mathrm{NotEquals}$, $\mathrm{Abs}$, $\mathrm{Element}$, $\mathrm{ArrayMin}$,
-$\mathrm{ArrayMax}$, $\mathrm{Count}$, $\mathrm{NValue}$,
-$\mathrm{AllDifferent}$ and $\mathrm{Table}$ satisfy L1 to L4 by inspection.
+$\globalcon{NotEquals}$, $\globalcon{Abs}$, $\globalcon{Element}$,
+$\globalcon{ArrayMin}$, $\globalcon{ArrayMax}$, $\globalcon{Count}$,
+$\globalcon{NValue}$, $\globalcon{AllDifferent}$ and $\globalcon{Table}$
+satisfy L1 to L4 by inspection.
 
 Two remarks are needed in the extended setting.
 
 First, a constraint's operands may be representations rather than base
 variables, and its linearisation is written over the operands.  Thus
-$\mathrm{AllDifferent}(W_1,\dots,W_n)$ linearises to
+$\globalcon{AllDifferent}(W_1,\dots,W_n)$ linearises to
 $u_{ij}\Rightarrow W_i - W_j > 0$ and $\bar u_{ij} \Rightarrow W_j - W_i > 0$
 over exactly the operands it was given, with no reference to their bases.  This
 is what ``the encoding is generic in the operand'' means, and it is the property
@@ -859,7 +878,7 @@ $t$ in the proof.
 \item[\invRep{}: representation closure and linking.]
   For every $W,W'\in\Rep(X)$: if an atomic variable of $W$ is defined, then so is
   the corresponding atomic variable of $W'$ (\cref{def:image} below); and for
-  every defined atomic variable of a derived $W$, the two clauses linking it to
+  every defined atomic variable of a proper $W$, the two clauses linking it to
   the corresponding atomic variable of the base $X$ appear in $F_t$.
 
 \item[\invName{}: cells are named.]
@@ -935,7 +954,7 @@ literal into a negative one, but leaves the polarity of equality and interval
 literals alone --- an interval is order-agnostic, a half-line is not.
 
 The linking clauses are exactly the clausal form of the biconditional
-$\ell \Leftrightarrow \ell^{X}$, for each defined atom of each derived
+$\ell \Leftrightarrow \ell^{X}$, for each defined atom of each proper
 representation:
 \begin{align}
   \text{ge-link:}\quad
@@ -954,13 +973,13 @@ representation:
 
 The eq-link and the in-link are RUP at the point they are emitted.  \textbf{The
 ge-link is not}, and this is worth being precise about, because the natural
-assumption is that it is.  Summing $\Def(\atge{w}{v})$, $\Link(W)$ and the
+assumption is that it is.  Summing $\Def(\atge{w}{v})$, $\ViewLink(W)$ and the
 corresponding half of $\Def((\atge{w}{v})^X)$ does make the $\BinEnc$ terms
 cancel exactly, and saturating leaves the clause --- but that is a
 \emph{cutting-planes} derivation, not a unit-propagation one.  What would make
 the configuration RUP is Theorem~2.9 of the thesis, and it requires the middle
 constraint's right-hand side to lie in $\{0,1\}$; here that constraint is a half
-of $\Link(W)$, so the right-hand side is $\pm c_W$, and the theorem does not
+of $\ViewLink(W)$, so the right-hand side is $\pm c_W$, and the theorem does not
 apply once $|c_W|>1$.  Example~2.15 of the thesis is a counterexample of exactly
 this shape.
 
@@ -1388,7 +1407,7 @@ $\ell^{W'}$ propagates under $R$.
 It suffices to show that a literal crosses a single link pair, in either
 direction and either polarity; a general $W\to W'$ transport is then at most two
 such crossings, through the base, because images compose:
-$(\ell^{X})^{W'} = \ell^{W'}$.  So take $W$ derived and consider its link to the
+$(\ell^{X})^{W'} = \ell^{W'}$.  So take $W$ proper and consider its link to the
 base.  By \invRep{} the atomic variable underlying $\ell^{X}$ is defined and the
 two linking clauses
 \cref{eq:gelink}, \cref{eq:eqlink} or \cref{eq:inlink} appear in $F_t$.  Those
@@ -1403,7 +1422,7 @@ combinations are therefore covered.
 \begin{remarkN}[Why naming, not requesting, is the trigger]
 \label{rem:naming}
 \cref{lem:transport} is only as good as \invRep{}, and \invRep{} is the
-invariant that is easiest to break silently.  Bound and equality atoms are
+invariant that is easiest to break silently.  Inequality and equality atoms are
 mirrored eagerly at the moment they are defined, so for them \invRep{} is
 maintained by construction.  Interval literals are not, because they come into
 existence two ways: because some consumer asked for one --- a conclusion, a
@@ -1557,14 +1576,14 @@ the pair
 \]
 each RUP by the Theorem~2.9 configuration --- which does apply here, the middle
 constraint being an equality between two bit-sums, so its right-hand side is
-zero.  The lemmas' \emph{conclusions} mention only order atoms, which is what
-lets them be shared by any interval literal with those endpoints; they are
+zero.  The lemmas' \emph{conclusions} mention only inequality atoms, which is
+what lets them be shared by any interval literal with those endpoints; they are
 nevertheless emitted under the propagator's reason, which does contain the
 interval literal, and are deleted with the scaffolding level rather than
 persisting.  This is
 \S3.4 material and we do not develop it here; we note only that the interval
 vocabulary does not change the situation, because an interval literal asserts
-only order atoms, never bits.
+only inequality atoms, never bits.
 
 We record the historical trap: when the literal layer is incomplete, a replay
 stalls, and the stalled trail's \emph{next} step is typically a bound crossing.
@@ -1575,7 +1594,7 @@ coverings, durable top-level lemmas --- for a problem that was a missing
 covering clause somewhere else entirely.
 
 \paragraph{Interval literals require a bit-vector representation.}
-\cref{eq:defin} reifies against two order atoms, which are in turn reified
+\cref{eq:defin} reifies against two inequality atoms, which are in turn reified
 against $\BinEnc(W)$.  A variable given a purely direct encoding --- one
 $0$--$1$ variable per value, with an at-least-one and an at-most-one clause,
 and no bit vector --- has no cuts to reify against, and no interval literals are
@@ -1774,7 +1793,7 @@ $X$ with initial bounds $l$ and $u$, these are
   \label{eq:rootbounds}
 \end{equation}
 These follow by RUP by the same argument as \cref{cor:chainrup}, since the bound
-constraints $\Bnd(X)$ are present, and likewise for every representation, derived
+constraints $\Bnd(X)$ are present, and likewise for every representation, proper
 ones included, because $\Bnd(W)$ is asserted for each.
 
 \begin{remark}[The eager introduction is load-bearing, and the solver is lazier]
@@ -1816,7 +1835,7 @@ Either way a contradiction is reached, so \invConflict{} is respected.
 Suppose instead a propagator has just made an inference that changed a domain,
 and logged $R\Rightarrow\ell\geq 1$.  The reason is valid at the point directly
 before the inference, so every literal of $R$, and hence $\ell$, propagates under
-$F_t\cup\{\neg B_t\}$.  If $\ell$ is stated over a derived representation $W$ of
+$F_t\cup\{\neg B_t\}$.  If $\ell$ is stated over a proper representation $W$ of
 $X$, then by \cref{lem:transport} its image on $X$ propagates too; either way the
 domain restriction $\ell$ encodes is incorporated into $\dm_L(X)$ for the
 propagated set $L$, since $\dm_L$ is computed over all representations.  Hence
@@ -1833,7 +1852,7 @@ by \cref{eq:rootbounds}.  Hence \invDomain{} is initially respected.
 \paragraph{Summary of the framework.}
 \begin{enumerate}[itemsep=1pt]
   \item Encode the problem using \cref{proc:encoding}, giving every operand
-    --- base variable or view --- its own bit vector, and every derived
+    --- base variable or view --- its own bit vector, and every proper
     representation its definitional link \cref{eq:link}.
   \item At the start of the proof, derive by RUP $\atge{x}{l}\geq 1$ and
     $\natge{x}{u+1}\geq 1$ for the bounds $l..u$ on each variable, and
@@ -1853,8 +1872,8 @@ by \cref{eq:rootbounds}.  Hence \invDomain{} is initially respected.
   \item Every defined interval literal must be maintained within its
     representation's partition, with its covering and its containment edges
     (\invPart{}, \invCover{}, \invCont{}).
-  \item Every defined atomic literal on a derived representation, and every one
-    on a base that has derived representations, must be mirrored onto the others
+  \item Every defined atomic literal on a proper representation, and every one
+    on a base that has proper representations, must be mirrored onto the others
     and joined to them by the linking clauses of
     \cref{eq:gelink,eq:eqlink,eq:inlink} --- for interval literals, triggered at
     the point the literal is \emph{named} (\invRep{}, \invName{}).
@@ -1911,17 +1930,18 @@ variables already known to propagate.  Three additions have to be checked in the
 extended encoding, and each extends the same recursion by one step.
 
 \begin{enumerate}[itemsep=1pt]
-  \item \textbf{Derived representations.}  Fixing $\BinEnc(X)$ reduces
-    $\Link(W)$, that is $\BinEnc(W) - s_W\BinEnc(X) = c_W$, to a pair of
+  \item \textbf{Proper representations.}  Fixing $\BinEnc(X)$ reduces
+    $\ViewLink(W)$, that is $\BinEnc(W) - s_W\BinEnc(X) = c_W$, to a pair of
     constraints of the form $\BinEnc(W)\geq A$ and $\BinEnc(W)\leq A$ for a
     constant $A$.  By Theorem~2.8 of the thesis these unit propagate to a fixed
     consistent assignment of every bit of $\BinEnc(W)$.  So the bits of every
-    derived representation propagate as soon as the base's bits are set.
-  \item \textbf{Bound and equality atoms} on any representation are fully
-    reified over that representation's bits, or over its bound atoms, so they
-    propagate by the existing recursion once step~1 has fired.
+    proper representation propagate as soon as the base's bits are set.
+  \item \textbf{Inequality and equality atoms} on any representation are fully
+    reified over that representation's bits, or over its inequality atoms, so
+    they propagate by the existing recursion once step~1 has fired.
   \item \textbf{Interval atoms} are fully reified, by \cref{eq:defin}, over two
-    bound atoms of the same representation, so they propagate once those do.
+    inequality atoms of the same representation, so they propagate once those
+    do.
 \end{enumerate}
 
 None of the linking clauses of \cref{eq:gelink,eq:eqlink,eq:inlink} is needed
@@ -1954,7 +1974,7 @@ The required property of the encoding is then:
 
 The extended encoding makes the choice of preserved set more delicate than it
 looks, and we state it explicitly: \textbf{the preserved set is the bits of the
-base variables only}.  It does not include the bits of derived representations,
+base variables only}.  It does not include the bits of proper representations,
 nor any atomic variable of any representation.  This is the right choice, and
 the only workable one, for three reasons.
 
@@ -1969,7 +1989,7 @@ the only workable one, for three reasons.
     exists to prevent.
   \item It is stable under adding a representation.  Two runs of the same solver
     that wrap the same variable in different views have different sets of
-    derived representations and therefore different encodings, but the same
+    proper representations and therefore different encodings, but the same
     preserved set and the same enumeration conclusion.
 \end{itemize}
 
@@ -1977,7 +1997,7 @@ One consequence deserves care.  A solution witness \emph{is} written over atomic
 variables --- one base equality literal per variable --- even though atomic
 variables are not preserved.  That is sound only because unit propagation
 completes such a witness to the preserved bits, and onward --- through
-\cref{sec:optimality}'s step~1 --- to the bits of every derived representation.
+\cref{sec:optimality}'s step~1 --- to the bits of every proper representation.
 The completion argument is therefore load-bearing for enumeration in a way it is
 not for optimality, and a representation whose bits did not propagate from the
 base's would break P3 rather than merely making a witness verbose.
@@ -2172,12 +2192,12 @@ point.  The known growth mode is a wide request over a heavily fragmented
 region, whose covering is as wide as the number of prior boundaries inside it,
 bounded by the request count rather than by the domain size.
 
-Per interval literal per derived representation: the mirrored literal on the
+Per interval literal per proper representation: the mirrored literal on the
 other side, with its own partition maintenance, plus two clauses.  This is the
-same constant factor that bound and equality atoms already pay for a wrapped
-variable.  Measured on a constraint over a bare variable of width $w$ and a
-two-value variable, so that root propagation prunes exactly one wide interior
-run:
+same constant factor that inequality and equality atoms already pay for a
+wrapped variable.  Measured on a constraint over a bare variable of width $w$
+and a two-value variable, so that root propagation prunes exactly one wide
+interior run:
 
 \begin{center}
 \small
@@ -2209,7 +2229,7 @@ constant is the price of the design; the slope was the point.
 
 Take $X$ with initial domain $1..20$, wrapped by the single registered view
 $V = -X + 30$, so $\varphi_V(k) = 30-k$ and $V$ has definition range $10..29$.
-The model contains $\Bnd(X)$, $\Bnd(V)$ and $\Link(V) := V + X = 30$, and
+The model contains $\Bnd(X)$, $\Bnd(V)$ and $\ViewLink(V) := V + X = 30$, and
 $\BinEnc(X)$ and $\BinEnc(V)$ are separate five-bit vectors.  No interval
 literal exists yet, and neither variable has a partition.
 
@@ -2324,10 +2344,10 @@ where 80\% of small random instances turn out to be one of them.
   gate is whether the variable has a registered bit vector, not what its domain
   looks like: a variable with domain exactly $\{0,1\}$, given a purely direct
   encoding, is registered with a one-element bit vector, and is therefore
-  \emph{not} the failing case, even though it has no order atoms until they are
-  built lazily.  Note that the test is on the two \emph{values}, not on the
-  width: a direct-only variable with domain $\{5,6\}$ has no bit vector and does
-  throw.  So the failing case is any direct-only variable other than a
+  \emph{not} the failing case, even though it has no inequality atoms until
+  they are built lazily.  Note that the test is on the two \emph{values}, not
+  on the width: a direct-only variable with domain $\{5,6\}$ has no bit vector
+  and does throw.  So the failing case is any direct-only variable other than a
   $\{0,1\}$ one.  Consumers guard on the
   same predicate, which resolves a view to its base --- correctly, since a view
   of a bit-vector-less variable would have to mirror onto a variable that cannot

--- a/dev_docs/literal-encodings.tex
+++ b/dev_docs/literal-encodings.tex
@@ -94,6 +94,10 @@
 \newcommand{\natge}[2]{\overline{#1}_{\geq #2}}
 \newcommand{\nateq}[2]{\overline{#1}_{= #2}}
 \newcommand{\natin}[3]{\overline{#1}_{\in[#2,#3]}}
+% The atom of a set of values, for when the set matters more than its endpoints.
+% A capital letter is always the set, never the atom over it.
+\newcommand{\atset}[2]{#1_{\in #2}}
+\newcommand{\natset}[2]{\overline{#1}_{\in #2}}
 \newcommand{\inv}[1]{\textnormal{\textsc{Inv-#1}}}
 \newcommand{\code}[1]{\texttt{#1}}
 % Unnumbered sections are referred to by title, so that the numbered ones
@@ -380,9 +384,10 @@ units on $W$'s own atoms.
 
 Clearly, if we construct a CSP with variables $\mathcal W$, constraints
 $\mathcal C \cup \Bnd(\mathcal W)\cup\ViewLink(\mathcal W)$, and unrestricted
-integer domains, then this has exactly the same solution set as our original
-CSP, projected onto $\mathcal V$: every proper representation is determined by
-its base through \cref{eq:link}.
+integer domains, then its solution set has the same cardinality as our original
+CSP's, and is identical to it under projection onto $\mathcal V$: every proper
+representation is determined by its base through \cref{eq:link}, so the
+projection is a bijection and not merely a surjection.
 
 \paragraph{Steps 4 and 5: atomic constraint variables.}
 These are fresh $0$--$1$ variables that can be shared between linearisations
@@ -748,8 +753,20 @@ proof, we mean that both directions of the reified definition for its
 underlying atomic variable have appeared in the accumulated formula and have
 not been deleted.
 
-Note the asymmetry between $\Def^{\Rightarrow}$ and $\Def^{\Leftarrow}$ for the
-two-cut atoms, \cref{eq:deq1,eq:deq2,eq:din1,eq:din2}.  The forward direction is
+Call the equality and interval atoms the \emph{two-cut} atoms, since each is
+defined by \cref{eq:defeq,eq:defin} from a pair of bound variables, and their
+literals the \emph{two-cut} literals.  From here on, when a two-cut atom is
+discussed through the set of values it names we write $\atset{w}{S}$ for the
+atom of $W$ that holds exactly when $W$ takes a value in the interval $S$, so
+that $\atset{w}{[a,b]}$ is $\atin{w}{a}{b}$ for $a<b$ and $\atset{w}{\{v\}}$ is
+$\ateq{w}{v}$ by \cref{def:widthone}.  In everything below, $E$, $C$, $G$ and
+$S$ denote sets of integers and never the atoms over them: $E\subseteq E'$,
+$E\cap[l_W,u_W]$ and $\bigcup_i C_i$ mean what they say about integers, while
+$\atset{w}{E}$ and $\natset{w}{E}$ are the two literals of the atom naming $E$.
+
+Note the asymmetry between
+$\Def^{\Rightarrow}$ and $\Def^{\Leftarrow}$ for them,
+\cref{eq:deq1,eq:deq2,eq:din1,eq:din2}.  The forward direction is
 a \emph{conjunction}: asserting $\ateq{w}{v}$ or $\atin{w}{a}{b}$ makes both
 cuts units.  The reverse direction is a \emph{disjunction}: asserting
 $\nateq{w}{v}$ or $\natin{w}{a}{b}$ makes neither cut a
@@ -838,36 +855,40 @@ $t$ in the proof.
   there is a finite set of \emph{boundaries} $\Bdry(W)\subseteq[l_W,u_W+1]$ with
   $l_W,u_W+1\in\Bdry(W)$.  The \emph{cells} $\Cells(W)$ are the intervals
   $[p,p'-1]$ for consecutive $p<p'$ in $\Bdry(W)$; they partition $[l_W,u_W]$.
-  Every cell is a defined literal --- an equality atom if it has width one, an
-  interval literal otherwise.  For every defined equality or interval literal
-  $E$ of $W$ whose in-bounds part $E\cap[l_W,u_W]$ is non-empty, both endpoints
-  of that part are boundaries; that is, $E\cap[l_W,u_W]$ is a union of adjacent
-  cells.  $\Bdry(W)$ only ever grows.
+  For every cell $C$ the atom $\atset{w}{C}$ is defined --- an equality atom if
+  $C$ has width one, an interval atom otherwise.  For every defined two-cut atom
+  $\atset{w}{E}$ of $W$ whose in-bounds part $E\cap[l_W,u_W]$ is non-empty, both
+  endpoints of that part are boundaries; that is, $E\cap[l_W,u_W]$ is a union of
+  adjacent cells.  $\Bdry(W)$ only ever grows.
 
 \item[\invCover{}: coverings.]
-  \emph{(i) Split coverings.}  For every defined literal $G\subseteq[l_W,u_W]$
-  that is a union of adjacent cells but is not itself a cell, $F_t$ contains a
-  clause $\overline{G}\vee C_1\vee\cdots\vee C_k$ with $k\geq 2$, where each
-  $C_i$ is a defined literal, each is a union of adjacent cells \emph{properly
-  contained} in $G$, and $\bigcup_i C_i = G$.
-  \emph{(ii) Overhanging coverings.}  For every defined literal $E$ whose
+  \emph{(i) Split coverings.}  For every $G\subseteq[l_W,u_W]$ with
+  $\atset{w}{G}$ defined, $G$ a union of adjacent cells but not itself a cell,
+  $F_t$ contains a clause
+  $\natset{w}{G}\vee\atset{w}{C_1}\vee\cdots\vee\atset{w}{C_k}$ with $k\geq 2$,
+  where every $\atset{w}{C_i}$ is defined, each $C_i$ is a union of adjacent
+  cells \emph{properly contained} in $G$, and $\bigcup_i C_i = G$.
+  \emph{(ii) Overhanging coverings.}  For every defined $\atset{w}{E}$ whose
   in-bounds part $S := E\cap[l_W,u_W]$ is non-empty and satisfies $E\neq S$,
-  $F_t$ contains a clause $\overline{E}\vee C_1\vee\cdots\vee C_k$ where each
-  $C_i$ is a defined literal that is a union of adjacent cells, and
+  $F_t$ contains a clause
+  $\natset{w}{E}\vee\atset{w}{C_1}\vee\cdots\vee\atset{w}{C_k}$ where every
+  $\atset{w}{C_i}$ is defined, each $C_i$ is a union of adjacent cells, and
   $\bigcup_i C_i = S$.
   \emph{(iii) The root covering.}  If $\Bdry(W)$ exists, $F_t$ contains a clause
-  $C_1\vee\cdots\vee C_m\geq 1$ where the $C_i$ are defined literals that are
-  unions of adjacent cells with $\bigcup_i C_i = [l_W,u_W]$.  A representation
+  $\atset{w}{C_1}\vee\cdots\vee\atset{w}{C_m}\geq 1$ where every
+  $\atset{w}{C_i}$ is defined, each $C_i$ is a union of adjacent cells, and
+  $\bigcup_i C_i = [l_W,u_W]$.  A representation
   with no interval literal, or with only out-of-bounds ones, has no partition and
   no root covering, and this clause holds vacuously --- which is what lets
   \cref{lem:covering} and \cref{thm:complete} still say something about a plain
   order/equality variable, the entire setting of the thesis.
 
 \item[\invCont{}: containment.]
-  For any two defined equality or interval literals $E\subsetneq E'$ of the same
-  representation $W$, there is a chain
-  $E=E_0\subsetneq E_1\subsetneq\cdots\subsetneq E_m=E'$ of defined literals
-  such that each clause $\overline{E}_j\vee E_{j+1}$ appears in $F_t$.
+  For any two defined two-cut atoms $\atset{w}{E}$ and $\atset{w}{E'}$ of the
+  same representation $W$ with $E\subsetneq E'$, there is a chain
+  $E=E_0\subsetneq E_1\subsetneq\cdots\subsetneq E_m=E'$ with every
+  $\atset{w}{E_j}$ defined, such that each clause
+  $\natset{w}{E_j}\vee\atset{w}{E_{j+1}}$ appears in $F_t$.
 
 \item[\invRep{}: representation closure and linking.]
   For every $W,W'\in\Rep(X)$: if an atomic variable of $W$ is defined, then so is
@@ -1108,60 +1129,67 @@ propagate through the machinery of \invCover{} and \invCont{}.
 
 \begin{lemmaN}[Containment closure]
 \label{lem:contclosure}
-Suppose that whenever an equality or interval literal $E$ of $W$ is defined, the
-clause $\overline{E}\vee E'$ is emitted for every \emph{minimal} defined $E'
-\supsetneq E$, and the clause $\overline{E''}\vee E$ for every \emph{maximal}
-defined $E''\subsetneq E$.  Then \invCont{} holds.
+Suppose that whenever a two-cut atom $\atset{w}{E}$ of $W$ is defined, the clause
+$\natset{w}{E}\vee\atset{w}{E'}$ is emitted for every \emph{minimal}
+$E'\supsetneq E$ whose atom is defined, and the clause
+$\natset{w}{E''}\vee\atset{w}{E}$ for every \emph{maximal} $E''\subsetneq E$
+whose atom is defined.  Then \invCont{} holds.
 \end{lemmaN}
 
 \begin{proof}
-By induction on the number of defined literals.  Let $E\subsetneq E'$ both be
-defined, and consider the later of the two to be defined, say at step $n$; by the
-inductive hypothesis \invCont{} held over the literals defined before step $n$.
+By induction on the number of defined atoms.  Let $\atset{w}{E}$ and
+$\atset{w}{E'}$ both be defined with $E\subsetneq E'$, and consider the later of
+the two to be defined, say at step $n$; by the inductive hypothesis \invCont{}
+held over the atoms defined before step $n$.
 
-If $E'$ is the later, then $E$ was already defined, so $E$ is contained in some
-maximal defined $E''\subsetneq E'$ with $E\subseteq E''$.  If $E=E''$ the edge
-$\overline{E}\vee E'$ is emitted directly; otherwise $E\subsetneq E''$, so the
-inductive hypothesis gives a chain from $E$ to $E''$, which the emitted edge
-$\overline{E''}\vee E'$ extends.  The case where $E$ is the later is symmetric,
-using a minimal defined container.  Emitting an edge never invalidates a chain,
-so \invCont{} continues to hold.
+If $\atset{w}{E'}$ is the later, then $\atset{w}{E}$ was already defined, so $E$
+is contained in some maximal $E''\subsetneq E'$ with $E\subseteq E''$ and
+$\atset{w}{E''}$ defined.  If $E=E''$ the edge
+$\natset{w}{E}\vee\atset{w}{E'}$ is emitted directly; otherwise $E\subsetneq
+E''$, so the inductive hypothesis gives a chain from $E$ to $E''$, which the
+emitted edge $\natset{w}{E''}\vee\atset{w}{E'}$ extends.  The case where
+$\atset{w}{E}$ is the later is symmetric, using a minimal container.  Emitting
+an edge never invalidates a chain, so \invCont{} continues to hold.
 \end{proof}
 
 \begin{remark}
 Interval requests may overlap without nesting --- $[7,15]$ after $[5,10]$ ---
-so the containment relation is a DAG, not a tree, and a literal may have several
+so the containment relation is a DAG, not a tree, and a set may have several
 incomparable minimal containers.  \cref{lem:contclosure} does not care.  Note
 also that it needs \emph{minimal} and \emph{maximal} to be computed over all
-currently defined literals of $W$, not merely over the cells.
+sets whose atoms are currently defined for $W$, not merely over the cells.
 \end{remark}
 
 \begin{lemmaN}[Cell exclusion]
 \label{lem:cell}
-Assume \invChain{}, \invCut{}, \invPart{} and \invCont{}.  Let
-$U\subseteq L^W$ be a cut-normalised set of literals each of which propagates
-under $R$, suppose $F_t\!\restriction_R$ does not propagate to conflict, and
+Assume \invChain{}, \invCut{}, \invPart{} and \invCont{}.  Let $R$ be a set of
+literals, let $U\subseteq L^W$ be a cut-normalised set of literals each of which
+propagates under $R$, suppose $F_t\!\restriction_R$ does not propagate to conflict, and
 write $D=\dm_U(W)$.  Let $C\in\Cells(W)$ be a cell with $D\cap C=\emptyset$.
-Then $\overline{C}$ propagates under $R$.
+Then $\natset{w}{C}$ propagates under $R$.
 \end{lemmaN}
 
 \begin{proof}
-Write $C=[p,q]$, so that $C$ is the literal $\atin{w}{p}{q}$ if $p<q$ and
-$\ateq{w}{p}$ if $p=q$; in either case \cref{eq:din1,eq:deq1} give the two
-clauses $\overline{C}\vee\atge{w}{p}$ and
-$\overline{C}\vee\natge{w}{q+1}$, and both cuts are defined by
-\invCut{}.
+Write $C=[p,q]$, so that $\atset{w}{C}$ is $\atin{w}{p}{q}$ if $p<q$ and
+$\ateq{w}{p}$ if $p=q$; in either case \cref{eq:deq1,eq:din1} give the single PB
+constraint $\atset{w}{C}\Rightarrow\atge{w}{p}+\natge{w}{q+1}\geq 2$, and both
+cuts are defined by \invCut{}.  That constraint is not a pair of clauses, but it
+propagates like one in each direction: $\atset{w}{C}$ makes both cuts units, and
+either $\natge{w}{p}$ or $\atge{w}{q+1}$ propagates $\natset{w}{C}$, which is
+the direction used below.
 
-\emph{Case 1: some negative two-cut literal of $U$ contains $C$.}  That is,
-$\overline{E}\in U$ for a defined $E$ with $C\subseteq E$.  If $E=C$ we are
-done.  Otherwise $C\subsetneq E$, and \invCont{} gives a chain of binary clauses
-$\overline{C}\vee E_1$, $\overline{E}_1\vee E_2$, \dots, $\overline{E}_{m-1}\vee
-E$; reading each contrapositive in turn from $\overline{E}$ propagates
-$\overline{C}$.
+\emph{Case 1: some negative two-cut literal of $U$ names a set containing $C$.}
+That is, $\natset{w}{E}\in U$ for a defined $\atset{w}{E}$ with $C\subseteq E$.
+If $E=C$ we are done.  Otherwise $C\subsetneq E$, and \invCont{} gives a chain of
+binary clauses $\natset{w}{C}\vee\atset{w}{E_1}$,
+$\natset{w}{E_1}\vee\atset{w}{E_2}$, \dots,
+$\natset{w}{E_{m-1}}\vee\atset{w}{E}$; reading each contrapositive in turn from
+$\natset{w}{E}$ propagates $\natset{w}{C}$.
 
-\emph{Case 2: no negative two-cut literal of $U$ contains $C$.}  We claim that
-then no negative two-cut literal of $U$ meets $C$ at all.  Let $\overline{E}\in
-U$.  If $E\cap[l,u]=\emptyset$ then $E\cap C=\emptyset$ since $C\subseteq[l,u]$.
+\emph{Case 2: no negative two-cut literal of $U$ names a set containing $C$.}
+We claim that then no negative two-cut literal of $U$ names a set meeting $C$ at
+all.  Let $\natset{w}{E}\in U$.  If $E\cap[l,u]=\emptyset$ then
+$E\cap C=\emptyset$ since $C\subseteq[l,u]$.
 Otherwise, by \invPart{}, $E\cap[l,u]$ is a union of adjacent cells, and $C$ is
 a cell, so either $C\subseteq E$ --- excluded by the case assumption --- or
 $C\cap E=\emptyset$.
@@ -1176,52 +1204,55 @@ conflict, contrary to assumption.  So $[v^{+},v^{-}-1]$ is a non-empty interval
 disjoint from the interval $C$, and $C$ lies wholly on one side of it.
 \begin{itemize}[itemsep=1pt]
   \item If $q<v^{+}$: then $q+1\leq v^{+}$, and $\atge{w}{q+1}$ is defined, so
-    \cref{lem:chain} propagates it from $\atge{w}{v^{+}}$.  The clause
-    $\overline{C}\vee\natge{w}{q+1}$ then propagates $\overline{C}$.
+    \cref{lem:chain} propagates it from $\atge{w}{v^{+}}$, and the constraint
+    above propagates $\natset{w}{C}$.
   \item If $p\geq v^{-}$: then $\atge{w}{p}$ is defined and \cref{lem:chain}
-    propagates $\natge{w}{p}$ from $\natge{w}{v^{-}}$.  The
-    clause $\overline{C}\vee\atge{w}{p}$ then propagates $\overline{C}$.
+    propagates $\natge{w}{p}$ from $\natge{w}{v^{-}}$, and the constraint
+    above propagates $\natset{w}{C}$.
     \qedhere
 \end{itemize}
 \end{proof}
 
 \begin{lemmaN}[Covering completeness]
 \label{lem:covering}
-Assume \inv{Bound}, \invCut{}, \invPart{} and \invCover{}.  Let $E$ be a defined
-equality or interval literal of $W$ and let $S=E\cap[l,u]$.
+Assume \inv{Bound}, \invCut{}, \invPart{} and \invCover{}.  Let $\atset{w}{E}$ be
+a defined two-cut atom of $W$ and let $S=E\cap[l,u]$.
 \begin{enumerate}[label=(\alph*),itemsep=1pt]
-  \item If $S=\emptyset$ then $\overline{E}$ propagates under any $R$.
-  \item If $S\neq\emptyset$, $E$ is not currently a cell, and $\overline{C}$
-    propagates for every cell $C\subseteq S$, then $\overline{E}$ propagates.
+  \item If $S=\emptyset$ then $\natset{w}{E}$ propagates under any $R$.
+  \item If $S\neq\emptyset$, $E$ is not currently a cell, and $\natset{w}{C}$
+    propagates for every cell $C\subseteq S$, then $\natset{w}{E}$ propagates.
 \end{enumerate}
 \end{lemmaN}
 
 \begin{proof}
 \emph{(a)}  Write $E=[a,b]$.  If $b<l$ then $\atge{w}{b+1}$ is defined by
 \invCut{} with $b+1\leq l$, so it is a unit by \inv{Bound}, and
-$\overline{E}\vee\natge{w}{b+1}$ propagates $\overline{E}$.  If $a>u$
-then $\atge{w}{a}$ is defined with $a>u$, so $\natge{w}{a}$ is a unit
-by \inv{Bound}, and $\overline{E}\vee\atge{w}{a}$ propagates $\overline{E}$.
+\cref{eq:deq1,eq:din1} propagate $\natset{w}{E}$.  If $a>u$ then $\atge{w}{a}$
+is defined with $a>u$, so $\natge{w}{a}$ is a unit by \inv{Bound}, and
+\cref{eq:deq1,eq:din1} propagate $\natset{w}{E}$ through the other cut.
 
 \emph{(b)}  For a set that is a union of adjacent cells, define its \emph{rank}
 to be the number of cells it contains.  We first show, by induction on rank,
-that $\overline{G}$ propagates for every defined literal $G\subseteq S$ that is
-a union of adjacent cells.
+that $\natset{w}{G}$ propagates for every $G\subseteq S$ with $\atset{w}{G}$
+defined and $G$ a union of adjacent cells.
 
 If $G$ has rank one then $G$ is a cell, since its two endpoints are boundaries
-and no boundary lies strictly inside it; as $G\subseteq S$, $\overline{G}$
+and no boundary lies strictly inside it; as $G\subseteq S$, $\natset{w}{G}$
 propagates by hypothesis.  If $G$ has rank at least two then $G$ is not a cell,
-so \invCover{}(i) puts $\overline{G}\vee C_1\vee\cdots\vee C_k$ in $F_t$ with
-each $C_i$ a defined literal, a union of adjacent cells, properly contained in
-$G$ --- hence of strictly smaller rank --- and contained in $S$.  By induction
-each $\overline{C}_i$ propagates, so the covering propagates $\overline{G}$.
+so \invCover{}(i) puts
+$\natset{w}{G}\vee\atset{w}{C_1}\vee\cdots\vee\atset{w}{C_k}$ in $F_t$ with
+every $\atset{w}{C_i}$ defined and each $C_i$ a union of adjacent cells,
+properly contained in $G$ --- hence of strictly smaller rank --- and contained
+in $S$.  By induction each $\natset{w}{C_i}$ propagates, so the covering
+propagates $\natset{w}{G}$.
 
 Now for $E$ itself.  If $E\subseteq[l,u]$ then $E=S$, which is a union of
 adjacent cells by \invPart{}, and the claim applies directly.  Otherwise
-$E\neq S$, and \invCover{}(ii) puts $\overline{E}\vee C_1\vee\cdots\vee C_k$ in
-$F_t$ with each $C_i$ a defined literal that is a union of adjacent cells and
-$\bigcup_i C_i=S$; each $C_i\subseteq S$, so $\overline{C}_i$ propagates by the
-claim, and the covering propagates $\overline{E}$.
+$E\neq S$, and \invCover{}(ii) puts
+$\natset{w}{E}\vee\atset{w}{C_1}\vee\cdots\vee\atset{w}{C_k}$ in $F_t$ with
+every $\atset{w}{C_i}$ defined, each $C_i$ a union of adjacent cells, and
+$\bigcup_i C_i=S$; each $C_i\subseteq S$, so $\natset{w}{C_i}$ propagates by the
+claim, and the covering propagates $\natset{w}{E}$.
 \end{proof}
 
 \begin{remark}
@@ -1346,11 +1377,11 @@ propagate by Cases 1 and 2, and \cref{eq:deq2} then propagates $\ell$.
 \emph{Case 4: $\ell=\nateq{w}{v}$, so $v\notin D$.}  Consider what excludes $v$;
 after cut normalisation the candidates are a bound literal and a negative
 two-cut literal.  If a bound literal does, then either $\atge{w}{v+1}$ or
-$\natge{w}{v}$ propagates by \cref{lem:chain}, and the corresponding
-clause of \cref{eq:deq1} propagates $\ell$.  If instead a negative two-cut
-literal $\overline{E}\in U$ with $v\in E$ does, then $\{v\}\subseteq E$; if
+$\natge{w}{v}$ propagates by \cref{lem:chain}, and \cref{eq:deq1} then
+propagates $\ell$ from whichever it is.  If instead a negative two-cut
+literal $\natset{w}{E}\in U$ with $v\in E$ does, then $\{v\}\subseteq E$; if
 $E=\{v\}$ then $\ell\in U$, and otherwise \invCont{} gives a chain of binary
-clauses whose contrapositives propagate $\ell$ from $\overline{E}$.  If a
+clauses whose contrapositives propagate $\ell$ from $\natset{w}{E}$.  If a
 positive two-cut literal excludes $v$, cut normalisation has already replaced it
 by bound literals, so this is the first case.
 
@@ -1364,7 +1395,7 @@ then propagates $\ell$.
 \emph{Case 6: $\ell=\natin{w}{a}{b}$, with $D\cap[a,b]=\emptyset$.}
 Write $E=[a,b]$ and $S=E\cap[l,u]$.  If $S=\emptyset$ then $\ell$ propagates by
 \cref{lem:covering}(a).  Otherwise, $S$ is a union of cells by \invPart{}, and
-every cell $C\subseteq S$ satisfies $D\cap C=\emptyset$, so $\overline{C}$
+every cell $C\subseteq S$ satisfies $D\cap C=\emptyset$, so $\natset{w}{C}$
 propagates by \cref{lem:cell}.  If $E$ is itself a current cell we are done; if
 not, \cref{lem:covering}(b) propagates $\ell$.
 \end{proof}
@@ -1374,10 +1405,10 @@ not, \cref{lem:covering}(b) propagates $\ell$.
 \cref{eq:domL} takes no account of $\Bnd(W)$, so $\dm_U(W)$ can contain values
 the variable's own bounds exclude, and \cref{thm:complete} is correspondingly
 narrower than its name suggests.  With cells $[1,3]$, $[4,6]$, $[7,10]$ on
-$[1,10]$ and $U = \{\overline{[1,3]}, \overline{[4,6]}\}$, unit propagation does
+$[1,10]$ and $U = \{\natset{w}{[1,3]}, \natset{w}{[4,6]}\}$, unit propagation does
 derive $\atge{w}{7}$ --- through the root covering and the surviving cell --- but
 $\atge{w}{7}\notin\ImpLits(\dm_U)$, so the theorem does not claim it.  With
-$U$ extended by $\overline{[7,10]}$, unit propagation reaches a conflict while
+$U$ extended by $\natset{w}{[7,10]}$, unit propagation reaches a conflict while
 $\dm_U(W)$ is still non-empty, so \cref{thm:wipeout}'s hypothesis does not hold
 either.  Neither is a counterexample to anything stated; both are consequences of
 $\dm_U$ being computed from $U$ alone.
@@ -1517,11 +1548,11 @@ one cut crossing the literal & $\nateq{w}{v}$ or
 $\nateq{w}{v}$ or $\natin{w}{a}{b}$ & a bound stepping over
   it & $\Def^{\Leftarrow}$: this is the hole jump, and the reason
   \cref{thm:wipeout} needs no covering \\
-$\overline{E'}$, $E\subsetneq E'$ & $\overline{E}$ & containment, \invCont{}
+$\natset{w}{E'}$, $E\subsetneq E'$ & $\natset{w}{E}$ & containment, \invCont{}
   (\cref{lem:contclosure}) \\
-$\overline{C}_1,\dots,\overline{C}_k$ & $\overline{E}$ & covering, \invCover{}
-  (\cref{lem:covering}) \\
-$E$ and all but one piece excluded & the surviving piece & covering \\
+$\natset{w}{C_1},\dots,\natset{w}{C_k}$ & $\natset{w}{E}$ & covering,
+  \invCover{} (\cref{lem:covering}) \\
+$\atset{w}{E}$ and all but one piece excluded & the surviving piece & covering \\
 every cell excluded & conflict & reverse reifications and the chain
   (\cref{thm:wipeout}); the root covering is redundant here, see
   \cref{rem:rootcovering} \\[4pt]

--- a/dev_docs/literal-encodings.tex
+++ b/dev_docs/literal-encodings.tex
@@ -816,17 +816,17 @@ $t$ in the proof.
 \item[\invChain{} (thesis Inv1): the order chain.]
   For any two bound variables $\atge{w}{v}$, $\atge{w}{v'}$ on the same
   representation $W$ with $v<v'$, if $\Def(\atge{w}{v})$ and
-  $\Def(\atge{w}{v'})$ appear in $F_t$, then either $\atge{w}{v''}$ is defined
-  for some $v<v''<v'$, or the constraint
-  $\natge{w}{v}$ appears in $F_t$.  A representation whose bounds are not a
-  consequence of the model --- a free bit-sum introduced inside the proof ---
-  is exempt, and its owner derives the bounds explicitly instead; no interval
-  literal is defined over such a variable today.
+  $\Def(\atge{w}{v'})$ appear in $F_t$, then either a bound variable is defined
+  for some value strictly between $v$ and $v'$, or the constraint
+  $\atge{w}{v'}\Rightarrow\atge{w}{v}\geq 1$ appears in $F_t$.
 
 \item[\inv{Bound}: boundary pins.]
   For every defined $\atge{w}{v}$ with $v\leq l_W$, the unit $\atge{w}{v}$
   appears in $F_t$; for every defined $\atge{w}{v}$ with $v>u_W$, the unit
-  $\natge{w}{v}$ appears in $F_t$.
+  $\natge{w}{v}$ appears in $F_t$.  A representation whose bounds are not a
+  consequence of the model --- a free bit-sum introduced inside the proof ---
+  is exempt, and its owner derives the bounds explicitly instead; no interval
+  literal is defined over such a variable today.
 
 \item[\invCut{}: cuts exist.]
   Whenever $\ateq{w}{v}$ is defined, so are $\atge{w}{v}$ and $\atge{w}{v+1}$;
@@ -883,17 +883,18 @@ $t$ in the proof.
   in-bounds part is empty is defined with no partition, no covering and no
   containment edge, and nothing names it; \invRep{} does not suffer, because such
   a literal can only arise from an explicit request, and the request path
-  establishes \invRep{} for itself.  See the remark after \cref{lem:transport}.
+  establishes \invRep{} for itself.  \cref{rem:naming} says why the trigger is
+  naming rather than requesting, which is what this invariant is for.
 
 \end{description}
-apparatus.  \invName{} is a hygiene condition that \invRep{} needs for the
-interval literals created as cells, and only for those --- see the remark after
-\cref{lem:transport}.
+
+\invChain{} and \inv{Bound} come from the thesis, generalised only by being
 stated per representation.  \invCut{} is implicit there; we make it explicit
 because both new literal kinds depend on it.  \invPart{}, \invCover{} and
 \invCont{} are the interval apparatus.  \invRep{} is the multi-representation
-apparatus.  \invName{} is a hygiene condition that \invRep{} needs for interval
-literals, and only for them --- see the remark after \cref{lem:transport}.
+apparatus.  \invName{} is a hygiene condition that \invRep{} needs for the
+interval literals created as cells, and only for those --- see
+\cref{rem:naming}.
 
 \begin{remark}
 Nothing above depends on the search state.  Every clause named is a tautology of

--- a/dev_docs/literal-encodings.tex
+++ b/dev_docs/literal-encodings.tex
@@ -1021,36 +1021,32 @@ $s = s_W s_{W'}$ and $d = c_{W'} - s\,c_W$.  The \emph{image} on $W'$ of a
 literal $\ell$ over an atomic variable of $W$, written $\ell^{W'}$, is the
 literal satisfied by exactly the same values of $X$:
 \[
-  \begin{array}{llll}
+  \begin{array}{lll}
     (\atge{w}{v})^{W'} &=
       \begin{cases}
-        \atge{w'}{\theta(v)} & s=+1\\[7pt]
+        \atge{w'}{\theta(v)} & s=+1\\[2pt]
         \natge{w'}{\theta(v)+1} & s=-1
       \end{cases}
     &\qquad
-    (\ateq{w}{v})^{W'} &= \ateq{w'}{\theta(v)}\\[2.6ex]
-    (\atin{w}{a}{b})^{W'} &=
-      \begin{cases}
-        \atin{w'}{\theta(a)}{\theta(b)} & s=+1\\[2pt]
-        \atin{w'}{\theta(b)}{\theta(a)} & s=-1
-      \end{cases}
-    &\qquad
-    (\natin{w}{a}{b})^{W'} &= \overline{(\atin{w}{a}{b})^{W'}}
+    (\atset{w}{S})^{W'} \;=\; \atset{w'}{\theta(S)}
   \end{array}
 \]
-Negation commutes with taking images --- the last entry above, and likewise for
-the other two kinds --- so the negated image of an atom may be written by barring
-the atom inside, which is what \cref{eq:gelink,eq:eqlink,eq:inlink} do.  Taking
-images is functorial: $(\ell^{W'})^{W''} = \ell^{W''}$, and $\ell^{W}=\ell$.
+writing $\theta(S) = \{\theta(k) : k\in S\}$.  Negation commutes with taking
+images, so the negated image of an atom may be written by barring the atom
+inside, which is what \cref{eq:gelink,eq:eqlink,eq:inlink} do.  Taking images is
+functorial: $(\ell^{W'})^{W''} = \ell^{W''}$, and $\ell^{W}=\ell$.
 \end{definitionT}
 
-Two facts about \cref{def:image} are worth stating because they are what make
-the design tractable.  First, $\theta$ preserves \emph{width}: an interval of
-width $k$ maps to an interval of width $k$, so the width-one identification of
-\cref{def:widthone} is stable, and the interval machinery never has to consider
-a width-one case on either side.  Second, a sign flip converts a positive bound
-literal into a negative one, but leaves the polarity of equality and interval
-literals alone --- an interval is order-agnostic, a half-line is not.
+Stating the two-cut case over the set rather than over the endpoints is what
+makes it one line instead of four, and the two facts that make the design
+tractable are then immediate rather than needing an argument.  First, $\theta$ is
+an affine bijection, so $\theta(S)$ is an interval of the same width as $S$: the
+width-one identification of \cref{def:widthone} is stable, equality and interval
+atoms have the same image rule, and the interval machinery never has to consider
+a width-one case on either side.  Second, a sign flip reverses the two endpoints
+of $\theta(S)$ but does not touch its polarity, whereas it converts a positive
+bound literal into a negative one --- an interval is order-agnostic, a half-line
+is not, which is why only the first entry above splits on $s$.
 
 The atom-level linking constraints are exactly the clausal form of the biconditional
 $\ell \Leftrightarrow \ell^{X}$, for each defined atom of each proper
@@ -1094,7 +1090,7 @@ For the eq-link, asserting one side and the negation of the other propagates bot
 cuts through \cref{eq:deq1}, carries each across by the ge-links, and closes on
 \cref{eq:deq2} of the far side.  For the in-link, the same argument with
 \cref{eq:din1,eq:din2}, noting that for $s=-1$ the two cuts exchange roles ---
-which is exactly the endpoint swap in \cref{def:image}.
+which is the endpoint reversal that $\theta(S)$ absorbs in \cref{def:image}.
 
 \begin{remarkN}[Both in-link clauses are needed, and neither for its implication]
 \label{rem:bothlinks}

--- a/dev_docs/literal-encodings.tex
+++ b/dev_docs/literal-encodings.tex
@@ -2207,19 +2207,40 @@ interior run:
 \toprule
 $w$ & bare & view, no interval links & view & negated view & mixed \\
 \midrule
-$10^3$ & 40 & $36{,}012$ & \textbf{106} & 106 & 109 \\
-$10^4$ & 40 & $360{,}012$ & \textbf{106} & 106 & 109 \\
-$10^5$ & 40 & \emph{timed out} & \textbf{106} & 106 & 109 \\
-$10^6$ & 40 & \emph{timed out} & \textbf{106} & 106 & 106 \\
+$10^3$ & 68 & $71{,}017$ & \textbf{200} & 200 & 200 \\
+$10^4$ & 68 & $710{,}017$ & \textbf{200} & 200 & 200 \\
+$10^5$ & 68 & \emph{timed out} & \textbf{200} & 200 & 200 \\
+$10^6$ & 68 & \emph{timed out} & \textbf{200} & 200 & 200 \\
 \bottomrule
 \end{tabular}
 \end{center}
 
 The third column is the per-value fallback a view had before it owned interval
-literals: $2+36w$ lines, unwritable past $10^4$.  The remaining columns are flat.
-They are $106$ rather than $40$ because the view carries its own bit vector, its
+literals: $17+71w$ lines, unwritable past $10^4$.  The remaining columns are flat.
+They are $200$ rather than $68$ because the view carries its own bit vector, its
 own atoms and the link constraints --- a constant, not a function of the width.  That
-constant is the price of the design; the slope was the point.
+constant is the price of the design; the slope was the point.  The bare column is
+the same number on both sides of the change, which is what makes the two
+measurements comparable: nothing here touches a variable that no view wraps.
+
+Checking bites before writing does.  The checker takes about $0.012$ seconds on
+each flat row, $42$ seconds on the $10^3$ row of the third column, and more than
+an hour on the $10^4$ row of that column, at which point the run was stopped.  So
+by the width at which the per-value fallback stops being writable, it has already
+stopped being checkable.
+
+Two cautions for anyone who repeats this measurement.  The offsets in the mixed
+column are not free to choose: the two wraps have to put both operands over the
+same interval, because otherwise their ranges are disjoint, the instance is
+unsatisfiable at the root, and the row measures a refutation instead of the
+interior-hole prune.  An earlier version of this measurement paired $x+10^6$ with
+$-y+2\cdot 10^6$, whose ranges meet only at $w=10^6$, so three of the four mixed
+rows were the wrong shape and the fourth was the right one; the only symptom was
+a three-line step in a column that is otherwise flat.  And the absolute numbers
+here are about twice the ones first measured, because every line defining part of
+a variable's encoding now also enters the checker's core set, which costs one
+further line each.  That scales both columns and leaves flat against linear
+untouched.
 
 \appendix
 \crefalias{section}{appendix}

--- a/dev_docs/literal-encodings.tex
+++ b/dev_docs/literal-encodings.tex
@@ -354,15 +354,9 @@ constraints may name the same view, and one variable may be named through
 several different views at once, which is precisely why representation
 variables have to be shared rather than private to a linearisation.
 
-We reject the alternative --- substituting $s X + c$ for the view wherever it
-occurs, and stating everything in $X$'s atoms --- for a reason that only becomes
-visible in \cref{sec:framework}.  It makes the atoms appearing in the encoding of
-a constraint depend on \emph{which} wrapper the constraint happened to be handed,
-so a generic constraint-logging procedure can no longer treat every operand
-identically, and a cutting-planes step that resolves an operand against a
-constraint body has to know which representation that body is stated in.  Giving
-the view a variable of its own costs one linear equality, and makes every operand
-look the same.
+A view therefore gets a variable of its own, at the cost of one linear equality.
+\Cref{sec:rationale} says why, and what the alternative --- substituting
+$sX+c$ wherever the view occurs --- would cost.
 
 \paragraph{Step 3: domain bound constraints.}
 For a representation $W$ of $X$ and domain state $\dm_0$, let $\Bnd(W,\dm_0)$
@@ -2188,6 +2182,7 @@ nothing about composition; and ``the suite passed'' must always be qualified by
 which gates and which branching were active.
 
 \subsubsection*{Cost}
+\phantomsection\addcontentsline{toc}{subsubsection}{Cost}\label{sec:cost}
 
 Per distinct interval literal requested on a representation: at most two cell
 splits, hence at most four new literals of which any width-one piece is an
@@ -2416,12 +2411,100 @@ where 80\% of small random instances turn out to be one of them.
 
 \end{enumerate}
 
+\section{Design rationale}
+\label{sec:rationale}
+
+The development above says what the encoding is and why it works.  Three of its
+choices are not forced, and each has an alternative that a reader will think of;
+the arguments are collected here rather than left in the construction, where they
+would interrupt it.  Designs that were tried and are \emph{wrong}, as opposed to
+merely worse than what we have, are under \cref{sec:refuted}.
+
+\paragraph{A binary encoding of the integer variables.}
+The thesis's reason is that $\BinEnc$ is a substitution and not a reformulation:
+a linear constraint stays a linear constraint, so P1 and P2 follow from a
+bijection between assignments rather than from an argument about what the
+constraints mean.  Two further reasons are worth stating, since $\BinEnc$ is
+admittedly ``a poor encoding from a solving perspective''.
+
+It is \emph{total}.  Every assignment to the bits denotes an integer, so a
+variable's encoding needs no auxiliary constraint to be well defined; $\Bnd(W)$
+restricts which integers are allowed, but nothing is needed to make the encoding
+mean anything in the first place.  Form preservation alone would not force the
+choice, because an order encoding also gives a linear term,
+$W = l_W + \sum_{v=l_W+1}^{u_W}\atge{w}{v}$ --- but that identity holds only
+where \invChain{} does, and a direct encoding needs an at-most-one for the same
+reason.  A bit vector needs nothing.
+
+It is \emph{compact}: $O(\log w)$ PB variables for a variable of width $w$,
+against $\Theta(w)$.  Bits are introduced unconditionally, at step~7, for every
+member of $\mathcal W$, whereas an atom is introduced only when a constraint or a
+propagator asks for one.  Encoding the variables themselves in order or direct
+form would therefore put $\Theta(w)$ variables into the formula before the solver
+had done anything, and nothing in this design is allowed to be proportional to a
+domain's width --- see \nsec{sec:cost}, where that is what the measurement is
+for.
+
+The price is propagation, and the design pays it explicitly.  Bit sums propagate
+badly: that is what thesis Theorems~2.7 to~2.9 are about, and what
+\nsec{sec:notprovided} restates here.  The atom families exist to supply what the
+bits cannot express, and the two are incomparable rather than ordered --- a
+single bit literal states that $W$ is even, which no atom does, and
+$\natge{w}{6}$ states $W\leq 5$, which no bit literal does.
+
+\paragraph{Equality and interval atoms, rather than conjunctions of inequality
+atoms.}
+Neither needs a Boolean of its own to be definable: $\ateq{w}{v}$ holds exactly
+when $\atge{w}{v}$ and $\natge{w}{v+1}$ do, and $\atin{w}{a}{b}$ exactly when
+$\atge{w}{a}$ and $\natge{w}{b+1}$ do.  A propagator could write the conjunction
+wherever it wants the fact, and the encoding could carry one atom family instead
+of three.
+
+The reason it does not is the negation.  Asserting the conjunction is harmless:
+both cuts become units either way.  Asserting its negation is not, because
+$\neg(\atge{w}{v}\wedge\natge{w}{v+1})$ is the disjunction
+$\natge{w}{v}\vee\atge{w}{v+1}$, which is a unit on neither cut.  Removing a
+value, or a run of values, is precisely asserting that negation --- so without a
+Boolean, the fact a propagator most often wants to state is the one fact unit
+propagation cannot use.  With one, the negation is a single literal,
+\cref{eq:deq2,eq:din2} are its reverse reifications, and the hole jump that
+\cref{thm:wipeout} turns on --- a bound at the lower cut stepping over the whole
+hole --- goes through in one step.
+
+Two things follow.  A reason is a set of literals concluding a single literal, so
+a propagator that removes a value needs a literal to conclude, and a conjunction
+gives it none.  And the same argument at width greater than one is why interval
+literals exist: not for strength, since $\atin{w}{a}{b}$ says exactly what its
+two cuts say, but because the alternative is $b-a+1$ separate equality atoms, so
+that naming a run of holes in a reason would cost the width of the run rather
+than one literal.
+
+Stated as a principle: the encoding gives a fact a Boolean of its own exactly
+when its \emph{negation} has to be usable as a unit.  That is also why there is
+no fourth family for $\leq$ --- $\natge{w}{v}$ already is one.
+
+\paragraph{A view with its own variable, rather than substituted away.}
+The alternative is to substitute $sX+c$ for the view wherever it occurs, and
+state everything in $X$'s atoms.  It would be sound, and it would save a linear
+equality and a bit vector for each view.  We do not do it, for a reason that only
+becomes visible in \cref{sec:framework}: it makes the atoms appearing in the
+encoding of a constraint depend on \emph{which} wrapper the constraint happened
+to be handed, so a generic constraint-logging procedure can no longer treat every
+operand identically, and a cutting-planes step that resolves an operand against a
+constraint body has to know which representation that body is stated in.  Giving
+the view a variable of its own costs one linear equality and makes every operand
+look the same.  The narrower version of the same question --- keep the view's
+variable, but state its \emph{intervals} on the base --- is the ``deviewing''
+entry of \cref{sec:refuted}, and fails the same way at the level of one atom
+kind.
+
 \section{Refuted designs}
 \label{sec:refuted}
 
 Each of the following was proposed, looked right, and is wrong.  They are
 recorded with the witness that catches each, so that a future simplification
-proposal can be tested rather than argued about.
+proposal can be tested rather than argued about.  Choices that are merely worse
+than the design we have, rather than wrong, are under \cref{sec:rationale}.
 
 \begin{enumerate}[itemsep=3pt]
 

--- a/dev_docs/literal-encodings.tex
+++ b/dev_docs/literal-encodings.tex
@@ -385,10 +385,38 @@ $[\,\min\varphi_W(\dm_0(X)),\ \max\varphi_W(\dm_0(X))\,]$ the \emph{definition
 range} of $W$ and denote it $[l_W,u_W]$.
 
 Note that $\Bnd(W)$ for a proper $W$ is implied by $\Bnd(X)$ together with
-$\ViewLink(W)$ (it is their sum, up to sign), so asserting it changes nothing.  It
-is asserted anyway, because unit propagation cannot add two constraints
-together, and several later arguments need $W$'s own bounds to be available as
-units on $W$'s own atoms.
+$\ViewLink(W)$: each of its two bounds is a single sum of one half of each, so
+asserting it changes nothing.  The arguments below do need $W$'s own bounds
+present as a constraint --- unit propagation cannot add two constraints
+together, and several of them want those bounds available as units on $W$'s own
+atoms --- but that is a reason to have the sum in $F_t$, not a reason to put it
+in the OPB, and one cutting-planes step per bound at the top of the proof would
+put it there.  The solver asserts it instead; \cref{rem:assertedbounds} says
+what that costs.
+
+\begin{remarkN}[What asserting the view bounds costs]
+\label{rem:assertedbounds}
+A proper view variable's bounds are written as two OPB rows, next to the two
+\ViewLink{} rows that imply them together with the base's own bound rows.  For
+$B\in[0,4]$ and $W=B+10$ the model contains $\BinEnc(W)\geq 10$ and
+$-\BinEnc(W)\geq -14$; the first is the sum of the view-link row
+$\BinEnc(W)-\BinEnc(B)\geq 10$ with $\BinEnc(B)\geq 0$, and the second the sum of
+the other view-link row with $-\BinEnc(B)\geq -4$.  So the OPB carries two rows
+per view variable that are a consequence of two other rows of the same OPB.
+
+Deriving them would be better, for the reason a proof-only variable introduced
+inside the proof is better than one asserted into the model: the OPB is then the
+model and nothing else, and a checker that re-derives the OPB from the CP model
+has nothing extra to reproduce.  The codebase already draws that distinction
+--- \code{create\_proof\_only\_integer\_variable\_in\_proof} exists so that a
+bit-sum's meaning is a conservative extension rather than a model axiom --- and
+view variables do not use it.  Two things would have to be got right.  The
+derivation has to precede every boundary pin on $W$, since a pin is a RUP line
+and would otherwise have nothing to propagate from.  And the pin has to stay
+RUP-derivable, which it is once $\Bnd(W)$ is a line over $W$'s own bit vector,
+but would not be if it had to cross $\ViewLink(W)$ instead --- that
+configuration is the one discussed after \cref{eq:inlink}, and it is not RUP.
+\end{remarkN}
 
 Clearly, if we construct a CSP with variables $\mathcal W$, constraints
 $\mathcal C \cup \Bnd(\mathcal W)\cup\ViewLink(\mathcal W\setminus\mathcal V)$, and unrestricted

--- a/dev_docs/literal-encodings.tex
+++ b/dev_docs/literal-encodings.tex
@@ -107,7 +107,7 @@
 % Invariant names, so a typo is a compile error rather than a silent
 % disagreement between two paragraphs.
 \newcommand{\invChain}{\inv{Chain}}
-\newcommand{\invCut}{\inv{Cut}}
+\newcommand{\invThresholds}{\inv{Thresholds}}
 \newcommand{\invPart}{\inv{Part}}
 \newcommand{\invCover}{\inv{Cover}}
 \newcommand{\invCont}{\inv{Cont}}
@@ -463,12 +463,16 @@ definition, writing $w$ for the PB name of the view variable $W$.
 \end{enumerate}
 
 Naturally, if an equality or interval variable is needed then so are the
-corresponding bound variables.
+corresponding bound variables.  We call those two the atom's \emph{thresholds}:
+$\atge{w}{v}$ and $\atge{w}{v+1}$ for $\ateq{w}{v}$, and $\atge{w}{a}$ and
+$\atge{w}{b+1}$ for $\atin{w}{a}{b}$.  A threshold is an atom, not a value ---
+the atom that says where the interval starts, or where it stops.
 
 An interval variable is a \emph{wide equality atom}: \cref{eq:defeq,eq:defin}
-are the same definition, cut at two values instead of at $v$ and $v+1$.  This
-is not a coincidence to be tidied away later, and we record the consequence
-immediately, because it is the single most expensive mistake available here.
+are the same definition, with thresholds at two values instead of at $v$ and
+$v+1$.  This is not a coincidence to be tidied away later, and we record the
+consequence immediately, because it is the single most expensive mistake
+available here.
 
 \begin{definitionT}[Width-one identification]
 \label{def:widthone}
@@ -495,22 +499,22 @@ variable.  Both polarities fold together and at the same place: the
 canonicalisation that performs the width-one identification of
 \cref{def:widthone} also rewrites $\atin{w}{a}{b}$ to $0$ and $\natin{w}{a}{b}$
 to $1$, so everything downstream sees only intervals of width at least two.
-There is no reified definition, no cut, nothing to name and nothing to cite.
+There is no reified definition, no threshold, nothing to name and nothing to cite.
 This is the encoding's general convention for a condition that is constant ---
 a condition on a constant variable folds the same way --- and not something
 special to intervals.
 
 An interval that is well formed but lies \emph{outside} the definition range is
 not a substitution: $\atin{w}{a}{b}$ with $a\leq b$ and $[a,b]\cap[l_W,u_W]$
-empty is a real variable with its reified definition and its two cuts, and the
+empty is a real variable with its reified definition and its two thresholds, and the
 boundary pins of \inv{Bound} falsify it by unit propagation.  It has no
 partition cell, no covering and no containment edge, which is why \invName{} is
 stated over cells rather than over every interval literal.
 
-An out-of-range \emph{cut}, $\atge{w}{v}$ with $v\leq l_W$ or $v>u_W$, is also a
+An out-of-range \emph{threshold}, $\atge{w}{v}$ with $v\leq l_W$ or $v>u_W$, is also a
 real variable, pinned by \inv{Bound}.  Substituting a constant for it instead
-would be wrong: the encoding needs it under a name, because it is the cut of
-some two-cut atom through \invCut{}, and \cref{lem:covering}(a) propagates
+would be wrong: the encoding needs it under a name, because it is the threshold of
+some membership atom through \invThresholds{}, and \cref{lem:covering}(a) propagates
 through exactly that.
 
 The cost of the substitution in the first case is the usual one: a caller that
@@ -831,9 +835,9 @@ proof, we mean that both directions of the reified definition for its
 underlying atomic variable have appeared in the accumulated formula and have
 not been deleted.
 
-Call the equality and interval atoms the \emph{two-cut} atoms, since each is
-defined by \cref{eq:defeq,eq:defin} from a pair of bound variables, and their
-literals the \emph{two-cut} literals.  From here on, when a two-cut atom is
+Call the equality and interval atoms the \emph{membership} atoms, since each
+asserts that $W$ takes a value in a set, and their literals the
+\emph{membership} literals.  From here on, when a membership atom is
 discussed through the set of values it names we write $\atset{w}{S}$ for the
 atom of $W$ that holds exactly when $W$ takes a value in the interval $S$, so
 that $\atset{w}{[a,b]}$ is $\atin{w}{a}{b}$ for $a<b$ and $\atset{w}{\{v\}}$ is
@@ -846,24 +850,24 @@ Note the asymmetry between
 $\Def^{\Rightarrow}$ and $\Def^{\Leftarrow}$ for them,
 \cref{eq:deq1,eq:deq2,eq:din1,eq:din2}.  The forward direction is
 a \emph{conjunction}: asserting $\ateq{w}{v}$ or $\atin{w}{a}{b}$ makes both
-cuts units.  The reverse direction is a \emph{disjunction}: asserting
-$\nateq{w}{v}$ or $\natin{w}{a}{b}$ makes neither cut a
+thresholds units.  The reverse direction is a \emph{disjunction}: asserting
+$\nateq{w}{v}$ or $\natin{w}{a}{b}$ makes neither threshold a
 unit; \cref{eq:deq2,eq:din2} become binary clauses that fire only when one of
-the two cuts is already known.  Almost everything in this section that is not
+the two thresholds is already known.  Almost everything in this section that is not
 already in the thesis exists because of that asymmetry.
 
 \begin{remark}
 The solver optionally uses a compact encoding in which an equality atom at a
-definition bound is defined by its one non-trivial cut only
+definition bound is defined by its one non-trivial threshold only
 ($\ateq{w}{l_W}\Leftrightarrow\natge{w}{l_W+1}$, and dually at
 $u_W$).  This is off by default, because the eager form matches
-\code{cake\_pb\_cp}'s.  Under that variant \invCut{} \emph{fails} at the
-definition bounds: the dropped cut is not a pinned atom but no atom at all ---
+\code{cake\_pb\_cp}'s.  Under that variant \invThresholds{} \emph{fails} at the
+definition bounds: the dropped threshold is not a pinned atom but no atom at all ---
 for $X\in[3,9]$ the equality atom at $3$ is defined and $\atge{x}{3}$ is never
 created.  Everything below is therefore stated for the default encoding.  The
-compact variant should be sound, the dropped cut being a constant of the
+compact variant should be sound, the dropped threshold being a constant of the
 encoding rather than a fact, but making the results unconditional would mean
-rereading every appeal to \invCut{} at a definition bound with a constant in
+rereading every appeal to \invThresholds{} at a definition bound with a constant in
 place of the atom, and we have not done that.
 \end{remark}
 
@@ -919,7 +923,7 @@ $t$ in the proof.
   If any $\atge{w}{v}$ with $v\leq l_W$ is defined, then for the largest such
   $v$ the unit $\atge{w}{v}$ appears in $F_t$; if any $\atge{w}{v}$ with
   $v>u_W$ is defined, then for the smallest such $v$ the unit $\natge{w}{v}$
-  appears in $F_t$.  One pin a side is enough: every other out-of-range cut
+  appears in $F_t$.  One pin a side is enough: every other out-of-range threshold
   follows from it by \invChain{}, through \cref{lem:chain}, which is why the
   arguments that use \inv{Bound} assume \invChain{} as well.  A view variable
   whose bounds are not a
@@ -927,7 +931,7 @@ $t$ in the proof.
   is exempt, and its owner derives the bounds explicitly instead; no interval
   literal is defined over such a variable today.
 
-\item[\invCut{}: cuts exist.]
+\item[\invThresholds{}: thresholds exist.]
   Whenever $\ateq{w}{v}$ is defined, so are $\atge{w}{v}$ and $\atge{w}{v+1}$;
   whenever $\atin{w}{a}{b}$ is defined, so are $\atge{w}{a}$ and
   $\atge{w}{b+1}$.
@@ -938,7 +942,7 @@ $t$ in the proof.
   $l_W,u_W+1\in\Bdry(W)$.  The \emph{cells} $\Cells(W)$ are the intervals
   $[p,p'-1]$ for consecutive $p<p'$ in $\Bdry(W)$; they partition $[l_W,u_W]$.
   For every cell $C$ the atom $\atset{w}{C}$ is defined --- an equality atom if
-  $C$ has width one, an interval atom otherwise.  For every defined two-cut atom
+  $C$ has width one, an interval atom otherwise.  For every defined membership atom
   $\atset{w}{E}$ of $W$ whose in-bounds part $E\cap[l_W,u_W]$ is non-empty, both
   endpoints of that part are boundaries; that is, $E\cap[l_W,u_W]$ is a union of
   adjacent cells.  $\Bdry(W)$ only ever grows.
@@ -966,8 +970,8 @@ $t$ in the proof.
   order/equality variable, the entire setting of the thesis.
 
 \item[\invCont{}: containment.]
-  For any two defined two-cut atoms $\atset{w}{E}$ and $\atset{w}{E'}$ of the
-  same view variable $W$ with $E\subsetneq E'$: if no defined two-cut atom
+  For any two defined membership atoms $\atset{w}{E}$ and $\atset{w}{E'}$ of the
+  same view variable $W$ with $E\subsetneq E'$: if no defined membership atom
   $\atset{w}{D}$ of $W$ has $E\subsetneq D\subsetneq E'$, then the clause
   $\natset{w}{E}\vee\atset{w}{E'}$ appears in $F_t$.  The arguments below use
   chains of these clauses rather than single edges; \cref{lem:contclosure}
@@ -993,7 +997,7 @@ $t$ in the proof.
 \end{description}
 
 \invChain{} and \inv{Bound} come from the thesis, generalised only by being
-stated per view variable.  \invCut{} is implicit there; we make it explicit
+stated per view variable.  \invThresholds{} is implicit there; we make it explicit
 because both new literal kinds depend on it.  \invPart{}, \invCover{} and
 \invCont{} are the interval apparatus.  \invView{} is the multi-view
 apparatus.  \invName{} is a hygiene condition that \invView{} needs for the
@@ -1037,7 +1041,7 @@ inside, which is what \cref{eq:gelink,eq:eqlink,eq:inlink} do.  Taking images is
 functorial: $(\ell^{W'})^{W''} = \ell^{W''}$, and $\ell^{W}=\ell$.
 \end{definitionT}
 
-Stating the two-cut case over the set rather than over the endpoints is what
+Stating the membership case over the set rather than over the endpoints is what
 makes it one line instead of four, and the two facts that make the design
 tractable are then immediate rather than needing an argument.  First, $\theta$ is
 an affine bijection, so $\theta(S)$ is an interval of the same width as $S$: the
@@ -1087,9 +1091,9 @@ emission to a RUP line would fail on the first view with a nonzero offset, and
 would fail intermittently, which is worse.
 
 For the eq-link, asserting one side and the negation of the other propagates both
-cuts through \cref{eq:deq1}, carries each across by the ge-links, and closes on
+thresholds through \cref{eq:deq1}, carries each across by the ge-links, and closes on
 \cref{eq:deq2} of the far side.  For the in-link, the same argument with
-\cref{eq:din1,eq:din2}, noting that for $s=-1$ the two cuts exchange roles ---
+\cref{eq:din1,eq:din2}, noting that for $s=-1$ the two thresholds exchange roles ---
 which is the endpoint reversal that $\theta(S)$ absorbs in \cref{def:image}.
 
 \begin{remarkN}[Both in-link clauses are needed, and neither for its implication]
@@ -1108,7 +1112,7 @@ contrapositives,
   \natin{w}{a}{b} \implies (\natin{w}{a}{b})^{X},
 \]
 and neither is derivable without its clause.  A negated interval literal is a
-unit on \emph{neither} of its cuts, by the asymmetry noted after
+unit on \emph{neither} of its thresholds, by the asymmetry noted after
 \cref{eq:din2}; all it can do is descend its own view variable's containment
 edges, and it bottoms out at cells that are themselves unlinked interval
 literals unless they happen to have width one.  Descending to width one is
@@ -1162,7 +1166,7 @@ We first establish everything for a single view variable $W$, writing $L^W$ for
 the atomic literals over atomic variables of $W$ defined in $F_t$, and $[l,u]$
 for $[l_W,u_W]$.  \cref{lem:transport} then lifts the results to a family.
 
-It is convenient to normalise away positive two-cut literals once and for all.
+It is convenient to normalise away positive membership literals once and for all.
 
 \begin{lemmaT}[Chain propagation]
 \label{lem:chain}
@@ -1182,7 +1186,7 @@ is a binary clause, so it propagates in one direction from $\atge{w}{v_j}$ and
 in the other from $\natge{w}{v_{j+1}}$.  Chaining gives both claims.
 \end{proof}
 
-\begin{lemmaN}[Cut normalisation]
+\begin{lemmaN}[Threshold normalisation]
 \label{lem:normalise}
 Let $R\subseteq L^W$ and let $R'$ be obtained from $R$ by replacing each
 positive literal $\ateq{w}{v}$ by $\{\atge{w}{v},\natge{w}{v+1}\}$ and
@@ -1193,21 +1197,21 @@ propagates under $R$, and $\dm_{R'}(W)=\dm_R(W)$.
 
 \begin{proof}
 The replacements are exactly what \cref{eq:deq1,eq:din1} propagate from the
-positive literal, and the cuts are defined by \invCut{}.  The two literal sets
+positive literal, and the thresholds are defined by \invThresholds{}.  The two literal sets
 allow the same values by \cref{eq:defeq,eq:defin}.
 \end{proof}
 
-Call a set of literals \emph{cut-normalised} if it contains no positive equality
-or interval literal.  \cref{lem:normalise} says that any set may be replaced by
-a cut-normalised one with the same defined domain, all of whose literals still
-propagate, so in the proofs below we may assume that the only two-cut literals
+Call a set of literals \emph{threshold-normalised} if it contains no positive
+membership literal.  \cref{lem:normalise} says that any set may be replaced by
+a threshold-normalised one with the same defined domain, all of whose literals still
+propagate, so in the proofs below we may assume that the only membership literals
 present are negative.  This is where the asymmetry bites: normalisation cannot be applied to
-a negative two-cut literal, and there is nothing else to do with one except
+a negative membership literal, and there is nothing else to do with one except
 propagate through the machinery of \invCover{} and \invCont{}.
 
 \begin{lemmaN}[Containment chains]
 \label{lem:contclosure}
-Assume \invCont{}.  Then for any two defined two-cut atoms $\atset{w}{E}$ and
+Assume \invCont{}.  Then for any two defined membership atoms $\atset{w}{E}$ and
 $\atset{w}{E'}$ of $W$ with $E\subsetneq E'$, there is a chain
 $E=E_0\subsetneq E_1\subsetneq\cdots\subsetneq E_m=E'$ with every
 $\atset{w}{E_j}$ defined and every clause
@@ -1215,7 +1219,7 @@ $\natset{w}{E_j}\vee\atset{w}{E_{j+1}}$ in $F_t$.
 \end{lemmaN}
 
 \begin{proof}
-By induction on the number of defined two-cut atoms $\atset{w}{D}$ of $W$ with
+By induction on the number of defined membership atoms $\atset{w}{D}$ of $W$ with
 $E\subsetneq D\subsetneq E'$.  If there are none, \invCont{} puts
 $\natset{w}{E}\vee\atset{w}{E'}$ in $F_t$, and the chain is that single edge.
 
@@ -1231,7 +1235,7 @@ the edge just obtained extends the chain it gives.
 \end{proof}
 
 \begin{remark}
-\invCont{} is maintained by emitting, whenever a two-cut atom $\atset{w}{E}$ is
+\invCont{} is maintained by emitting, whenever a membership atom $\atset{w}{E}$ is
 defined, the clause $\natset{w}{E}\vee\atset{w}{E'}$ for every \emph{minimal}
 $E'\supsetneq E$ whose atom is defined, and $\natset{w}{E''}\vee\atset{w}{E}$
 for every \emph{maximal} $E''\subsetneq E$ whose atom is defined --- which is
@@ -1254,8 +1258,8 @@ whose atoms are currently defined for $W$, not merely over the cells.
 
 \begin{lemmaN}[Cell exclusion]
 \label{lem:cell}
-Assume \invChain{}, \invCut{}, \invPart{} and \invCont{}.  Let $R$ be a set of
-literals, let $U\subseteq L^W$ be a cut-normalised set of literals each of which
+Assume \invChain{}, \invThresholds{}, \invPart{} and \invCont{}.  Let $R$ be a set of
+literals, let $U\subseteq L^W$ be a threshold-normalised set of literals each of which
 propagates under $R$, suppose $F_t\!\restriction_R$ does not propagate to conflict, and
 write $D=\dm_U(W)$.  Let $C\in\Cells(W)$ be a cell with $D\cap C=\emptyset$.
 Then $\natset{w}{C}$ propagates under $R$.
@@ -1265,12 +1269,12 @@ Then $\natset{w}{C}$ propagates under $R$.
 Write $C=[p,q]$, so that $\atset{w}{C}$ is $\atin{w}{p}{q}$ if $p<q$ and
 $\ateq{w}{p}$ if $p=q$; in either case \cref{eq:deq1,eq:din1} give the single PB
 constraint $\atset{w}{C}\Rightarrow\atge{w}{p}+\natge{w}{q+1}\geq 2$, and both
-cuts are defined by \invCut{}.  That constraint is not a pair of clauses, but it
-propagates like one in each direction: $\atset{w}{C}$ makes both cuts units, and
+thresholds are defined by \invThresholds{}.  That constraint is not a pair of clauses, but it
+propagates like one in each direction: $\atset{w}{C}$ makes both thresholds units, and
 either $\natge{w}{p}$ or $\atge{w}{q+1}$ propagates $\natset{w}{C}$, which is
 the direction used below.
 
-\emph{Case 1: some negative two-cut literal of $U$ names a set containing $C$.}
+\emph{Case 1: some negative membership literal of $U$ names a set containing $C$.}
 That is, $\natset{w}{E}\in U$ for a defined $\atset{w}{E}$ with $C\subseteq E$.
 If $E=C$ we are done.  Otherwise $C\subsetneq E$, and \cref{lem:contclosure}
 gives a chain of binary clauses $\natset{w}{C}\vee\atset{w}{E_1}$,
@@ -1278,8 +1282,8 @@ $\natset{w}{E_1}\vee\atset{w}{E_2}$, \dots,
 $\natset{w}{E_{m-1}}\vee\atset{w}{E}$; reading each contrapositive in turn from
 $\natset{w}{E}$ propagates $\natset{w}{C}$.
 
-\emph{Case 2: no negative two-cut literal of $U$ names a set containing $C$.}
-We claim that then no negative two-cut literal of $U$ names a set meeting $C$ at
+\emph{Case 2: no negative membership literal of $U$ names a set containing $C$.}
+We claim that then no negative membership literal of $U$ names a set meeting $C$ at
 all.  Let $\natset{w}{E}\in U$.  If $E\cap[l,u]=\emptyset$ then
 $E\cap C=\emptyset$ since $C\subseteq[l,u]$.
 Otherwise, by \invPart{}, $E\cap[l,u]$ is a union of adjacent cells, and $C$ is
@@ -1307,8 +1311,8 @@ disjoint from the interval $C$, and $C$ lies wholly on one side of it.
 
 \begin{lemmaN}[Covering completeness]
 \label{lem:covering}
-Assume \invChain{}, \inv{Bound}, \invCut{}, \invPart{} and \invCover{}.  Let
-$\atset{w}{E}$ be a defined two-cut atom of $W$ and let $S=E\cap[l,u]$.
+Assume \invChain{}, \inv{Bound}, \invThresholds{}, \invPart{} and \invCover{}.  Let
+$\atset{w}{E}$ be a defined membership atom of $W$ and let $S=E\cap[l,u]$.
 \begin{enumerate}[label=(\alph*),itemsep=1pt]
   \item If $S=\emptyset$ then $\natset{w}{E}$ propagates under any $R$.
   \item If $S\neq\emptyset$, $E$ is not currently a cell, and $\natset{w}{C}$
@@ -1318,12 +1322,12 @@ $\atset{w}{E}$ be a defined two-cut atom of $W$ and let $S=E\cap[l,u]$.
 
 \begin{proof}
 \emph{(a)}  Write $E=[a,b]$.  If $b<l$ then $\atge{w}{b+1}$ is defined by
-\invCut{} with $b+1\leq l$, so \inv{Bound} makes $\atge{w}{v}$ a unit for some
+\invThresholds{} with $b+1\leq l$, so \inv{Bound} makes $\atge{w}{v}$ a unit for some
 $b+1\leq v\leq l$, \cref{lem:chain} propagates $\atge{w}{b+1}$ from it, and
 \cref{eq:deq1,eq:din1} propagate $\natset{w}{E}$.  If $a>u$ then $\atge{w}{a}$
 is defined with $a>u$, so \inv{Bound} makes $\natge{w}{v}$ a unit for some
 $u<v\leq a$, \cref{lem:chain} propagates $\natge{w}{a}$ from it, and
-\cref{eq:deq1,eq:din1} propagate $\natset{w}{E}$ through the other cut.
+\cref{eq:deq1,eq:din1} propagate $\natset{w}{E}$ through the other threshold.
 
 \emph{(b)}  For a set that is a union of adjacent cells, define its \emph{rank}
 to be the number of cells it contains.  We first show, by induction on rank,
@@ -1374,20 +1378,20 @@ special-case it; the structural form does not.
 \label{thm:wipeout}
 Let $F_t$ be a set of PB constraints either in the encoding of a CP problem, as
 produced by \cref{proc:encoding}, or derived from it, and suppose \invChain{}
-and \invCut{} are respected.  Let $W$ be a view variable, and let $U\subseteq
+and \invThresholds{} are respected.  Let $W$ be a view variable, and let $U\subseteq
 L^W$ be a set of literals each of which propagates under some $R$.  If
 $\dm_U(W)=\emptyset$ then $F_t\!\restriction_R$ propagates to conflict.
 \end{theoremT}
 
 \begin{proof}
-Suppose not, and cut-normalise $U$ using \cref{lem:normalise}, which preserves
+Suppose not, and threshold-normalise $U$ using \cref{lem:normalise}, which preserves
 both the defined domain and the property of propagating under $R$.
 
 Since $\dm_U(W)=\emptyset$, every integer is excluded by $U$ somehow.  In
 particular the values below any fixed point must be excluded.  No literal
 $\natge{w}{v}$ excludes anything below $v$, and $U$ is finite --- it is a subset
 of $L^W$, and only finitely many atomic variables are defined in a finite
-formula --- so its negative two-cut literals between them exclude only a bounded
+formula --- so its negative membership literals between them exclude only a bounded
 set.  Hence $U$ contains at least one literal $\atge{w}{v}$.  Let $v^{+}$ be the
 largest value such that $\atge{w}{v^{+}}$ propagates under $R$; this exists for
 the same reason.
@@ -1396,7 +1400,7 @@ $\natge{w}{v^{-}}$ propagates; this exists for the mirrored reason.
 
 If $v^{+}\geq v^{-}$ then \cref{lem:contra-bounds} gives a conflict.  So
 $v^{+}<v^{-}$, and in particular the value $v^{+}$ is not excluded by any bound
-literal of $U$.  It must therefore be excluded by a negative two-cut literal of
+literal of $U$.  It must therefore be excluded by a negative membership literal of
 $U$, and there are two cases.
 \begin{itemize}[itemsep=1pt]
   \item $\nateq{w}{v^{+}}\in U$.  Then $\atge{w}{v^{+}}$ propagates,
@@ -1404,7 +1408,7 @@ $U$, and there are two cases.
     $\ateq{w}{v^{+}}\vee\natge{w}{v^{+}}\vee\atge{w}{v^{+}+1}$ ---
     propagates $\atge{w}{v^{+}+1}$, contradicting the maximality of $v^{+}$.
   \item $\natin{w}{a}{b}\in U$ with $a\leq v^{+}\leq b$.  By
-    \invCut{}, $\atge{w}{a}$ is defined, and $a\leq v^{+}$, so
+    \invThresholds{}, $\atge{w}{a}$ is defined, and $a\leq v^{+}$, so
     \cref{lem:chain} propagates it.  Then \cref{eq:din2} --- the clause
     $\atin{w}{a}{b}\vee\natge{w}{a}\vee\atge{w}{b+1}$ --- propagates
     $\atge{w}{b+1}$, and $b+1>v^{+}$, again contradicting maximality.
@@ -1415,11 +1419,11 @@ $U$, and there are two cases.
 \begin{remarkN}[The root covering is not load-bearing here]
 \label{rem:rootcovering}
 \cref{thm:wipeout} uses only the reverse reifications, the order chain, and the
-fact that both cuts of a two-cut literal are defined.  It does \emph{not} use
+fact that both thresholds of a membership literal are defined.  It does \emph{not} use
 \invCover{} at all, and in particular not the root covering \invCover{}(iii),
 which is the clause one would naively expect to be responsible for detecting
 wipeout at the literal level.  The reason is the second bullet above: a negated
-interval literal, combined with a bound that has reached its lower cut, jumps
+interval literal, combined with a bound that has reached its lower threshold, jumps
 the bound over the whole interval in one step.  Walking those jumps from the
 bottom of the domain is exactly a traversal of the excluded region.
 
@@ -1433,20 +1437,20 @@ before in this design --- see \nsec{sec:loadbearing}.
 \begin{theoremT}[Complete propagation of implied atomic literals]
 \label{thm:complete}
 Let $F_t$ be as in \cref{thm:wipeout}, and suppose \invChain{}, \inv{Bound},
-\invCut{}, \invPart{}, \invCover{} and \invCont{} are respected.  Let $W$ be a
+\invThresholds{}, \invPart{}, \invCover{} and \invCont{} are respected.  Let $W$ be a
 view variable and $U\subseteq L^W$ a set of literals each of which propagates
 under some $R$.  If $F_t\!\restriction_R$ does not propagate to contradiction,
 then every literal in $\ImpLits(\dm_U(X))\cap L^W$ propagates under $R$.
 \end{theoremT}
 
 \begin{proof}
-Cut-normalise $U$ by \cref{lem:normalise}, and write $D=\dm_U(W)$, which is
+Threshold-normalise $U$ by \cref{lem:normalise}, and write $D=\dm_U(W)$, which is
 non-empty since otherwise \cref{thm:wipeout} would give a contradiction.
 Consider a literal $\ell\in\ImpLits(\dm_U(X))\cap L^W$.  By \cref{eq:implits}
 there are six cases.
 
 \emph{Case 1: $\ell=\atge{w}{v}$, with $v'\notin D$ for all $v'<v$.}  In
-particular $D$ is bounded from below.  Since $U$ is finite, its negative two-cut
+particular $D$ is bounded from below.  Since $U$ is finite, its negative membership
 literals exclude only a bounded set, so $U$ must contain a positive bound
 literal, and we may let $v^{+}$ be the largest value with $\atge{w}{v^{+}}$
 propagating.
@@ -1455,32 +1459,32 @@ $\ell$ propagates by definition of $v^{+}$.  Otherwise $v^{+}<v$, so
 $v^{+}\notin D$, and $v^{+}$ is not excluded by any bound literal of $U$ (by
 maximality of $v^{+}$ and, on the other side, because
 $\natge{w}{v'}\in U$ with $v'\leq v^{+}$ would give a conflict by
-\cref{lem:contra-bounds}).  So $v^{+}$ is excluded by a negative two-cut
+\cref{lem:contra-bounds}).  So $v^{+}$ is excluded by a negative membership
 literal, and exactly as in the two bullets of \cref{thm:wipeout} we derive
 $\atge{w}{v''}$ for some $v''>v^{+}$, contradicting maximality.
 
 \emph{Case 2: $\ell=\natge{w}{v}$.}  Symmetric to Case 1, taking
 $v^{-}$ the smallest value with $\natge{w}{v^{-}}$ propagating and
-using the other cut in each reverse reification.
+using the other threshold in each reverse reification.
 
 \emph{Case 3: $\ell=\ateq{w}{v}$, so $D=\{v\}$.}  Since $\ell$ is defined, so
-are $\atge{w}{v}$ and $\atge{w}{v+1}$ by \invCut{}; both
+are $\atge{w}{v}$ and $\atge{w}{v+1}$ by \invThresholds{}; both
 $\atge{w}{v}\in\ImpLits$ and $\natge{w}{v+1}\in\ImpLits$, so they
 propagate by Cases 1 and 2, and \cref{eq:deq2} then propagates $\ell$.
 
 \emph{Case 4: $\ell=\nateq{w}{v}$, so $v\notin D$.}  Consider what excludes $v$;
-after cut normalisation the candidates are a bound literal and a negative
-two-cut literal.  If a bound literal does, then either $\atge{w}{v+1}$ or
+after threshold normalisation the candidates are a bound literal and a negative
+membership literal.  If a bound literal does, then either $\atge{w}{v+1}$ or
 $\natge{w}{v}$ propagates by \cref{lem:chain}, and \cref{eq:deq1} then
-propagates $\ell$ from whichever it is.  If instead a negative two-cut
+propagates $\ell$ from whichever it is.  If instead a negative membership
 literal $\natset{w}{E}\in U$ with $v\in E$ does, then $\{v\}\subseteq E$; if
 $E=\{v\}$ then $\ell\in U$, and otherwise \cref{lem:contclosure} gives a chain of
 binary clauses whose contrapositives propagate $\ell$ from $\natset{w}{E}$.  If a
-positive two-cut literal excludes $v$, cut normalisation has already replaced it
+positive membership literal excludes $v$, threshold normalisation has already replaced it
 by bound literals, so this is the first case.
 
 \emph{Case 5: $\ell=\atin{w}{a}{b}$, with $D\subseteq[a,b]$.}  Since $\ell$ is
-defined, $\atge{w}{a}$ and $\atge{w}{b+1}$ are defined by \invCut{}.  Every
+defined, $\atge{w}{a}$ and $\atge{w}{b+1}$ are defined by \invThresholds{}.  Every
 $v<a$ is outside $D$ and every $v\geq b+1$ is outside $D$, so
 $\atge{w}{a}$ and $\natge{w}{b+1}$ are in
 $\ImpLits(\dm_U(X))\cap L^W$ and propagate by Cases 1 and 2.  \cref{eq:din2}
@@ -1568,7 +1572,7 @@ one unlinked, and nothing would notice.
 \setcounter{theoremP}{1}
 \begin{theoremP}[Empty defined domain, family version]
 \label{thm:wipeout-family}
-Let $F_t$ be as in \cref{thm:wipeout}, and suppose \invChain{}, \invCut{} and
+Let $F_t$ be as in \cref{thm:wipeout}, and suppose \invChain{}, \invThresholds{} and
 \invView{} are respected.  Let $L$ be the atomic literals defined in $F_t$ for
 any view variable of $X$, and let $U\subseteq L$ be a set of literals each of
 which propagates under $R$.  If $\dm_U(X)=\emptyset$ then
@@ -1633,11 +1637,11 @@ $\atge{w}{v}$ & $\atge{w}{v'}$, $v'<v$ & order chain, \invChain{}
   (\cref{lem:chain}) \\
 $\natge{w}{v}$ & $\natge{w}{v'}$, $v'>v$ & the same clauses,
   read the other way \\
-$\ateq{w}{v}$ or $\atin{w}{a}{b}$ & its two cuts & $\Def^{\Rightarrow}$,
+$\ateq{w}{v}$ or $\atin{w}{a}{b}$ & its two thresholds & $\Def^{\Rightarrow}$,
   \cref{eq:deq1,eq:din1} \\
-both cuts & $\ateq{w}{v}$ or $\atin{w}{a}{b}$ & $\Def^{\Leftarrow}$,
+both thresholds & $\ateq{w}{v}$ or $\atin{w}{a}{b}$ & $\Def^{\Leftarrow}$,
   \cref{eq:deq2,eq:din2} \\
-one cut crossing the literal & $\nateq{w}{v}$ or
+one threshold crossing the literal & $\nateq{w}{v}$ or
   $\natin{w}{a}{b}$ & $\Def^{\Rightarrow}$, contrapositive \\
 $\nateq{w}{v}$ or $\natin{w}{a}{b}$ & a bound stepping over
   it & $\Def^{\Leftarrow}$: this is the hole jump, and the reason
@@ -1723,7 +1727,7 @@ covering clause somewhere else entirely.
 \cref{eq:defin} reifies against two inequality atoms, which are in turn reified
 against $\BinEnc(W)$.  A variable given a purely direct encoding --- one
 $0$--$1$ variable per value, with an at-least-one and an at-most-one clause,
-and no bit vector --- has no cuts to reify against, and no interval literals are
+and no bit vector --- has no thresholds to reify against, and no interval literals are
 available for it.  This is a property of the variable, not of views: whether a
 view may carry interval literals is decided by whether its \emph{base} has a bit
 vector.  Consumers that would state an interval fact fall back to stating it per
@@ -1799,7 +1803,7 @@ $\dm_L(X)\subseteq\dm_t(X)$ is between two subsets of the same set of integers.
 \begin{theoremT}
 \label{thm:btrup}
 If \invConflict{} and \invDomain{} are respected, the literal-layer invariants
-\cref{thm:wipeout-family} needs hold --- \invChain{}, \invCut{} and \invView{} ---
+\cref{thm:wipeout-family} needs hold --- \invChain{}, \invThresholds{} and \invView{} ---
 and a complete solver always logs backtracking justifications, then every
 backtracking justification $B_t$ follows by RUP.
 \end{theoremT}
@@ -1881,7 +1885,7 @@ taken on the base.  All three meet only through \cref{lem:transport}.
 \label{lem:reasons}
 If $R$ is a finite set of literals defined in $F_t$ with
 $R\subseteq\bigcup_i\ImpLits(\dm_t(X_i))$, and \invChain{}, \inv{Bound},
-\invCut{}, \invPart{}, \invCover{}, \invCont{}, \invView{} and \invDomain{} are
+\invThresholds{}, \invPart{}, \invCover{}, \invCont{}, \invView{} and \invDomain{} are
 respected, then $F_t\cup\{\neg B_t\}$ either propagates to contradiction or
 propagates every literal in $R$.
 \end{lemmaT}
@@ -1939,15 +1943,15 @@ for \cref{eq:rootbounds} as written.
 
 In the other direction the implementation is \emph{stronger} than \inv{Bound}
 asks, and this one costs measurable proof.  \code{fix\_bound} emits a pin for
-every out-of-range cut it creates, not one a side, so a variable can accumulate
+every out-of-range threshold it creates, not one a side, so a variable can accumulate
 hundreds of top-of-proof units that \cref{lem:chain} would supply from one.  On
 the TSP example this is $2{,}258$ pins over $68$ distinct variable-and-side
 pairs, the worst single variable carrying $255$ --- a cost variable with lower
-bound $0$ whose cuts run from $\atge{w}{-482}$ up to $\atge{w}{0}$, each pinned
+bound $0$ whose thresholds run from $\atge{w}{-482}$ up to $\atge{w}{0}$, each pinned
 separately.  Weakening the emission to match the invariant is not quite as
-simple as pinning the extreme cut, because the cuts are created one at a time
+simple as pinning the extreme threshold, because the thresholds are created one at a time
 and in no particular order, and the pin has to be a persistent top-of-proof line
-rather than one re-derived per use; the workable version pins the cut at the
+rather than one re-derived per use; the workable version pins the threshold at the
 definition bound once, on the first out-of-range request for the variable, and
 nothing after that.
 \end{remark}
@@ -1995,7 +1999,7 @@ by \cref{eq:rootbounds}.  Hence \invDomain{} is initially respected.
     view variable its definitional link \cref{eq:link}.
   \item At the start of the proof, derive by RUP $\atge{x}{l}\geq 1$ and
     $\natge{x}{u+1}\geq 1$ for the bounds $l..u$ on each variable, and
-    likewise for any out-of-range cut subsequently created on any view variable.
+    likewise for any out-of-range threshold subsequently created on any view variable.
   \item Any time the solver backtracks, derive by RUP a backtracking
     justification $G\Rightarrow 0\geq 1$, where $G$ is the sequence of decisions
     prior to backtracking.
@@ -2172,7 +2176,7 @@ incorrectly three times on the strength of tests that stayed green.
 \end{description}
 
 Everything in \cref{sec:atomprops} beyond the definitions themselves guards
-against P2.  \invChain{}, \invCut{}, \invPart{}, \invCover{}, \invCont{},
+against P2.  \invChain{}, \invThresholds{}, \invPart{}, \invCover{}, \invCont{},
 \invView{} and \invName{} contribute nothing to the validity of any individual
 line; they exist so that \cref{thm:complete-family} holds, and
 \cref{thm:complete-family} exists so that \cref{lem:reasons} holds, and
@@ -2261,7 +2265,7 @@ because wipeout is also derivable by the bound-axiom walk of
 \cref{rem:rootcovering}.  They remain in the suite as composed end-to-end
 regression nets.  Two known gaps: there is no deterministic witness for split
 coverings composing across refinements with no bound anchor (the shape
-\cref{lem:covering}(b) is proved for), and none for \invCut{} in isolation.
+\cref{lem:covering}(b) is proved for), and none for \invThresholds{} in isolation.
 
 \subsubsection*{The coincidence trap}
 \phantomsection\label{sec:coincidence}
@@ -2278,7 +2282,7 @@ at all} whenever any of four things happens:
     already inconsistent under unit propagation and the check passes vacuously;
   \item the interval abuts or extends below the lower bound, so that the
     boundary pin of \inv{Bound} --- through the order chain, if the pin is not
-    at the cut itself --- makes \cref{eq:din2} a unit, the ge-link carries it,
+    at the threshold itself --- makes \cref{eq:din2} a unit, the ge-link carries it,
     and the far side's \emph{forward} reification finishes the job;
   \item the interval abuts or extends above the upper bound, the mirror image;
   \item every cell inside the interval is a singleton --- and one well-placed
@@ -2402,7 +2406,7 @@ decision.  On $X$:
 \begin{itemize}[itemsep=0pt]
   \item the partition is created, with boundaries $\{1,5,11,21\}$ and cells
     $[1,4]$, $[5,10]$, $[11,20]$, each defined as an interval literal with its
-    two cuts threaded into the order chain;
+    two thresholds threaded into the order chain;
   \item the root covering
     $\atin{x}{1}{4}\vee\atin{x}{5}{10}\vee\atin{x}{11}{20}\geq 1$ is emitted;
   \item there is no containment yet, nothing being nested.
@@ -2455,7 +2459,7 @@ roles.
 Suppose the solver now decides $\natin{x}{7}{10}$ --- the \emph{cell} $[7,10]$,
 not the request $[7,15]$ --- and, deeper in the subtree, a propagator's reason
 names $[V\in 20..23]$, which is its image.  In the replay,
-$\natin{x}{7}{10}$ is asserted.  It is a unit on neither of its cuts:
+$\natin{x}{7}{10}$ is asserted.  It is a unit on neither of its thresholds:
 \cref{eq:din2} for it is the ternary clause
 $\atin{x}{7}{10}\vee\natge{x}{7}\vee\atge{x}{11}$, and with the first literal
 false and neither bound known, nothing propagates.  Its containment edges are no
@@ -2503,7 +2507,7 @@ where 80\% of small random instances turn out to be one of them.
 \begin{enumerate}[itemsep=3pt]
 
 \item \textbf{Variables with no bit vector.}  As noted in
-  \nsec{sec:notprovided}, interval literals need cuts to reify against.  The
+  \nsec{sec:notprovided}, interval literals need thresholds to reify against.  The
   gate is whether the variable has a registered bit vector, not what its domain
   looks like: a variable with domain exactly $\{0,1\}$, given a purely direct
   encoding, is registered with a one-element bit vector, and is therefore
@@ -2622,21 +2626,21 @@ wherever it wants the fact, and the encoding could carry one atom family instead
 of three.
 
 The reason it does not is the negation.  Asserting the conjunction is harmless:
-both cuts become units either way.  Asserting its negation is not, because
+both thresholds become units either way.  Asserting its negation is not, because
 $\neg(\atge{w}{v}\wedge\natge{w}{v+1})$ is the disjunction
-$\natge{w}{v}\vee\atge{w}{v+1}$, which is a unit on neither cut.  Removing a
+$\natge{w}{v}\vee\atge{w}{v+1}$, which is a unit on neither threshold.  Removing a
 value, or a run of values, is precisely asserting that negation --- so without a
 Boolean, the fact a propagator most often wants to state is the one fact unit
 propagation cannot use.  With one, the negation is a single literal,
 \cref{eq:deq2,eq:din2} are its reverse reifications, and the hole jump that
-\cref{thm:wipeout} turns on --- a bound at the lower cut stepping over the whole
+\cref{thm:wipeout} turns on --- a bound at the lower threshold stepping over the whole
 hole --- goes through in one step.
 
 Two things follow.  A reason is a set of literals concluding a single literal, so
 a propagator that removes a value needs a literal to conclude, and a conjunction
 gives it none.  And the same argument at width greater than one is why interval
 literals exist: not for strength, since $\atin{w}{a}{b}$ says exactly what its
-two cuts say, but because the alternative is $b-a+1$ separate equality atoms, so
+two thresholds say, but because the alternative is $b-a+1$ separate equality atoms, so
 that naming a run of holes in a reason would cost the width of the run rather
 than one literal.
 
@@ -2669,7 +2673,7 @@ than the design we have, rather than wrong, are under \cref{sec:rationale}.
 
 \begin{enumerate}[itemsep=3pt]
 
-\item \textbf{``Reify to the two cuts and use the order chain; no covering, no
+\item \textbf{``Reify to the two thresholds and use the order chain; no covering, no
   containment.''}  A falsification matrix of \emph{derivations} passes --- that
   is P1 only.  Caught by W4 (containment) and W2, W3, W5 (covering).
 

--- a/dev_docs/literal-encodings.tex
+++ b/dev_docs/literal-encodings.tex
@@ -474,7 +474,9 @@ immediately, because it is the single most expensive mistake available here.
 \label{def:widthone}
 For $a=b$, the interval variable $\atin{w}{a}{b}$ \emph{is} the equality
 variable $\ateq{w}{a}$: the same PB variable, not a second one with the same
-definition.  For $a>b$, the interval condition is the constant false.
+definition.  For $a>b$ there is no variable at all: $\atin{w}{a}{b}$ is
+\emph{substituted} by the constant $0$ and $\natin{w}{a}{b}$ by the constant
+$1$, wherever either would have appeared.
 \end{definitionT}
 
 A separate width-one interval flag would be an unlinked doppelg\"anger of the
@@ -482,6 +484,46 @@ equality atom: two Booleans with identical definitions, and nothing in the
 formula connecting them, so that a fact recorded in one is invisible through
 the other.  It cannot be repaired by adding the equivalence after the fact ---
 see \nsec{sec:loadbearing} below, where this is witness~W1.
+
+\begin{remarkN}[Which degenerate intervals get a variable, and which do not]
+\label{rem:degenerate}
+Three nearby cases behave differently, and the difference is worth stating
+because only one of them is a substitution.
+
+A \emph{reversed} request, $a>b$, names no set of values, so it gets no
+variable.  Both polarities fold together and at the same place: the
+canonicalisation that performs the width-one identification of
+\cref{def:widthone} also rewrites $\atin{w}{a}{b}$ to $0$ and $\natin{w}{a}{b}$
+to $1$, so everything downstream sees only intervals of width at least two.
+There is no reified definition, no cut, nothing to name and nothing to cite.
+This is the encoding's general convention for a condition that is constant ---
+a condition on a constant variable folds the same way --- and not something
+special to intervals.
+
+An interval that is well formed but lies \emph{outside} the definition range is
+not a substitution: $\atin{w}{a}{b}$ with $a\leq b$ and $[a,b]\cap[l_W,u_W]$
+empty is a real variable with its reified definition and its two cuts, and the
+boundary pins of \inv{Bound} falsify it by unit propagation.  It has no
+partition cell, no covering and no containment edge, which is why \invName{} is
+stated over cells rather than over every interval literal.
+
+An out-of-range \emph{cut}, $\atge{w}{v}$ with $v\leq l_W$ or $v>u_W$, is also a
+real variable, pinned by \inv{Bound}.  Substituting a constant for it instead
+would be wrong: the encoding needs it under a name, because it is the cut of
+some two-cut atom through \invCut{}, and \cref{lem:covering}(a) propagates
+through exactly that.
+
+The cost of the substitution in the first case is the usual one: a caller that
+requires a \emph{named} literal --- a \code{pol} operand, a hint, a reason
+element to be cited --- gets a constant instead, and has to say so rather than
+carry on.  The solver's convention is to throw, as subset-sum strengthening
+does on a constantly false term.  The alternative, giving the empty interval a
+Boolean forced false by definition constraints, would buy a name at the price of
+putting the empty set into the containment order, where it is below everything
+and is a cell of nothing; \invPart{} and \invCont{} would both need a special
+case for an object with no values in it.
+\end{remarkN}
+
 
 Because these are fully reified constraints on fresh variables, they are
 entirely redundant: the values of the atomic variables are uniquely determined

--- a/dev_docs/literal-encodings.tex
+++ b/dev_docs/literal-encodings.tex
@@ -1,0 +1,2329 @@
+% Pseudo-Boolean encodings and proof logging for integer variables with
+% multiple representations.
+%
+% Build with: latexmk -pdf literal-encodings.tex
+%
+\documentclass[11pt,a4paper]{article}
+
+\usepackage[a4paper,margin=2.6cm]{geometry}
+\usepackage{amsmath,amssymb,amsthm}
+\usepackage{mathtools}
+\usepackage{booktabs}
+\usepackage{enumitem}
+\usepackage[T1]{fontenc}
+\usepackage{lmodern}
+\usepackage{microtype}
+\usepackage{xcolor}
+\usepackage[colorlinks,linkcolor=blue!50!black,citecolor=blue!50!black,urlcolor=blue!50!black]{hyperref}
+\usepackage{cleveref}
+
+% ---------------------------------------------------------------- theorem envs
+% Numbering follows the thesis: results that are the thesis's results keep the
+% thesis's numbers, and results that are new to this document are lettered.  See
+% "About this document".
+\theoremstyle{plain}
+\newtheorem{theoremT}{Theorem}
+\newtheorem{lemmaT}{Lemma}
+\newtheorem{corollaryT}{Corollary}
+\renewcommand{\thetheoremT}{3.\arabic{theoremT}}
+\renewcommand{\thelemmaT}{3.\arabic{lemmaT}}
+\renewcommand{\thecorollaryT}{3.\arabic{corollaryT}}
+
+\newtheorem{theoremN}{Theorem}
+\newtheorem{lemmaN}{Lemma}
+\renewcommand{\thetheoremN}{3.\Alph{theoremN}}
+\renewcommand{\thelemmaN}{3.\Alph{lemmaN}}
+
+% Family versions of thesis theorems keep the thesis's number, with a prime.
+\newtheorem{theoremP}{Theorem}
+\renewcommand{\thetheoremP}{3.\arabic{theoremP}$'$}
+
+\theoremstyle{definition}
+\newtheorem{definitionT}{Definition}
+\renewcommand{\thedefinitionT}{3.\arabic{definitionT}}
+\newtheorem{exampleT}{Example}
+\renewcommand{\theexampleT}{3.\arabic{exampleT}}
+\newtheorem{procedureT}{Encoding Procedure}
+\renewcommand{\theprocedureT}{3.\arabic{procedureT}}
+
+\theoremstyle{remark}
+\newtheorem*{remark}{Remark}
+\newtheorem{remarkN}{Remark}
+\renewcommand{\theremarkN}{3.\arabic{remarkN}}
+
+\renewcommand{\theequation}{3.\arabic{equation}}
+
+\crefname{theoremT}{Theorem}{Theorems}
+\crefname{theoremP}{Theorem}{Theorems}
+\crefname{theoremN}{Theorem}{Theorems}
+\crefname{lemmaT}{Lemma}{Lemmas}
+\crefname{lemmaN}{Lemma}{Lemmas}
+\crefname{corollaryT}{Corollary}{Corollaries}
+\crefname{definitionT}{Definition}{Definitions}
+\crefname{procedureT}{Encoding Procedure}{Encoding Procedures}
+\crefname{exampleT}{Example}{Examples}
+\crefname{remarkN}{Remark}{Remarks}
+
+% ---------------------------------------------------------------------- macros
+\newcommand{\BinEnc}{\ensuremath{\operatorname{BinEnc}}}
+\newcommand{\Bnd}{\ensuremath{\operatorname{Bnd}}}
+\newcommand{\Def}{\ensuremath{\operatorname{Def}}}
+\newcommand{\Lin}{\ensuremath{\operatorname{Lin}}}
+\newcommand{\Aux}{\ensuremath{\operatorname{Aux}}}
+\newcommand{\Vars}{\ensuremath{\operatorname{Vars}}}
+\newcommand{\Rep}{\ensuremath{\operatorname{Rep}}}
+\newcommand{\Link}{\ensuremath{\operatorname{Link}}}
+\newcommand{\Cells}{\ensuremath{\operatorname{Cells}}}
+\newcommand{\Bdry}{\ensuremath{\operatorname{Bd}}}
+\newcommand{\dm}{\ensuremath{\operatorname{dom}}}
+\newcommand{\ImpLits}{\ensuremath{\operatorname{ImpLits}}}
+\newcommand{\Standardise}{\ensuremath{\operatorname{Standardise}}}
+\newcommand{\Linearise}{\ensuremath{\operatorname{Linearise}}}
+\newcommand{\atge}[2]{#1_{\geq #2}}
+\newcommand{\ateq}[2]{#1_{= #2}}
+\newcommand{\atin}[3]{#1_{\in[#2,#3]}}
+\newcommand{\inv}[1]{\textnormal{\textsc{Inv-#1}}}
+\newcommand{\code}[1]{\texttt{#1}}
+% Unnumbered sections are referred to by title, so that the numbered ones
+% keep the thesis's numbering.
+\newcommand{\nsec}[1]{\hyperref[#1]{``\nameref*{#1}''}}
+
+% Invariant names, so a typo is a compile error rather than a silent
+% disagreement between two paragraphs.
+\newcommand{\invChain}{\inv{Chain}}
+\newcommand{\invCut}{\inv{Cut}}
+\newcommand{\invPart}{\inv{Part}}
+\newcommand{\invCover}{\inv{Cover}}
+\newcommand{\invCont}{\inv{Cont}}
+\newcommand{\invRep}{\inv{Rep}}
+\newcommand{\invName}{\inv{Name}}
+\newcommand{\invConflict}{\inv{Conflict}}
+\newcommand{\invDomain}{\inv{Domain}}
+
+\title{Representing Problems for Proofs, and a Proof Logging Framework,\\
+  for Integer Variables with Several Representations}
+\author{Matthew McIlree \and Ciaran McCreesh}
+\date{}
+
+\begin{document}
+\maketitle
+
+\section*{About this document}
+
+This is a revised and extended version of Sections~3.2 and~3.3 of the first
+author's PhD thesis, \emph{Proof Logging for Constraint Programming}
+(University of Glasgow, 2026), adapted and reused with substantial additions.
+It exists for three reasons: as the basis of a journal treatment of
+pseudo-Boolean proof logging for constraint programming; as the single
+authoritative account, for the Glasgow Constraint Solver's developers, of what
+a literal is and what makes the literal layer work; and as a target for
+adversarial review, since a subtle defect in this design is much cheaper to
+find now than to diagnose later from an incomprehensible verifier rejection.
+
+The thesis presents a single integer variable represented one way (a
+two's-complement bit vector) and carrying two families of atomic literal (order
+atoms $\atge{x}{v}$ and equality atoms $\ateq{x}{v}$).  Two things have changed
+in the solver since.
+
+\begin{itemize}
+  \item \textbf{Interval literals.}  There is now a third family, $\atin{x}{a}{b}$,
+    asserting that $X$ takes a value in the closed interval $[a,b]$.  It exists so
+    that a propagator can remove a run of values, and a reason can name a run of
+    holes, at constant rather than linear cost in the width of the run.  A
+    width-one interval literal \emph{is} the equality atom, not a separate
+    Boolean.
+  \item \textbf{Several representations of one variable.}  A constraint may be
+    posted over an affine \emph{view} $V = sX+c$ of a variable $X$, and one $X$
+    may be wrapped by several views at once.  Each registered view is given its
+    own encoded variable, its own bit vector, and its own complete family of
+    atomic literals, joined to $X$'s by a definitional link and by atom-level
+    linking clauses.
+\end{itemize}
+
+Neither addition is conservative over the thesis's propagation results.  Order
+and equality atoms are complete under unit propagation given the order chain
+alone; interval literals are not, and need two further families of
+state-independent clause.  Facts move between two representations of the same
+variable only through linking clauses, and --- for interval literals --- the
+direction that a proof actually needs is the one that is \emph{not} derivable
+from the others.  The theorems below are therefore restated over a
+\emph{representation family} and over all three literal kinds, and reproved.
+
+\paragraph{Numbering.}  Results that correspond to results of the thesis keep
+the thesis's numbers, so that citations from the thesis and from our earlier
+papers still land where they should: \cref{lem:composing,lem:contra-bounds,%
+lem:chain,lem:reasons}, \cref{cor:chainrup}, and
+\cref{thm:p1p2,thm:wipeout,thm:complete,thm:btrup,thm:maintain}.  Results that
+are new to this document are lettered: \cref{lem:normalise,lem:contclosure,lem:cell,lem:covering,%
+lem:transport}, and the family versions of \cref{thm:wipeout} and
+\cref{thm:complete} are primed.  Invariants are named rather than numbered, with the
+thesis's numbers given alongside, because an argument about \textsc{Inv-Cover}
+is easier to follow than one about ``Inv5''.
+
+\paragraph{Scope.}  Section~3.4 of the thesis, on justification procedures for
+individual propagators, is unchanged by any of this and is not reproduced.  Two
+points at which it meets the material here are flagged under
+\nsec{sec:notprovided}.
+
+\setcounter{section}{2}
+\section{Proof Logging for Constraint Programming}
+
+\subsection*{3.1\quad Constraint Programming Fundamentals}
+\addtocounter{subsection}{1}
+
+Unchanged; see the thesis.  We assume a constraint satisfaction problem
+$P=\langle\mathcal V,\dm_0,\mathcal C\rangle$ with finite integer domains, and
+a solver that alternates constraint propagation with backtracking search.
+
+\subsection{Representing Problems for Proofs}
+\label{sec:representing}
+
+The philosophy of using pseudo-Boolean proof logging for constraint programming
+solvers hinges on the idea that, for any CSP or COP, we can produce a
+pseudo-Boolean encoding that can be reasonably understood as (and trusted to
+be) the same problem.
+
+\setcounter{exampleT}{2}
+\begin{exampleT}[PB encoding of a CP problem]
+\label{ex:pbenc}
+Consider the CSP with variables $X,Y,Z$ all with domain $\{0,\dots,7\}$ and
+constraints $X=Y$, $Y\neq Z$, $X+Z\geq 3$.  Intuitively, the PB formula
+\begin{align}
+  x_0+2x_1+4x_2-y_0-2y_1-4y_2 &\geq 0; \label{eq:ex1}\\
+  -x_0-2x_1-4x_2+y_0+2y_1+4y_2 &\geq 0; \\
+  u \Rightarrow y_0+2y_1+4y_2-z_0-2z_1-4z_2 &\geq 1;\\
+  \bar u \Rightarrow -y_0-2y_1-4y_2+z_0+2z_1+4z_2 &\geq 1;\\
+  x_0+2x_1+4x_2+z_0+2z_1+4z_2 &\geq 3 \label{eq:ex5}
+\end{align}
+represents the same problem, since we can view each of the PB variables $x_i$,
+$y_i$ and $z_i$ as representing the value of the $i$-th bit in the binary
+representation of the CP variables, and the ``flag'' variable $u$ ensures that
+either $Y>Z$ or $Z>Y$.
+\end{exampleT}
+
+In this section we expand on the intuition of the above example and give a
+method, following Gocht et al., for producing a PB formula that is obviously
+equivalent to an input CSP, at least for some generalised definition of the
+word ``obvious''.  For clarity, we will talk about transforming a ``CP
+problem'' into a ``PB problem''.
+
+\subsubsection{The Difficulty of Equivalence}
+
+The ultimate goal of encoding for proof logging purposes is to trust that the
+process preserves the integrity of the proof with respect to the original
+problem, and potentially to verify this process formally in a theorem prover.
+So at one level, the only guarantees we really need are:
+
+\begin{description}[font=\normalfont\bfseries,leftmargin=2.4em]
+  \item[P1.] The PB problem is satisfiable if and only if the CP problem is
+    satisfiable.
+  \item[P2.] If there is an objective variable, the optimal value of the CP
+    objective is equal to the optimal value of the PB objective.
+\end{description}
+
+To make it easier to obtain these guarantees, we employ very restricted
+transformations with minimal reformulation --- much less than one might use if
+encoding in order to solve the problem with a PB or SAT system.  We want our
+encodings to be as ``dumb'' as possible, because we want to be extremely
+certain that the two properties hold.  So in practice, our working definition
+of equivalence is: ``the PB problem is the result of applying
+\cref{proc:encoding} to the CP problem''.
+
+The one substantive change to this section from the thesis is that the encoding
+now admits two further \emph{shared} classes of introduced variable, beyond the
+atomic constraint variables: \emph{representation variables} for affine views,
+and a third kind of atomic variable for intervals.  Both are still fully
+determined by an assignment to the original variables, which is what keeps P1
+and P2 easy to argue.
+
+\subsubsection{A Transformation Procedure}
+\label{sec:transformation}
+
+The basic idea is to first turn the CP problem into an equivalent problem with
+only reified linear constraints (an ``intermediate ILP'').  This still contains
+the original non-Boolean variables of the problem, so it is easy to argue
+equivalence by showing that the effect of the linear constraints is to restrict
+the variables' values in exactly the same way as the original CP constraints.
+We have the freedom to introduce auxiliary variables at this stage to assist in
+the linearisation (such as the $u$ flag in \cref{ex:pbenc}).
+
+Three classes of introduced variable are \emph{shared} between linearisations
+rather than private to one, and each is fully determined by an assignment to
+the original variables:
+
+\begin{itemize}
+  \item \textbf{Representation variables} name affine images $sX+c$ of an
+    original variable.  A constraint posted over a \emph{view} of $X$ is
+    linearised over the corresponding representation variable.
+  \item \textbf{Atomic constraint variables} are $0$--$1$ variables denoting
+    basic relationships between a variable and a value or an interval of values.
+  \item Both come with \emph{definition constraints}, which are fully reified
+    and hence entirely redundant.
+\end{itemize}
+
+Everything else introduced by a linearisation is private to it.  The soundness
+of concatenating linearisations rests on exactly that division; see
+\cref{lem:composing}.
+
+We assume we start with a general constraint satisfaction problem, with
+variable set $\mathcal V$, finite domains $\dm_0(X_i)$ for $X_i\in\mathcal V$,
+and constraints $\mathcal C$.  All domains can be assumed to be ranges of
+integers without holes, since any missing values can be modelled with
+additional constraints if necessary.  We also assume that the constraints are a
+flat list.
+
+\begin{procedureT}
+\label{proc:encoding}
+For a CSP with variables $\mathcal V$, initial domain state (without holes)
+$\dm_0$, and constraints $\mathcal C$, we can produce a PB formula as follows.
+\begin{enumerate}[label=\arabic*:,leftmargin=2.6em,itemsep=1pt]
+  \item $\mathcal R \leftarrow \bigcup_{X\in\mathcal V}\{X\}
+        \cup \bigcup_{C\in\mathcal C}\text{NeededRepresentations}(C)$
+  \item $\Bnd(\mathcal R) \leftarrow \bigcup_{W\in\mathcal R}\Bnd(W,\dm_0)$
+  \item $\Link(\mathcal R) \leftarrow \bigcup_{W\in\mathcal R}\Link(W)$
+  \item $\mathcal A \leftarrow \bigcup_{C\in\mathcal C}
+        \text{NeededAtomicVariables}(C,\dm_0)$
+  \item $\Def(\mathcal A) \leftarrow \bigcup_{y\in\mathcal A}\Def(y)$
+  \item $\Lin(\mathcal C) \leftarrow \bigcup_{C\in\mathcal C}\Linearise(C,\dm_0)$
+  \item $F \leftarrow \BinEnc\bigl(\Bnd(\mathcal R)\cup\Link(\mathcal R)
+        \cup\Def(\mathcal A)\cup\Lin(\mathcal C)\bigr)$
+  \item $F \leftarrow \Standardise(F)$
+\end{enumerate}
+\end{procedureT}
+
+Steps~1 and~3 are new; step~5 now has a third case.  The remainder of this
+section gives more detail on each stage along with soundness arguments, and
+introduces notation used throughout.
+
+\paragraph{Step 1 and 3: representations and their links.}
+
+\begin{definitionT}[Representation]
+\label{def:rep}
+A \emph{representation} of a CP variable $X$ is an integer variable $W$
+together with a sign $s_W\in\{+1,-1\}$ and an offset $c_W\in\mathbb Z$, subject
+to $W = s_W X + c_W$.  Write
+\[
+  \varphi_W(k) = s_W k + c_W, \qquad
+  \psi_W(v) = \varphi_W^{-1}(v) = s_W(v - c_W),
+\]
+so that $\varphi_W$ is an order-preserving bijection $\mathbb Z\to\mathbb Z$
+when $s_W=+1$ and an order-reversing one when $s_W=-1$.  Every CP variable is a
+representation of itself, with $\varphi_X=\mathrm{id}$.  We write $\Rep(X)$ for
+the set of representations of $X$ occurring in the encoding, and
+$\mathcal R = \bigcup_{X\in\mathcal V}\Rep(X)$.  A representation $W\neq X$ is
+\emph{derived}, and $X$ is its \emph{base}; $\Rep$ is a partition of $\mathcal
+R$ by base.
+\end{definitionT}
+
+For each derived $W\in\Rep(X)$, $\Link(W)$ is the single linear equality
+\begin{equation}
+  \Link(W) \;:=\; W - s_W X = c_W ,
+  \label{eq:link}
+\end{equation}
+which \Standardise{} will split into a $\geq$ and a $\leq$ row.  For a base
+variable, $\Link(X)$ is empty.
+
+Representation variables arise because constraints are posted over
+\emph{operands}, and an operand may be a view.  A modelling layer that writes
+$\mathrm{AllDifferent}(X_1, X_2+1, X_3+2)$ is naming three operands, two of
+which are derived representations of $X_2$ and $X_3$.  Two different
+constraints may name the same view, and one variable may be named through
+several different views at once, which is precisely why representation
+variables have to be shared rather than private to a linearisation.
+
+The alternative --- substituting $s X + c$ for the view wherever it occurs, and
+stating everything in $X$'s atoms --- is rejected, for a reason that only
+becomes visible in \cref{sec:framework}: it makes the atoms appearing in the
+encoding of a constraint depend on \emph{which} wrapper the constraint happened
+to be handed, so a generic constraint-logging procedure can no longer treat
+every operand identically, and a cutting-planes step that resolves an operand
+against a constraint body has to know which representation that body is stated
+in.  Giving the view its own variable costs one linear equality and makes every
+operand look the same.
+
+\paragraph{Step 2: domain bound constraints.}
+For a representation $W$ of $X$ and domain state $\dm_0$, let $\Bnd(W,\dm_0)$
+be the two linear constraints
+\begin{equation}
+  W \geq \min \varphi_W(\dm_0(X)) \qquad\text{and}\qquad
+  W \leq \max \varphi_W(\dm_0(X)) ,
+  \label{eq:bnd}
+\end{equation}
+that is, $W\geq \varphi_W(l)$ and $W \leq \varphi_W(u)$ when $s_W=+1$, and the
+two swapped when $s_W=-1$, writing $l$ and $u$ for the bounds of $\dm_0(X)$.
+When it is clear from context we omit $\dm_0$ and write $\Bnd(W)$.  We call
+$[\,\min\varphi_W(\dm_0(X)),\ \max\varphi_W(\dm_0(X))\,]$ the \emph{definition
+range} of $W$ and denote it $[l_W,u_W]$.
+
+Note that $\Bnd(W)$ for a derived $W$ is implied by $\Bnd(X)$ together with
+$\Link(W)$ (it is their sum, up to sign), so asserting it changes nothing.  It
+is asserted anyway, because unit propagation cannot add two constraints
+together, and several later arguments need $W$'s own bounds to be available as
+units on $W$'s own atoms.
+
+Clearly, if we construct a CSP with variables $\mathcal R$, constraints
+$\mathcal C \cup \Bnd(\mathcal R)\cup\Link(\mathcal R)$, and unrestricted
+integer domains, then this has exactly the same solution set as our original
+CSP, projected onto $\mathcal V$: every derived representation is determined by
+its base through \cref{eq:link}.
+
+\paragraph{Steps 4 and 5: atomic constraint variables.}
+These are fresh $0$--$1$ variables that can be shared between linearisations
+and have a special meaning.  For each supported constraint type $C$ we need to
+know which atomic variables it requires, so $\text{NeededAtomicVariables}$ is
+defined on a per-constraint basis; usually this is immediately clear from the
+definition of $\Linearise(C,\dm_0)$.
+
+Each atomic variable $y$ requires a fully reified linear definition constraint
+$\Def(y)$ of the form $y\Leftrightarrow C$.  We allow three types of atomic
+variable definition, each associated with a \emph{representation}
+$W\in\mathcal R$ --- not merely with a CP variable --- and with one or two
+integers.  For clarity we always use subscripted names suggestive of the
+definition, writing $w$ for the PB name of the representation $W$.
+
+\begin{enumerate}[leftmargin=2.2em]
+  \item A \textbf{bound variable} $\atge{w}{v}$ represents whether $W$ must be
+    at least $v$:
+    \begin{equation}
+      \Def(\atge{w}{v}) := \atge{w}{v} \Leftrightarrow W \geq v .
+      \label{eq:defge}
+    \end{equation}
+  \item An \textbf{equality variable} $\ateq{w}{v}$ represents whether $W$ must
+    equal $v$:
+    \begin{equation}
+      \Def(\ateq{w}{v}) := \ateq{w}{v} \Leftrightarrow
+        \atge{w}{v} + \overline{\atge{w}{v+1}} \geq 2 .
+      \label{eq:defeq}
+    \end{equation}
+  \item An \textbf{interval variable} $\atin{w}{a}{b}$, for $a<b$, represents
+    whether $W$ must take a value in the closed interval $[a,b]$:
+    \begin{equation}
+      \Def(\atin{w}{a}{b}) := \atin{w}{a}{b} \Leftrightarrow
+        \atge{w}{a} + \overline{\atge{w}{b+1}} \geq 2 .
+      \label{eq:defin}
+    \end{equation}
+\end{enumerate}
+
+Naturally, if an equality or interval variable is needed then so are the
+corresponding bound variables.
+
+An interval variable is a \emph{wide equality atom}: \cref{eq:defeq,eq:defin}
+are the same definition, cut at two values instead of at $v$ and $v+1$.  This
+is not a coincidence to be tidied away later, and we record the consequence
+immediately, because it is the single most expensive mistake available here.
+
+\begin{definitionT}[Width-one identification]
+\label{def:widthone}
+For $a=b$, the interval variable $\atin{w}{a}{b}$ \emph{is} the equality
+variable $\ateq{w}{a}$: the same PB variable, not a second one with the same
+definition.  For $a>b$, the interval condition is the constant false.
+\end{definitionT}
+
+A separate width-one interval flag would be an unlinked doppelg\"anger of the
+equality atom: two Booleans with identical definitions, and nothing in the
+formula connecting them, so that a fact recorded in one is invisible through
+the other.  It cannot be repaired by adding the equivalence after the fact ---
+see \nsec{sec:loadbearing} below, where this is witness~W1.
+
+Because these are fully reified constraints on fresh variables, they are
+entirely redundant: the values of the atomic variables are uniquely determined
+for any solution.  This means the solution set projected onto the original
+variables remains exactly the same, and in particular adding them cannot
+possibly change satisfiability or the objective value.  The same is true of
+representation variables, by \cref{eq:link}.
+
+Recalling $0$--$1$ literals, we can represent $W$ being at most $v$, not equal
+to $v$, or outside $[a,b]$ by negating the corresponding variables.
+Collectively we refer to literals of the form $\atge{w}{v}$,
+$\overline{\atge{w}{v}}$, $\ateq{w}{v}$, $\overline{\ateq{w}{v}}$,
+$\atin{w}{a}{b}$ and $\overline{\atin{w}{a}{b}}$ as \emph{atomic (constraint)
+literals}.
+
+\paragraph{Step 6: linearise constraints.}
+For each constraint $C$ we require a function $\Linearise(C,\dm_0)$ turning it
+into a set of reified linear constraints $\Lin(C)$.  This can use
+representation variables, atomic literals, and further auxiliary variables.
+Write $\Vars(\Lin(C))$ for the set of variables appearing in the
+linearisation, and let $\Aux(C) = \Vars(\Lin(C))\setminus(\mathcal R\cup
+\mathcal A)$ be the auxiliary variables introduced.  We require:
+
+\begin{description}[font=\normalfont\bfseries,leftmargin=2.4em]
+  \item[L1.] Each constraint in any $\Lin(C)$ fits one of two general forms:
+    either
+    \begin{equation}
+      \sum_{j=0}^{n-1} a_j\cdot V_j \bowtie b
+      \qquad\text{or}\qquad
+      r_1\wedge\cdots\wedge r_k \rightleftharpoons \sum_{j=0}^{n-1} a_j\cdot V_j \bowtie b
+      \label{eq:forms}
+    \end{equation}
+    where $b$ and each $a_j$ are integers; each $r_k$ is a $0$--$1$ literal;
+    each $V_j$ is either a $0$--$1$ or an integer variable; $\rightleftharpoons$
+    is one of $\{\Leftarrow,\Rightarrow,\Leftrightarrow\}$; and $\bowtie$ is one
+    of $\{\geq,\leq,=\}$.
+  \item[L2.] Any non-$0$--$1$ auxiliary integer variable $V_j\in\Aux(C)$ must be
+    bounded with corresponding bound constraints $\Bnd(V_j)$, considered part of
+    the linearisation.
+  \item[L3.] Auxiliary variables must not be shared between linearisations:
+    $\Aux(C_1)\cap\Aux(C_2)=\emptyset$ for all $C_1\neq C_2$.  Representation
+    variables and atomic variables are \emph{not} auxiliary variables and may be
+    shared freely.
+  \item[L4.] Most importantly, $\Lin(C)\cup\Def(\mathcal A)\cup\Link(\mathcal R)$
+    must enforce the same restriction as $C$ on the variables in $\mathcal V$.
+    That is, a valid assignment $\sigma:\mathcal V\to\mathbb Z$ satisfies $C$ if
+    and only if it can be extended to a valid assignment
+    $\sigma^+:\Vars(\Lin(C)\cup\Def(\mathcal A)\cup\Link(\mathcal R))\to\mathbb Z$
+    satisfying $\Lin(C)\cup\Def(\mathcal A)\cup\Link(\mathcal R)$.
+\end{description}
+
+L3 is where representation variables differ from the thesis's presentation:
+they are shared, and they are shared for the same reason atomic variables are.
+The proof of \cref{lem:composing} shows that this is safe precisely because
+\cref{eq:link}, like \cref{eq:defge,eq:defeq,eq:defin}, determines the shared
+variable's value uniquely from the assignment to $\mathcal V$.
+
+\begin{lemmaT}[Composing linearisations]
+\label{lem:composing}
+Let $P$ be a CSP with variables $\mathcal V$ and constraints $\mathcal C$,
+where all domains are integer ranges.  After executing steps~1 to~6 of
+\cref{proc:encoding} let $P'$ be the CSP with constraints
+$\mathcal C' := \Lin(\mathcal C)\cup\Bnd(\mathcal R)\cup\Link(\mathcal R)
+\cup\Def(\mathcal A)$, whose variables are precisely those occurring in
+$\mathcal C'$, and whose domain for every non-$0$--$1$ variable is $\mathbb Z$.
+Then:
+\begin{enumerate}[label=\arabic*.,itemsep=0pt]
+  \item every solution $\sigma$ of $P$ can be extended to a solution $\sigma'$
+    of $P'$;
+  \item every solution $\sigma'$ of $P'$ can be restricted to a solution
+    $\sigma$ of $P$.
+\end{enumerate}
+\end{lemmaT}
+
+\begin{proof}
+Call a variable of $P'$ \emph{determined} if its value is a function of the
+restriction of an assignment to $\mathcal V$ alone.  Every variable in
+$\mathcal R\cup\mathcal A$ is determined: a derived representation by
+\cref{eq:link}, and an atomic variable by its definition constraint, which is a
+fully reified constraint over $\mathcal R$ (for $\atge{w}{v}$) or over
+previously determined atomic variables (for $\ateq{w}{v}$ and $\atin{w}{a}{b}$,
+whose definitions mention only bound variables of the same representation).
+The determination is well founded because the dependency order is
+$\mathcal V \to \mathcal R \to \{\text{bound}\} \to
+\{\text{equality},\text{interval}\}$, with no cycles.
+
+\emph{Part 1.}  Let $\sigma$ be a solution to $P$ and $C_1,\dots,C_n$ the
+constraints of $P$.  By validity, $\sigma$ satisfies $\Bnd(\mathcal V)$, and
+extending it by the determined values satisfies $\Bnd(\mathcal
+R)\cup\Link(\mathcal R)$.  By L4, $\sigma$ can be extended to a solution
+$\sigma_1$ of $\Bnd(\mathcal R)\cup\Link(\mathcal R)\cup\Def(\mathcal
+A)\cup\Lin(C_1)$.
+
+Now assume we have extended $\sigma$ to a solution $\sigma_{k-1}$ of
+$\Bnd(\mathcal R)\cup\Link(\mathcal R)\cup\Def(\mathcal A)\cup
+\bigcup_{i<k}\Lin(C_i)$.  By L4 again, $\sigma$ can be extended to a solution
+$\sigma'_k$ of $\Bnd(\mathcal R)\cup\Link(\mathcal R)\cup\Def(\mathcal
+A)\cup\Lin(C_k)$.  Define $\sigma_k$ by
+\begin{align}
+  \sigma_k(V) &= \sigma(V) && \text{if } V\in\mathcal V; \\
+  \sigma_k(V) &= \sigma_{k-1}(V) && \text{if } V\in\mathcal R\cup\mathcal A; \\
+  \sigma_k(V) &= \sigma_{k-1}(V) && \text{if otherwise }
+     V\in\Vars\bigl(\bigcup_{i<k}\Lin(C_i)\bigr); \\
+  \sigma_k(V) &= \sigma'_k(V) && \text{if otherwise } V\in\Vars(\Lin(C_k)).
+\end{align}
+This is an extension of $\sigma$, and it satisfies both $\Lin(C_k)$ and
+$\Bnd(\mathcal R)\cup\Link(\mathcal R)\cup\Def(\mathcal A)\cup
+\bigcup_{i<k}\Lin(C_i)$, because
+$\sigma_k(V)=\sigma_{k-1}(V)=\sigma'_k(V)$ for every $V\in\mathcal
+V\cup\mathcal R\cup\mathcal A$ --- each such $V$ being determined by $\sigma$,
+which all three assignments extend --- while
+$\Vars(\bigcup_{i<k}\Lin(C_i))\cap\Vars(\Lin(C_k))\subseteq
+\mathcal V\cup\mathcal R\cup\mathcal A$ by L3, so $\sigma_k$ is an extension of
+both $\sigma_{k-1}$ and $\sigma'_k$.  The claim follows by induction.
+
+\emph{Part 2.}  Let $\sigma'$ be a solution to $P'$.  There is only one
+possible restriction of $\sigma'$ to a valid assignment to $\mathcal V$; and by
+L4, since $\sigma'$ satisfies $\Lin(C_i)\cup\Def(\mathcal A)\cup\Link(\mathcal
+R)$ for each $i$, that restriction must satisfy each $C_i$ and hence $P$.
+\end{proof}
+
+We refer to the result of steps~1 to~6 as the \emph{intermediate ILP}.  In the
+linearisations presented here, L1 to L4 are verifiable by inspection.
+
+\begin{exampleT}
+An intermediate ILP for the CSP of \cref{ex:pbenc}, where the third constraint
+is posted over the view $Z' = -Z + 7$ as $X - Z' \geq -4$, could be
+\begin{align}
+  &X,Y,Z,Z',u\in\mathbb Z ;\\
+  &0\leq X\leq 7;\quad 0\leq Y\leq 7;\quad 0\leq Z\leq 7;\quad
+    0\leq Z'\leq 7;\quad 0\leq u\leq 1;\\
+  &Z' + Z = 7; \label{eq:exlink}\\
+  &X - Y = 0;\\
+  &u \Rightarrow X - Y > 0; \qquad \bar u \Rightarrow Y - X > 0;\\
+  &X - Z' \geq -4 .
+\end{align}
+Line \cref{eq:exlink} is $\Link(Z')$, and $\Bnd(Z')$ is the image of
+$\Bnd(Z)$ under $\varphi_{Z'}(k) = -k+7$.
+\end{exampleT}
+
+\paragraph{Step 7: binary encoding of integer variables.}
+$\BinEnc$ turns the intermediate ILP into a $0$--$1$ ILP by replacing each
+occurrence of a non-Boolean variable with a binary exponential sum.  This may
+be a poor encoding from a solving perspective, but it maintains the form of the
+ILP, letting us ``pretend'' we have integer variables while working honestly
+with native PB constraints.  Every variable in $\mathcal R$ --- derived
+representations included --- is replaced, and each gets its \emph{own} bit
+vector: $\BinEnc(W)$ and $\BinEnc(X)$ share no PB variables, and are related
+only by the encoded form of $\Link(W)$.
+
+Specifically, for any non-$0$--$1$ variable $W$ with definition range
+$[l_W,u_W]$: if $l_W\geq 0$, let $h$ be least with $2^h\geq u_W+1$ and define
+$\BinEnc(W) := \sum_{i=0}^{h-1}2^i w_i$; otherwise let $h$ be least with
+$2^{h-1}\geq \max\{|u_W|+1,|l_W|\}$ and define
+$\BinEnc(W) := -2^{h-1}w_{h-1}+\sum_{i=0}^{h-2}2^i w_i$, the two's-complement
+representation.  We overload the notation and write $\BinEnc(C)$ and
+$\BinEnc(F)$ for the results of replacing every eligible variable in a
+constraint or a set of constraints.
+
+The soundness of this replacement follows directly from the validity of binary
+and two's-complement encodings: there is a one-to-one correspondence between
+the solutions of the $0$--$1$ ILP and those of the intermediate ILP, given by
+the encoding.
+
+\begin{remark}
+Two width details matter in practice and neither affects the argument.  First,
+the bit vector of a derived representation is sized from $[l_W,u_W]$, and can be
+\emph{wider} than that of its base: a view of a variable with range $[1,8]$ has
+range $[1,8]$ too but a bit vector spanning $[0,15]$, and a view $X+10^6$ has a
+much wider one.  Any coefficient bound or big-$M$ computed for a line mentioning
+$W$ must be measured against $\BinEnc(W)$, not against the value range of $X$.
+Second, the solver's implementation allocates no magnitude bit that cannot reach
+a value of the domain, so a variable with range $[0,0]$ has the empty sum,
+identically zero; the thesis's ``least strictly positive $h$'' would give it one
+bit.  This is a deliberate divergence, for conformance with the verified
+encoder \code{cake\_pb\_cp}.
+\end{remark}
+
+\paragraph{Step 8: standardise constraints.}
+Finally we ensure all remaining constraints are in canonical form: convert
+reifications to native PB constraints, replace $=$ constraints with a pair of
+$\geq$ and $\leq$ constraints, and multiply through by $-1$ and/or add $1$ as
+needed so that all inequalities are in $\geq$ form.  Such transformations do not
+affect the solution set.
+
+\begin{theoremT}
+\label{thm:p1p2}
+Let $P$ be a CSP with variables $\mathcal V$ and constraints $\mathcal C$, where
+all domains are integer ranges.  Let $F$ be the result of executing
+\cref{proc:encoding} on $P$.  Additionally, if $P$ has an associated objective
+variable $X_o\in\mathcal V$ to minimise or maximise, let $\BinEnc(X_o)$ be the
+PB objective function.  Then P1 and P2 hold.
+\end{theoremT}
+
+\begin{proof}
+Let $P'$ be the intermediate ILP produced after steps~1 to~6.
+\cref{lem:composing} gives a bijection between the solutions of $P$ and the set
+of assignments to $\mathcal V$ (projected from full assignments) that satisfy
+$P'$.  Let $F^*$ be the $0$--$1$ linear CSP obtained after step~7.  Every
+solution to $P'$ corresponds to a solution of $F^*$, by assigning to each
+non-$0$--$1$ variable $W$ the unique $h$-bit vector representing its value ---
+note that this is well defined for a derived representation exactly as for a
+base one, since $\Link(W)$ and $\Bnd(W)$ force $W$'s value into $[l_W,u_W]$,
+which its bit width covers.  Conversely, every solution to $F^*$ corresponds to
+a solution of $P'$ by decoding each bit vector.  The final formula $F$ obtained
+after step~8 has exactly the same solutions as $F^*$.
+
+So there is a bijection $\phi$ between the solutions of $P$ and the solutions of
+$F$ projected onto the bit variables appearing in $\BinEnc(X)$ for
+$X\in\mathcal V$.  In particular $F$ is satisfiable iff $P'$ is satisfiable iff
+$P$ is satisfiable, so P1 holds; and for all $X\in\mathcal V$ and all solutions
+$\sigma$ to $P$ we have $\sigma(X)=\BinEnc(X)\!\restriction_{\phi(\sigma)}$, so
+P2 holds.
+\end{proof}
+
+\begin{remark}
+The projection in \cref{thm:p1p2} is onto the bits of the \emph{base} variables
+only.  The bits of derived representations, and all atomic variables, are
+determined but not projected onto.  This matters for enumeration; see
+\cref{sec:enumeration}.
+\end{remark}
+
+\subsubsection{PB Encodings for Fundamental Constraints}
+
+To instantiate the encoding method for concrete CSPs we exhibit ``sufficiently
+obvious'' linearisations for all supported non-linear constraints.  These are
+unchanged from the thesis, and are not reproduced here; the encodings for
+$\mathrm{NotEquals}$, $\mathrm{Abs}$, $\mathrm{Element}$, $\mathrm{ArrayMin}$,
+$\mathrm{ArrayMax}$, $\mathrm{Count}$, $\mathrm{NValue}$,
+$\mathrm{AllDifferent}$ and $\mathrm{Table}$ satisfy L1 to L4 by inspection.
+
+Two remarks are needed in the extended setting.
+
+First, a constraint's operands may be representations rather than base
+variables, and its linearisation is written over the operands.  Thus
+$\mathrm{AllDifferent}(W_1,\dots,W_n)$ linearises to
+$u_{ij}\Rightarrow W_i - W_j > 0$ and $\bar u_{ij} \Rightarrow W_j - W_i > 0$
+over exactly the operands it was given, with no reference to their bases.  This
+is what ``the encoding is generic in the operand'' means, and it is the property
+that \cref{sec:framework} preserves at the level of atoms.
+
+Second, no linearisation mentions interval variables.  Interval literals do not
+appear in the model at all: they are introduced inside the proof, by redundance,
+as the proof needs them.  The one place where the question arises --- whether
+holes in an initial domain should be stated in the model as
+$\overline{\atin{x}{a}{b}}$ rather than derived at the root of the proof --- is
+an open decision recorded in \cref{sec:open}.
+
+\subsection{A Proof Logging Framework}
+\label{sec:framework}
+
+We begin from the assumption that we have used an encoding method following
+\cref{proc:encoding}.  So before logging anything in the proof, we have a
+correct PB representation of an input CP problem in terms of binary-encoded
+representations of the CP variables, atomic literals defined for certain
+representations and values, and some other auxiliary variables.
+
+Based on this encoding method, we formulate a proof logging framework based on
+maintaining invariants relating the solver's explored domain states to the
+verifier's PB constraint database.  Certain properties of atomic literals are
+crucial for this setup, so we demonstrate these first.
+
+Throughout, ``UP'' means plain unit propagation from the empty assignment, with
+no case splitting: the propagation a RUP check performs after asserting the
+negation of the line being checked.  We write $F\!\restriction_R$ for the
+formula $F$ restricted by the literals of $R$, and say that a literal $\ell$
+\emph{propagates under $R$} if $\ell\in R$ or unit propagation of
+$F\!\restriction_R$ sets $\ell$.
+
+\subsubsection{Properties of Atomic Literals}
+\label{sec:atomprops}
+
+\paragraph{Definitions in the proof.}
+We can always freely introduce in the proof further atomic variables with
+definitions corresponding to \cref{eq:defge,eq:defeq,eq:defin}, by
+redundance-based strengthening.  After binary encoding and standardisation
+these amount, for a representation $W$ of $X$, to the PB constraints
+\begin{align}
+  \Def^{\Rightarrow}(\atge{w}{v}) &:= \atge{w}{v} \Rightarrow \BinEnc(W)\geq v;
+    \label{eq:dge1}\\
+  \Def^{\Leftarrow}(\atge{w}{v}) &:= \overline{\atge{w}{v}} \Rightarrow
+    -\BinEnc(W)\geq -v+1; \label{eq:dge2}\\
+  \Def^{\Rightarrow}(\ateq{w}{v}) &:= \ateq{w}{v} \Rightarrow
+    \atge{w}{v} + \overline{\atge{w}{v+1}} \geq 2; \label{eq:deq1}\\
+  \Def^{\Leftarrow}(\ateq{w}{v}) &:= \overline{\ateq{w}{v}} \Rightarrow
+    \overline{\atge{w}{v}} + \atge{w}{v+1} \geq 1; \label{eq:deq2}\\
+  \Def^{\Rightarrow}(\atin{w}{a}{b}) &:= \atin{w}{a}{b} \Rightarrow
+    \atge{w}{a} + \overline{\atge{w}{b+1}} \geq 2; \label{eq:din1}\\
+  \Def^{\Leftarrow}(\atin{w}{a}{b}) &:= \overline{\atin{w}{a}{b}} \Rightarrow
+    \overline{\atge{w}{a}} + \atge{w}{b+1} \geq 1. \label{eq:din2}
+\end{align}
+
+We assume in what follows that any PB literal appearing in a derivation with
+these suggestive names is accompanied by the necessary definition constraints,
+either in the input formula or derived by redundance at an earlier point.  When
+we say an atomic literal $\ell$ is \emph{defined} at a particular point in the
+proof, we mean that both directions of the reified definition for its
+underlying atomic variable have appeared in the accumulated formula and have
+not been deleted.
+
+Note the asymmetry between $\Def^{\Rightarrow}$ and $\Def^{\Leftarrow}$ for the
+two-cut atoms, \cref{eq:deq1,eq:deq2,eq:din1,eq:din2}.  The forward direction is
+a \emph{conjunction}: asserting $\ateq{w}{v}$ or $\atin{w}{a}{b}$ makes both
+cuts units.  The reverse direction is a \emph{disjunction}: asserting
+$\overline{\ateq{w}{v}}$ or $\overline{\atin{w}{a}{b}}$ makes neither cut a
+unit; \cref{eq:deq2,eq:din2} become binary clauses that fire only when one of
+the two cuts is already known.  Almost everything in this section that is not
+already in the thesis exists because of that asymmetry.
+
+\begin{remark}
+The solver optionally uses a compact encoding in which an equality atom at a
+definition bound is defined by its one non-trivial cut only
+($\ateq{w}{l_W}\Leftrightarrow\overline{\atge{w}{l_W+1}}$, and dually at
+$u_W$).  This is off by default, because the eager form matches
+\code{cake\_pb\_cp}'s.  Every argument below survives it, because the dropped
+cut is a pinned unit by \invCut{} and \inv{Bound}, but the reader checking the
+proofs against an implementation should be aware of the variation.
+\end{remark}
+
+\begin{lemmaT}[Propagation of contradictory bound literals]
+\label{lem:contra-bounds}
+Suppose two bound variables $\atge{w}{v}$ and $\atge{w}{v'}$ are defined for
+some representation $W$ and values $v\geq v'$.  Then if $\atge{w}{v}$ and
+$\overline{\atge{w}{v'}}$ propagate, further unit propagation will result in a
+conflict.
+\end{lemmaT}
+
+\begin{proof}
+Directly from Theorem~2.7 of the thesis, since even if $W$ requires a
+two's-complement encoding, the definition constraints
+$\Def^{\Rightarrow}(\atge{w}{v})$ and $\Def^{\Leftarrow}(\atge{w}{v'})$ are in
+the required form after substituting $\atge{w}{v}\mapsto 1$,
+$\atge{w}{v'}\mapsto 0$.  Note that both constraints are over the \emph{same}
+bit vector $\BinEnc(W)$; this is why a representation is given its own bit
+vector rather than being unfolded into its base's.
+\end{proof}
+
+\begin{corollaryT}[RUP properties of atomic literals]
+\label{cor:chainrup}
+For two bound variables $\atge{w}{v}$ and $\atge{w}{v'}$ defined on the same
+representation $W$ with $v\geq v'$, the constraint
+\begin{equation}
+  \atge{w}{v} \Rightarrow \atge{w}{v'} \geq 1
+  \label{eq:chainlink}
+\end{equation}
+always follows by RUP.
+\end{corollaryT}
+
+\paragraph{The invariants of the literal layer.}
+We now state the invariants that the proof must maintain for the literal layer
+to behave.  They are all \emph{state independent}: each is a tautological
+consequence of the definitions, emitted once, at the top proof level, with
+nothing to undo on backtracking.  We name them rather than number them; the
+first, and the two in \cref{sec:unsat}, are Inv1, Inv2 and Inv3 of the thesis.
+
+Fix a base variable $X$, and let $F_t$ be the constraints accumulated at a point
+$t$ in the proof.
+
+\begin{description}[font=\normalfont\bfseries,leftmargin=3.2em,style=nextline]
+
+\item[\invChain{} (thesis Inv1): the order chain.]
+  For any two bound variables $\atge{w}{v}$, $\atge{w}{v'}$ on the same
+  representation $W$ with $v<v'$, if $\Def(\atge{w}{v})$ and
+  $\Def(\atge{w}{v'})$ appear in $F_t$, then either $\atge{w}{v''}$ is defined
+  for some $v<v''<v'$, or the constraint
+  $\atge{w}{v'}\Rightarrow\atge{w}{v}\geq 1$ appears in $F_t$.
+
+\item[\inv{Bound}: boundary pins.]
+  For every defined $\atge{w}{v}$ with $v\leq l_W$, the unit $\atge{w}{v}$
+  appears in $F_t$; for every defined $\atge{w}{v}$ with $v>u_W$, the unit
+  $\overline{\atge{w}{v}}$ appears in $F_t$.
+
+\item[\invCut{}: cuts exist.]
+  Whenever $\ateq{w}{v}$ is defined, so are $\atge{w}{v}$ and $\atge{w}{v+1}$;
+  whenever $\atin{w}{a}{b}$ is defined, so are $\atge{w}{a}$ and
+  $\atge{w}{b+1}$.
+
+\item[\invPart{}: the partition.]
+  If any interval literal is defined for $W$, then there is a finite set of
+  \emph{boundaries} $\Bdry(W)\subseteq[l_W,u_W+1]$ with
+  $l_W,u_W+1\in\Bdry(W)$.  The \emph{cells} $\Cells(W)$ are the intervals
+  $[p,p'-1]$ for consecutive $p<p'$ in $\Bdry(W)$; they partition $[l_W,u_W]$.
+  Every cell is a defined literal --- an equality atom if it has width one, an
+  interval literal otherwise.  For every defined equality or interval literal
+  $E$ of $W$ whose in-bounds part $E\cap[l_W,u_W]$ is non-empty, both endpoints
+  of that part are boundaries; that is, $E\cap[l_W,u_W]$ is a union of adjacent
+  cells.  $\Bdry(W)$ only ever grows.
+
+\item[\invCover{}: coverings.]
+  \emph{(i) Split coverings.}  For every defined literal $G\subseteq[l_W,u_W]$
+  that is a union of adjacent cells but is not itself a cell, $F_t$ contains a
+  clause $\overline{G}\vee C_1\vee\cdots\vee C_k$ with $k\geq 2$, where each
+  $C_i$ is a defined literal, each is a union of adjacent cells \emph{properly
+  contained} in $G$, and $\bigcup_i C_i = G$.
+  \emph{(ii) Overhanging coverings.}  For every defined literal $E$ whose
+  in-bounds part $S := E\cap[l_W,u_W]$ is non-empty and satisfies $E\neq S$,
+  $F_t$ contains a clause $\overline{E}\vee C_1\vee\cdots\vee C_k$ where each
+  $C_i$ is a defined literal that is a union of adjacent cells, and
+  $\bigcup_i C_i = S$.
+  \emph{(iii) The root covering.}  $F_t$ contains a clause
+  $C_1\vee\cdots\vee C_m\geq 1$ where the $C_i$ are defined literals that are
+  unions of adjacent cells with $\bigcup_i C_i = [l_W,u_W]$.
+
+\item[\invCont{}: containment.]
+  For any two defined equality or interval literals $E\subsetneq E'$ of the same
+  representation $W$, there is a chain
+  $E=E_0\subsetneq E_1\subsetneq\cdots\subsetneq E_m=E'$ of defined literals
+  such that each clause $\overline{E_j}\vee E_{j+1}$ appears in $F_t$.
+
+\item[\invRep{}: representation closure and linking.]
+  For every $W,W'\in\Rep(X)$: if an atomic variable of $W$ is defined, then so is
+  the corresponding atomic variable of $W'$ (\cref{def:image} below); and for
+  every defined atomic variable of a derived $W$, the two clauses linking it to
+  the corresponding atomic variable of the base $X$ appear in $F_t$.
+
+\item[\invName{}: everything is named.]
+  Every defined interval literal has appeared in some emitted proof line other
+  than its own reification.
+
+\end{description}
+
+\invChain{} and \inv{Bound} come from the thesis, generalised only by being
+stated per representation.  \invCut{} is implicit there; we make it explicit
+because both new literal kinds depend on it.  \invPart{}, \invCover{} and
+\invCont{} are the interval apparatus.  \invRep{} is the multi-representation
+apparatus.  \invName{} is a hygiene condition that \invRep{} needs for interval
+literals, and only for them --- see the remark after \cref{lem:transport}.
+
+\begin{remark}
+Nothing above depends on the search state.  Every clause named is a tautology of
+the encoding, RUP at the moment it is emitted, and is emitted at the top proof
+level.  The alternative --- emitting a covering over whatever facts currently
+witness an exclusion --- is also sound, but makes the invariant depend on what
+was live when, and drags a level-aware registry of live conclusions into the
+encoding layer.  It was implemented, and rejected for complexity rather than for
+soundness.
+\end{remark}
+
+\paragraph{Correspondence between representations.}
+
+\begin{definitionT}[Image of a literal]
+\label{def:image}
+Let $W,W'\in\Rep(X)$ and let $\theta = \varphi_{W'}\circ\psi_W$, an affine
+bijection $\mathbb Z\to\mathbb Z$ with $\theta(v) = s v + d$ where
+$s = s_W s_{W'}$ and $d = c_{W'} - s\,c_W$.  The \emph{image} on $W'$ of a
+literal $\ell$ over an atomic variable of $W$, written $\ell^{W'}$, is the
+literal satisfied by exactly the same values of $X$:
+\[
+  \begin{array}{llll}
+    (\atge{w}{v})^{W'} &=
+      \begin{cases}
+        \atge{w'}{\theta(v)} & s=+1\\
+        \overline{\atge{w'}{\theta(v)+1}} & s=-1
+      \end{cases}
+    &\qquad
+    (\ateq{w}{v})^{W'} &= \ateq{w'}{\theta(v)}\\[2.2ex]
+    (\atin{w}{a}{b})^{W'} &=
+      \begin{cases}
+        \atin{w'}{\theta(a)}{\theta(b)} & s=+1\\
+        \atin{w'}{\theta(b)}{\theta(a)} & s=-1
+      \end{cases}
+    &\qquad
+    (\overline{\ell})^{W'} &= \overline{\ell^{W'}}
+  \end{array}
+\]
+Taking images is functorial: $(\ell^{W'})^{W''} = \ell^{W''}$, and
+$\ell^{W}=\ell$.
+\end{definitionT}
+
+Two facts about \cref{def:image} are worth stating because they are what make
+the design tractable.  First, $\theta$ preserves \emph{width}: an interval of
+width $k$ maps to an interval of width $k$, so the width-one identification of
+\cref{def:widthone} is stable, and the interval machinery never has to consider
+a width-one case on either side.  Second, a sign flip converts a positive bound
+literal into a negative one, but leaves the polarity of equality and interval
+literals alone --- an interval is order-agnostic, a half-line is not.
+
+The linking clauses are exactly the clausal form of the biconditional
+$\ell \Leftrightarrow \ell^{X}$, for each defined atom of each derived
+representation:
+\begin{align}
+  \text{ge-link:}\quad
+    &\overline{\atge{w}{v}}\vee (\atge{w}{v})^{X}, \qquad
+     \overline{(\atge{w}{v})^{X}}\vee \atge{w}{v};
+     \label{eq:gelink}\\
+  \text{eq-link:}\quad
+    &\overline{\ateq{w}{v}}\vee \ateq{x}{\psi_W(v)}, \qquad
+     \overline{\ateq{x}{\psi_W(v)}}\vee \ateq{w}{v};
+     \label{eq:eqlink}\\
+  \text{in-link:}\quad
+    &\overline{\atin{w}{a}{b}}\vee (\atin{w}{a}{b})^{X}, \qquad
+     \overline{(\atin{w}{a}{b})^{X}}\vee \atin{w}{a}{b}.
+     \label{eq:inlink}
+\end{align}
+
+Each is RUP at the point it is emitted.  For the ge-link this is Theorem~2.9 of
+the thesis applied to $\Def(\atge{w}{v})$, $\Link(W)$ and the corresponding half
+of $\Def((\atge{w}{v})^X)$, whose $\BinEnc$ terms cancel exactly; in the solver
+it is emitted as an explicit cutting-planes step rather than as a RUP line, so
+that the derivation is checkable in one pass.  For the eq-link, asserting one
+side and the negation of the other propagates both cuts through
+\cref{eq:deq1}, carries each across by the ge-links, and closes on
+\cref{eq:deq2} of the far side.  For the in-link, the same argument with
+\cref{eq:din1,eq:din2}, noting that for $s=-1$ the two cuts exchange roles ---
+which is exactly the endpoint swap in \cref{def:image}.
+
+\begin{remarkN}[Both in-link clauses are needed, and neither for its implication]
+\label{rem:bothlinks}
+The two clauses of \cref{eq:inlink} are, as \emph{implications},
+$\atin{w}{a}{b}\rightarrow(\atin{w}{a}{b})^X$ and its converse, and both are
+already derivable by unit propagation from
+\cref{eq:din1,eq:din2} and the ge-links --- one forward
+reification, two ge-links, one reverse reification.  That observation is
+correct and it is beside the point.  Unit propagation uses a clause in whichever
+direction has a unit, and the directions that matter here are the
+contrapositives,
+\[
+  \overline{(\atin{w}{a}{b})^X} \implies \overline{\atin{w}{a}{b}}
+  \qquad\text{and}\qquad
+  \overline{\atin{w}{a}{b}} \implies \overline{(\atin{w}{a}{b})^X},
+\]
+and neither is derivable without its clause.  A negated interval literal is a
+unit on \emph{neither} of its cuts, by the asymmetry noted after
+\cref{eq:din2}; all it can do is descend its own representation's containment
+edges, and it bottoms out at cells that are themselves unlinked interval
+literals unless they happen to have width one.  Descending to width one is
+precisely the per-value shattering that interval literals exist to avoid.  The
+underlying error is to decompose a negated interval as if it were a conjunction
+of two bounds; it is a \emph{disjunction} of two bounds, and unit propagation
+cannot carry a disjunction across one disjunct at a time.
+
+By contrast, one clause of each of \cref{eq:gelink,eq:eqlink} would be enough
+for the positive direction, and the pair is emitted for the negative one in
+exactly the same way; the interval case is not special in needing two clauses,
+only in that the shortcut is tempting.
+\end{remarkN}
+
+\paragraph{Defined domains over a representation family.}
+Any set of atomic literals $L$ defined over representations of the same base
+$X$ represents a restriction of $X$ to some feasible set of values.  We call
+the values allowed the \emph{defined domain}, stated on the base's value scale,
+so that literals over different representations can be intersected directly:
+\begin{multline}
+  \dm_L(X) := \{k : \forall\,\atge{w}{v}\in L .\ \varphi_W(k)\geq v\}
+      \cap \{k : \forall\,\overline{\atge{w}{v}}\in L .\ \varphi_W(k)< v\} \\
+    {}\cap \{k : \forall\,\ateq{w}{v}\in L .\ \varphi_W(k) = v\}
+      \cap \{k : \forall\,\overline{\ateq{w}{v}}\in L .\ \varphi_W(k)\neq v\} \\
+    {}\cap \{k : \forall\,\atin{w}{a}{b}\in L .\ a\leq\varphi_W(k)\leq b\}
+      \cap \{k : \forall\,\overline{\atin{w}{a}{b}}\in L .\
+        \varphi_W(k)<a \text{ or } \varphi_W(k)>b\}.
+  \label{eq:domL}
+\end{multline}
+This set may be empty, or infinite, since $\dm_{\emptyset}(X)=\mathbb Z$.  When
+$\Rep(X)=\{X\}$ and no interval literal is defined, \cref{eq:domL} is exactly
+the thesis's definition.  We write $\dm_L(W) := \varphi_W(\dm_L(X))$ for the
+same set on $W$'s scale.
+
+Conversely, the complete (potentially infinite) set of atomic literals over
+\emph{every} representation of $X$ that should be true for a domain
+$\dm_t(X)$ is
+\begin{align}
+  \ImpLits(\dm_t(X)) := \bigcup_{W\in\Rep(X)}\Bigl(
+    &\{\ateq{w}{v} : \dm_t(W)=\{v\}\}
+    \cup \{\overline{\ateq{w}{v}} : v\notin\dm_t(W)\} \notag\\
+    {}\cup{}&\{\atge{w}{v} : \forall\,v'<v .\ v'\notin\dm_t(W)\}
+    \cup \{\overline{\atge{w}{v}} : \forall\,v'\geq v .\ v'\notin\dm_t(W)\}
+      \notag\\
+    {}\cup{}&\{\atin{w}{a}{b} : \dm_t(W)\subseteq[a,b]\}
+    \cup \{\overline{\atin{w}{a}{b}} : \dm_t(W)\cap[a,b]=\emptyset\}\Bigr).
+  \label{eq:implits}
+\end{align}
+
+\paragraph{Propagation results, one representation at a time.}
+We first establish everything for a single representation $W$, writing $L^W$ for
+the atomic literals over atomic variables of $W$ defined in $F_t$, and $[l,u]$
+for $[l_W,u_W]$.  \cref{lem:transport} then lifts the results to a family.
+
+It is convenient to normalise away positive two-cut literals once and for all.
+
+\begin{lemmaT}[Chain propagation]
+\label{lem:chain}
+If \invChain{} is respected, then for any $W$, if $\atge{w}{v}$ and
+$\atge{w}{v'}$ are both defined in $F_t$ for $v>v'$, then if $\atge{w}{v}$
+propagates so does $\atge{w}{v'}$, and if $\overline{\atge{w}{v'}}$ propagates
+so does $\overline{\atge{w}{v}}$.
+\end{lemmaT}
+
+\begin{proof}
+Let $v = v_1 > v_2 > \cdots > v_k = v'$ be the finite sequence of values for
+which $\atge{w}{v_j}$ is defined, with nothing defined strictly between
+consecutive terms.  Since only finitely many bound literals are defined in a
+finite formula, this sequence exists.  \invChain{} puts
+$\atge{w}{v_j}\Rightarrow\atge{w}{v_{j+1}}\geq 1$ in $F_t$ for each $j$, and each
+is a binary clause, so it propagates in one direction from $\atge{w}{v_j}$ and
+in the other from $\overline{\atge{w}{v_{j+1}}}$.  Chaining gives both claims.
+\end{proof}
+
+\begin{lemmaN}[Cut normalisation]
+\label{lem:normalise}
+Let $R\subseteq L^W$ and let $R'$ be obtained from $R$ by replacing each
+positive literal $\ateq{w}{v}$ by $\{\atge{w}{v},\overline{\atge{w}{v+1}}\}$ and
+each positive literal $\atin{w}{a}{b}$ by
+$\{\atge{w}{a},\overline{\atge{w}{b+1}}\}$.  Then every literal of $R'$
+propagates under $R$, and $\dm_{R'}(W)=\dm_R(W)$.
+\end{lemmaN}
+
+\begin{proof}
+The replacements are exactly what \cref{eq:deq1,eq:din1} propagate from the
+positive literal, and the cuts are defined by \invCut{}.  The two literal sets
+allow the same values by \cref{eq:defeq,eq:defin}.
+\end{proof}
+
+Call a set of literals \emph{cut-normalised} if it contains no positive equality
+or interval literal.  \cref{lem:normalise} says that any set may be replaced by
+a cut-normalised one with the same defined domain, all of whose literals still
+propagate, so in the proofs below we may assume that the only two-cut literals
+present are negative.  This is where the asymmetry bites: normalisation cannot be applied to
+a negative two-cut literal, and there is nothing else to do with one except
+propagate through the machinery of \invCover{} and \invCont{}.
+
+\begin{lemmaN}[Containment closure]
+\label{lem:contclosure}
+Suppose that whenever an equality or interval literal $E$ of $W$ is defined, the
+clause $\overline{E}\vee E'$ is emitted for every \emph{minimal} defined $E'
+\supsetneq E$, and the clause $\overline{E''}\vee E$ for every \emph{maximal}
+defined $E''\subsetneq E$.  Then \invCont{} holds.
+\end{lemmaN}
+
+\begin{proof}
+By induction on the number of defined literals.  Let $E\subsetneq E'$ both be
+defined, and consider the later of the two to be defined, say at step $n$; by the
+inductive hypothesis \invCont{} held over the literals defined before step $n$.
+
+If $E'$ is the later, then $E$ was already defined, so $E$ is contained in some
+maximal defined $E''\subsetneq E'$ with $E\subseteq E''$.  If $E=E''$ the edge
+$\overline{E}\vee E'$ is emitted directly; otherwise $E\subsetneq E''$, so the
+inductive hypothesis gives a chain from $E$ to $E''$, which the emitted edge
+$\overline{E''}\vee E'$ extends.  The case where $E$ is the later is symmetric,
+using a minimal defined container.  Emitting an edge never invalidates a chain,
+so \invCont{} continues to hold.
+\end{proof}
+
+\begin{remark}
+Interval requests may overlap without nesting --- $[7,15]$ after $[5,10]$ ---
+so the containment relation is a DAG, not a tree, and a literal may have several
+incomparable minimal containers.  \cref{lem:contclosure} does not care.  Note
+also that it needs \emph{minimal} and \emph{maximal} to be computed over all
+currently defined literals of $W$, not merely over the cells.
+\end{remark}
+
+\begin{lemmaN}[Cell exclusion]
+\label{lem:cell}
+Assume \invChain{}, \inv{Bound}, \invCut{}, \invPart{} and \invCont{}.  Let
+$U\subseteq L^W$ be a cut-normalised set of literals each of which propagates
+under $R$, suppose $F_t\!\restriction_R$ does not propagate to conflict, and
+write $D=\dm_U(W)$.  Let $C\in\Cells(W)$ be a cell with $D\cap C=\emptyset$.
+Then $\overline{C}$ propagates under $R$.
+\end{lemmaN}
+
+\begin{proof}
+Write $C=[p,q]$, so that $C$ is the literal $\atin{w}{p}{q}$ if $p<q$ and
+$\ateq{w}{p}$ if $p=q$; in either case \cref{eq:din1,eq:deq1} give the two
+clauses $\overline{C}\vee\atge{w}{p}$ and
+$\overline{C}\vee\overline{\atge{w}{q+1}}$, and both cuts are defined by
+\invCut{}.
+
+\emph{Case 1: some negative two-cut literal of $U$ contains $C$.}  That is,
+$\overline{E}\in U$ for a defined $E$ with $C\subseteq E$.  If $E=C$ we are
+done.  Otherwise $C\subsetneq E$, and \invCont{} gives a chain of binary clauses
+$\overline{C}\vee E_1$, $\overline{E_1}\vee E_2$, \dots, $\overline{E_{m-1}}\vee
+E$; reading each contrapositive in turn from $\overline{E}$ propagates
+$\overline{C}$.
+
+\emph{Case 2: no negative two-cut literal of $U$ contains $C$.}  We claim that
+then no negative two-cut literal of $U$ meets $C$ at all.  Let $\overline{E}\in
+U$.  If $E\cap[l,u]=\emptyset$ then $E\cap C=\emptyset$ since $C\subseteq[l,u]$.
+Otherwise, by \invPart{}, $E\cap[l,u]$ is a union of adjacent cells, and $C$ is
+a cell, so either $C\subseteq E$ --- excluded by the case assumption --- or
+$C\cap E=\emptyset$.
+
+So every value of $C$ is excluded by a bound literal of $U$.  Put
+$v^{+}=\max\{v : \atge{w}{v}\in U\}$ (with $v^{+}=-\infty$ if there is none)
+and $v^{-}=\min\{v : \overline{\atge{w}{v}}\in U\}$ (with $v^{-}=+\infty$ if
+there is none).  The values \emph{not} excluded by bounds of $U$ are exactly
+$[v^{+},v^{-}-1]$.  If $v^{-}\leq v^{+}$ then $\atge{w}{v^{+}}$ and
+$\overline{\atge{w}{v^{-}}}$ propagate and \cref{lem:contra-bounds} gives a
+conflict, contrary to assumption.  So $[v^{+},v^{-}-1]$ is a non-empty interval
+disjoint from the interval $C$, and $C$ lies wholly on one side of it.
+\begin{itemize}[itemsep=1pt]
+  \item If $q<v^{+}$: then $q+1\leq v^{+}$, and $\atge{w}{q+1}$ is defined, so
+    \cref{lem:chain} propagates it from $\atge{w}{v^{+}}$.  The clause
+    $\overline{C}\vee\overline{\atge{w}{q+1}}$ then propagates $\overline{C}$.
+  \item If $p\geq v^{-}$: then $\atge{w}{p}$ is defined and \cref{lem:chain}
+    propagates $\overline{\atge{w}{p}}$ from $\overline{\atge{w}{v^{-}}}$.  The
+    clause $\overline{C}\vee\atge{w}{p}$ then propagates $\overline{C}$.
+    \qedhere
+\end{itemize}
+\end{proof}
+
+\begin{lemmaN}[Covering completeness]
+\label{lem:covering}
+Assume \inv{Bound}, \invCut{}, \invPart{} and \invCover{}.  Let $E$ be a defined
+equality or interval literal of $W$ and let $S=E\cap[l,u]$.
+\begin{enumerate}[label=(\alph*),itemsep=1pt]
+  \item If $S=\emptyset$ then $\overline{E}$ propagates under any $R$.
+  \item If $S\neq\emptyset$, $E$ is not currently a cell, and $\overline{C}$
+    propagates for every cell $C\subseteq S$, then $\overline{E}$ propagates.
+\end{enumerate}
+\end{lemmaN}
+
+\begin{proof}
+\emph{(a)}  Write $E=[a,b]$.  If $b<l$ then $\atge{w}{b+1}$ is defined by
+\invCut{} with $b+1\leq l$, so it is a unit by \inv{Bound}, and
+$\overline{E}\vee\overline{\atge{w}{b+1}}$ propagates $\overline{E}$.  If $a>u$
+then $\atge{w}{a}$ is defined with $a>u$, so $\overline{\atge{w}{a}}$ is a unit
+by \inv{Bound}, and $\overline{E}\vee\atge{w}{a}$ propagates $\overline{E}$.
+
+\emph{(b)}  For a set that is a union of adjacent cells, define its \emph{rank}
+to be the number of cells it contains.  We first show, by induction on rank,
+that $\overline{G}$ propagates for every defined literal $G\subseteq S$ that is
+a union of adjacent cells.
+
+If $G$ has rank one then $G$ is a cell, since its two endpoints are boundaries
+and no boundary lies strictly inside it; as $G\subseteq S$, $\overline{G}$
+propagates by hypothesis.  If $G$ has rank at least two then $G$ is not a cell,
+so \invCover{}(i) puts $\overline{G}\vee C_1\vee\cdots\vee C_k$ in $F_t$ with
+each $C_i$ a defined literal, a union of adjacent cells, properly contained in
+$G$ --- hence of strictly smaller rank --- and contained in $S$.  By induction
+each $\overline{C_i}$ propagates, so the covering propagates $\overline{G}$.
+
+Now for $E$ itself.  If $E\subseteq[l,u]$ then $E=S$, which is a union of
+adjacent cells by \invPart{}, and the claim applies directly.  Otherwise
+$E\neq S$, and \invCover{}(ii) puts $\overline{E}\vee C_1\vee\cdots\vee C_k$ in
+$F_t$ with each $C_i$ a defined literal that is a union of adjacent cells and
+$\bigcup_i C_i=S$; each $C_i\subseteq S$, so $\overline{C_i}$ propagates by the
+claim, and the covering propagates $\overline{E}$.
+\end{proof}
+
+\begin{remark}
+\invCover{} is stated structurally, over the \emph{current} partition, but an
+implementation emits each clause once and never revisits it: a split covering
+when a cell is first split into two halves, and a request covering when a
+literal spanning several cells is defined.  Both statements are then maintained
+by later refinement without re-emission, which is the whole content of
+``coverings compose across refinements'' --- a covering whose pieces are later
+subdivided still satisfies \invCover{}, because the pieces remain defined
+literals and remain unions of adjacent cells.  This is why \cref{lem:covering}
+is proved by induction on rank rather than by a direct appeal to the clauses
+that happen to have been written: the induction descends through whatever
+coverings exist now, not through the order in which they were emitted.
+
+The distinction matters for one specific reason.  An equality atom created
+before its representation has any partition is not covered by any clause at
+that point; when the partition is later created it becomes a width-one cell,
+and a width-one cell can never be split, so it never needs a covering.  A
+formulation of \invCover{} in terms of ``was a cell when defined'' would have to
+special-case it; the structural form does not.
+\end{remark}
+
+\begin{theoremT}[Empty defined domain propagates to conflict]
+\label{thm:wipeout}
+Let $F_t$ be a set of PB constraints either in the encoding of a CP problem, as
+produced by \cref{proc:encoding}, or derived from it, and suppose \invChain{}
+and \invCut{} are respected.  Let $W$ be a representation, and let $U\subseteq
+L^W$ be a set of literals each of which propagates under some $R$.  If
+$\dm_U(W)=\emptyset$ then $F_t\!\restriction_R$ propagates to conflict.
+\end{theoremT}
+
+\begin{proof}
+Suppose not, and cut-normalise $U$ using \cref{lem:normalise}, which preserves
+both the defined domain and the property of propagating under $R$.
+
+Since $\dm_U(W)=\emptyset$, every integer is excluded by $U$ somehow.  In
+particular the values below any fixed point must be excluded, and no negative
+two-cut literal and no literal $\overline{\atge{w}{v}}$ excludes a value below
+$v$; so $U$ contains at least one literal $\atge{w}{v}$.  Let $v^{+}$ be the
+largest value such that $\atge{w}{v^{+}}$ propagates under $R$; this exists
+because only finitely many bound variables are defined in a finite formula.
+Symmetrically, let $v^{-}$ be the smallest value such that
+$\overline{\atge{w}{v^{-}}}$ propagates; this exists for the mirrored reason.
+
+If $v^{+}\geq v^{-}$ then \cref{lem:contra-bounds} gives a conflict.  So
+$v^{+}<v^{-}$, and in particular the value $v^{+}$ is not excluded by any bound
+literal of $U$.  It must therefore be excluded by a negative two-cut literal of
+$U$, and there are two cases.
+\begin{itemize}[itemsep=1pt]
+  \item $\overline{\ateq{w}{v^{+}}}\in U$.  Then $\atge{w}{v^{+}}$ propagates,
+    and \cref{eq:deq2} --- the clause
+    $\ateq{w}{v^{+}}\vee\overline{\atge{w}{v^{+}}}\vee\atge{w}{v^{+}+1}$ ---
+    propagates $\atge{w}{v^{+}+1}$, contradicting the maximality of $v^{+}$.
+  \item $\overline{\atin{w}{a}{b}}\in U$ with $a\leq v^{+}\leq b$.  By
+    \invCut{}, $\atge{w}{a}$ is defined, and $a\leq v^{+}$, so
+    \cref{lem:chain} propagates it.  Then \cref{eq:din2} --- the clause
+    $\atin{w}{a}{b}\vee\overline{\atge{w}{a}}\vee\atge{w}{b+1}$ --- propagates
+    $\atge{w}{b+1}$, and $b+1>v^{+}$, again contradicting maximality.
+    \qedhere
+\end{itemize}
+\end{proof}
+
+\begin{remarkN}[The root covering is not load-bearing here]
+\label{rem:rootcovering}
+\cref{thm:wipeout} uses only the reverse reifications, the order chain, and the
+fact that both cuts of a two-cut literal are defined.  It does \emph{not} use
+\invCover{} at all, and in particular not the root covering \invCover{}(iii),
+which is the clause one would naively expect to be responsible for detecting
+wipeout at the literal level.  The reason is the second bullet above: a negated
+interval literal, combined with a bound that has reached its lower cut, jumps
+the bound over the whole interval in one step.  Walking those jumps from the
+bottom of the domain is exactly a traversal of the excluded region.
+
+The root covering is nonetheless emitted, and we do not propose removing it.  It
+is one clause per variable; it is the flag-level analogue of the direct
+encoding's at-least-one clause; and the argument above is a hand analysis of
+unit propagation, which is precisely the kind of argument that has been wrong
+before in this design --- see \nsec{sec:loadbearing}.
+\end{remarkN}
+
+\begin{theoremT}[Complete propagation of implied atomic literals]
+\label{thm:complete}
+Let $F_t$ be as in \cref{thm:wipeout}, and suppose \invChain{}, \inv{Bound},
+\invCut{}, \invPart{}, \invCover{} and \invCont{} are respected.  Let $W$ be a
+representation and $U\subseteq L^W$ a set of literals each of which propagates
+under some $R$.  If $F_t\!\restriction_R$ does not propagate to contradiction,
+then every literal in $\ImpLits(\dm_U(X))\cap L^W$ propagates under $R$.
+\end{theoremT}
+
+\begin{proof}
+Cut-normalise $U$ by \cref{lem:normalise}, and write $D=\dm_U(W)$, which is
+non-empty since otherwise \cref{thm:wipeout} would give a contradiction.
+Consider a literal $\ell\in\ImpLits(\dm_U(X))\cap L^W$.  By \cref{eq:implits}
+there are six cases.
+
+\emph{Case 1: $\ell=\atge{w}{v}$, with $v'\notin D$ for all $v'<v$.}  In
+particular $D$ is bounded from below, so $U$ contains a positive bound literal,
+and we may let $v^{+}$ be the largest value with $\atge{w}{v^{+}}$ propagating.
+If $v^{+}>v$ then $\ell$ propagates by \cref{lem:chain}.  If $v^{+}=v$ then
+$\ell$ propagates by definition of $v^{+}$.  Otherwise $v^{+}<v$, so
+$v^{+}\notin D$, and $v^{+}$ is not excluded by any bound literal of $U$ (by
+maximality of $v^{+}$ and, on the other side, because
+$\overline{\atge{w}{v'}}\in U$ with $v'\leq v^{+}$ would give a conflict by
+\cref{lem:contra-bounds}).  So $v^{+}$ is excluded by a negative two-cut
+literal, and exactly as in the two bullets of \cref{thm:wipeout} we derive
+$\atge{w}{v''}$ for some $v''>v^{+}$, contradicting maximality.
+
+\emph{Case 2: $\ell=\overline{\atge{w}{v}}$.}  Symmetric to Case 1, taking
+$v^{-}$ the smallest value with $\overline{\atge{w}{v^{-}}}$ propagating and
+using the other cut in each reverse reification.
+
+\emph{Case 3: $\ell=\ateq{w}{v}$, so $D=\{v\}$.}  Since $\ell$ is defined, so
+are $\atge{w}{v}$ and $\atge{w}{v+1}$ by \invCut{}; both
+$\atge{w}{v}\in\ImpLits$ and $\overline{\atge{w}{v+1}}\in\ImpLits$, so they
+propagate by Cases 1 and 2, and \cref{eq:deq2} then propagates $\ell$.
+
+\emph{Case 4: $\ell=\overline{\ateq{w}{v}}$, so $v\notin D$.}  If
+$\ateq{w}{v}\in U$ then $D=\{v\}$, contradiction; so consider what excludes $v$.
+If a bound literal does, then either $\atge{w}{v+1}$ or
+$\overline{\atge{w}{v}}$ propagates by \cref{lem:chain}, and the corresponding
+clause of \cref{eq:deq1} propagates $\ell$.  If instead a negative two-cut
+literal $\overline{E}\in U$ with $v\in E$ does, then $\{v\}\subseteq E$; if
+$E=\{v\}$ then $\ell\in U$, and otherwise \invCont{} gives a chain of binary
+clauses whose contrapositives propagate $\ell$ from $\overline{E}$.  If a
+positive two-cut literal excludes $v$, cut normalisation has already replaced it
+by bound literals, so this is the first case.
+
+\emph{Case 5: $\ell=\atin{w}{a}{b}$, with $D\subseteq[a,b]$.}  Since $\ell$ is
+defined, $\atge{w}{a}$ and $\atge{w}{b+1}$ are defined by \invCut{}.  Every
+$v<a$ is outside $D$ and every $v\geq b+1$ is outside $D$, so
+$\atge{w}{a}$ and $\overline{\atge{w}{b+1}}$ are in
+$\ImpLits(\dm_U(X))\cap L^W$ and propagate by Cases 1 and 2.  \cref{eq:din2}
+then propagates $\ell$.
+
+\emph{Case 6: $\ell=\overline{\atin{w}{a}{b}}$, with $D\cap[a,b]=\emptyset$.}
+Write $E=[a,b]$ and $S=E\cap[l,u]$.  If $S=\emptyset$ then $\ell$ propagates by
+\cref{lem:covering}(a).  Otherwise, $S$ is a union of cells by \invPart{}, and
+every cell $C\subseteq S$ satisfies $D\cap C=\emptyset$, so $\overline{C}$
+propagates by \cref{lem:cell}.  If $E$ is itself a current cell we are done; if
+not, \cref{lem:covering}(b) propagates $\ell$.
+\end{proof}
+
+\paragraph{Lifting to a representation family.}
+
+\begin{lemmaN}[Unit transport]
+\label{lem:transport}
+Assume \invRep{}.  Let $W,W'\in\Rep(X)$ and let $\ell$ be a literal over an
+atomic variable of $W$ defined in $F_t$.  If $\ell$ propagates under $R$, then
+$\ell^{W'}$ propagates under $R$.
+\end{lemmaN}
+
+\begin{proof}
+Images compose, $(\ell^{X})^{W'} = \ell^{W'}$, so it suffices to prove the claim
+for $W'=X$ and for $W$ derived, and then apply it twice.  By \invRep{} the
+atomic variable underlying $\ell^{X}$ is defined and the two linking clauses
+\cref{eq:gelink}, \cref{eq:eqlink} or \cref{eq:inlink} appear in $F_t$.  Those
+two clauses are $\overline{p}\vee q$ and $\overline{q}\vee p$ for
+$p$ the positive literal of $W$'s atom and $q$ its image; a binary clause
+propagates its other literal from a unit, so $p\mapsto q$ uses the first and
+$\overline{q}\mapsto\overline{p}$ the same one, while $q\mapsto p$ and
+$\overline{p}\mapsto\overline{q}$ use the second.  All four polarity
+combinations are therefore covered.
+\end{proof}
+
+\begin{remarkN}[Why naming, not requesting, is the trigger]
+\label{rem:naming}
+\cref{lem:transport} is only as good as \invRep{}, and \invRep{} is the
+invariant that is easiest to break silently.  Bound and equality atoms are
+mirrored eagerly at the moment they are defined, so for them \invRep{} is
+maintained by construction.  Interval literals are not, because they come into
+existence two ways: because some consumer asked for one --- a conclusion, a
+reason element, a branching decision --- or because the partition machinery
+created it as a cell, which no consumer ever asked for.  A rule that mirrors
+``requested'' literals leaves every cell unlinked, and a later decision, reason
+or conclusion that happens to name one of those cells then has no link at all:
+a unit-propagation dead end, with nothing wrong at the point of failure.
+
+The correct trigger is \emph{naming}: an interval literal is mirrored and linked
+the first time it appears in an emitted proof line, from whichever side names it
+first.  \invName{} then says that this covers every defined interval literal,
+and it does, because every creation path writes a line naming the literal it has
+just created, in the same call: a split emits its split covering, a partition
+creation its root covering, a request its own covering, and a definition its
+containment edges.  Only the \code{red} reification lines name a literal without
+going through the naming hook.  The invariant to preserve is therefore: every
+non-\code{red} emission names its literals.  A future code path that rendered an
+interval literal into a line without going through the naming hook would leave
+one unlinked, and nothing would notice.
+\end{remarkN}
+
+\setcounter{theoremP}{1}
+\begin{theoremP}[Empty defined domain, family version]
+\label{thm:wipeout-family}
+Let $F_t$ be as in \cref{thm:wipeout}, and suppose \invChain{}, \invCut{} and
+\invRep{} are respected.  Let $L$ be the atomic literals defined in $F_t$ for
+any representation of $X$, and let $U\subseteq L$ be a set of literals each of
+which propagates under $R$.  If $\dm_U(X)=\emptyset$ then
+$F_t\!\restriction_R$ propagates to conflict.
+\end{theoremP}
+
+\begin{proof}
+Fix any $W\in\Rep(X)$ and let $U^W = \{\ell^{W} : \ell\in U\}$.  By
+\cref{lem:transport} every literal of $U^{W}$ propagates under $R$, and
+$U^W\subseteq L^W$ by \invRep{}.  Images preserve satisfaction by base values,
+so $\dm_{U^W}(X)=\dm_U(X)=\emptyset$.  \cref{thm:wipeout} applied to $U^W$ gives
+the conflict.
+\end{proof}
+
+\begin{theoremP}[Complete propagation, family version]
+\label{thm:complete-family}
+Let $F_t$, $L$ and $U$ be as in \cref{thm:wipeout-family}, and suppose in
+addition that \inv{Bound}, \invPart{}, \invCover{} and \invCont{} are respected
+for every representation of $X$.  If $F_t\!\restriction_R$ does not propagate to
+contradiction, then every literal in $\ImpLits(\dm_U(X))\cap L$ propagates
+under $R$.
+\end{theoremP}
+
+\begin{proof}
+Let $\ell\in\ImpLits(\dm_U(X))\cap L$ be a literal over the representation $W$.
+Transport $U$ to $U^{W}$ as in the previous proof; every literal of $U^W$
+propagates and $\dm_{U^W}(X)=\dm_U(X)$.  Then \cref{thm:complete} applied on
+$W$ gives that $\ell$ propagates.
+\end{proof}
+
+The shape of this argument is worth stating explicitly, because it is what makes
+the design maintainable: \textbf{transport, then argue on one side}.  Two
+representations of one variable end up holding the same literals, by \invRep{},
+but there is no reason for them to hold those literals in the same \emph{roles},
+and in practice they do not always: we have observed proofs in which an interval
+is a partition cell on one representation and a request with its own covering on
+its image, and in which the two containment DAGs are not isomorphic.
+\cref{thm:complete-family} does not care, because \cref{thm:complete} is proved
+per representation from invariants that each side satisfies independently.  That
+is deliberate, and it is worth being explicit about why: an argument that
+appealed to the two sides having corresponding clause sets would be unsound
+reasoning \emph{even in the runs where the correspondence happens to hold},
+because nothing maintains it.
+
+\subsubsection*{How facts move: a summary}
+\phantomsection\addcontentsline{toc}{subsubsection}{How facts move: a summary}\label{sec:crossings}
+
+\cref{thm:complete-family} says that everything implied propagates.  It is
+worth setting out separately \emph{which} clause family carries each kind of
+crossing, because that is the level at which the design is modified, and
+because a clause family with no crossing to its name is a candidate for
+deletion --- correctly or, as has happened three times, incorrectly.
+
+\begin{center}
+\small
+\begin{tabular}{@{}p{3.9cm}p{3.0cm}p{7.0cm}@{}}
+\toprule
+\textbf{Fact} & \textbf{Becomes} & \textbf{Carried by} \\
+\midrule
+\multicolumn{3}{@{}l}{\emph{Within one representation}}\\[2pt]
+$\atge{w}{v}$ & $\atge{w}{v'}$, $v'<v$ & order chain, \invChain{}
+  (\cref{lem:chain}) \\
+$\overline{\atge{w}{v}}$ & $\overline{\atge{w}{v'}}$, $v'>v$ & the same clauses,
+  read the other way \\
+$\ateq{w}{v}$ or $\atin{w}{a}{b}$ & its two cuts & $\Def^{\Rightarrow}$,
+  \cref{eq:deq1,eq:din1} \\
+both cuts & $\ateq{w}{v}$ or $\atin{w}{a}{b}$ & $\Def^{\Leftarrow}$,
+  \cref{eq:deq2,eq:din2} \\
+one cut crossing the literal & $\overline{\ateq{w}{v}}$ or
+  $\overline{\atin{w}{a}{b}}$ & $\Def^{\Rightarrow}$, contrapositive \\
+$\overline{\ateq{w}{v}}$ or $\overline{\atin{w}{a}{b}}$ & a bound stepping over
+  it & $\Def^{\Leftarrow}$: this is the hole jump, and the reason
+  \cref{thm:wipeout} needs no covering \\
+$\overline{E'}$, $E\subsetneq E'$ & $\overline{E}$ & containment, \invCont{}
+  (\cref{lem:contclosure}) \\
+$\overline{C_1},\dots,\overline{C_k}$ & $\overline{E}$ & covering, \invCover{}
+  (\cref{lem:covering}) \\
+$E$ and all but one piece excluded & the surviving piece & covering \\
+every cell excluded & conflict & reverse reifications and the chain
+  (\cref{thm:wipeout}); the root covering is redundant here, see
+  \cref{rem:rootcovering} \\[4pt]
+\multicolumn{3}{@{}l}{\emph{Between two representations of the same variable}}\\[2pt]
+$\atge{w}{v}$, either polarity & its image on $X$ & ge-links,
+  \cref{eq:gelink}; polarity flips when $s_W=-1$ \\
+$\ateq{w}{v}$, either polarity & its image on $X$ & eq-links, \cref{eq:eqlink} \\
+$\atin{w}{a}{b}$, either polarity & its image on $X$ & in-links,
+  \cref{eq:inlink}; \emph{both} clauses needed, see \cref{rem:bothlinks} \\
+anything on $W_1$ & its image on $W_2$ & two hops through the base
+  (\cref{lem:transport}) \\[4pt]
+\multicolumn{3}{@{}l}{\emph{Between different variables}}\\[2pt]
+a value & a value, across $\BinEnc$ equality & thesis Theorem~2.8 \\
+opposing bounds & conflict, across $\BinEnc$ equality & thesis Theorems~2.7,~2.9 \\
+a lone bound & the same bound on the other side & \textbf{not available in
+  general}; see \nsec{sec:notprovided} \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+\subsubsection*{What this does not provide}
+\phantomsection\addcontentsline{toc}{subsubsection}{What this does not provide}\label{sec:notprovided}
+
+Two limits are worth stating plainly, because misreading either of them has
+cost time.
+
+\paragraph{A lone bound does not cross a constraint.}
+The results above are entirely about one CP variable and its representations.
+Nothing here lets unit propagation move a bound literal on $X$ to a bound
+literal on $Y$ across a constraint such as $\BinEnc(X)=\BinEnc(Y)$: doing so
+would require adding two constraints together, which unit propagation never
+does.  Example~2.15 of the thesis exhibits an explicitly contradictory triple of
+bit-sum constraints that does not unit propagate at all.  This limit is real,
+and it is not repaired by anything in this document.
+
+What removes the difficulty is that no replay obligation ever requires it, once
+the vocabulary is complete: reasons and conclusions are single-literal facts
+over the vocabulary of \S3.3.1, values cross by thesis
+Theorem~2.8, and contradictions by Theorems~2.7 and~2.9.  Where a propagator
+genuinely needs a bound to cross, it emits explicit bridge lemmas as part of its
+justification.  For an interval conclusion pruned across an equality, those are
+the pair
+\[
+  \atge{x}{a}\Rightarrow\atge{y}{a'}
+  \qquad\text{and}\qquad
+  \atge{y}{b'+1}\Rightarrow\atge{x}{b+1},
+\]
+each RUP by the Theorem~2.9 configuration, mentioning no interval literal and
+therefore reusable by any literal sharing those endpoints.  This is
+\S3.4 material and we do not develop it here; we note only that the interval
+vocabulary does not change the situation, because an interval literal asserts
+only order atoms, never bits.
+
+We record the historical trap: when the literal layer is incomplete, a replay
+stalls, and the stalled trail's \emph{next} step is typically a bound crossing.
+The failure therefore looks exactly like ``unit propagation cannot thread a
+bound across the equality''.  It usually is not.  Twice, that misdiagnosis
+produced elaborate and unnecessary machinery --- global cross-variable
+coverings, durable top-level lemmas --- for a problem that was a missing
+covering clause somewhere else entirely.
+
+\paragraph{Interval literals require a bit-vector representation.}
+\cref{eq:defin} reifies against two order atoms, which are in turn reified
+against $\BinEnc(W)$.  A variable given a purely direct encoding --- one
+$0$--$1$ variable per value, with an at-least-one and an at-most-one clause,
+and no bit vector --- has no cuts to reify against, and no interval literals are
+available for it.  This is a property of the variable, not of views: whether a
+view may carry interval literals is decided by whether its \emph{base} has a bit
+vector.  Consumers that would state an interval fact fall back to stating it per
+value, which is correct but linear in the width.  There is no such fallback
+inside the literal layer itself: a request for an interval literal on a
+bit-vector-less variable is an error.  One degenerate case of the direct
+encoding does have a bit vector and is therefore not affected; see
+\cref{sec:open}.
+
+\subsubsection{Unsatisfiability Proofs from Backtracking Search}
+\label{sec:unsat}
+
+We can now explain how a CP solver creates a PB proof when it determines, via
+decisions, backtracking and constraint propagation, that a problem is
+unsatisfiable.  In short: every time the solver backtracks, it immediately logs
+a PB constraint encoding, via atomic literals, the negation of the sequence of
+decisions made prior to discovering a conflict.  This can be thought of as a
+nogood clause from a solving perspective, but we refer to it as a
+\emph{backtracking justification} once written in the proof log.
+
+The solver is not restricted to guessing assignments, but we require that each
+branching decision can be expressed as a single atomic literal, and that for the
+decision variable all assignments are somehow partitioned by the branches.  In
+general, if there are $k$ decisions before a particular backtrack, the required
+backtracking justification is
+\begin{equation}
+  B_t := \sum_{i=0}^{k-1}\overline{d_i} \geq 1
+  \label{eq:bt}
+\end{equation}
+where each $d_i$ is an atomic literal representing the branching decision at
+level $i$ of the current search path.
+
+The extended vocabulary widens what may appear as a $d_i$ in two ways, and both
+are used.  A decision may be an interval literal, so that interval splitting
+(``$X\in[a,b]$'' versus ``$X\notin[a,b]$'') is a two-way branch over one atomic
+literal rather than a pair of bounds; and a decision may be stated over any
+representation, though in practice a solver branches on the variables it has
+state for, which are the base variables.  Neither changes \cref{eq:bt}.
+
+When the solver backtracks from the root decision level, the sequence of
+decisions is empty and \cref{eq:bt} becomes $0\geq 1$: the trivial
+unsatisfiability conclusion we want to reach.
+
+For these logged constraints to be efficiently checkable, they need to follow
+by RUP.  The idea, going back to Elffers et al.\ and stated explicitly by Gocht
+et al., is to maintain an invariant so that every backtracking clause does.  For
+any base variable $X$, and any point $t$ immediately prior to backtracking or
+immediately before any domain change, let $\dm_t(X)$ be the current domain of
+$X$ as stored by the solver; let $B_t$ be the backtracking justification for the
+current sequence of decisions; and let $F_t$ be the constraints in the input
+encoding or derived in the proof up to $t$.  We must have logged enough that:
+
+\begin{description}[font=\normalfont\bfseries,leftmargin=3.2em,style=nextline]
+\item[\invConflict{} (thesis Inv2).]
+  If the solver has detected contradiction for the current state of domains,
+  then $F_t\cup\{\neg B_t\}$ must unit propagate to contradiction.
+\item[\invDomain{} (thesis Inv3).]
+  For every base variable $X$, if $L$ is the set of atomic literals defined for
+  \emph{any representation of} $X$ that would propagate during unit propagation
+  of $F_t\cup\{\neg B_t\}$, then unless contradiction is reached beforehand, we
+  must have $\dm_L(X)\subseteq\dm_t(X)$.
+\end{description}
+
+\invDomain{} is where the multi-representation setting shows up in the search
+invariants, and it shows up in exactly the way one would want.  The solver holds
+one domain per base variable; a view has no domain of its own, only an affine
+window onto its base's.  Correspondingly, $\dm_L(X)$ in \cref{eq:domL} is an
+intersection over the literals of \emph{all} representations, stated on the
+base's value scale.  A fact learned about a view therefore constrains the same
+object the solver's domain constrains, and the containment
+$\dm_L(X)\subseteq\dm_t(X)$ is between two subsets of the same set of integers.
+
+\begin{theoremT}
+\label{thm:btrup}
+If \invConflict{} and \invDomain{} are respected, and a complete solver always
+logs backtracking justifications, then every backtracking justification $B_t$
+follows by RUP.
+\end{theoremT}
+
+\begin{proof}
+In a standard backtracking and propagation solver there are three cases in which
+the solver backtracks.
+
+\emph{Case 1: a propagator has detected infeasibility.}  Then \invConflict{}
+implies $B_t$ is RUP.
+
+\emph{Case 2: a propagator has removed all remaining values from the domain of
+some base variable $X$.}  Then \invDomain{} implies that unit propagation on
+$F_t\cup\{\neg B_t\}$ either obtains a contradiction, or propagates a set of
+literals $L$ over representations of $X$ with $\dm_L(X)=\emptyset$.  In the
+latter case \cref{thm:wipeout-family} implies that further unit propagation must
+still result in contradiction.
+
+\emph{Case 3: the solver has exhausted all branching possibilities for its
+current branching variable $X$.}  Let $\dm_t(X)$ be the domain of $X$ after
+propagation at the current decision level.  The branching choices partition
+$\dm_t(X)$.  Since this is not a leaf node, backtracking justifications have
+already been logged for each of the $k$ child branches, each of the form
+$G\Rightarrow \overline{d_i}\geq 1$ where $G$ encodes the decisions above this
+level and $d_i$ is the $i$th branching decision on $X$; so each
+$\overline{d_i}$ propagates under $F_t\cup\{\neg B_t\}$.
+
+Now suppose $F_t\cup\{\neg B_t\}$ does not propagate to contradiction, and let
+$L$ be the set of atomic literals over representations of $X$ that propagate
+under unit propagation to fixpoint.  We must have $\dm_L(X)\neq\emptyset$, since
+otherwise \cref{thm:wipeout-family} gives a conflict; so pick $v\in\dm_L(X)$.
+By \invDomain{}, $v\in\dm_t(X)$, so some branch decision $d_i$ is satisfied by
+$v$, the branches being a partition of $\dm_t(X)$.  But $\overline{d_i}\in L$,
+and $v\in\dm_L(X)$ means $v$ satisfies every literal of $L$, so $v$ does not
+satisfy $d_i$ --- a contradiction.  Note that $d_i$ may be stated over any
+representation of $X$, and that $\dm_L$ is computed over all of them, so no
+transport step is needed here beyond the one inside
+\cref{thm:wipeout-family}.
+\end{proof}
+
+\paragraph{Maintaining the invariants.}
+If the CP solver happened to perform only inferences no stronger than unit
+propagation on the input PB formula, \invConflict{} and \invDomain{} would be
+maintained trivially.  But the encoding is deliberately not informing the
+solving process.  So we require further justification constraints to be logged.
+
+To define these we make use of \emph{reasons}, which for CP proof logging are
+just literal sets $R$ used to reify intermediate facts written in the proof log.
+We say a reason $R$ is \emph{valid} for a domain state $\dm_t$ at time $t$ if
+every $\ell\in R$ is guaranteed to propagate under $F_t\cup\{\neg B_t\}$, if
+contradiction is not reached first.
+
+Whenever the solver detects contradiction from the current domain state, it must
+derive in the proof a constraint of the form
+\begin{equation}
+  R \Rightarrow 0\geq 1
+  \label{eq:conflictjust}
+\end{equation}
+where $R$ is a reason valid at the point of conflict; we call this a
+\emph{conflict justification}.  Whenever a propagator makes an inference, it
+must derive a \emph{propagation justification}
+\begin{equation}
+  R \Rightarrow \ell \geq 1
+  \label{eq:propjust}
+\end{equation}
+where $\ell$ is an atomic literal describing the inference and $R$ is a reason
+valid immediately before the domain change.
+
+Two things about \cref{eq:propjust} are new.  First, $\ell$ may be a negated
+interval literal: a propagator that removes a run of values from a domain states
+that as one conclusion $\overline{\atin{w}{a}{b}}$, not as $b-a+1$ conclusions.
+Second, $\ell$ and the literals of $R$ need not be stated over the same
+representation, and routinely are not.  A propagator whose operand is a view
+concludes over the view; a reason derived from the solver's domains is stated
+over whichever representation the propagator holds; and a branching decision was
+taken on the base.  All three meet only through \cref{lem:transport}.
+
+\begin{lemmaT}
+\label{lem:reasons}
+If $R$ is a finite set of literals defined in $F_t$ with
+$R\subseteq\bigcup_i\ImpLits(\dm_t(X_i))$, and \invChain{}, \inv{Bound},
+\invCut{}, \invPart{}, \invCover{}, \invCont{}, \invRep{} and \invDomain{} are
+respected, then $F_t\cup\{\neg B_t\}$ either propagates to contradiction or
+propagates every literal in $R$.
+\end{lemmaT}
+
+\begin{proof}
+Let $\ell\in R$ be a literal over a representation $W$ of the base variable
+$X_i$, so $\ell\in\ImpLits(\dm_t(X_i))$.  Suppose $F_t\cup\{\neg B_t\}$ does not
+propagate to contradiction, and let $L$ be the atomic literals over
+representations of $X_i$ that propagate, as guaranteed by \invDomain{}.  Since
+we do not reach conflict, $\dm_L(X_i)\neq\emptyset$ by
+\cref{thm:wipeout-family}.  Then $\dm_L(X_i)\subseteq\dm_t(X_i)$, so
+$\ImpLits(\dm_L(X_i))\supseteq\ImpLits(\dm_t(X_i))$ by \cref{eq:implits}, and
+hence $\ell\in\ImpLits(\dm_L(X_i))$.  \cref{thm:complete-family} then tells us
+that $\ell$ propagates.
+\end{proof}
+
+There are two standard ways to obtain a valid reason.  The atomic literals
+representing the current decisions $G$ are always valid for the current subtree,
+as they are by definition propagated by $\neg B_t$.  Alternatively, by
+\cref{lem:reasons}, any finite set of literals implied by the current domains
+will do --- and this is the form that matters here, because it is what lets a
+propagator state ``this run of values is absent from the domain'' as a single
+reason element rather than as one literal per value.  Our definition of reasons
+is more permissive than the reason clauses of lazy clause generation: we retain
+the ability to use auxiliary variables from the PB encoding, or fresh variables
+introduced by redundance, as part of a reason.
+
+To ensure that justifications suffice to maintain the invariants, we also
+require the solver to introduce by redundance the atomic literals for the
+initial bounds at the start of the proof, if not already present, and derive by
+RUP the units stating that they hold at the root decision level: for a variable
+$X$ with initial bounds $l$ and $u$, these are
+\begin{equation}
+  \atge{x}{l}\geq 1 \qquad\text{and}\qquad \overline{\atge{x}{u+1}}\geq 1 .
+  \label{eq:rootbounds}
+\end{equation}
+These follow by RUP by the same argument as \cref{cor:chainrup}, since the bound
+constraints $\Bnd(X)$ are present.  \inv{Bound} is the lazy generalisation
+actually implemented: the unit is emitted for whichever out-of-range cut is
+first created, and the same argument applies, because $\Bnd(W)$ is asserted for
+every representation, derived ones included.
+
+\begin{theoremT}
+\label{thm:maintain}
+A correct proof logging CP solver that always logs propagation and conflict
+justifications, maintains the literal-layer invariants of \cref{sec:atomprops},
+and initially introduces bound literals, will always maintain \invConflict{} and
+\invDomain{}.
+\end{theoremT}
+
+\begin{proof}
+Let $t$ be any point immediately before a backtrack or domain change, with
+$B_t$ and $F_t$ as above, and assume \invDomain{} has been maintained at all
+relevant earlier points.
+
+Suppose the solver has detected infeasibility of the current domain state.  Then
+it will just have logged a conflict justification $R\Rightarrow 0\geq 1$.
+\cref{lem:reasons} tells us that reverse unit propagation of the backtracking
+justification either reaches contradiction or propagates every literal of $R$.
+Either way a contradiction is reached, so \invConflict{} is respected.
+
+Suppose instead a propagator has just made an inference that changed a domain,
+and logged $R\Rightarrow\ell\geq 1$.  The reason is valid at the point directly
+before the inference, so every literal of $R$, and hence $\ell$, propagates under
+$F_t\cup\{\neg B_t\}$.  If $\ell$ is stated over a derived representation $W$ of
+$X$, then by \cref{lem:transport} its image on $X$ propagates too; either way the
+domain restriction $\ell$ encodes is incorporated into $\dm_L(X)$ for the
+propagated set $L$, since $\dm_L$ is computed over all representations.  Hence
+\invDomain{} continues to be respected.
+
+It remains to argue that there is a starting point at which \invDomain{} holds.
+Consider the very first conflict or propagation inference.  The only domain
+changes that could have happened are those due to initial decisions, which by
+definition propagate on reverse unit propagation of the backtracking
+justification, and the initial domain bounds, which we have introduced as units
+by \cref{eq:rootbounds}.  Hence \invDomain{} is initially respected.
+\end{proof}
+
+\paragraph{Summary of the framework.}
+\begin{enumerate}[itemsep=1pt]
+  \item Encode the problem using \cref{proc:encoding}, giving every operand
+    --- base variable or view --- its own bit vector, and every derived
+    representation its definitional link \cref{eq:link}.
+  \item At the start of the proof, derive by RUP $\atge{x}{l}\geq 1$ and
+    $\overline{\atge{x}{u+1}}\geq 1$ for the bounds $l..u$ on each variable, and
+    likewise for any out-of-range cut subsequently created on any representation.
+  \item Any time the solver backtracks, derive by RUP a backtracking
+    justification $G\Rightarrow 0\geq 1$, where $G$ is the sequence of decisions
+    prior to backtracking.
+  \item Any time the solver detects infeasibility, derive a conflict
+    justification $R\Rightarrow 0\geq 1$.
+  \item Any time a propagator makes an inference, derive a propagation
+    justification $R\Rightarrow\ell\geq 1$.
+  \item Any atomic variables needed for the above must be defined in the proof,
+    if not already in the input model, with the corresponding definition
+    constraints \cref{eq:defge,eq:defeq,eq:defin}.
+  \item Every defined bound literal must be threaded into its representation's
+    order chain (\invChain{}).
+  \item Every defined interval literal must be maintained within its
+    representation's partition, with its covering and its containment edges
+    (\invPart{}, \invCover{}, \invCont{}).
+  \item Every defined atomic literal on a derived representation, and every one
+    on a base that has derived representations, must be mirrored onto the others
+    and joined to them by the linking clauses of
+    \cref{eq:gelink,eq:eqlink,eq:inlink} --- for interval literals, triggered at
+    the point the literal is \emph{named} (\invRep{}, \invName{}).
+\end{enumerate}
+
+Steps~1 to~6 are the thesis's framework; steps~7 to~9 are the literal-layer
+invariants stated as obligations.  Despite requiring a delicate set-up in terms
+of variable encodings and propagation properties, the resulting proof has a
+relatively intuitive structure: other than the definition, chain, covering,
+containment and linking clauses, it is essentially the solver writing down all
+the facts that it learned, at the points that it learned them.
+
+\subsubsection{Optimality Proofs from Solution-Improving Search}
+\label{sec:optimality}
+
+There is not a large conceptual difference between complete backtracking search
+to establish unsatisfiability and solution-improving search to determine an
+optimum.  The only change required from the proof's point of view is that
+whenever the solver finds a solution and introduces a new objective bound, it
+should use the solution-logging rule to witness a solution, introducing a
+constraint requiring objective improvement, define the corresponding bound
+literal, and introduce by RUP the constraint setting it to true.
+
+In general, for an objective variable $W$ and attained objective value $o$, a
+solution witness introduces
+\[
+  \BinEnc(W) \geq o+1 \quad\text{for maximisation, or}\quad
+  -\BinEnc(W) \geq -o-1 \quad\text{for minimisation,}
+\]
+followed by a literal definition and the RUP constraint $\atge{w}{o+1}\geq 1$ or
+$\overline{\atge{w}{o}}\geq 1$.  This fits neatly into the framework, as the RUP
+constraint derived after a solution is found is simply a propagation
+justification with $R=\emptyset$, as if the objective-improving constraint had
+always been part of the model.  It has the effect of maintaining \invDomain{} by
+ensuring the bound restriction on the objective variable's domain propagates ---
+and, by \cref{lem:transport}, on every representation of it.
+
+\paragraph{A requirement for partial solution witnessing.}
+For solution witnessing to be compact and user-friendly, we would like to
+witness only a single equality literal for each variable-value pair in the found
+assignment to the original CP variables, rather than writing out a complete
+assignment to every PB variable in the encoding.  For a partial assignment to be
+verifiable as a solution witness, the checker requires that the given assignment
+unit propagates to a complete solution of the PB problem.  We guarantee this by
+requiring the encoding to have the property that any partial assignment setting
+all the bit variables $x_i\in\BinEnc(X)$ for every $X\in\mathcal V$ propagates
+to a total assignment or to contradiction.
+
+For the linearisations of the thesis, this is established by observing that any
+variable fully reified on a constraint involving only bit variables is
+propagated true or false by an assignment to those bit variables, and then
+recursively for any variable fully reified on a constraint containing only
+variables already known to propagate.  Three additions have to be checked in the
+extended encoding, and each extends the same recursion by one step.
+
+\begin{enumerate}[itemsep=1pt]
+  \item \textbf{Derived representations.}  Fixing $\BinEnc(X)$ reduces
+    $\Link(W)$, that is $\BinEnc(W) - s_W\BinEnc(X) = c_W$, to a pair of
+    constraints of the form $\BinEnc(W)\geq A$ and $\BinEnc(W)\leq A$ for a
+    constant $A$.  By Theorem~2.8 of the thesis these unit propagate to a fixed
+    consistent assignment of every bit of $\BinEnc(W)$.  So the bits of every
+    derived representation propagate as soon as the base's bits are set.
+  \item \textbf{Bound and equality atoms} on any representation are fully
+    reified over that representation's bits, or over its bound atoms, so they
+    propagate by the existing recursion once step~1 has fired.
+  \item \textbf{Interval atoms} are fully reified, by \cref{eq:defin}, over two
+    bound atoms of the same representation, so they propagate once those do.
+\end{enumerate}
+
+None of the linking clauses of \cref{eq:gelink,eq:eqlink,eq:inlink} is needed
+for this argument, and none of the covering or containment clauses is either;
+they are implied clauses over variables that already propagate, and cannot
+block a propagation that would otherwise occur.
+
+\subsubsection{Enumeration Proofs from Solution-Excluding Search}
+\label{sec:enumeration}
+
+When a solver performs complete solution-excluding search --- adding a nogood
+eliminating each solution once found --- the conclusion can be handled in a
+manner conceptually similar to proofs of optimality: witness each solution,
+relying on unit propagation for completion as above, with a rule that introduces
+the negation of the conjunction of literals encoding the solution; then, when
+the solver establishes unsatisfiability, conclude that the problem has no
+solutions other than those witnessed.
+
+Because the proof system is not implicational --- redundance and dominance can
+add or remove solutions --- a formal enumeration conclusion requires a
+guarantee that a distinguished set of variables is \emph{preserved}, in the
+sense that no rule application may change the projected solution set for them.
+The required property of the encoding is then:
+
+\begin{description}[font=\normalfont\bfseries,leftmargin=2.4em]
+  \item[P3.] There is a one-to-one correspondence between the solutions to the
+    CP problem, and the solutions to the PB problem projected onto a preserved
+    set.
+\end{description}
+
+The extended encoding makes the choice of preserved set more delicate than it
+looks, and we state it explicitly: \textbf{the preserved set is the bits of the
+base variables only}.  It does not include the bits of derived representations,
+nor any atomic variable of any representation.  This is the right choice, and
+the only workable one, for three reasons.
+
+\begin{itemize}[itemsep=1pt]
+  \item It is sufficient.  By \cref{thm:p1p2} the bijection $\phi$ is already
+    onto the bits of $\mathcal V$; every other variable in the encoding is
+    determined by those, by \cref{lem:composing}.
+  \item It is necessary.  Atomic variables are introduced lazily, by redundance,
+    during the proof, and the set of them in existence depends on what the
+    solver happened to do.  A preserved set that grew as the proof ran would make
+    the conclusion depend on the search, which is exactly what a preserved set
+    exists to prevent.
+  \item It is stable under adding a representation.  Two runs of the same solver
+    that wrap the same variable in different views have different sets of
+    derived representations and therefore different encodings, but the same
+    preserved set and the same enumeration conclusion.
+\end{itemize}
+
+One consequence deserves care.  Because atomic variables are not preserved, a
+solution witness must not be stated purely in terms of them.  It is stated over
+base equality literals, and unit propagation completes it --- through
+\cref{sec:optimality}'s step~1 --- to the bits of every derived representation.
+The completion argument is therefore load-bearing for enumeration in a way it is
+not for optimality, and a representation whose bits did not propagate from the
+base's would break P3 rather than merely making a witness verbose.
+
+There is a second, quieter interaction.  Some of the units this framework pins
+at the top of the proof --- the boundary pins of \inv{Bound} in particular ---
+must survive the point at which enumeration restricts the formula, since they
+are facts about the encoding rather than about any one solution.  Emitting them
+once as persistent top-of-proof lines, rather than re-deriving them at each use,
+is what makes that work.
+
+\subsection*{Interlude: what is load-bearing, and how it fails}
+\phantomsection\addcontentsline{toc}{subsection}{Interlude: what is load-bearing, and how it fails}\label{sec:loadbearing}
+
+This section is not part of the theory.  It records how the theory fails when
+one of its invariants is dropped, because that turns out to be much harder to
+observe than one would expect, and because the design has been simplified
+incorrectly three times on the strength of tests that stayed green.
+
+\subsubsection*{Two failure modes that look identical}
+\phantomsection\label{sec:p1p2}
+
+\begin{description}[font=\normalfont\bfseries,leftmargin=2.4em]
+  \item[P1.] A line we emit is not itself accepted by the verifier.  These
+    failures are loud, immediate and local: the checker rejects at the line, and
+    the error points at the culprit.
+  \item[P2.] Every line checks individually, but the clause set does not keep
+    unit propagation strong enough for \emph{later} RUP checks --- backtracking
+    justifications, other constraints' inferences --- to re-derive the facts they
+    depend on.  The eventual rejection lands on an unrelated later line, only
+    under composition, and only for particular search shapes.
+\end{description}
+
+Everything in \cref{sec:atomprops} beyond the definitions themselves guards
+against P2.  \invChain{}, \invCut{}, \invPart{}, \invCover{}, \invCont{},
+\invRep{} and \invName{} contribute nothing to the validity of any individual
+line; they exist so that \cref{thm:complete-family} holds, and
+\cref{thm:complete-family} exists so that \cref{lem:reasons} holds, and
+\cref{lem:reasons} exists so that a backtracking justification three thousand
+lines later is RUP.
+
+The trap follows immediately, and is worth stating as a rule:
+
+\begin{quote}
+  \textbf{A RUP check is strictly stronger than the single unit-propagation pass
+  that later checks rely on.  Every P2 clause therefore looks deletable under
+  P1 testing.}
+\end{quote}
+
+Any linking, covering or containment clause can be removed and a local test will
+stay green, because the RUP check re-finds the derivation that unit propagation
+would have needed the clause for.  ``This clause was never load-bearing in my
+tests'' is \emph{always} observable for a P2 clause on small tests.  It is not
+evidence.  In particular, a witness stated as a RUP line asserting the fact one
+cares about tests nothing at all: only a \emph{backtracking justification},
+checked by RUP after the decisions have been asserted, discriminates.
+
+\subsubsection*{The witness suite}
+
+Each clause family has a deterministic counterexample that fails within
+milliseconds if the family is removed or weakened.  These are checked in as
+gate-on, verifier-checked tests, and any change to the clause set must run them.
+
+\begin{center}
+\small
+\begin{tabular}{@{}llp{7.1cm}@{}}
+\toprule
+& \textbf{Guards} & \textbf{Shape} \\
+\midrule
+W1 & \cref{def:widthone} & Three chained (dis)equalities on three-value domains;
+  branch, then backtrack.  If width-one removals mint interval flags instead of
+  using the equality atom, the replay stalls: ``$b$ lost the value $1$'' is
+  locked inside a flag with no link to $\ateq{b}{1}$. \\
+W2 & \invCover{} & Two variables, one equality and one disequality, with a hole
+  run named in a reason.  If that literal cannot be falsified by unit
+  propagation, the replay stalls in five steps. \\
+W3 & \invCover{}, \invCont{} & A hole run concluded in two pieces and named as
+  one interval in a reason.  Containment points the wrong way; only the request
+  covering lets the replay through. \\
+W4 & \invCont{} & The whole constraint suite run under interval-rejecting
+  branching.  Fails within seconds on several counting constraints if the
+  containment edges are dropped. \\
+W5 & \invCover{}(iii) & A variable whose cells are all excluded must reach
+  contradiction at the literal level. \\
+W6 & \cref{eq:inlink}, first clause & An interval fact concluded on a base
+  variable reaching a reason literal on a view of it. \\
+W7 & \cref{eq:inlink}, second clause & The mirror image: concluded on the view,
+  needed on the base. \\
+W8 & \invName{} & As W6, but the literal named is one the partition machinery
+  created as a cell, so it is invisible to a request-driven linking rule. \\
+W9 & \cref{eq:inlink} and \invName{} & W8's two-view form, where the fact
+  composes $W_1\to X\to W_2$ and the unlinked literal is a conclusion rather
+  than a decision. \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+Each of W6 to W9 has been validated by ablation, and every clause and rule is
+separately load-bearing:
+
+\begin{center}
+\small
+\begin{tabular}{@{}lcccc@{}}
+\toprule
+\textbf{Ablation} & W6 & W7 & W8 & W9 \\
+\midrule
+none & passes & passes & passes & passes \\
+both in-link clauses removed & \textbf{fails} & \textbf{fails} & \textbf{fails} & \textbf{fails} \\
+first in-link clause removed & \textbf{fails} & passes & \textbf{fails} & \textbf{fails} \\
+second in-link clause removed & passes & \textbf{fails} & passes & \textbf{fails} \\
+link on request rather than on naming & passes & passes & \textbf{fails} & \textbf{fails} \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+W2 and W5 are, by contrast, structural: no single-family ablation makes either
+fail, because under \invPart{} the vocabulary always matches or grounds out, and
+because wipeout is also derivable by the bound-axiom walk of
+\cref{rem:rootcovering}.  They remain in the suite as composed end-to-end
+regression nets.  Two known gaps: there is no deterministic witness for split
+coverings composing across refinements with no bound anchor (the shape
+\cref{lem:covering}(b) is proved for), and none for \invCut{} in isolation.
+
+\subsubsection*{The coincidence trap}
+\phantomsection\label{sec:coincidence}
+
+A randomised sweep over views is close to no evidence about the in-links, and it
+is worth knowing by how much, because the natural reaction to
+\cref{rem:bothlinks} is to test it rather than to prove it.
+
+The negative crossing of \cref{eq:inlink} succeeds \emph{with no linking clause
+at all} whenever any of four things happens:
+
+\begin{itemize}[itemsep=1pt]
+  \item the interval is the whole definition range, so asserting its negation is
+    already inconsistent under unit propagation and the check passes vacuously;
+  \item the interval abuts or extends below the lower bound, so that the
+    boundary pin of \inv{Bound} makes \cref{eq:din2} a unit, the ge-link carries
+    it, and the far side's \emph{forward} reification finishes the job;
+  \item the interval abuts or extends above the upper bound, the mirror image;
+  \item every cell inside the interval is a singleton --- and one well-placed
+    equality atom shatters a width-two cell on \emph{both} sides, so any
+    per-value activity anywhere near the interval silently makes the case work.
+\end{itemize}
+
+Measured over domain widths $4$ to $16$ with zero to seven random interval
+requests per instance: \textbf{80\% of instances cross successfully with no
+linking clause at all} --- abutting above $39\%$, abutting below $23\%$, whole
+range $12\%$, fully shattered $5.6\%$ --- and of the $20\%$ that stall, a single
+wide cell accounts for $88\%$.  Measured the other way, over $987$ randomly
+generated instances that actually reach a conflict, ablating the link clauses
+makes only $37$ of them notice.  The sweep is about $96\%$ coincidence.
+
+A discriminating instance therefore needs \emph{all} of: an interval strictly
+inside both representations' definition ranges; at least one interior cell of
+width at least two that no per-value machinery touches; and a replay that has to
+reach the far side's literal from the near side's negation rather than from a
+bound.  W6 to W9 are constructed against exactly this.
+
+\subsubsection*{Corroboration, and what it is worth}
+
+The following are not proofs, and are recorded only for calibration.
+
+\begin{itemize}[itemsep=1pt]
+  \item $3{,}204{,}000$ randomised instances with interval inference enabled and
+    no verifier failures, once the width-one gap of \cref{def:widthone} was
+    closed.  Every failure class encountered before that was reproduced and then
+    eliminated by exactly the clauses \cref{sec:atomprops} mandates.
+  \item $3{,}000$ randomly generated view proofs with zero \invRep{} violations,
+    over nine constraint families with holey domains, three-view bases, and
+    intervals pushed outside the definition bounds.
+  \item Over $8{,}000$ constraint tests under every view wrap and position,
+    including mixed wraps of opposite sign in one constraint, verified.
+\end{itemize}
+
+Testing doctrine learned at cost, for anyone extending the suite: a capped or
+gate-off green run certifies nothing about P2; two-variable instances certify
+nothing about composition; and ``the suite passed'' must always be qualified by
+which gates and which branching were active.
+
+\subsubsection*{Cost}
+
+Per distinct interval literal requested on a representation: at most two cell
+splits, hence at most four new literals of which any width-one piece is an
+equality atom, plus the requested literal; two redundance lines per literal;
+binary coverings for each split; one covering for the request, as wide as the
+number of prior boundaries inside it; and containment edges to immediate
+neighbours.  \textbf{Nothing is proportional to the domain width}, which was the
+point.  The known growth mode is a wide request over a heavily fragmented
+region, whose covering is as wide as the number of prior boundaries inside it,
+bounded by the request count rather than by the domain size.
+
+Per interval literal per derived representation: the mirrored literal on the
+other side, with its own partition maintenance, plus two clauses.  This is the
+same constant factor that bound and equality atoms already pay for a wrapped
+variable.  Measured on a constraint over a bare variable of width $w$ and a
+two-value variable, so that root propagation prunes exactly one wide interior
+run:
+
+\begin{center}
+\small
+\begin{tabular}{@{}rrrrrr@{}}
+\toprule
+$w$ & bare & view, no interval links & view & negated view & mixed \\
+\midrule
+$10^3$ & 40 & $36{,}012$ & \textbf{106} & 106 & 109 \\
+$10^4$ & 40 & $360{,}012$ & \textbf{106} & 106 & 109 \\
+$10^5$ & 40 & \emph{timed out} & \textbf{106} & 106 & 109 \\
+$10^6$ & 40 & \emph{timed out} & \textbf{106} & 106 & 106 \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+The third column is the per-value fallback a view had before it owned interval
+literals: $2+36w$ lines, unwritable past $10^4$.  The remaining columns are flat.
+They are $106$ rather than $40$ because the view carries its own bit vector, its
+own atoms and the link clauses --- a constant, not a function of the width.  That
+constant is the price of the design; the slope was the point.
+
+\appendix
+\crefalias{section}{appendix}
+\crefname{appendix}{Appendix}{Appendices}
+\Crefname{appendix}{Appendix}{Appendices}
+
+\section{A worked example}
+\label{sec:worked}
+
+Take $X$ with initial domain $1..20$, wrapped by the single registered view
+$V = -X + 30$, so $\varphi_V(k) = 30-k$ and $V$ has definition range $10..29$.
+The model contains $\Bnd(X)$, $\Bnd(V)$ and $\Link(V) := V + X = 30$, and
+$\BinEnc(X)$ and $\BinEnc(V)$ are separate five-bit vectors.  No interval
+literal exists yet, and neither variable has a partition.
+
+\paragraph{First request: $[X\in 5..10]$.}
+This may come from any source: a conclusion, a reason element, or a branching
+decision.  On $X$:
+\begin{itemize}[itemsep=0pt]
+  \item the partition is created, with boundaries $\{1,5,11,21\}$ and cells
+    $[1,4]$, $[5,10]$, $[11,20]$, each defined as an interval literal with its
+    two cuts threaded into the order chain;
+  \item the root covering
+    $\atin{x}{1}{4}\vee\atin{x}{5}{10}\vee\atin{x}{11}{20}\geq 1$ is emitted;
+  \item there is no containment yet, nothing being nested.
+\end{itemize}
+Because the literal has now been \emph{named} --- by the root covering, if
+nothing else --- the mirroring hook fires, and $[X\in 5..10]$ maps to
+$[V\in 20..25]$: the endpoints swap because $\varphi_V$ reverses the order,
+and $30-10=20$, $30-5=25$.  On $V$ the partition is created in turn, with
+boundaries $\{10,20,26,30\}$, cells $[10,19]$, $[20,25]$, $[26,29]$, and its own
+root covering.  Finally the two clauses
+\[
+  \overline{\atin{x}{5}{10}}\vee\atin{v}{20}{25}
+  \qquad\text{and}\qquad
+  \overline{\atin{v}{20}{25}}\vee\atin{x}{5}{10}
+\]
+are emitted.  The recursion terminates because the pair is recorded before the
+two \code{need} calls are made.
+
+\paragraph{Second request: $[X\in 7..15]$.}
+Both endpoints fall strictly inside existing cells, so both cells split first:
+\begin{itemize}[itemsep=0pt]
+  \item $[5,10]$ splits at $7$ into $[5,6]$ and $[7,10]$, with the split covering
+    $\overline{\atin{x}{5}{10}}\vee\atin{x}{5}{6}\vee\atin{x}{7}{10}$;
+  \item $[11,20]$ splits at $16$ into $[11,15]$ and $[16,20]$, with its split
+    covering.
+\end{itemize}
+Then $[7,15]$ is defined, with the covering
+$\overline{\atin{x}{7}{15}}\vee\atin{x}{7}{10}\vee\atin{x}{11}{15}$ and the two
+containment edges $\overline{\atin{x}{7}{10}}\vee\atin{x}{7}{15}$ and
+$\overline{\atin{x}{11}{15}}\vee\atin{x}{7}{15}$.  The root covering is
+\emph{not} touched: to falsify $[5,10]$ later, unit propagation goes through its
+own split covering.  The same sequence then happens on $V$ for the image
+$[V\in 15..23]$, and the link pair joins the two.
+
+The state now is: boundaries $\{1,5,7,11,16,21\}$ on $X$ and
+$\{10,15,20,24,26,30\}$ on $V$; five cells each, in bijection under $\varphi_V$;
+and defined non-cell literals $[X\in 5..10]$, $[X\in 11..20]$, $[X\in 7..15]$
+with their images.
+
+\paragraph{A negative crossing.}
+Suppose the solver now decides $\neg[X\in 7..15]$ and, deeper in the subtree, a
+propagator's reason names $[V\in 15..23]$, which is the image.  In the replay,
+$\overline{\atin{x}{7}{15}}$ is asserted.  It is a unit on neither of its cuts:
+\cref{eq:din2} for it is the ternary clause
+$\atin{x}{7}{15}\vee\overline{\atge{x}{7}}\vee\atge{x}{16}$, and with the first
+literal false and neither bound known, nothing propagates.  Its containment
+edges point the wrong way --- they carry $\overline{\atin{x}{7}{15}}$ \emph{down}
+to $[7,10]$ and $[11,15]$, not across.  The only thing that carries the fact to
+$V$ is the \emph{first} clause of the link pair,
+$\overline{\atin{v}{15}{23}}\vee\atin{x}{7}{15}$: with $\atin{x}{7}{15}$ false it
+propagates $\overline{\atin{v}{15}{23}}$ in one step.  Read as an implication that
+clause says $\atin{v}{15}{23}\to\atin{x}{7}{15}$, which is not the direction
+anything needs; it is here for its contrapositive.  Delete it and the
+backtracking justification fails, while every individual line of the proof still
+verifies.  This is witness W6 in miniature; W7 is the mirror image --- a fact
+decided on $V$ and needed on $X$ --- and it needs the other clause.
+
+\paragraph{Why a nearby instance proves nothing.}
+Replace the decision by $\neg[X\in 1..15]$, whose interval abuts the lower bound.
+Now no link clause is needed at all.  \cref{eq:din2} for it is
+$\atin{x}{1}{15}\vee\overline{\atge{x}{1}}\vee\atge{x}{16}$; the boundary pin
+$\atge{x}{1}$ of \inv{Bound} is a unit, so $\atge{x}{16}$ propagates.  The ge-link
+carries that to $\overline{\atge{v}{15}}$, since $X\geq 16$ is $V\leq 14$, and the
+\emph{forward} reification of the image literal $\atin{v}{15}{29}$ then falsifies
+it.  A green result on this instance says nothing whatever about the link pair,
+and three further shapes have the same property --- see \nsec{sec:coincidence},
+where 80\% of small random instances turn out to be one of them.
+
+\section{Residues and open questions}
+\label{sec:open}
+
+\begin{enumerate}[itemsep=3pt]
+
+\item \textbf{Variables with no bit vector.}  As noted in
+  \nsec{sec:notprovided}, interval literals need cuts to reify against.  The
+  gate is whether the variable has a registered bit vector, not what its domain
+  looks like: a two-valued variable given a purely direct encoding is registered
+  with a one-element bit vector, and is therefore \emph{not} the failing case,
+  even though it has no order atoms until they are built lazily.  The failing
+  case is a direct-only variable of width three or more.  Consumers guard on the
+  same predicate, which resolves a view to its base --- correctly, since a view
+  of a bit-vector-less variable would have to mirror onto a variable that cannot
+  hold the mirror.
+
+\item \textbf{Initial-domain gaps.}  Holes in an initial domain are currently
+  derived at the root of the proof, by root propagation of the constraint that
+  posts the domain.  They could instead be stated in the model, as
+  $\overline{\atin{x}{a}{b}}\geq 1$ rows forming part of the domain definition.
+  That formulation is equally definitional and slightly more direct, but it
+  requires interval literals to exist during model writing, and it changes the
+  OPB surface that a verified encoder conforms against.  The decision is open
+  and should be taken alongside that work.
+
+\item \textbf{Assertion levels.}  Where the checker is asked to take the
+  definitional layer on trust rather than checking it, the linking clauses are
+  asserted rather than derived, and the covering and containment apparatus is
+  omitted entirely.  This is consistent --- if the definitions are not present,
+  neither are the facts they would let unit propagation derive --- but the
+  theorems above are stated for the fully-derived setting, and the trusted
+  settings are not separately exercised by the witness suite.
+
+\item \textbf{Unregistered views.}  A view first encountered during proof
+  logging, after the model is closed, cannot be given a representation variable,
+  because \cref{eq:link} is a model constraint.  Such a view is instead rewritten
+  onto its base: a bound becomes a bound (with the polarity flip of
+  \cref{def:image}), an equality becomes an equality, and an interval becomes
+  the image interval with its endpoints swapped when $s=-1$ and re-canonicalised,
+  since a width-one image is an equality atom.  This path is sound but it is
+  \emph{not} the design of \cref{sec:framework}: nothing about it is in
+  $V$-form, and a cutting-planes step that resolved such a literal against a
+  constraint body stated over a registered view would strand.  Constants fold to
+  the Boolean constants and never reach the literal layer at all.
+
+\item \textbf{Re-entrancy.}  Mirroring an interval literal onto another
+  representation can, in the same call, cause that representation's partition to
+  split, which can mirror back and split this one.  The machinery is therefore
+  re-entrant: a boundary is published before the two halves it creates are
+  defined, so for that window the partition claims a cell that does not yet
+  exist, and definition must be idempotent.  This is one reason \invCover{} is
+  stated as a property of the clause set rather than as a rule about when to
+  emit what: the emission order is genuinely hard to reason about, whereas the
+  structural condition is checkable at any quiescent point.
+
+\item \textbf{Do the two sides really differ?}  We have observed proofs in which
+  an interval is a partition cell on one representation and a request with its
+  own covering on its image, and in which the containment DAGs of two
+  representations are not isomorphic.  We have not characterised when this
+  happens.  It does not matter for any result here, and that is deliberate:
+  \cref{thm:complete-family} is proved by transporting to one side and then
+  arguing there, so it never appeals to a correspondence between the two sides'
+  clause sets.  An argument that did appeal to such a correspondence would be
+  unsound reasoning even in the runs where the correspondence happens to hold.
+
+\end{enumerate}
+
+\section{Refuted designs}
+\label{sec:refuted}
+
+Each of the following was proposed, looked right, and is wrong.  They are
+recorded with the witness that catches each, so that a future simplification
+proposal can be tested rather than argued about.
+
+\begin{enumerate}[itemsep=3pt]
+
+\item \textbf{``Reify to the two cuts and use the order chain; no covering, no
+  containment.''}  A falsification matrix of \emph{derivations} passes --- that
+  is P1 only.  Caught by W4 (containment) and W2, W3, W5 (covering).
+
+\item \textbf{``Containment yes, covering unnecessary --- the chain gives those
+  deductions.''}  True for RUP-derivability, false for unit propagation.  Caught
+  by W2 and W3.
+
+\item \textbf{``An interval removal is one RUP line and the per-value facts
+  follow for free.''}  False across a bit-sum equality; needs the explicit
+  bridge lemmas under \nsec{sec:notprovided}.
+
+\item \textbf{Coalescing per-value reasons into interval flags after the fact.}
+  Mints literals that nothing concludes and nothing covers, hence unfalsifiable
+  in a replay; and materialises the per-value equality atoms anyway, through
+  reason naming.  Caught by W2 and W3.
+
+\item \textbf{Width-one interval flags.}  Doppelg\"angers of the equality atom;
+  see \cref{def:widthone}.  Caught by W1 --- and it bites harder than predicted:
+  with width-one flags defined instead of equality atoms, W1 fails \emph{even
+  with the coverings and containment intact}, contrary to a pre-implementation
+  analysis which held that a flag-to-atom covering would rescue it.
+
+\item \textbf{``The composition failure is specific to one constraint'' /
+  ``two variables versus three'' / ``unit propagation cannot thread a bound, so
+  a global cross-variable covering $\atge{x}{k}\Leftrightarrow\atge{y}{k}$ is
+  required.''}  All artefacts of P2 gaps, diagnosed on populations contaminated
+  by the width-one bug.  No cross-variable covering exists in this design and
+  none is needed; see \nsec{sec:notprovided}.
+
+\item \textbf{Cover-on-use over the live witness set,} instead of the partition
+  invariant.  Sound, and validated, but it drags search state into the encoding
+  layer --- a level-aware registry of live conclusions --- and makes the
+  completeness argument depend on what was live when.  Rejected for complexity,
+  not for soundness.
+
+\item \textbf{Rewriting a view's interval conditions onto its base}
+  (``deviewing''), instead of giving the view its own interval literals.  This
+  would leave intervals as the one atom kind not stated in the view's own
+  representation, so a cutting-planes step resolving an interval literal against
+  a constraint body would find nothing to cancel against.  It is the right
+  answer only for the unregistered-view path of \cref{sec:open}, which has no
+  encoded variable to be consistent with.
+
+\item \textbf{``A registered view needs no interval linking, because an
+  interval fact decomposes into: cross one bound, move within one variable,
+  cross back.''}  The decomposition is correct for a \emph{positive} interval
+  literal, which is a conjunction of two bounds.  It is false for a negated one,
+  which is a disjunction.  See \cref{rem:bothlinks}; caught by W6 and W7, and by
+  neither a randomised sweep (\nsec{sec:coincidence}) nor a witness stated as a
+  RUP line (\nsec{sec:p1p2}).
+
+\end{enumerate}
+
+\paragraph{Change protocol.}  Any proposal to weaken or remove a clause family
+from \cref{sec:atomprops} must (a) say which of W1 to W9 it expects to remain
+green and why, (b) run the full witness suite with the verifier enabled, and
+(c) account for the P1/P2 distinction explicitly.  A locally green test is not
+evidence.  Three prior simplifications passed every test their authors thought
+to run.
+
+\end{document}

--- a/dev_docs/literals.md
+++ b/dev_docs/literals.md
@@ -5,7 +5,7 @@ what clauses hold the layer together, and why unit propagation can be relied on
 to re-derive a solver fact during a backtrack-clause replay — lives in one
 document:
 
-- **[literal-encodings.tex](literal-encodings.tex)**, 30 pages when typeset.
+- **[literal-encodings.tex](literal-encodings.tex)**, 34 pages when typeset.
 
 It is a revised and extended version of §3.2 and §3.3 of Matthew McIlree's
 thesis, covering the two things the thesis does not: **range ("in") literals**,
@@ -25,7 +25,7 @@ checked in.
 | "How facts move" | A table of every crossing and the clause family that carries it. Start here if you only read one page. |
 | §3.3.2–4 | Backtracking, optimality and enumeration, with the preserved set pinned down (base bits only). |
 | Interlude | The P1/P2 distinction, the W1–W9 witness suite and its ablation matrix, the coincidence trap, and the cost model. |
-| Appendices | A worked example; residues and open questions; the refuted designs, each with the witness that catches it. |
+| Appendices | A worked example; residues and open questions; the design rationale (why a binary encoding, why equality and interval atoms rather than conjunctions of inequality atoms, why a view gets its own variable); the refuted designs, each with the witness that catches it. |
 
 ## Where each invariant lives in the code
 

--- a/dev_docs/literals.md
+++ b/dev_docs/literals.md
@@ -34,7 +34,7 @@ All in `gcs/innards/proofs/names_and_ids_tracker.cc` unless noted.
 | Invariant | Maintained by |
 |---|---|
 | `Inv-Chain`, `Inv-Bound` | `need_gevar` (the chain `pol`s, and `fix_bound`) |
-| `Inv-Cut` | `define_plain_invar`'s two `need_gevar` calls; `need_all_proof_names_in` on an eq atom's reification |
+| `Inv-Thresholds` | `define_plain_invar`'s two `need_gevar` calls; `need_all_proof_names_in` on an eq atom's reification |
 | `Inv-Part` | `init_interval_partition`, `ensure_partition_cut`, and `need_direct_encoding_for`'s singleton splits |
 | `Inv-Cover` | the three `emit_rup_proof_line` covering emissions in `ensure_partition_cut`, `init_interval_partition`, `define_invar_with_covering` |
 | `Inv-Cont` | `link_immediate_containment` |

--- a/dev_docs/literals.md
+++ b/dev_docs/literals.md
@@ -9,7 +9,7 @@ document:
 
 It is a revised and extended version of §3.2 and §3.3 of Matthew McIlree's
 thesis, covering the two things the thesis does not: **range ("in") literals**,
-and **several representations of one variable** (views). It keeps the thesis's
+and **several views of one variable**. It keeps the thesis's
 numbering, so Theorem 3.3 is still "complete propagation of implied atomic
 literals" and Inv1/Inv2/Inv3 are still the invariants they were there.
 
@@ -20,8 +20,8 @@ checked in.
 
 | | |
 |---|---|
-| §3.2 | The encoding procedure, extended with *representation variables* (a registered view is an encoded variable with a definitional link `V − sX = c`) and a third kind of atomic variable (`[X ∈ a..b]`, reified against two order cuts, width-1 being the eq atom). |
-| §3.3.1 | The nine invariants of the literal layer, the definition of a *defined domain* over a whole representation family, and the reproved Theorems 3.2 and 3.3 with their family versions 3.2′ and 3.3′. |
+| §3.2 | The encoding procedure, extended with *view variables* (a registered view is an encoded variable with a definitional link `V − sX = c`) and a third kind of atomic variable (`[X ∈ a..b]`, reified against two order cuts, width-1 being the eq atom). |
+| §3.3.1 | The nine invariants of the literal layer, the definition of a *defined domain* over a whole view family, and the reproved Theorems 3.2 and 3.3 with their family versions 3.2′ and 3.3′. |
 | "How facts move" | A table of every crossing and the clause family that carries it. Start here if you only read one page. |
 | §3.3.2–4 | Backtracking, optimality and enumeration, with the preserved set pinned down (base bits only). |
 | Interlude | The P1/P2 distinction, the W1–W9 witness suite and its ablation matrix, the coincidence trap, and the cost model. |
@@ -38,7 +38,7 @@ All in `gcs/innards/proofs/names_and_ids_tracker.cc` unless noted.
 | `Inv-Part` | `init_interval_partition`, `ensure_partition_cut`, and `need_direct_encoding_for`'s singleton splits |
 | `Inv-Cover` | the three `emit_rup_proof_line` covering emissions in `ensure_partition_cut`, `init_interval_partition`, `define_invar_with_covering` |
 | `Inv-Cont` | `link_immediate_containment` |
-| `Inv-Rep` | `need_view`'s backfill; the view hooks in `need_gevar` and `need_direct_encoding_for`; `mirror_invar_across_view_link` |
+| `Inv-View` | `need_view`'s backfill; the view hooks in `need_gevar` and `need_direct_encoding_for`; `mirror_invar_across_view_link` |
 | `Inv-Name` | `need_invar` (outside the definition guard) and `xliteral_for_ensuring` |
 | `Inv-Conflict`, `Inv-Domain` | the solver: every inference is logged eagerly, every backtrack writes its clause |
 

--- a/dev_docs/literals.md
+++ b/dev_docs/literals.md
@@ -1,0 +1,61 @@
+# What a literal is: the unified account
+
+The theory of the literal layer — what an order, equality or range atom *is*,
+what clauses hold the layer together, and why unit propagation can be relied on
+to re-derive a solver fact during a backtrack-clause replay — lives in one
+document:
+
+- **[literal-encodings.tex](literal-encodings.tex)**, 30 pages when typeset.
+
+It is a revised and extended version of §3.2 and §3.3 of Matthew McIlree's
+thesis, covering the two things the thesis does not: **range ("in") literals**,
+and **several representations of one variable** (views). It keeps the thesis's
+numbering, so Theorem 3.3 is still "complete propagation of implied atomic
+literals" and Inv1/Inv2/Inv3 are still the invariants they were there.
+
+Build it with `latexmk -pdf dev_docs/literal-encodings.tex`; the .pdf is not
+checked in.
+
+## What is in it
+
+| | |
+|---|---|
+| §3.2 | The encoding procedure, extended with *representation variables* (a registered view is an encoded variable with a definitional link `V − sX = c`) and a third kind of atomic variable (`[X ∈ a..b]`, reified against two order cuts, width-1 being the eq atom). |
+| §3.3.1 | The nine invariants of the literal layer, the definition of a *defined domain* over a whole representation family, and the reproved Theorems 3.2 and 3.3 with their family versions 3.2′ and 3.3′. |
+| "How facts move" | A table of every crossing and the clause family that carries it. Start here if you only read one page. |
+| §3.3.2–4 | Backtracking, optimality and enumeration, with the preserved set pinned down (base bits only). |
+| Interlude | The P1/P2 distinction, the W1–W9 witness suite and its ablation matrix, the coincidence trap, and the cost model. |
+| Appendices | A worked example; residues and open questions; the refuted designs, each with the witness that catches it. |
+
+## Where each invariant lives in the code
+
+All in `gcs/innards/proofs/names_and_ids_tracker.cc` unless noted.
+
+| Invariant | Maintained by |
+|---|---|
+| `Inv-Chain`, `Inv-Bound` | `need_gevar` (the chain `pol`s, and `fix_bound`) |
+| `Inv-Cut` | `define_plain_invar`'s two `need_gevar` calls; `need_all_proof_names_in` on an eq atom's reification |
+| `Inv-Part` | `init_interval_partition`, `ensure_partition_cut`, and `need_direct_encoding_for`'s singleton splits |
+| `Inv-Cover` | the three `emit_rup_proof_line` covering emissions in `ensure_partition_cut`, `init_interval_partition`, `define_invar_with_covering` |
+| `Inv-Cont` | `link_immediate_containment` |
+| `Inv-Rep` | `need_view`'s backfill; the view hooks in `need_gevar` and `need_direct_encoding_for`; `mirror_invar_across_view_link` |
+| `Inv-Name` | `need_invar` (outside the definition guard) and `xliteral_for_ensuring` |
+| `Inv-Conflict`, `Inv-Domain` | the solver: every inference is logged eagerly, every backtrack writes its clause |
+
+## The companion documents
+
+These cover the *implementation*, and defer to the document above for the
+theory:
+
+- [range_literals_spec.md](range_literals_spec.md) — the reimplementation
+  specification: what was built, in what order, the witness suite as checked in,
+  and the edge-case inventory.
+- [view-range-literals.md](view-range-literals.md) — issue #882's write-up: the
+  ten deleted view detours, the ablation table, the measured proof sizes.
+- [view-proof-logging.md](view-proof-logging.md) — working with views as a
+  propagator author: `pol` cancellation, big-M sizing, the test harness.
+
+## Further reading
+
+Matthew McIlree, *Proof Logging for Constraint Programming*, PhD thesis,
+University of Glasgow, 2026. <https://theses.gla.ac.uk/86049/>

--- a/dev_docs/literals.md
+++ b/dev_docs/literals.md
@@ -47,13 +47,21 @@ All in `gcs/innards/proofs/names_and_ids_tracker.cc` unless noted.
 These cover the *implementation*, and defer to the document above for the
 theory:
 
-- [range_literals_spec.md](range_literals_spec.md) — the reimplementation
-  specification: what was built, in what order, the witness suite as checked in,
-  and the edge-case inventory.
-- [view-range-literals.md](view-range-literals.md) — issue #882's write-up: the
-  ten deleted view detours, the ablation table, the measured proof sizes.
+- [range_literals_spec.md](range_literals_spec.md) — what was built, in what
+  order, which witness test guards what, and the edge-case inventory. Its
+  section numbers are cited from the code; don't renumber them.
+- [view-range-literals.md](view-range-literals.md) — issue #882's record: where
+  the naming trigger lives in the code, the measured role divergence between the
+  two sides, and the residue.
 - [view-proof-logging.md](view-proof-logging.md) — working with views as a
-  propagator author: `pol` cancellation, big-M sizing, the test harness.
+  propagator author: `pol` cancellation, big-M sizing, the test harness. Its
+  three numbered invariants are cited by number from `difference-logic.md` and
+  from `difference_constraints.cc`.
+
+Between them and the document above the rule is: **statements, arguments and
+measured numbers live in `literal-encodings.tex`; function names, test names,
+dates and decisions live in the Markdown.** A number in two places is a number
+that will disagree with itself.
 
 ## Further reading
 

--- a/dev_docs/literals.md
+++ b/dev_docs/literals.md
@@ -5,7 +5,7 @@ what clauses hold the layer together, and why unit propagation can be relied on
 to re-derive a solver fact during a backtrack-clause replay — lives in one
 document:
 
-- **[literal-encodings.tex](literal-encodings.tex)**, 34 pages when typeset.
+- **[literal-encodings.tex](literal-encodings.tex)**, 35 pages when typeset.
 
 It is a revised and extended version of §3.2 and §3.3 of Matthew McIlree's
 thesis, covering the two things the thesis does not: **range ("in") literals**,

--- a/dev_docs/literals.md
+++ b/dev_docs/literals.md
@@ -65,5 +65,7 @@ that will disagree with itself.
 
 ## Further reading
 
-Matthew McIlree, *Proof Logging for Constraint Programming*, PhD thesis,
-University of Glasgow, 2026. <https://theses.gla.ac.uk/86049/>
+Matthew McIlree, *Pseudo-Boolean Proof Logging for Constraint Propagation
+Algorithms*, PhD thesis, University of Glasgow, 2026.
+<https://theses.gla.ac.uk/86049/> — that is the exact title; it is not "Proof
+Logging for Constraint Programming", which is the title of its chapter 3.

--- a/dev_docs/range_literals_spec.md
+++ b/dev_docs/range_literals_spec.md
@@ -1,132 +1,105 @@
-# Range ("in") literals: reimplementation design specification
+# Range ("in") literals: implementation specification
+
+**Theory.** The definitions, invariants and completeness proofs for this layer
+now live in [literal-encodings.tex](literal-encodings.tex), a revised version of
+§3.2 and §3.3 of Matthew's thesis covering interval literals and views. Read
+that first, or [literals.md](literals.md) for the index. **This document is what
+was built, in what order, and what to be careful of** — the API propagator
+authors see, the witness suite as checked in, the status log, and the edge-case
+inventory.
 
 **Status.** This spec supersedes the design narrative that lived in
 `dev_docs/range_literals.md` and `dev_docs/range_literals_theory.md` on the
 `range-literals` branch (PR #281). That branch is retained, unmerged, as the
-archaeological record; its conclusions that survive are restated here, and its
-conclusions that were wrong are listed in Appendix B with the test that
-catches each. This branch (`range-literal-foundation`) carries the parts of
-that work that the new design keeps unchanged; everything else is to be
-implemented fresh, against this spec.
+archaeological record; its conclusions that survive are restated here or in
+`literal-encodings.tex`, and its conclusions that were wrong are listed in
+Appendix B with the test that catches each.
 
 **Audience.** Someone implementing or reviewing the interval-literal layer of
-the proof encoding. Familiarity with the McIlree thesis machinery (BinEnc,
-order atoms `x≥v`, eq atoms `x=v`, Inv1/Inv2/Inv3, Theorems 2.7–2.9, 3.2–3.4)
-is assumed.
+the proof encoding.
 
 ---
 
 ## 1. Two ways a proof goes wrong — read this first
 
-Throughout, "UP" means plain unit propagation from the empty assignment,
-with no case-splitting: the propagation a RUP check performs after asserting
-the negation of the line being checked. Everything that went wrong in the
-first implementation attempt, three separate times, came from conflating two
-failure modes that look identical on small tests:
+*Stated in full, with the rule that follows from it, in the "Interlude" of
+[literal-encodings](literal-encodings.tex).* In brief:
 
-- **P1.** A line we emit is not itself accepted by VeriPB. These failures
-  are loud, immediate, and local: veripb rejects at the line, and the error
-  points at the culprit.
+- **P1.** A line we emit is not itself accepted by VeriPB. Loud, immediate,
+  local: veripb rejects at the line and the error points at the culprit.
+- **P2.** Every line checks individually, but the clause set does not keep UP
+  strong enough for **later** RUP checks — backtrack clauses, other constraints'
+  inferences — to re-derive the solver facts they depend on. The rejection lands
+  on an unrelated later line, only under composition, only for particular search
+  shapes.
 
-- **P2.** Every line checks individually, but the clause set does not keep
-  UP strong enough for **later** RUP checks — backtrack clauses, other
-  constraints' inferences — to re-derive the solver facts they depend on.
-  The root cause of the eventual proof failure is then nowhere near the line
-  VeriPB takes issue with: the rejection lands on an unrelated later line
-  (typically a backtrack clause), only under composition, only for
-  particular search shapes, and the missing clause is the real culprit.
+The operative consequence, which every section below assumes:
 
-The trap: **a RUP check is strictly stronger than the single UP pass later
-checks rely on, so every P2 clause looks deletable under P1 testing.** Any
-linking clause can be removed and a local test stays green, because RUP
-re-finds the derivation that UP would have needed the clause for. "This
-clause was never load-bearing in my tests" is *always* observable for P2
-clauses on small tests. It is not evidence. The only evidence that a P2
-clause is unnecessary is passing the witness suite of §8, which was built so
-that each clause family's removal fails within milliseconds.
+> **A RUP check is strictly stronger than the single UP pass later checks rely
+> on, so every P2 clause looks deletable under P1 testing.**
 
-Each clause family below is labelled with the failure mode it guards
-against.
+Any linking clause can be removed and a local test stays green. "This clause was
+never load-bearing in my tests" is *always* observable for P2 clauses on small
+tests. It is not evidence. The only evidence that a P2 clause is unnecessary is
+passing the witness suite of §8. Each clause family below is labelled with the
+failure mode it guards against.
 
 ## 2. The objects
 
-For a plain integer variable X (views and constants: see §9.1):
+*Definitions and their PB forms are §3.3.1 of
+[literal-encodings](literal-encodings.tex); this is the one-line index.*
 
 | object | meaning | definition |
 |---|---|---|
 | bits | BinEnc(X) | core OPB |
-| `x≥v` (gevar) | order atom | reified on the bit sum; chained (Inv1) |
-| `x=v` (eqvar) | direct atom | `⇔ (x≥v ∧ ¬x≥v+1)` |
-| `[x in a..b]` (invar) | interval literal | `⇔ (x≥a ∧ ¬x≥b+1)`, `a < b` |
+| `x>=v` (gevar) | order atom | reified on the bit sum; chained (Inv1) |
+| `x=v` (eqvar) | direct atom | `<=> (x>=v & ~x>=v+1)` |
+| `[x in a..b]` (invar) | interval literal | `<=> (x>=a & ~x>=b+1)`, `a < b` |
 
 An interval literal is a *wide equality atom*: same shape of definition, two
-cuts. **A width-1 interval IS the eq atom**: `need_invar(v, v)` must return
-the eq atom itself, never a separate flag. A separate width-1 flag is an
-unlinked doppelgänger of the eq atom (same boundary cuts, different Boolean,
-nothing connects them) and is the subject of witness W1.
+cuts. **A width-1 interval IS the eq atom**: `need_invar(v, v)` must return the
+eq atom itself, never a separate flag. A separate width-1 flag is an unlinked
+doppelganger of the eq atom (same boundary cuts, different Boolean, nothing
+connects them) and is the subject of witness W1.
 
 ## 3. The invariant: always-covered partitions
 
-The interval literals on each variable are maintained so that, at all times:
+*The statement and the proof of what these clauses buy have moved to §3.3.1 of
+[literal-encodings](literal-encodings.tex), where they are the invariants
+`Inv-Part`, `Inv-Cover` and `Inv-Cont`, and to
+[literals.md](literals.md), which maps each invariant to the function that
+maintains it.* What follows is the implementation summary only.
 
-1. **Partition.** The minimal ("leaf cell") literals partition the variable's
-   initial bound range. Cells are intervals; width-1 cells are eq atoms.
+Interval literals on each variable are maintained so that, at all times:
+
+1. **Partition** (`init_interval_partition`, `ensure_partition_cut`). The leaf
+   cells partition the variable's initial bound range. Cells are intervals;
+   width-1 cells are eq atoms. Every in-bounds endpoint of every defined eq or
+   interval literal is a partition boundary — which is why
+   `need_direct_encoding_for` cuts at `v` and `v+1` on a partitioned variable.
 2. **Every requested interval is a union of adjacent cells.** A request whose
-   endpoint falls strictly inside an existing cell *splits* that cell first
-   (≤ 2 splits per request, one per endpoint).
-3. **Covering (P2).** Every non-leaf literal carries one clause
-   `F → C₁ ∨ … ∨ Cₖ` over a partition of itself into existing literals,
-   emitted once when F is defined (or when F is split, for the two halves).
-   Coverings compose through UP across refinements — to falsify a node,
-   falsify its pieces, recursively — so a covering is never revisited or
-   re-emitted after later splits.
-4. **Root covering (P2).** Each variable with any interval literal carries
-   one clause `C₁ ∨ … ∨ Cₖ ≥ 1` over its top-level partition (RUP from the
-   lb/ub axioms). This is the flag-level analogue of the direct encoding's
-   at-least-one clause, and gives wipeout detection (Theorem 3.2 analogue)
-   without descending to the bits.
-
-   *Decided (2026-06-11 review):* conceptually this is the covering of the
-   whole-variable literal `[x in lb..ub]`, so the covering rule is uniform
-   with no special root case — but that literal is **never materialised**.
-   The clause over the top-level partition is emitted directly: it has the
-   same propagation power given the root bound units, positively asserts the
-   last surviving piece without a detour through a root reification (which is
-   what feeds Theorem 2.8 value-crossing), and avoids introducing a literal
-   nothing else references.
-5. **Containment (P2).** Child → parent edges (`¬C ∨ F` for C immediately
-   inside F), as in the current implementation. Needed so a *rejected*
-   literal (`¬F` as a branching decision or derived fact) pushes down to the
-   atoms a conflict is written over. Note requests may overlap (e.g.
-   `[7,15]` after `[5,10]`): the family is a DAG, not a tree; cells remain a
-   partition; multiple incomparable parents are fine (this already works).
-6. **Reification (P1+P2).** The usual red pair per literal. The reverse
-   direction `(F ∨ ¬x≥a ∨ x≥b+1)` is what lets a bound walk past a dead
-   interval (hole-jump) and is also what falsifies F when a bound crosses it
-   — bound-truncation needs no special clauses given (3).
+   endpoint falls strictly inside an existing cell splits that cell first
+   (at most 2 splits per request, one per endpoint).
+3. **Covering** (P2). Every non-cell literal carries one clause
+   `F -> C1 v ... v Ck` over a partition of itself into existing literals, and
+   every split cell carries `C -> C1 v C2`. Coverings compose through UP across
+   later refinements, so a covering is never revisited or re-emitted.
+4. **Root covering** (P2). One clause over the top-level partition, emitted at
+   partition creation. UP-redundant (see §5) and kept anyway.
+5. **Containment** (P2). Child-to-parent edges (`~C v F`) between immediate
+   neighbours, via a per-variable interval tree. Requests may overlap without
+   nesting, so the family is a DAG; cells remain a partition.
+6. **Reification** (P1+P2). The usual red pair per literal.
 
 All of these are **state-independent tautologies of the encoding, emitted at
 `ProofLevel::Top`**. There is no search-state bookkeeping, nothing to undo on
-backtrack, and emission order does not matter for soundness (each clause is
-RUP at emission given the reifications and the chain). This is what makes the
-invariant maintainable at definition time: the alternative ("emit a covering over
-whatever facts currently witness the exclusion") is also sound but drags
-search state into the tracker; it was considered and rejected — see
-Appendix B7.
+backtrack, and emission order does not matter for soundness. The alternative
+("emit a covering over whatever facts currently witness the exclusion") is also
+sound but drags search state into the tracker; it was considered and rejected —
+refuted design 7 in Appendix C of `literal-encodings.tex`.
 
 Lazy throughout: nothing is defined for a variable until the first interval
 request, exactly as gevars are lazy today.
-
-### 3.1 Worked example
-
-X in 1..20. First request `[5,10]` (from any source — conclusion, reason, or
-branch guess): define `[1,4]`, `[5,10]`, `[11,20]` (cells), the root covering
-`[1,4] ∨ [5,10] ∨ [11,20]`, reifications, no containment yet (no nesting).
-Next request `[7,15]`: split `[5,10]` into `[5,6]`,`[7,10]` (covering
-`[5,10] → [5,6] ∨ [7,10]`), split `[11,20]` into `[11,15]`,`[16,20]`
-(covering), define `[7,15]` with covering `[7,15] → [7,10] ∨ [11,15]` and
-containment `[7,10] → [7,15]`, `[11,15] → [7,15]`. The root covering is not
-touched: to falsify `[5,10]` later, UP goes through its own covering.
 
 ## 4. One vocabulary, end to end
 
@@ -139,7 +112,8 @@ encoding layer, never by propagator authors:
   `¬[lo,hi]` (defined the same way). There is **no per-value reason loop and
   no after-the-fact coalescing pass**: the Stage-2 coalescer
   (`coalesce_holes_in_reason`, `GCS_RANGE_REASONS`) is deleted, not ported.
-  It introduced flags that nothing could falsify (Appendix B4/B5); under this
+  It introduced flags that nothing could falsify (refuted designs 4 and 5 in
+  Appendix C of `literal-encodings.tex`); under this
   spec the covering makes any defined literal falsifiable, and the reason
   never materialises per-value eq atoms.
 - **Branching.** Range guesses are ordinary range conditions, mapping to the
@@ -175,58 +149,50 @@ independent functions is how they drift. A run whose variable is a view is
 spelled per value, per §9.1 — one run, not the whole rule, and the witness does
 not notice, because stepping over a run is internal to that variable either way.
 
-## 5. Why this is believed complete (and what still needs proving)
+## 5. Why this is complete
 
-Intra-variable falsification induction: if interval F is truly excluded by
-the facts UP has, then every piece of F's covering is excluded, each either
-by a **bound** (its reverse reification fires via the chain), by a **derived
-or asserted ¬ancestor** (containment pushes down; order-independent because
-edges are emitted whenever either endpoint is created), or **recursively** by
-its own covering — grounding out at cells, whose exclusions are exactly the
-logged conclusions. Positive directions (assert F → bounds; sandwiched bounds
-→ F; F ∧ ¬child → sibling) come from reification + chain + covering.
+*Resolved.* What this section used to record as lemma obligations L1 and L2 are
+now proved, as Theorems 3.3 / 3.3' (complete propagation of implied atomic
+literals, over a whole representation family) and Theorem 3.5, in
+[literal-encodings](literal-encodings.tex). Read §3.3.1 there for the argument
+and the invariants it depends on, and the "How facts move" table for which
+clause family carries which crossing.
 
-Cross-variable, nothing new is needed: reasons and conclusions are
-single-literal interval facts; values cross bit-sum equalities by Theorem 2.8,
-contradictions by 2.7/2.9, and the *backtracking* obligation (Inv2) reduces to
-leaf-conflict replays (a parent backtrack clause is RUP from its two child
-clauses), where the path's own inference clauses are live and fire over the
-vocabulary above. **A lone bound still cannot cross a bit-sum equality — the
-thesis Example 2.15 limit is real — but no replay obligation requires it once
-the vocabulary is complete.** The 2026-06 experiments that seemed to show
-otherwise were P2 gaps in disguise (Appendix B).
+Two results from that write-up are worth knowing before touching this code:
 
-**Lemma obligations (to be formalised, not assumed):**
+- **The root covering (§3.4) is UP-redundant.** Wipeout detection at the literal
+  level follows from the reverse reifications and the order chain alone: a
+  negated interval literal, combined with a bound that has reached its lower cut,
+  jumps the bound over the whole interval in one step. This was observed here in
+  §8.1 as an unexplained fact; it is now Remark 3.2 there, with a proof. We are
+  *not* proposing to remove the clause — see the change protocol.
+- **The coverings and containment edges exist for the reasons, not for wipeout.**
+  They are what makes a negated interval literal falsifiable by unit propagation,
+  which is what Lemma 3.4 (reason validity) needs.
 
-- **L1 (intra-variable).** With §3 maintained, the {gevar, eqvar, invar}
-  layer is UP-complete with respect to the variable's possible
-  values: every implied literal propagates, and an empty domain propagates to
-  contradiction. (Induction over the partition DAG; extends Theorem 3.3.)
-- **L2 (Inv2 restoration).** With L1, reasons/conclusions in interval
-  vocabulary, and eager per-inference logging, every backtrack clause is RUP
-  (leaf-replay induction over trail order + parent-from-children).
-
-Empirical support, for calibration only (it is not a proof): 3,204,000
-randomized instances with interval inference enabled and zero veripb
-failures, once the only-then-known P2 gap (width-1) was closed; every
-remaining failure class reproduced and then eliminated by exactly the clauses
-this spec mandates, validated by hand-elaborating the failing proofs.
+Empirical support, for calibration only: 3,204,000 randomized instances with
+interval inference enabled and zero veripb failures, once the only-then-known P2
+gap (width-1) was closed; every remaining failure class reproduced and then
+eliminated by exactly the clauses this spec mandates, validated by
+hand-elaborating the failing proofs.
 
 ## 6. Cost model
 
-Per distinct requested interval: ≤ 2 cell splits (≤ 4 new literals, of which
-width-1 pieces are eq atoms) + the requested literal; 2 red lines per literal,
-binary coverings per split, one covering for the request (width = number of
-pieces it spans), O(immediate neighbours) containment edges. **Nothing is
-O(domain width)** — that was the point of interval literals, and the first
-implementation lost it twice by materialising per-value eq atoms through
-reason naming and through `In`'s per-value root pruning.
+Per distinct requested interval: at most 2 cell splits (at most 4 new literals,
+of which width-1 pieces are eq atoms) plus the requested literal; 2 red lines
+per literal; binary coverings per split; one covering for the request; and
+`O(immediate neighbours)` containment edges. **Nothing is O(domain width)** —
+that was the point of interval literals, and the first implementation lost it
+twice, by materialising per-value eq atoms through reason naming and through
+`In`'s per-value root pruning.
 
 Known growth mode: a wide request over a heavily fragmented region gets a
-covering as wide as the number of prior boundaries inside it (bounded by
-request count, not domain size). Acceptable; measure, don't pre-optimise.
-Flag reuse is high in practice (measured ~40× per flag under interval
-branching), so per-literal fixed costs amortise.
+covering as wide as the number of prior boundaries inside it, bounded by request
+count rather than domain size. Acceptable; measure, don't pre-optimise. Flag
+reuse is high in practice (measured ~40x per flag under interval branching), so
+per-literal fixed costs amortise. The measured numbers, including what a view
+adds, are in the "Cost" part of
+[literal-encodings](literal-encodings.tex).
 
 ## 7. What this branch already contains (kept from PR #281)
 
@@ -439,57 +405,24 @@ and which branching were active.
    codebase's `//` line-ending convention applies in cxxopts blocks only —
    write emission code so reformatting cannot reorder emission.
 
-## Appendix A — glossary of the failure that motivated all of this
+## Appendix A — the failure that motivated all of this
 
-A backtrack clause `Bt = ¬d₁ ∨ … ∨ ¬dₖ` is checked by RUP: assert all
-decisions, expect UP to re-reach the conflict. Every solver inference along
-the path is logged as `reason → conclusion` and is live, so the replay
-succeeds exactly when each reason's literals become UP-units in turn. The
-moment any solver fact is held in a Boolean that UP cannot derive from the
-others — a width-1 doppelgänger, an uncovered reason flag, a union literal —
-the chain stops, veripb rejects Bt, and the trace (six lines long, in W1)
-*looks like* "UP cannot thread a bound across the equality" because the
-bound-crossing steps are the next thing the stalled trail would have needed.
-That misdiagnosis cost two sessions and a theory document. The bound-crossing
-limit is real (thesis Example 2.15); it just was never the binding
-constraint.
+The glossary that lived here — what a backtrack clause is, why it is checked by
+RUP, and how a missing P2 clause makes the trace *look* like "unit propagation
+cannot thread a bound across the equality" — is now "What this does not provide"
+in [literal-encodings](literal-encodings.tex), where it sits next to the
+statement of what actually is and is not derivable. The bound-crossing limit is
+real (thesis Example 2.15); it just was never the binding constraint.
 
-## Appendix B — refuted designs and simplifications. Do not retry without new theory.
+## Appendix B — refuted designs
 
-Each entry: the claim, why it looked right, what catches it now.
+Moved to Appendix C of [literal-encodings](literal-encodings.tex), which lists
+each refuted design together with the witness that catches it, and adds the two
+that issue #882 produced (deviewing an interval, and "a registered view needs no
+interval linking").
 
-1. **"Reify to cuts + the order chain; no covering, no containment"**
-   (Stage 0). Looked right: a falsification matrix of *derivations* all
-   passed — P1 only. Caught by: W4 (containment), W2/W3/W5 (covering).
-2. **"Containment yes, covering unnecessary — the chain gives those
-   deductions"** (Phase A). True for RUP-derivability, false for UP.
-   Caught by: W2, W3.
-3. **"A range removal is one RUP line, per-value facts follow free"**
-   (early Stage 3). False across bit-sum equalities; needs the 2.9 bridge
-   lemmas (kept, in `justify_not_in_range_across_equality`). Caught by:
-   `range_infer_test` with the bridge deleted.
-4. **Coalescing per-value reasons into flags after the fact**
-   (Stage 2, `GCS_RANGE_REASONS`). Mints literals that nothing concludes and
-   nothing covers; un-falsifiable in replays; also materialises the eq atoms
-   anyway via reason naming. Deleted. Caught by: W2, W3.
-5. **Width-1 range flags** (Stage 3 consumer). Doppelgängers of eq atoms.
-   Caught by: W1.
-6. **"The composition failure is AllEqual-specific" / "2 vs ≥3 variables" /
-   "UP can't thread a bound, so a global cross-variable covering
-   `(x≥k)⇔(y≥k)` is required"** (the misdiagnosis era — pairwise OPB,
-   durable Top lemmas, and star-funnel "fixes" all evaluated on
-   width-1-contaminated populations). All artefacts of P2 gaps. W1–W3 are
-   the corrected understanding; no cross-variable covering exists in this
-   design and none is needed.
-7. **Cover-on-use over the live witness set** (instead of the partition
-   invariant). Sound, validated, but drags search state into the tracker
-   (level-aware registry of live conclusions) and makes the completeness
-   argument depend on what was live when. The partition invariant gets the
-   same clauses as state-independent tautologies. Rejected for complexity,
-   not soundness.
-
-**Change protocol.** Any proposal to weaken or remove a clause family from §3
-must (a) say which of W1–W5 it expects to remain green and why, (b) run the
-full witness suite gate-on, and (c) account for the P1/P2 distinction
-explicitly — a local green test is not evidence (§1). Three prior
-simplifications passed every test their authors thought to run.
+**Change protocol.** Any proposal to weaken or remove a clause family must
+(a) say which of W1 to W9 it expects to remain green and why, (b) run the full
+witness suite gate-on, and (c) account for the P1/P2 distinction explicitly —
+a local green test is not evidence. Three prior simplifications passed every
+test their authors thought to run.

--- a/dev_docs/range_literals_spec.md
+++ b/dev_docs/range_literals_spec.md
@@ -12,8 +12,8 @@ inventory.
 `dev_docs/range_literals.md` and `dev_docs/range_literals_theory.md` on the
 `range-literals` branch (PR #281). That branch is retained, unmerged, as the
 archaeological record; its conclusions that survive are restated here or in
-`literal-encodings.tex`, and its conclusions that were wrong are listed in
-Appendix B with the test that catches each.
+`literal-encodings.tex`, and its conclusions that were wrong are listed, each
+with the witness that catches it, in that document's Appendix C.
 
 **Audience.** Someone implementing or reviewing the interval-literal layer of
 the proof encoding.
@@ -22,84 +22,45 @@ the proof encoding.
 
 ## 1. Two ways a proof goes wrong — read this first
 
-*Stated in full, with the rule that follows from it, in the "Interlude" of
-[literal-encodings](literal-encodings.tex).* In brief:
-
-- **P1.** A line we emit is not itself accepted by VeriPB. Loud, immediate,
-  local: veripb rejects at the line and the error points at the culprit.
-- **P2.** Every line checks individually, but the clause set does not keep UP
-  strong enough for **later** RUP checks — backtrack clauses, other constraints'
-  inferences — to re-derive the solver facts they depend on. The rejection lands
-  on an unrelated later line, only under composition, only for particular search
-  shapes.
-
-The operative consequence, which every section below assumes:
+*Stated in full in the "Interlude" of
+[literal-encodings](literal-encodings.tex).* The one-line version, which every
+section below assumes:
 
 > **A RUP check is strictly stronger than the single UP pass later checks rely
 > on, so every P2 clause looks deletable under P1 testing.**
 
-Any linking clause can be removed and a local test stays green. "This clause was
-never load-bearing in my tests" is *always* observable for P2 clauses on small
-tests. It is not evidence. The only evidence that a P2 clause is unnecessary is
-passing the witness suite of §8. Each clause family below is labelled with the
-failure mode it guards against.
+P1 is "a line we emit is rejected" — loud and local. P2 is "every line checks,
+but unit propagation is no longer strong enough for a backtrack clause three
+thousand lines later" — and the rejection lands nowhere near the cause. The only
+evidence that a P2 clause is unnecessary is passing the witness suite of §8.
 
 ## 2. The objects
 
-*Definitions and their PB forms are §3.3.1 of
-[literal-encodings](literal-encodings.tex); this is the one-line index.*
+*Their PB definitions are §3.3.1 of
+[literal-encodings](literal-encodings.tex).* This table is the mapping from
+the code's names, which that document does not use:
 
-| object | meaning | definition |
+| code | document | definition |
 |---|---|---|
-| bits | BinEnc(X) | core OPB |
-| `x>=v` (gevar) | order atom | reified on the bit sum; chained (Inv1) |
-| `x=v` (eqvar) | direct atom | `<=> (x>=v & ~x>=v+1)` |
-| `[x in a..b]` (invar) | interval literal | `<=> (x>=a & ~x>=b+1)`, `a < b` |
+| gevar | order atom `x>=v` | reified on the bit sum; chained (`Inv-Chain`) |
+| eqvar | equality atom `x=v` | `<=> (x>=v & ~x>=v+1)` |
+| invar | interval literal `[x in a..b]` | `<=> (x>=a & ~x>=b+1)`, `a < b` |
 
-An interval literal is a *wide equality atom*: same shape of definition, two
-cuts. **A width-1 interval IS the eq atom**: `need_invar(v, v)` must return the
-eq atom itself, never a separate flag. A separate width-1 flag is an unlinked
-doppelganger of the eq atom (same boundary cuts, different Boolean, nothing
-connects them) and is the subject of witness W1.
+`need_invar(v, v)` returns the eq atom itself, never a separate flag
+(Definition 3.2 there; witness W1).
 
 ## 3. The invariant: always-covered partitions
 
-*The statement and the proof of what these clauses buy have moved to §3.3.1 of
-[literal-encodings](literal-encodings.tex), where they are the invariants
-`Inv-Part`, `Inv-Cover` and `Inv-Cont`, and to
-[literals.md](literals.md), which maps each invariant to the function that
-maintains it.* What follows is the implementation summary only.
+*The invariants are `Inv-Part`, `Inv-Cover` and `Inv-Cont` of §3.3.1 of
+[literal-encodings](literal-encodings.tex); [literals.md](literals.md) maps each
+to the function that maintains it.* Two implementation facts that live here and
+nowhere else:
 
-Interval literals on each variable are maintained so that, at all times:
-
-1. **Partition** (`init_interval_partition`, `ensure_partition_cut`). The leaf
-   cells partition the variable's initial bound range. Cells are intervals;
-   width-1 cells are eq atoms. Every in-bounds endpoint of every defined eq or
-   interval literal is a partition boundary — which is why
-   `need_direct_encoding_for` cuts at `v` and `v+1` on a partitioned variable.
-2. **Every requested interval is a union of adjacent cells.** A request whose
-   endpoint falls strictly inside an existing cell splits that cell first
-   (at most 2 splits per request, one per endpoint).
-3. **Covering** (P2). Every non-cell literal carries one clause
-   `F -> C1 v ... v Ck` over a partition of itself into existing literals, and
-   every split cell carries `C -> C1 v C2`. Coverings compose through UP across
-   later refinements, so a covering is never revisited or re-emitted.
-4. **Root covering** (P2). One clause over the top-level partition, emitted at
-   partition creation. UP-redundant (see §5) and kept anyway.
-5. **Containment** (P2). Child-to-parent edges (`~C v F`) between immediate
-   neighbours, via a per-variable interval tree. Requests may overlap without
-   nesting, so the family is a DAG; cells remain a partition.
-6. **Reification** (P1+P2). The usual red pair per literal.
-
-All of these are **state-independent tautologies of the encoding, emitted at
-`ProofLevel::Top`**. There is no search-state bookkeeping, nothing to undo on
-backtrack, and emission order does not matter for soundness. The alternative
-("emit a covering over whatever facts currently witness the exclusion") is also
-sound but drags search state into the tracker; it was considered and rejected —
-refuted design 7 in Appendix C of `literal-encodings.tex`.
-
-Lazy throughout: nothing is defined for a variable until the first interval
-request, exactly as gevars are lazy today.
+- Everything is emitted at `ProofLevel::Top`. There is no search-state
+  bookkeeping and nothing to undo on backtrack, which is what makes the
+  invariant maintainable at definition time.
+- Lazy throughout: nothing is defined for a variable until its first interval
+  request, exactly as gevars are lazy today.
 
 ## 4. One vocabulary, end to end
 
@@ -151,55 +112,27 @@ not notice, because stepping over a run is internal to that variable either way.
 
 ## 5. Why this is complete
 
-*Resolved.* What this section used to record as lemma obligations L1 and L2 are
-now proved, as Theorems 3.3 / 3.3' (complete propagation of implied atomic
-literals, over a whole representation family) and Theorem 3.5, in
-[literal-encodings](literal-encodings.tex). Read §3.3.1 there for the argument
-and the invariants it depends on, and the "How facts move" table for which
-clause family carries which crossing.
-
-Two results from that write-up are worth knowing before touching this code:
-
-- **The root covering (§3.4) is UP-redundant.** Wipeout detection at the literal
-  level follows from the reverse reifications and the order chain alone: a
-  negated interval literal, combined with a bound that has reached its lower cut,
-  jumps the bound over the whole interval in one step. This was observed here in
-  §8.1 as an unexplained fact; it is now Remark 3.2 there, with a proof. We are
-  *not* proposing to remove the clause — see the change protocol.
-- **The coverings and containment edges exist for the reasons, not for wipeout.**
-  They are what makes a negated interval literal falsifiable by unit propagation,
-  which is what Lemma 3.4 (reason validity) needs.
-
-Empirical support, for calibration only: 3,204,000 randomized instances with
-interval inference enabled and zero veripb failures, once the only-then-known P2
-gap (width-1) was closed; every remaining failure class reproduced and then
-eliminated by exactly the clauses this spec mandates, validated by
-hand-elaborating the failing proofs.
+*Resolved and moved.* The lemma obligations this section used to record as L1
+and L2 are proved as Theorems 3.3 / 3.3' and Theorem 3.5 of
+[literal-encodings](literal-encodings.tex). Two of its results bear on this code
+directly: wipeout detection does **not** need the coverings (Remark 3.2 — the
+root covering is UP-redundant, and we keep it anyway), and the coverings and
+containment edges exist for reason validity (Lemma 3.4).
 
 ## 6. Cost model
 
-Per distinct requested interval: at most 2 cell splits (at most 4 new literals,
-of which width-1 pieces are eq atoms) plus the requested literal; 2 red lines
-per literal; binary coverings per split; one covering for the request; and
-`O(immediate neighbours)` containment edges. **Nothing is O(domain width)** —
-that was the point of interval literals, and the first implementation lost it
-twice, by materialising per-value eq atoms through reason naming and through
-`In`'s per-value root pruning.
-
-Known growth mode: a wide request over a heavily fragmented region gets a
-covering as wide as the number of prior boundaries inside it, bounded by request
-count rather than domain size. Acceptable; measure, don't pre-optimise. Flag
-reuse is high in practice (measured ~40x per flag under interval branching), so
-per-literal fixed costs amortise. The measured numbers, including what a view
-adds, are in the "Cost" part of
-[literal-encodings](literal-encodings.tex).
+*Measured numbers, including what a view adds, are the "Cost" part of
+[literal-encodings](literal-encodings.tex).* The rule to hold on to: **nothing
+is O(domain width)** — that was the point of interval literals, and the first
+implementation lost it twice, by materialising per-value eq atoms through reason
+naming and through `In`'s per-value root pruning.
 
 ## 7. What this branch already contains (kept from PR #281)
 
 Sound under this spec, and either already correct or a strict subset of §3:
 
 - `need_invar` reification + idempotence; Inv1 chain threading (`need_gevar`).
-- Laminar containment edges, immediate-parent/child (Phase A/B) — §3.5.
+- Laminar containment edges, immediate-parent/child (Phase A/B) — `Inv-Cont`.
 - The `BranchGuess` guess channel, `reject_random_interval` (width-1 → eq
   atom), backtrack clauses over range guesses; suite-default interval-reject
   branching as a standing regression net.
@@ -228,7 +161,8 @@ Sound under this spec, and either already correct or a strict subset of §3:
   off) with the width-1 guard.
 
 To be implemented fresh: partition + splits + coverings + root covering in
-`need_invar` (§3.1–3.4), `need_invar(v,v)` returning the eq atom, first-class
+`need_invar` (the partition, the coverings and the root covering),
+`need_invar(v,v)` returning the eq atom, first-class
 interval reason elements (§4), retiring the env gates once §8 is in place.
 
 *Status (2026-06-11, revised same day): all of the above implemented.
@@ -263,48 +197,22 @@ literals rather than by scanning them.*
 
 ## 8. The witness suite — the actual defence against re-simplification
 
-Each clause family has a deterministic counterexample that fails veripb
-within milliseconds if that family is removed or weakened. These MUST be
-checked in as gate-on, veripb-verified tests alongside the reimplementation,
-and any change to the clause set MUST run them. They are all tiny (2–3
-variables, 2–3 bits, one scripted decision pair) and were each found the
-expensive way.
+*What each witness guards, its shape, and the W6–W9 ablation matrix are the
+"Interlude" of [literal-encodings](literal-encodings.tex). This section is the
+operational record: which test, gated how, validated how.*
 
-- **W1 — width-1 unification** (else: first backtrack clause not RUP).
-  `a∈{0,2,3}, b∈{0,1,3}, c∈{0,1,2,3}`; `Equals(a,b)`, `Equals(b,c)`,
-  `NotEquals(a,c)`; branch `c≠0` then `c=0`. If width-1 removals make flags
-  instead of using eq atoms, the replay stalls in 6 steps: "b lost 1" is
-  locked inside `¬f[in_b_1_1]` with no link to `b=1`.
-- **W2 — reason falsifiability, exact match** (else: first backtrack clause
-  not RUP). `a∈0..4, b∈{0,4}`; `Equals(a,b)`, `NotEquals(a,b)`; branch
-  `a≠0` then `a=0`. Two variables suffice: the reason names `¬[b in 1..3]`,
-  and if that literal cannot be falsified by UP (no covering, hole concluded
-  in a different vocabulary), the replay stalls in 5 steps. Kills the
-  "two-variable isolation is safe" heuristic as well: safety claims made on
-  one vocabulary mode do not transfer.
-- **W3 — union coverage** (else: first backtrack clause not RUP).
-  `a∈{0,1,2,3,7}, b∈{0,4,5,6,7}, c∈0..7`; `Equals(a,b)`, `Equals(b,c)`,
-  `NotEquals(a,c)`; branch `c≠0` then `c=0`. b's combined hole [1,6] is
-  concluded as [1,3] and [4,6] separately; the reason names `¬[b in 1..6]`.
-  Containment points the wrong way; only the covering
-  `[1,6] → [1,3] ∨ [4,6]` (one RUP line) lets the replay through. This is
-  the partition invariant earning its keep: under §3, `[1,6]` is defined as a
-  union of cells and gets that covering when defined.
-- **W6/W7/W8/W9 — the view crossing** (else: backtrack clauses not RUP).
-  W6 and W7 are the two directions of a fact crossing between a view's range
-  literals and its underlying variable's; W8 and W9 are the *trigger*, a literal
-  the partition machinery created as a cell rather than one any caller
-  requested. All four are described, with their ablation matrix and with the
-  reason the `--view-wrap` sweep is not by itself evidence, in
-  `dev_docs/view-range-literals.md`.
-- **W4 — containment** (else: backtrack clauses over interval-reject
-  decisions not RUP). Regression net: the whole constraint suite runs under
-  `reject_random_interval` by default and fails on Count/Among/Element
-  within seconds if containment edges are dropped (this is how the need for
-  them was discovered). Keep `range_branch_test` as the focused version.
-- **W5 — root covering / wipeout** (to be written with the implementation):
-  a variable whose cells are all excluded must reach contradiction by UP at
-  the flag level.
+| | test | gate |
+|---|---|---|
+| W1 | `range_witness_w1_test.cc` | gate-on, veripb-verified |
+| W2 | `range_witness_w2_test.cc` | gate-on, veripb-verified |
+| W3 | `range_witness_w3_test.cc` | gate-on, veripb-verified |
+| W4 | `range_branch_test.cc`, plus the suite-wide `reject_random_interval` branching | always on |
+| W5 | `range_witness_w5_test.cc` | gate-on, veripb-verified |
+| W6–W9 | `range_witness_w{6,7,8,9}_test.cc` | gate-on, veripb-verified |
+
+They are all tiny — 2–3 variables, 2–3 bits, one scripted decision pair — and
+each was found the expensive way. Registration is in `gcs/CMakeLists.txt`, which
+points back at this section. Any change to the clause set MUST run them all.
 
 ### 8.1 Implementation notes (2026-06-11, first full implementation)
 
@@ -326,7 +234,7 @@ were removed:
   out); W5's wipeout is also derivable by the bound-axiom walk through
   reverse reifications and the order chain, independent of the root covering.
   They stay in the suite as composed end-to-end regression nets.
-- **Observation, not a proposal**: the root covering (§3.4) appears
+- **Observation, not a proposal**: the root covering (`Inv-Cover`(iii)) appears
   UP-redundant given the bound-axiom units, the reverse reifications,
   and the Inv1 chain (the walk derives both wipeout and the positive "last
   surviving piece"). Per the change protocol this is recorded for review, not
@@ -405,24 +313,9 @@ and which branching were active.
    codebase's `//` line-ending convention applies in cxxopts blocks only —
    write emission code so reformatting cannot reorder emission.
 
-## Appendix A — the failure that motivated all of this
+## Appendix — where the theory went
 
-The glossary that lived here — what a backtrack clause is, why it is checked by
-RUP, and how a missing P2 clause makes the trace *look* like "unit propagation
-cannot thread a bound across the equality" — is now "What this does not provide"
-in [literal-encodings](literal-encodings.tex), where it sits next to the
-statement of what actually is and is not derivable. The bound-crossing limit is
-real (thesis Example 2.15); it just was never the binding constraint.
-
-## Appendix B — refuted designs
-
-Moved to Appendix C of [literal-encodings](literal-encodings.tex), which lists
-each refuted design together with the witness that catches it, and adds the two
-that issue #882 produced (deviewing an interval, and "a registered view needs no
-interval linking").
-
-**Change protocol.** Any proposal to weaken or remove a clause family must
-(a) say which of W1 to W9 it expects to remain green and why, (b) run the full
-witness suite gate-on, and (c) account for the P1/P2 distinction explicitly —
-a local green test is not evidence. Three prior simplifications passed every
-test their authors thought to run.
+The P1/P2 glossary, the refuted-design list and the change protocol that used to
+live here are all in [literal-encodings](literal-encodings.tex): the
+"Interlude" and its Appendix C. That version also carries the two refutations
+issue #882 produced, and the witness that catches each.

--- a/dev_docs/range_literals_spec.md
+++ b/dev_docs/range_literals_spec.md
@@ -116,8 +116,8 @@ not notice, because stepping over a run is internal to that variable either way.
 and L2 are proved as Theorems 3.3 / 3.3' and Theorem 3.5 of
 [literal-encodings](literal-encodings.tex). Two of its results bear on this code
 directly: wipeout detection does **not** need the coverings (the remark "The root
-covering is not load-bearing here", 3.3 as the remarks are currently numbered —
-it is UP-redundant, and we keep it anyway), and the coverings and
+covering is not load-bearing here" — it is UP-redundant, and we keep it
+anyway), and the coverings and
 containment edges exist for reason validity (Lemma 3.4).
 
 ## 6. Cost model

--- a/dev_docs/range_literals_spec.md
+++ b/dev_docs/range_literals_spec.md
@@ -115,8 +115,9 @@ not notice, because stepping over a run is internal to that variable either way.
 *Resolved and moved.* The lemma obligations this section used to record as L1
 and L2 are proved as Theorems 3.3 / 3.3' and Theorem 3.5 of
 [literal-encodings](literal-encodings.tex). Two of its results bear on this code
-directly: wipeout detection does **not** need the coverings (Remark 3.2 — the
-root covering is UP-redundant, and we keep it anyway), and the coverings and
+directly: wipeout detection does **not** need the coverings (the remark "The root
+covering is not load-bearing here", 3.3 as the remarks are currently numbered —
+it is UP-redundant, and we keep it anyway), and the coverings and
 containment edges exist for reason validity (Lemma 3.4).
 
 ## 6. Cost model

--- a/dev_docs/view-proof-logging.md
+++ b/dev_docs/view-proof-logging.md
@@ -24,30 +24,13 @@ Everything about how facts cross between the two — including the fact that uni
 propagation *cannot* do it without those clauses — is set out there, with a
 table of every crossing under "How facts move".
 
-The short version, for orientation:
-
-- A view `V = sX + c` gets its **own bit-vector** `BinEnc(V)`, its own order,
-  equality and range atoms, defined by reification exactly as chapter 3 defines
-  them for any integer variable. From the proof's point of view `V` is
-  indistinguishable from a bare variable, and every constraint body and
-  propagator inference that mentions the operand is logged purely in `V`'s atoms
-  and bits. The generic machinery never has to know it handed out a view.
-- The only thing tying `V` to `X` is a single **definitional link** axiom
-  `V - sX = c`, emitted as a `>=`/`<=` pair over the two bit vectors. This is the
-  one and only place the two encodings meet.
-- The tempting alternative — substituting `sX + c` and reasoning in `X`'s atoms
-  — makes the atoms appearing in the OPB depend on *which* wrapper a constraint
-  was given, so the generic constraint-logging code can no longer treat every
-  operand identically.
-- **Unit propagation cannot cross the link by itself.** Combining a `V`-fact
-  with the link is a *linear addition of two constraints*, and UP (hence RUP)
-  only ever derives forced literals from individual constraints — it never adds
-  two together. So a crossing must either be an explicit `pol` step, or be
-  pre-supplied in a form UP *can* consume.
-- **So we pre-derive the boundary as atom-level clauses**, lazily, for each atom
-  that actually appears: `[V >= v] <=> [X >= k]`, `[V = v] <=> [X = k]`, and
-  `[V in a..b] <=> [X in a'..b']`. Then a single atom crosses in one UP step. The
-  cost tracks the proof rather than the domain size.
+The one thing worth carrying in your head without opening it: a view gets its
+**own bit vector**, sharing no PB variable with its underlying variable's, and
+the two are related only by the definitional link axiom `V - sX = c`. Unit
+propagation cannot cross that link on its own — combining a `V`-fact with the
+link is a linear addition of two constraints, which UP never performs — so the
+framework pre-derives the crossing as atom-level clauses, lazily, for each atom
+that actually appears.
 
 The range-literal case is the one that is *not* like the others, because a
 negated range literal is a unit on neither of its cuts. Read

--- a/dev_docs/view-proof-logging.md
+++ b/dev_docs/view-proof-logging.md
@@ -12,81 +12,46 @@ The short version: every constraint currently registered in the view-wrap
 sweep verifies under every wrap. Abs and AllDifferent — historically the
 hard cases — are now in that set.
 
-## Part 1 — The idea, on top of the thesis
+## Part 1 — The idea
 
-This assumes you know the proof-logging foundations from chapter 3 of
-Matthew's thesis. Recapping only what we build on:
+**The encoding-side account is now
+[literal-encodings.tex](literal-encodings.tex)**, a revised version of §3.2 and
+§3.3 of Matthew's thesis. A view is a *representation* there (Definition 3.1); it
+is given its own encoded variable and its own complete family of atomic
+literals, joined to the underlying variable's by the definitional link
+`V - sX = c` and by the atom-level linking clauses of eqs. (3.29) to (3.31).
+Everything about how facts cross between the two — including the fact that unit
+propagation *cannot* do it without those clauses — is set out there, with a
+table of every crossing under "How facts move".
 
-- Each integer variable is represented in the pseudo-Boolean model by a
-  **bit-vector** `BinEnc(X)` (magnitude bits, plus a sign bit / offset for
-  variables that can go negative).
-- On top of the bits sit **order atoms** `[X ≥ v]` and **equality atoms**
-  `[X = v]`, each *defined* by a reified constraint against the bits
-  (`[X ≥ v] ⇔ BinEnc(X) ≥ v`), together with the order-consistency chain
-  (`[X ≥ v] → [X ≥ v-1]`).
-- The OPB file states the constraints over these atoms/bits. The proof
-  derives new facts with **RUP** (unit propagation to contradiction),
-  **`pol`** (cutting-planes: add/multiply/saturate existing lines), and
-  **`red`** (redundance-based introduction of fresh atoms).
-- A propagator inference "literal `ℓ` follows from reason `R`" is logged
-  as the clause `¬R ∨ ℓ` and discharged either by RUP or by an explicit
-  derivation.
+The short version, for orientation:
 
-### The problem a view poses
+- A view `V = sX + c` gets its **own bit-vector** `BinEnc(V)`, its own order,
+  equality and range atoms, defined by reification exactly as chapter 3 defines
+  them for any integer variable. From the proof's point of view `V` is
+  indistinguishable from a bare variable, and every constraint body and
+  propagator inference that mentions the operand is logged purely in `V`'s atoms
+  and bits. The generic machinery never has to know it handed out a view.
+- The only thing tying `V` to `X` is a single **definitional link** axiom
+  `V - sX = c`, emitted as a `>=`/`<=` pair over the two bit vectors. This is the
+  one and only place the two encodings meet.
+- The tempting alternative — substituting `sX + c` and reasoning in `X`'s atoms
+  — makes the atoms appearing in the OPB depend on *which* wrapper a constraint
+  was given, so the generic constraint-logging code can no longer treat every
+  operand identically.
+- **Unit propagation cannot cross the link by itself.** Combining a `V`-fact
+  with the link is a *linear addition of two constraints*, and UP (hence RUP)
+  only ever derives forced literals from individual constraints — it never adds
+  two together. So a crossing must either be an explicit `pol` step, or be
+  pre-supplied in a form UP *can* consume.
+- **So we pre-derive the boundary as atom-level clauses**, lazily, for each atom
+  that actually appears: `[V >= v] <=> [X >= k]`, `[V = v] <=> [X = k]`, and
+  `[V in a..b] <=> [X in a'..b']`. Then a single atom crosses in one UP step. The
+  cost tracks the proof rather than the domain size.
 
-A view `V = sX + c` (`s = ±1`, `c` an integer) is just an affine image of
-`X`. The tempting move is to write every constraint over `V` by
-substituting `sX + c` and reasoning in `X`'s atoms. That breaks down
-because constraints are posted generically over "an operand", and one `X`
-may be wrapped by several views at once. Rewriting into `X`-space makes the
-atoms that appear in the OPB depend on *which* wrapper a constraint was
-given, so the generic constraint-logging code can no longer treat every
-operand identically.
-
-### What we do instead
-
-We give the view its **own encoded variable**. `V` gets its own bit-vector
-`BinEnc(V)`, its own order and equality atoms, all defined by reification
-exactly as chapter 3 defines them for any integer variable. From the
-proof's point of view `V` is indistinguishable from a bare variable, and
-*every* constraint body and propagator inference that mentions the operand
-is logged purely in `V`'s atoms and bits. The generic machinery never has
-to know it handed out a view.
-
-The only thing tying `V` to `X` is a single **definitional link** axiom:
-
-```
-V − sX = c
-```
-
-emitted as a `≥`/`≤` pair over the two bit-vectors. This is the one and
-only place the two encodings meet.
-
-### Why that works
-
-- **Everything from chapter 3 transfers for free.** `V` has the identical
-  structure to a bare variable, so any fact the chapter-3 machinery can
-  prove about a variable, it can prove about `V`. A constraint that is
-  stated and propagated entirely in `V`-space verifies with zero awareness
-  that `X` exists.
-- **The link is only needed when an inference crosses representations** —
-  e.g. two constraints share `X` through different views, or a
-  propagator's reason is naturally about `X` but its consequence is about
-  `V`. To move a fact from `V`-space to `X`-space you *add* the `V`-form
-  line to the link: the `BinEnc(V)` terms cancel and an `X`-form line
-  drops out (and symmetrically the other way).
-- **But unit propagation cannot do that crossing by itself.** Combining a
-  `V`-fact with the link is a *linear addition of two constraints*, and UP
-  (hence RUP) only ever derives forced literals from individual
-  constraints — it never adds two together. So a crossing must either be
-  an explicit `pol` step, or be pre-supplied in a form UP *can* consume.
-- **So we pre-derive the boundary as atom-level clauses.** For each atom
-  actually used, the framework derives the biconditionals
-  `[V ≥ v] ⇔ [X ≥ k]` and `[V = v] ⇔ [X = k]` as small clauses. Then any
-  time a proof needs to carry a *single atom* across the `V`/`X` boundary,
-  UP does it in one step — no bit-chasing, no `pol`. These are emitted
-  lazily, only for atoms that appear, so the cost tracks the proof rather
-  than the domain size.
+The range-literal case is the one that is *not* like the others, because a
+negated range literal is a unit on neither of its cuts. Read
+[view-range-literals.md](view-range-literals.md) before touching it.
 
 ### The three invariants that make it sound
 

--- a/dev_docs/view-proof-logging.md
+++ b/dev_docs/view-proof-logging.md
@@ -16,8 +16,8 @@ hard cases — are now in that set.
 
 **The encoding-side account is now
 [literal-encodings.tex](literal-encodings.tex)**, a revised version of §3.2 and
-§3.3 of Matthew's thesis. A view is a *representation* there (Definition 3.1); it
-is given its own encoded variable and its own complete family of atomic
+§3.3 of Matthew's thesis. A view gets its own *view variable* there
+(Definition 3.1); it has its own complete family of atomic
 literals, joined to the underlying variable's by the definitional link
 `V - sX = c` and by the atom-level linking clauses of eqs. (3.29) to (3.31).
 Everything about how facts cross between the two — including the fact that unit

--- a/dev_docs/view-range-literals.md
+++ b/dev_docs/view-range-literals.md
@@ -61,8 +61,8 @@ are `~F_V | F_X` and `~F_X | F_V`. **Both are needed, each for its
 contrapositive rather than its implication** — as implications both directions
 are already derivable by unit propagation, which is what issue #882 observed, and
 is true but beside the point. *The argument is the remark "Both in-link clauses
-are needed, and neither for its implication" (3.2 as the remarks are currently
-numbered) of [literal-encodings.tex](literal-encodings.tex).*
+are needed, and neither for its implication" in
+[literal-encodings.tex](literal-encodings.tex).*
 
 Why the negative directions come up at all is the part specific to this code:
 search branches on real variables only (`reject_random_interval` requires a
@@ -75,9 +75,8 @@ over `X`.
 
 This is the part that is easy to get wrong, and getting it wrong is silent.
 *Why naming is the right trigger is the remark "Why naming, not requesting, is
-the trigger" (3.4 as the remarks are currently numbered) of
-[literal-encodings.tex](literal-encodings.tex);* what follows is where it lives
-in the code.
+the trigger" in [literal-encodings.tex](literal-encodings.tex);* what follows is
+where it lives in the code.
 
 A range literal comes into existence two ways. Either a caller asks for it — a
 conclusion, a reason element, a branching guess — reaching `need_invar`; or the

--- a/dev_docs/view-range-literals.md
+++ b/dev_docs/view-range-literals.md
@@ -60,8 +60,9 @@ Writing `F_V` for `[V in a..b]` and `F_X` for its image, the two clauses emitted
 are `~F_V | F_X` and `~F_X | F_V`. **Both are needed, each for its
 contrapositive rather than its implication** — as implications both directions
 are already derivable by unit propagation, which is what issue #882 observed, and
-is true but beside the point. *The argument is Remark 3.1 of
-[literal-encodings.tex](literal-encodings.tex).*
+is true but beside the point. *The argument is the remark "Both in-link clauses
+are needed, and neither for its implication" (3.2 as the remarks are currently
+numbered) of [literal-encodings.tex](literal-encodings.tex).*
 
 Why the negative directions come up at all is the part specific to this code:
 search branches on real variables only (`reject_random_interval` requires a
@@ -73,7 +74,8 @@ over `X`.
 ## 3. Linking is triggered by *naming*, not by requesting and not by defining
 
 This is the part that is easy to get wrong, and getting it wrong is silent.
-*Why naming is the right trigger is Remark 3.3 of
+*Why naming is the right trigger is the remark "Why naming, not requesting, is
+the trigger" (3.4 as the remarks are currently numbered) of
 [literal-encodings.tex](literal-encodings.tex);* what follows is where it lives
 in the code.
 

--- a/dev_docs/view-range-literals.md
+++ b/dev_docs/view-range-literals.md
@@ -51,251 +51,141 @@ corresponds to
     s = +1:  [a - c,  b - c]
     s = -1:  [c - b,  c - a]
 
-on `X`'s — the endpoints swap for a negated view, because it reverses the
-order, and the map is then its own inverse. Width is preserved either way, which
-is why a width-1 request is the eq atom on both sides and never reaches this
-machinery at all. `interval_on_underlying` and `interval_on_view` are the two
-directions.
+on `X`'s — the endpoints swap for a negated view, and the map is its own
+inverse. `interval_on_underlying` and `interval_on_view` are the two directions.
+Width is preserved either way, which is why a width-1 request is the eq atom on
+both sides and never reaches this machinery.
 
-Writing `F_V` for `[V in a..b]` and `F_X` for its image, the link is
+Writing `F_V` for `[V in a..b]` and `F_X` for its image, the two clauses emitted
+are `~F_V | F_X` and `~F_X | F_V`. **Both are needed, each for its
+contrapositive rather than its implication** — as implications both directions
+are already derivable by unit propagation, which is what issue #882 observed, and
+is true but beside the point. *The argument is Remark 3.1 of
+[literal-encodings.tex](literal-encodings.tex).*
 
-    L1:  ~F_V | F_X
-    L2:  ~F_X | F_V
-
-Each is RUP at emission: assert one and the negation of the other, and the
-forward reification gives that side's two cuts, the ge-links carry each cut
-across (for `s = -1` the two cuts swap roles, which is exactly the endpoint
-swap above), and the far side's reverse reification fires.
-
-**Both clauses are needed, and each for its contrapositive rather than for its
-implication.** As implications, both directions are already derivable by unit
-propagation — one forward reification, two ge-links, one reverse reification,
-no new clauses. That is what issue #882 observed, and it is true; it is also
-beside the point, because the directions unit propagation actually needs are the
-negative ones, and neither of those is derivable without its clause. The
-argument is Remark 3.1 of [literal-encodings.tex](literal-encodings.tex); the
-one-line version is that a negated interval literal is a *disjunction* of two
-bounds, not a conjunction, and unit propagation cannot carry a disjunction
-across one disjunct at a time.
-
-Both negative directions are ordinary rather than exotic. Search branches on
-real variables only — `reject_random_interval` requires a
-`SimpleIntegerVariableID` — while `generic_reason` states hole runs over the
+Why the negative directions come up at all is the part specific to this code:
+search branches on real variables only (`reject_random_interval` requires a
+`SimpleIntegerVariableID`), while `generic_reason` states hole runs over the
 *operand*, which under a wrap is the view. So a range decision on `X` routinely
-has to reach a reason literal on `V`, and a conclusion on `V` routinely has to
-reach a reason stated over `X`.
+has to reach a reason literal on `V`, and a conclusion on `V` a reason stated
+over `X`.
 
 ## 3. Linking is triggered by *naming*, not by requesting and not by defining
 
 This is the part that is easy to get wrong, and getting it wrong is silent.
+*Why naming is the right trigger is Remark 3.3 of
+[literal-encodings.tex](literal-encodings.tex);* what follows is where it lives
+in the code.
 
-A range literal can come into existence two ways. Either some caller asks for it
-— a conclusion, a reason element, a branching guess — which reaches
-`need_invar`; or the partition machinery creates it as a **cell**, from
-`ensure_partition_cut` or `init_interval_partition`, straight through
-`define_plain_invar`, without going anywhere near `need_invar`. A cell is
-therefore never "requested", and:
+A range literal comes into existence two ways. Either a caller asks for it — a
+conclusion, a reason element, a branching guess — reaching `need_invar`; or the
+partition machinery creates it as a **cell**, from `ensure_partition_cut` or
+`init_interval_partition`, straight through `define_plain_invar`, never going
+near `need_invar`. A cell is therefore never "requested", and both
+`need_proof_name` and `xliteral_for_ensuring` short-circuit on a condition that
+already has a proof name. So "link the literals that are requested" leaves every
+cell unlinked.
 
-- `need_proof_name` short-circuits on a condition that already has a proof name;
-- `xliteral_for_ensuring`, which is where the emission path actually resolves
-  literals, does the same.
+`mirror_invar_across_view_link` is therefore called from two places: from
+`need_invar`, *outside* the "already defined" guard, and from
+`xliteral_for_ensuring` whenever a range condition that already has a name
+reaches a proof line. It is idempotent, and a set probe after the first time.
+`ProofLogger::emit` and `emit_under_reason` render with `EnsureNames::Yes`, so
+every `rup` / `a` / `ia` line takes each range condition through
+`xliteral_for_ensuring`; only the `red` reifications bypass it.
 
-So "link the literals that are requested" leaves every cell unlinked, and a
-later decision, reason or conclusion that happens to name one of those cells
-gets no link — a unit-propagation dead end with nothing to see at the point of
-failure. `mirror_invar_across_view_link` is therefore called from `need_invar`
-*outside* the "already defined" guard, and again from `xliteral_for_ensuring`
-whenever a range condition that already has a name reaches a proof line. It is
-idempotent, and after the first time it is a set probe.
+**The invariant to preserve is that every non-`red` emission names its
+literals.** A path that rendered a range literal without going through
+`need_all_proof_names_in` or `xliteral_for_ensuring` would leave a cell
+unlinked, and nothing would notice.
 
-**In a definitions-on proof there is in fact no such thing as an unnamed range
-literal**, which is what makes the rule complete rather than merely better than
-the alternative. `ProofLogger::emit` and `emit_under_reason` render with
-`EnsureNames::Yes`, so every `rup` / `a` / `ia` line takes each range condition
-through `xliteral_for_ensuring`. Every creation path writes such a line about the
-literal it has just created, in the same call: `ensure_partition_cut` writes the
-split covering, `init_interval_partition` the root covering,
-`define_invar_with_covering` the request covering, `link_immediate_containment`
-the containment edges. Only the `red` reifications go out through the ostream
-overload with `EnsureNames::No`. So a cell is linked when its own covering is
-written, not when some later solver fact happens to mention it.
+*Correction (2026-09-09).* An earlier version of this section claimed there is
+no such thing as an unnamed range literal. That is false: a literal whose
+in-bounds part is empty is defined by `define_invar_with_covering`'s
+`span_lo > span_hi` branch with no partition, no covering and no containment
+edge, and nothing names it. `Inv-Rep` survives because such a literal can only
+arise from a request, and `need_invar` mirrors unconditionally — but the
+"everything is named" form of the argument does not hold, and the invariant in
+`literal-encodings.tex` is stated over cells for exactly this reason.
 
-That is the invariant to preserve: **every non-`red` emission names its
-literals**. A future path that rendered a range literal without going through
-`need_all_proof_names_in` or `xliteral_for_ensuring` could leave one unlinked,
-and nothing would notice.
-
-One consequence worth knowing about: `need_invar` is now genuinely re-entrant,
-because resolving a literal while emitting a covering can re-enter it.
+One consequence worth knowing: `need_invar` is genuinely re-entrant, because
+resolving a literal while emitting a covering can re-enter it.
 `ensure_partition_cut` publishes a partition boundary *before* defining the two
-halves that boundary creates, so during that window the partition claims a cell
-that does not exist yet. `define_invar_with_covering`'s single-cell path defines
-it in that case, and `define_plain_invar` is idempotent so that
-`ensure_partition_cut` does not then define it a second time.
+halves it creates, so for that window the partition claims a cell that does not
+exist yet. `define_invar_with_covering`'s single-cell path defines it in that
+case, and `define_plain_invar` is idempotent so the split does not define it
+twice.
 
 ## 4. The two sides hold the same literals, but not in the same roles
 
-Because every literal is linked at creation (§3), and linking creates the mirror
-on the far side, the two sides end up holding **the same set of literals** up to
-the affine map. Measured on `equals_test --view-position=mixed`, 258 proofs, every
-registered (variable, view) pair whose view appears in the proof: 300 pairs, 300
-matches, no exceptions.
+The two sides end up holding the same set of literals up to the affine map.
+Measured on `equals_test --view-position=mixed`, 258 proofs, every registered
+(variable, view) pair whose view appears in the proof: 300 pairs, 300 matches,
+no exceptions.
 
 What does *not* correspond is a literal's **role**. `need_direct_encoding_for`'s
 eq-atom backfill re-enters `ensure_partition_cut` on the far side before the
 request's own second cut arrives, so the two sides reach the same set by
-different routes, and the same interval can be a root cell on one side and a
-split half or a request with its own covering on the other. Measured over 400
-sweep proofs: 66 contained such a difference, 297 literals in all, every proof
-verifying. So the split coverings and the containment DAGs genuinely differ.
+different routes, and the same interval can be a cell on one side and a request
+with its own covering on the other. Measured over 400 sweep proofs: 66 contained
+such a difference, 297 literals in all, every proof verifying. So the split
+coverings and the containment DAGs genuinely differ.
 
-**Argue per side, never by isomorphism.** The correctness argument runs: every
-fact is a unit on every side (bounds via the ge-links, equalities via the
-eq-links, intervals via L1/L2), and then per-side UP-completeness derives every
-implied literal on the side that needs it. That argument does not care which
-role a literal plays, which is exactly why it survives the role differences. An
-argument that appealed to the two sides having the same clauses would not. This
-is Theorem 3.3' and the paragraph after it in
-[literal-encodings.tex](literal-encodings.tex).
+*Why that does not matter — argue per side, never by isomorphism — is Theorem
+3.3' and the paragraph after it in
+[literal-encodings.tex](literal-encodings.tex).*
 
 ## 5. Why this is complete
 
-*Resolved, and moved.* The argument is now written out and proved, over a whole
-representation family and all three literal kinds, in §3.3.1 of
-[literal-encodings.tex](literal-encodings.tex) — see Lemma 3.E (unit transport),
-Theorems 3.2' and 3.3' (the family versions of wipeout and complete
-propagation), and Lemma 3.4 (reason validity). The three parts this document
-originally identified — mirror closure, unit transport, and per-side
-UP-completeness — survive as `Inv-Rep`, Lemma 3.E, and Theorem 3.3
-respectively.
-
-Two things from that write-up bear on this code specifically.
-
-- **Argue per side, never by isomorphism.** The correctness argument transports
-  every fact to one representation and then works there, which is why the role
-  differences of §4 do not matter. An argument that appealed to the two sides
-  having corresponding clause sets would be unsound reasoning even in the runs
-  where the correspondence holds, because nothing maintains it.
-- **What it depends on**, and therefore what would break it: that every
-  non-`red` emission names its literals (§3); that every domain change is logged
-  eagerly, as the range spec already assumes; and that in-bounds endpoints are
-  partition boundaries — which is why `need_direct_encoding_for` cuts at `v` and
-  `v+1` when a partition exists, and dropping that would break the base case of
-  the cell-exclusion lemma.
-
-Corroboration, which is not the argument but is worth having: 3000 randomly
-generated view proofs verified with zero mirror-closure violations, over Equals,
-NotEquals, AllEqual, Min, Max, In, LessThan, LessThanEqual and AllDifferent with
-holey domains, three-view bases, and intervals pushed outside the definition
-bounds.
+*Resolved and moved.* The argument — mirror closure, unit transport, per-side
+UP-completeness — is proved over a whole representation family in §3.3.1 of
+[literal-encodings.tex](literal-encodings.tex), as `Inv-Rep`, Lemma 3.E and
+Theorem 3.3. What it depends on, and so what would break it: that every non-`red`
+emission names its literals (§3); that every domain change is logged eagerly; and
+that in-bounds endpoints are partition boundaries, which is why
+`need_direct_encoding_for` cuts at `v` and `v+1` when a partition exists.
 
 ## 6. The coincidence trap — read this before believing a green test
 
-The negative crossing is derivable *without any linking clause* in a large
-fraction of small configurations, for four separate reasons:
-
-- the range is the whole definition range, so asserting its negation is
-  UP-inconsistent and the check passes vacuously;
-- the range abuts or sticks out below (`a ≤ lb`): the boundary pin
-  `need_gevar`'s `fix_bound` emits makes the reverse reification a unit, the
-  ge-link carries it, and the far side's *forward* reification finishes the job;
-- the range abuts or sticks out above (`b ≥ ub`): the mirror image;
-- every cell inside the range is a singleton — and one well-placed eq atom
-  shatters a width-2 cell on *both* sides, so any per-value activity anywhere
-  near the range (Table reasons, equality holes, `x = v` branching, enumeration
-  nogoods, width-1 `In` gaps) silently makes the case work.
-
-Measured two ways, both damning for the sweep as evidence. Over domain widths
-4–16 with 0–7 random requests per instance: **80% of instances cross successfully
-with no linking clause at all** — abut-high 39%, abut-low 23%, whole-range 12%,
-shattered 5.6% — and of the 20% that stall, a single wide cell accounts for 88%.
-And over 987 randomly generated instances that actually reach a conflict, with
-the link clauses ablated: only **37 of them notice**. The sweep is about 96%
-coincidence.
-
-A discriminating instance therefore needs *all* of: the range strictly inside
-both variables' definition bounds; at least one interior cell of width ≥ 2 that
-no per-value machinery touches; and a backtrack replay that has to reach the far
-side's literal from the near side's negation rather than from a bound. This is
-why the `--view-wrap` sweep passing is not by itself evidence, and why the
-witnesses below are.
+The negative crossing succeeds **with no linking clause at all** in about 80% of
+small random configurations, and over 987 conflict-reaching instances, ablating
+the links makes only 37 notice. A green `--view-wrap` sweep is therefore close to
+no evidence. *The four mechanisms that make it pass by coincidence, with the
+measurements, are "The coincidence trap" in
+[literal-encodings.tex](literal-encodings.tex).* W6–W9 are constructed against
+them.
 
 ## 7. The witnesses
 
-`dev_docs/range_literals_spec.md` §8 is the suite; these four are its view half,
-all gate-on and veripb-verified.
+`range_witness_w{6,7,8,9}_test.cc`, all gate-on and veripb-verified. *What each
+one guards, and the ablation matrix showing every clause and rule separately
+load-bearing, are in the "Interlude" of
+[literal-encodings.tex](literal-encodings.tex).*
 
-- **W6** — an interval fact concluded on a plain variable reaching a reason
-  literal on a view of it (`X → V`, so L1's contrapositive).
-- **W7** — the mirror image (`V → X`, L2's contrapositive).
-- **W8** — the *trigger*: the named literal is one the partition machinery
-  already created as a cell, so it is invisible to a request-driven link rule.
-- **W9** — W8's two-view form, where the fact composes `view1 → b → view2`, and
-  where the unlinked literal is a conclusion rather than a decision.
-
-Validated by ablation, with a temporary knob since removed:
-
-| ablation                | W6     | W7     | W8     | W9     |
-|-------------------------|--------|--------|--------|--------|
-| none                    | passes | passes | passes | passes |
-| both link clauses gone  | FAILS  | FAILS  | FAILS  | FAILS  |
-| L1 removed              | FAILS  | passes | FAILS  | FAILS  |
-| L2 removed              | passes | FAILS  | passes | FAILS  |
-| link on request only    | passes | passes | FAILS  | FAILS  |
-
-Each fails within milliseconds, on a backtrack clause. W6 and W7 separate the
-two clauses cleanly, one each; W8 and W9 fail whenever linking is driven by
-requests rather than by naming, whichever clauses are present; and W9, whose
-fact has to compose `view1 → b → view2`, needs both clauses. Every clause and
-every rule here is separately load-bearing, which is a stronger result than the
-spec records for W2 and W5, both of which are structural.
-
-`invar_view_test` sits alongside them and covers something different: the
+`invar_view_test.cc` sits alongside them and covers something different: the
 `need_pol_item_defining_literal` range arms, which no propagator reaches, and the
 sign arithmetic of the endpoint map in both directions — checked with
 `find_xliteral_for`, which does not introduce what it fails to find, so "the
 mirror exists at exactly these bounds and not at the neighbouring ones" is a real
 assertion. Both an off-by-one and a dropped endpoint-swap mutant are killed by
-it. It deliberately does **not** witness the link clauses, and says so: it states
-the crossings as RUP lines, and every one of them still verifies with the link
-pair deleted, because a RUP check is strictly stronger than the single
-unit-propagation pass the links exist for. That is §1's P1/P2 distinction, and it
-caught this document claiming otherwise in an earlier draft.
+it. It deliberately does **not** witness the link clauses, and says so.
 
-Two notes for anyone adding to this set. The obvious control for W8 — decide
-`¬[b in 3..4]` instead of `¬[b in 3..5]`, so the decision names a fresh interval
-rather than a cell — verifies with *either* link clause removed, because the
-interval then sits at the bottom of a covering-forced block and the bound
-crosses. And a witness stated as a RUP line of the fact you care about tests
-nothing at all here. Ablate before claiming a witness bites.
+Two notes for anyone adding to this set. A witness stated as a RUP line of the
+fact you care about tests nothing at all, because RUP is strictly stronger than
+the single unit-propagation pass the links exist for. And a decision naming a
+literal that is not a **cell** on both sides is not discriminating either:
+containment carries the negation down to the cells, the cells' own link pairs
+cross, and the far side's covering lifts it back, so no single clause is
+load-bearing there. Ablate before claiming a witness bites.
 
 ## 8. Cost
 
 Per interval literal per registered view: the mirrored literal on the other side
-(with its own partition maintenance) plus two rup lines. That is the same
-constant factor the eq and ge atoms already pay for a wrapped variable, and
-nothing here is proportional to a domain width.
-
-Measured on one `Equals` whose operands are a bare `0..w` and a two-value
-`{0, w}`, so root propagation prunes exactly one wide interior run; proofs on,
-root propagation only, `.pbp` lines, every `after` row VeriPB-verified with
-`--force-checked-deletion`. `view` wraps both operands as `x + 10^6`, `negview`
-as `-x + 10^6`, `mixed` as `x + 10^6` against `-y + 10^6 + w`.
-
-| width | plain | view before | view after | negview after | mixed after |
-|---|---|---|---|---|---|
-| 10^3 | 68 | 71,017 | **200** | 200 | 200 |
-| 10^4 | 68 | 710,017 | **200** | 200 | 200 |
-| 10^5 | 68 | *timed out at 300 s* | **200** | 200 | 200 |
-| 10^6 | 68 | *timed out at 300 s* | **200** | 200 | 200 |
-
-The `before` column is `17 + 71·w` lines and stops being writable at all between
-10^4 and 10^5. The `after` columns are flat, and 200 rather than 68 because the
-view carries its own bit-vector encoding, its own order and equality atoms and
-the link pairs — a constant, not a function of the width. That constant is the
-price of the design; the slope was the point of the issue. `plain` is the
-control that makes the two builds comparable: it is the same 68 on either side
-of the change, as it should be, since nothing here touches a bare variable.
+(with its own partition maintenance) plus two rup lines — the same constant
+factor the eq and ge atoms already pay for a wrapped variable, and nothing
+proportional to a domain width. *The measured table, including the `17 + 71w`
+per-value fallback this replaced and where it stopped being writable at all, is
+the "Cost" part of [literal-encodings.tex](literal-encodings.tex).*
 
 VeriPB checks every `after` row in about 0.012 s. The `before` row at 10^3 takes
 42 s, and the one at 10^4 — ten times the lines — was still going after an hour,
@@ -303,41 +193,19 @@ when it was stopped. So writability is the generous half of the `before`
 column's problem: the widths that can still be written are already past the
 widths that can be checked.
 
-The `mixed` offsets are not free to choose, and getting them wrong is quiet.
-The two wraps have to put both operands over the *same* interval; otherwise they
-stop overlapping, the instance is unsatisfiable at the root, and the row measures
-a refutation rather than the hole prune. An earlier version of this probe paired
-`x + 10^6` with `-y + 2·10^6`, which overlap only at `w = 10^6` — so three of the
-four `mixed` rows were the wrong shape, and the fourth was the right one. The
-only tell was a three-line step in a column that should have been flat.
-
-These figures are against `main` at 7b582656, and are about twice the ones this
-branch first reported. #914 puts each of the tracker's definition lines into
-VeriPB's core set, which writes an extra `core id` line for each; both columns
-grow by that factor. Flat against linear is unchanged, and so is everything the
-table is used for.
-
 ## 9. The one residue
 
-A variable with no bit-vector representation has no order cuts to reify against,
-so `need_invar` throws for it. The gate is `has_bit_representation`, i.e.
-whether the variable is in `integer_variable_bits_to_size_and_proof_vars` — not
-what its domain looks like.
+Range literals need a bit-vector representation; `need_invar` throws without one.
+The gate is `has_bit_representation` (membership of
+`integer_variable_bits_to_size_and_proof_vars`), and the throwing case is a
+direct-only variable whose domain is **not** `{0,1}` — a `{0,1}` one is
+registered with a one-element bit vector by
+`set_up_direct_only_variable_encoding` and works. See Appendix B item 1 of
+[literal-encodings.tex](literal-encodings.tex), which also records that two
+earlier versions of this section named the wrong case.
 
-**Correction (2026-09-09).** An earlier version of this section said the case
-was a real variable with `lower == 0 && upper == 1` and no explicit
-representation. That is wrong. `set_up_direct_only_variable_encoding`'s `{0,1}`
-branch calls `track_bits(id, 0, {{1, eqvar}})`, giving such a variable a
-one-element bit vector, so `has_bit_representation` is true for it and
-`need_invar` does *not* throw. Confirmed by probe: for a `{0,1}` direct-only
-variable, `need_invar(b, 0, 1)` returns a literal and the resulting proof
-verifies; for a width-6 direct-only variable, `has_bit_representation` is false
-and `need_invar` throws `range literal requested for a variable without a bits
-encoding`. So the throwing case is a **direct-only variable of width three or
-more**, which is a property of the variable and not of views.
-
-Either way this is not a view detour. `ProofLogger::infer` and `infer_explicitly`
-fall back to per-value when `can_represent_range_literal_for` is false, and that
-predicate resolves a view to its underlying variable, so a view of such a
-variable never asks for a mirror the underlying cannot hold. It is the bits-less
-fallback, which bare variables have too, and it is the only detour left.
+This is a property of the variable, not of views:
+`can_represent_range_literal_for` resolves a view to its underlying variable, so
+a view never asks for a mirror the underlying cannot hold, and
+`ProofLogger::infer` / `infer_explicitly` fall back to per-value. It is the
+bits-less fallback bare variables have too, and it is the only detour left.

--- a/dev_docs/view-range-literals.md
+++ b/dev_docs/view-range-literals.md
@@ -7,6 +7,13 @@ literal at all, and every part of the solver that wanted to say something
 interval-shaped about a view carried its own detour — three that threw, and five,
 later seven, that silently degraded to one literal per value.
 
+**Theory.** The general account — what these literals are, what the invariants
+are, and why the design is complete — is
+[literal-encodings.tex](literal-encodings.tex), which subsumes the argument that
+used to be §5 here. This document is the issue-#882 implementation record: the
+sites that changed, the trigger that is easy to get wrong, the ablation table,
+and what was measured.
+
 **Audience.** Anyone touching `need_invar`, `simplify_literal`, the view
 machinery in `NamesAndIDsTracker`, or a propagator that emits explicit `pol`
 over a range literal. Read both of the documents above first; this one assumes
@@ -52,8 +59,8 @@ directions.
 
 Writing `F_V` for `[V in a..b]` and `F_X` for its image, the link is
 
-    L1:  ¬F_V ∨ F_X
-    L2:  ¬F_X ∨ F_V
+    L1:  ~F_V | F_X
+    L2:  ~F_X | F_V
 
 Each is RUP at emission: assert one and the negation of the other, and the
 forward reification gives that side's two cuts, the ge-links carry each cut
@@ -61,26 +68,15 @@ across (for `s = -1` the two cuts swap roles, which is exactly the endpoint
 swap above), and the far side's reverse reification fires.
 
 **Both clauses are needed, and each for its contrapositive rather than for its
-implication.** As implications, `F_V → F_X` and `F_X → F_V` are both already
-derivable by unit propagation — one forward reification, two ge-links, one
-reverse reification, no new clauses. That is what issue #882 observed, and it
-is true. But UP uses a clause in whichever direction has a unit, and the
-directions that matter are the negative ones:
-
-    ¬F_X ⟹ ¬F_V   (L1's contrapositive)
-    ¬F_V ⟹ ¬F_X   (L2's contrapositive)
-
-and neither is derivable without the clause. A negated interval literal is a
-unit on *neither* of its cuts — its reverse reification leaves only the binary
-clause `¬(Y≥p) ∨ (Y≥q+1)` — so all it can do is descend its own variable's
-containment edges, and it bottoms out at cells that are themselves unlinked
-range literals unless they happen to be width 1. Descending to width 1 is
-precisely the per-value shattering the interval vocabulary exists to avoid.
-The issue's argument ("a range literal never has to cross an equality: it is
-reified against its own two order cuts, so an interval fact decomposes into
-cross one bound, move within one variable, cross back") decomposes a
-*conjunction* of two bounds; a negated interval is a *disjunction* of two
-bounds, and UP cannot carry a disjunction across one disjunct at a time.
+implication.** As implications, both directions are already derivable by unit
+propagation — one forward reification, two ge-links, one reverse reification,
+no new clauses. That is what issue #882 observed, and it is true; it is also
+beside the point, because the directions unit propagation actually needs are the
+negative ones, and neither of those is derivable without its clause. The
+argument is Remark 3.1 of [literal-encodings.tex](literal-encodings.tex); the
+one-line version is that a negated interval literal is a *disjunction* of two
+bounds, not a conjunction, and unit propagation cannot carry a disjunction
+across one disjunct at a time.
 
 Both negative directions are ordinary rather than exotic. Search branches on
 real variables only — `reject_random_interval` requires a
@@ -155,51 +151,37 @@ verifying. So the split coverings and the containment DAGs genuinely differ.
 
 **Argue per side, never by isomorphism.** The correctness argument runs: every
 fact is a unit on every side (bounds via the ge-links, equalities via the
-eq-links, intervals via L1/L2), and then per-side UP-completeness — the range
-spec's Lemma L1 — derives every implied literal on the side that needs it. That
-argument does not care which role a literal plays, which is exactly why it
-survives the role differences. An argument that appealed to the two sides having
-the same clauses would not.
+eq-links, intervals via L1/L2), and then per-side UP-completeness derives every
+implied literal on the side that needs it. That argument does not care which
+role a literal plays, which is exactly why it survives the role differences. An
+argument that appealed to the two sides having the same clauses would not. This
+is Theorem 3.3' and the paragraph after it in
+[literal-encodings.tex](literal-encodings.tex).
 
 ## 5. Why this is complete
 
-The obligation is: in a backtrack-clause replay, after asserting the decisions,
-every logged inference's reason must become unit in trail order. The argument has
-three parts, and it was formalised rather than assumed.
+*Resolved, and moved.* The argument is now written out and proved, over a whole
+representation family and all three literal kinds, in §3.3.1 of
+[literal-encodings.tex](literal-encodings.tex) — see Lemma 3.E (unit transport),
+Theorems 3.2' and 3.3' (the family versions of wipeout and complete
+propagation), and Lemma 3.4 (reason validity). The three parts this document
+originally identified — mirror closure, unit transport, and per-side
+UP-completeness — survive as `Inv-Rep`, Lemma 3.E, and Theorem 3.3
+respectively.
 
-**Mirror closure.** For every registered `V = sX + c` and every other view `V'`
-of `X`, an interval exists on one iff its image exists on the others, with the
-link pair present for each view/underlying pair. This is §3's invariant plus the
-fact that `link` requests the far side, which itself mirrors onward — so a
-literal first seen on `V₁` reaches `V₂` through `X` in the same call.
+Two things from that write-up bear on this code specifically.
 
-**Unit transport.** Any literal that is a unit on one side has its image a unit
-on every other side of the same base: ge-links for bounds, eq-links for
-equalities, L1/L2 for intervals (L1 carrying `+F_V` and `¬F_X`, L2 the other
-two). Two hops compose through the underlying variable.
-
-**Per-side UP-completeness.** For a single variable, given any set of unit
-literals from its own family, UP derives every bound implied by the surviving
-values, every interval and equality the surviving values are contained in, every
-one they are disjoint from, and contradiction if none survive. The interesting
-case is the last: induction on (number of current cells inside the literal,
-width), using containment for a cell under a rejected ancestor, reification and
-the chain for one cleared by a bound, and the covering for the step — which works
-because every in-bounds endpoint of every interval and equality is a partition
-boundary, so a cell is either wholly inside a literal or disjoint from it.
-Notably the root covering is *not* needed, matching the observation already
-recorded in §8.1 of the range spec.
-
-Together: assert the decisions; by transport the unit set on any side is the
-image of every fact so far; per-side completeness derives whatever that
-inference's reason needs on the side it is stated on; the inference clause fires;
-induct.
-
-**What it depends on**, and therefore what would break it: that every non-`red`
-emission names its literals (§3); that every domain change is logged eagerly, as
-the range spec already assumes; and that in-bounds endpoints are partition
-boundaries — which is why `need_direct_encoding_for` cuts at `v` and `v+1` when a
-partition exists, and dropping that would break the base case above.
+- **Argue per side, never by isomorphism.** The correctness argument transports
+  every fact to one representation and then works there, which is why the role
+  differences of §4 do not matter. An argument that appealed to the two sides
+  having corresponding clause sets would be unsound reasoning even in the runs
+  where the correspondence holds, because nothing maintains it.
+- **What it depends on**, and therefore what would break it: that every
+  non-`red` emission names its literals (§3); that every domain change is logged
+  eagerly, as the range spec already assumes; and that in-bounds endpoints are
+  partition boundaries — which is why `need_direct_encoding_for` cuts at `v` and
+  `v+1` when a partition exists, and dropping that would break the base case of
+  the cell-exclusion lemma.
 
 Corroboration, which is not the argument but is worth having: 3000 randomly
 generated view proofs verified with zero mirror-closure violations, over Equals,
@@ -337,16 +319,25 @@ table is used for.
 
 ## 9. The one residue
 
-A real variable with `lower == 0 && upper == 1` and no explicit representation
-is `DirectOnly`, so it has no bit vector and no order cuts to reify against, and
-`need_invar` throws for it. That is pre-existing and applies to bare variables
-too. A view of such a variable *does* get bits, so its mirror would be the first
-thing to ask `need_invar` for a bits-less variable.
+A variable with no bit-vector representation has no order cuts to reify against,
+so `need_invar` throws for it. The gate is `has_bit_representation`, i.e.
+whether the variable is in `integer_variable_bits_to_size_and_proof_vars` — not
+what its domain looks like.
 
-It cannot arise — a two-value domain has no interior hole, `reject_random_interval`
-needs three values, and `each_interval_minus` on a two-value domain yields only
-width-1 intervals — but `ProofLogger::infer` and `infer_explicitly` fall back to
-per-value when `can_represent_range_literal_for` is false, and that predicate
-resolves a view to its underlying variable, so the case stays correct if it ever
-does. That is the bits-less fallback, which bare variables have too. It is not a
-view detour, and it is the only one left.
+**Correction (2026-09-09).** An earlier version of this section said the case
+was a real variable with `lower == 0 && upper == 1` and no explicit
+representation. That is wrong. `set_up_direct_only_variable_encoding`'s `{0,1}`
+branch calls `track_bits(id, 0, {{1, eqvar}})`, giving such a variable a
+one-element bit vector, so `has_bit_representation` is true for it and
+`need_invar` does *not* throw. Confirmed by probe: for a `{0,1}` direct-only
+variable, `need_invar(b, 0, 1)` returns a literal and the resulting proof
+verifies; for a width-6 direct-only variable, `has_bit_representation` is false
+and `need_invar` throws `range literal requested for a variable without a bits
+encoding`. So the throwing case is a **direct-only variable of width three or
+more**, which is a property of the variable and not of views.
+
+Either way this is not a view detour. `ProofLogger::infer` and `infer_explicitly`
+fall back to per-value when `can_represent_range_literal_for` is false, and that
+predicate resolves a view to its underlying variable, so a view of such a
+variable never asks for a mirror the underlying cannot hold. It is the bits-less
+fallback, which bare variables have too, and it is the only detour left.

--- a/dev_docs/view-range-literals.md
+++ b/dev_docs/view-range-literals.md
@@ -103,7 +103,7 @@ unlinked, and nothing would notice.
 no such thing as an unnamed range literal. That is false: a literal whose
 in-bounds part is empty is defined by `define_invar_with_covering`'s
 `span_lo > span_hi` branch with no partition, no covering and no containment
-edge, and nothing names it. `Inv-Rep` survives because such a literal can only
+edge, and nothing names it. `Inv-View` survives because such a literal can only
 arise from a request, and `need_invar` mirrors unconditionally — but the
 "everything is named" form of the argument does not hold, and the invariant in
 `literal-encodings.tex` is stated over cells for exactly this reason.
@@ -138,8 +138,8 @@ coverings and the containment DAGs genuinely differ.
 ## 5. Why this is complete
 
 *Resolved and moved.* The argument — mirror closure, unit transport, per-side
-UP-completeness — is proved over a whole representation family in §3.3.1 of
-[literal-encodings.tex](literal-encodings.tex), as `Inv-Rep`, Lemma 3.E and
+UP-completeness — is proved over a whole view family in §3.3.1 of
+[literal-encodings.tex](literal-encodings.tex), as `Inv-View`, Lemma 3.E and
 Theorem 3.3. What it depends on, and so what would break it: that every non-`red`
 emission names its literals (§3); that every domain change is logged eagerly; and
 that in-bounds endpoints are partition boundaries, which is why

--- a/gcs/constraints/innards/justify_not_in_range.hh
+++ b/gcs/constraints/innards/justify_not_in_range.hh
@@ -16,9 +16,11 @@ namespace gcs::innards
     // each of which is RUP by Theorem 2.9 of Matthew's thesis (contradictory
     // constraints on binary sums): its negation supplies a *lower* bound on one
     // operand against an *upper* bound on the other, across a row that is their
-    // difference, which always unit propagates to contradiction. The lemmas
-    // mention no range literal, so any literal sharing these endpoints can reuse
-    // them.
+    // difference, which always unit propagates to contradiction. Their
+    // *conclusions* mention no range literal, which is what lets any literal
+    // sharing these endpoints reuse them; the emitted lines are still written
+    // under the caller's reason, which does name the range literal, and are
+    // Temporary, so they do not persist past the conclusion.
     //
     // [other_lo, other_hi] are the bounds the range forces on `other` through the
     // equality; for a plain `pruned = other` they are [lo, hi].


### PR DESCRIPTION
Documentation only, apart from one corrected code comment. #904, which this was stacked on, has merged, so the base is now `main`.

`dev_docs/literal-encodings.tex` is a revised and extended version of §3.2 and §3.3 of Matthew's thesis, covering the two things the thesis does not: **interval literals** `[X in a..b]`, and **several representations of one variable** (registered views). Neither addition is conservative over the thesis's propagation results — interval literals are not complete under unit propagation given the order chain alone, and the direction a view's interval link is actually needed for is the one that is *not* derivable from the others.

**The built PDF is not committed**, and the branch has been rewritten so that it never was: a 560 kB binary that changes with every edit to the text does not belong in the history. Build it with `latexmk -pdf dev_docs/literal-encodings.tex` — `dev_docs/*.pdf` is now gitignored, alongside the LaTeX intermediates. `dev_docs/literals.md`, `dev_docs/README.md` and `range_literals_spec.md` point at the `.tex` and say how to build it.

## Numbering

Results corresponding to results of the thesis keep the thesis's numbers, so existing citations still land: Lemmas 3.1–3.4, Corollary 3.1, Theorems 3.1–3.5, Encoding Procedure 3.1, and the section numbers 3.2.1–3.3.4. New results are lettered (Lemmas 3.A–3.E); the family versions of Theorems 3.2 and 3.3 are primed. Invariants are named rather than numbered, with the thesis's numbers alongside.

## What is new rather than restated

* **Encoding Procedure 3.1 gains representation variables.** A registered view is an encoded variable with a definitional link `V − sX = c`. Like atomic variables they are *shared* between linearisations, so L3 is relaxed and Lemma 3.1 and Theorem 3.1 needed reproving.
* **A third atomic variable kind**, with the width-one identification stated as a definition rather than left implicit.
* **Nine named invariants**, replacing prose spread across three dev_docs. `Inv-Cover` is stated structurally rather than in terms of what was a cell when defined — the historical form does not cover an equality atom created before its variable has a partition.
* **Theorems 3.2 and 3.3 reproved** over all three literal kinds, then lifted to a representation family by a transport lemma. The shape of that argument — *transport, then argue on one side* — is what makes the role differences between two representations harmless.
* **Theorem 3.2 turns out not to need the coverings.** Wipeout follows from the reverse reifications and the order chain; the coverings exist for Lemma 3.4, reason validity. This was an unexplained observation in `range_literals_spec.md` §8.1 and now has a proof. **No clause is being removed.**
* **The preserved set for enumeration is pinned down**: base bits only, with the argument for why that is both sufficient and necessary.
* A table of **every way a fact can cross** from one literal to another, and the clause family that carries it.

## Adversarial review, and what it found

Three reviewers were pointed at the document with disjoint remits (encoding side; the §3.3.1 proofs; code faithfulness and the search framework). **No solver bug and no false theorem** — but about a dozen false statements *about* the design, all now fixed. Each was checked against the code or against VeriPB before being acted on. Two are worth a reviewer's attention:

**The ge-link is not RUP, and the document said it was.** Theorem 2.9 requires the middle constraint's right-hand side in `{0,1}`; for `Link(W) : W − sX = c` that RHS is `±c`, so the theorem does not apply once `|c| > 1`, and Example 2.15 is a counterexample of the same shape. Confirmed with VeriPB over a three-bit base: only `c = 0` verifies as `rup` at every threshold, and `X ∈ [0,7]`, `W = X+1`, `v = 6` is a concrete rejection. **No impact on the solver** — `need_gevar` emits these by `pol` — but the stated reason was wrong, and simplifying that emission to a RUP line would fail *intermittently*.

**A single in-link clause is load-bearing only for a literal that is a cell on both sides.** Appendix A's worked crossing originally decided `¬[X in 7..15]`, a union of two cells: containment carries it down to the cells, the cells' own link pairs cross, and the far side's covering lifts it back, so deleting the named clause leaves the proof verifying. The example now uses a cell, and a new paragraph states the general rule. This is also why W6–W9 are built on unsplit cells.

The rest: `Inv-Part` assumed a partition that an out-of-bounds literal does not create; `Inv-Cover`(iii) asserted a root covering unconditionally, so as written the results said nothing about a plain order/equality variable; `Inv-Name` was false on that same path and is now stated over cells; the compact-encoding remark justified itself by `Inv-Cut`, which is exactly what that encoding drops. On the proofs: Lemma 3.E's reduction covered one of two hops, Theorems 3.2/3.3 used finiteness a step before invoking it, Lemma 3.C listed an unused hypothesis, Theorem 3.4's hypotheses were incomplete.

One item is flagged rather than resolved: **`Inv-Domain` needs the eager root-bound introduction of eq. (3.44) and the solver pins lazily**, so the base case does not literally hold as stated. Weakening `Inv-Domain` to `dom_L ∩ [l,u] ⊆ dom_t` breaks the antitonicity step in Lemma 3.4, so the discrepancy is recorded as an open point (Remark 3.5) rather than papered over. **This is the thing I would most like a second opinion on.**

Not found, though looked for hard: a cell defined on one representation with no counterpart on the other. 4698 interval literals across 60 seeds and three representations, through all three creation paths, with a mutation-validated checker — every one mirrored, linked and named.

## Documents it supersedes

`range_literals_spec.md` (426 → 318), `view-range-literals.md` (324 → 208) and `view-proof-logging.md` (257 → 240) keep their implementation content and lose their theory. The witness suite had existed in three places and the cost table and coincidence-trap figures in two. The division of labour is now written down in the new `dev_docs/literals.md`: **statements, arguments and measured numbers live in the `.tex`; function names, test names, dates and decisions live in the Markdown.**

Section numbers in `range_literals_spec.md` are cited from nine witness tests, `gcs/CMakeLists.txt`, `names_and_ids_tracker.hh` and `invar_view_test.cc`, so every cut shrinks a section rather than removing one. `view-proof-logging.md`'s three numbered invariants are cited from `difference-logic.md` and `difference_constraints.cc` and are untouched.

## Code change

One header comment. `justify_not_in_range.hh` said the bridge lemmas "mention no range literal"; their *conclusions* do not, but the emitted lines are under the caller's reason, which does. The document had inherited the same error.

## Corrections recorded rather than quietly fixed

Both were believed and written down before being tested: that `need_invar` throws for a real `{0,1}` variable (it does not — that path registers a one-element bit vector, so the throwing case is a direct-only variable whose domain is not `{0,1}`), and that there is no such thing as an unnamed range literal (there is).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018s5Rxd5qtz8CRHe53cFzLy

