### PR TITLE
Ask the divide/modulus view sweep for GAC only where it is promised (#903)

### DIFF
--- a/gcs/constraints/divide_modulus/divide_modulus_test.cc
+++ b/gcs/constraints/divide_modulus/divide_modulus_test.cc
@@ -64,6 +64,17 @@ namespace
             .visit(level);
     }
 
+    auto wrap_label(const vector<ViewWrap> & wraps) -> string
+    {
+        string s = "(";
+        for (const auto & w : wraps) {
+            if (s.size() > 1)
+                s += ", ";
+            s += std::to_string(w.bare ? 1 : (w.negate ? -1 : 1)) + ", " + std::to_string(w.bare ? 0 : w.offset);
+        }
+        return s + ")";
+    }
+
     auto post_divmod(Problem & p, bool is_div, IntegerVariableID x, IntegerVariableID y, IntegerVariableID out, const DivideConsistency & level)
         -> void
     {
@@ -74,38 +85,30 @@ namespace
     }
 }
 
-// Three distinct variables, optionally through views: constrain
-// (m1 * x + o1) op (m2 * y + o2) = (m3 * out + o3), enumerating over the
-// underlying variables.
+// Three distinct variables, optionally through views. The wraps invert the
+// underlying domain, so the VISIBLE domains stay x_range / y_range / out_range
+// and the expected solution set is the same under every wrap -- only the
+// constraint-side encoding differs, which is what the view sweep is for.
 string test_proof_suffix = "";
 
 auto run_divmod_test(bool proofs, bool is_div, const DivideConsistency & level, bool check_gac, pair<int, int> x_range, pair<int, int> y_range,
-    pair<int, int> out_range, tuple<int, int, int, int, int, int> view_spec = {1, 0, 1, 0, 1, 0}) -> void
+    pair<int, int> out_range, vector<ViewWrap> wraps = {view_none(), view_none(), view_none()}) -> void
 {
-    const auto & [m1, o1, m2, o2, m3, o3] = view_spec;
     print(cerr, "{} {} {} {} {} {} views {} {}", is_div ? "divide" : "modulus", level_name(level), check_gac ? "gac-checked" : "plain", x_range,
-        y_range, out_range, view_spec, proofs ? " with proofs:" : ":");
+        y_range, out_range, wrap_label(wraps), proofs ? " with proofs:" : ":");
     cerr << flush;
     set<tuple<int, int, int>> expected, actual;
 
-    auto is_satisfying = [&](int a, int b, int c) {
-        return is_div ? div_ok(m1 * a + o1, m2 * b + o2, m3 * c + o3) : mod_ok(m1 * a + o1, m2 * b + o2, m3 * c + o3);
-    };
+    auto is_satisfying = [&](int a, int b, int c) { return is_div ? div_ok(a, b, c) : mod_ok(a, b, c); };
     build_expected(expected, is_satisfying, x_range, y_range, out_range);
     println(cerr, " expecting {} solutions", expected.size());
 
     Problem p;
-    auto x = p.create_integer_variable(Integer(x_range.first), Integer(x_range.second), "x");
-    auto y = p.create_integer_variable(Integer(y_range.first), Integer(y_range.second), "y");
-    auto out = p.create_integer_variable(Integer(out_range.first), Integer(out_range.second), "out");
+    auto x = create_integer_variable_or_constant_with_view(p, x_range, wraps.at(0), "x");
+    auto y = create_integer_variable_or_constant_with_view(p, y_range, wraps.at(1), "y");
+    auto out = create_integer_variable_or_constant_with_view(p, out_range, wraps.at(2), "out");
 
-    auto wrap = [&](SimpleIntegerVariableID v, int m, int o) -> IntegerVariableID {
-        IntegerVariableID result = v;
-        if (m == -1)
-            result = -result;
-        return result + Integer{o};
-    };
-    post_divmod(p, is_div, wrap(x, m1, o1), wrap(y, m2, o2), wrap(out, m3, o3), level);
+    post_divmod(p, is_div, x, y, out, level);
 
     auto proof_name = proofs ? make_optional("divide_modulus_test" + test_proof_suffix) : nullopt;
 
@@ -237,22 +240,22 @@ auto main(int argc, char * argv[]) -> int
     if (! view_wrap_config_is_effectively_bare(view_cfg, n_positions)) {
         test_proof_suffix = "_" + view_wrap_config_label(view_cfg);
         auto wraps = wraps_for_positions(view_cfg, n_positions);
-        auto spec_of = [&](int pos) -> pair<int, int> {
-            if (wraps[static_cast<size_t>(pos)].bare)
-                return {1, 0};
-            return {wraps[static_cast<size_t>(pos)].negate ? -1 : 1, wraps[static_cast<size_t>(pos)].offset};
-        };
-        auto [m1, o1] = spec_of(0);
-        auto [m2, o2] = spec_of(1);
-        auto [m3, o3] = spec_of(2);
         for (bool proofs : {false, true}) {
             if (proofs && ! can_run_veripb())
                 break;
             for (bool is_div : {true, false})
                 for (const auto & level : vector<DivideConsistency>{consistency::Auto{}, consistency::BC{}, consistency::Tabulated{}}) {
                     bool is_bc = holds_alternative<consistency::BC>(level);
-                    run_divmod_test(proofs, is_div, level, ! is_bc, {-4, 4}, {-2, 3}, {-4, 4}, tuple{m1, o1, m2, o2, m3, o3});
-                    run_divmod_test(proofs, is_div, level, ! is_bc, {0, 5}, {1, 3}, {0, 5}, tuple{m1, o1, m2, o2, m3, o3});
+                    bool force_gac = holds_alternative<consistency::Tabulated>(level);
+                    // Inside Auto's budget under every wrap (3 * 2 * 4 = 24 for divide, 3 * 2 * 8 = 48
+                    // for modulus, against default_tabulation_threshold() = 100), so Auto tabulates and
+                    // GAC is checked at every level but BC.
+                    run_divmod_test(proofs, is_div, level, ! is_bc, {0, 2}, {1, 2}, {-1, 2}, wraps);
+                    // Over Auto's budget (486 and 108 for divide, 432 and 144 for modulus), where Auto
+                    // is documented to fall back on the decomposition: soundness and completeness at
+                    // every level, GAC only where it is promised.
+                    run_divmod_test(proofs, is_div, level, force_gac, {-4, 4}, {-2, 3}, {-4, 4}, wraps);
+                    run_divmod_test(proofs, is_div, level, force_gac, {0, 5}, {1, 3}, {0, 5}, wraps);
                 }
         }
         return EXIT_SUCCESS;
@@ -291,7 +294,7 @@ auto main(int argc, char * argv[]) -> int
                 run_divmod_test(proofs, is_div, level, ! is_bc, {0, 1}, {-1, 1}, {-2, 2});
 
                 // Views on each slot.
-                run_divmod_test(proofs, is_div, level, ! is_bc, {0, 2}, {0, 1}, {-1, 2}, {1, -1, 1, 1, -1, 1});
+                run_divmod_test(proofs, is_div, level, ! is_bc, {0, 2}, {0, 1}, {-1, 2}, {view_offset(-1), view_offset(1), view_neg_offset(1)});
 
                 // Negative divisors, mixed signs: GAC-checked only when
                 // forced, since the tree is over the Auto threshold.

--- a/gcs/constraints/innards/constraints_test_utils.hh
+++ b/gcs/constraints/innards/constraints_test_utils.hh
@@ -1130,20 +1130,28 @@ namespace gcs::test_innards
         data.emplace_back(generate_random_data_item(rand, std::forward<Args_>(args))...);
     }
 
-    auto create_integer_variable_or_constant(Problem & problem, std::pair<int, int> bounds) -> IntegerVariableID
+    /// The optional name is passed on to Problem::create_integer_variable(), so a
+    /// test's proof log names its variables rather than numbering them.
+    auto create_integer_variable_or_constant(Problem & problem, std::pair<int, int> bounds, const std::optional<std::string> & name = std::nullopt)
+        -> IntegerVariableID
     {
-        return problem.create_integer_variable(Integer(bounds.first), Integer(bounds.second));
+        return problem.create_integer_variable(Integer(bounds.first), Integer(bounds.second), name);
     }
 
-    auto create_integer_variable_or_constant(Problem & problem, std::vector<int> values) -> IntegerVariableID
+    /// As above, for an explicitly enumerated domain.
+    auto create_integer_variable_or_constant(Problem & problem, std::vector<int> values, const std::optional<std::string> & name = std::nullopt)
+        -> IntegerVariableID
     {
         std::vector<Integer> vs;
         for (auto v : values)
             vs.push_back(Integer(v));
-        return problem.create_integer_variable(vs);
+        return problem.create_integer_variable(vs, name);
     }
 
-    auto create_integer_variable_or_constant(Problem &, int value) -> IntegerVariableID
+    /// A constant is not a variable, so there is nothing for a name to attach to:
+    /// the argument exists so that a caller iterating over mixed var/const argument
+    /// lists can pass one uniformly, and is ignored.
+    auto create_integer_variable_or_constant(Problem &, int value, const std::optional<std::string> & = std::nullopt) -> IntegerVariableID
     {
         return ConstantIntegerVariableID{Integer(value)};
     }
@@ -1268,18 +1276,22 @@ namespace gcs::test_innards
      * SimpleIntegerVariableID with domain [invert(lo), invert(hi)] (swapped if
      * needed for negation), then applies the view operators to land back on
      * the requested visible domain.
+     *
+     * The name, if given, goes on the underlying variable, which is what a proof
+     * log talks about; the visible domain is the one named in the test.
      */
-    auto create_integer_variable_or_constant_with_view(Problem & problem, std::pair<int, int> bounds, ViewWrap wrap) -> IntegerVariableID
+    auto create_integer_variable_or_constant_with_view(
+        Problem & problem, std::pair<int, int> bounds, ViewWrap wrap, const std::optional<std::string> & name = std::nullopt) -> IntegerVariableID
     {
         if (wrap.bare)
-            return create_integer_variable_or_constant(problem, bounds);
+            return create_integer_variable_or_constant(problem, bounds, name);
 
         auto u_lo = invert_view(wrap, bounds.first);
         auto u_hi = invert_view(wrap, bounds.second);
         if (u_lo > u_hi)
             std::swap(u_lo, u_hi);
 
-        IntegerVariableID v = problem.create_integer_variable(Integer(u_lo), Integer(u_hi));
+        IntegerVariableID v = problem.create_integer_variable(Integer(u_lo), Integer(u_hi), name);
         if (wrap.negate)
             v = -v;
         if (wrap.offset != 0)
@@ -1295,16 +1307,17 @@ namespace gcs::test_innards
      * Each value is inverted through the wrap so that, once the view applies
      * its transformation, the visible value set matches the input.
      */
-    auto create_integer_variable_or_constant_with_view(Problem & problem, std::vector<int> values, ViewWrap wrap) -> IntegerVariableID
+    auto create_integer_variable_or_constant_with_view(
+        Problem & problem, std::vector<int> values, ViewWrap wrap, const std::optional<std::string> & name = std::nullopt) -> IntegerVariableID
     {
         if (wrap.bare)
-            return create_integer_variable_or_constant(problem, values);
+            return create_integer_variable_or_constant(problem, values, name);
 
         std::vector<Integer> vs;
         for (auto value : values)
             vs.push_back(Integer(invert_view(wrap, value)));
 
-        IntegerVariableID v = problem.create_integer_variable(vs);
+        IntegerVariableID v = problem.create_integer_variable(vs, name);
         if (wrap.negate)
             v = -v;
         if (wrap.offset != 0)
@@ -1322,7 +1335,8 @@ namespace gcs::test_innards
      * that callers iterating over mixed var/const argument lists can apply a
      * wrap uniformly.
      */
-    auto create_integer_variable_or_constant_with_view(Problem & problem, int value, ViewWrap) -> IntegerVariableID
+    auto create_integer_variable_or_constant_with_view(Problem & problem, int value, ViewWrap, const std::optional<std::string> & = std::nullopt)
+        -> IntegerVariableID
     {
         return create_integer_variable_or_constant(problem, value);
     }
@@ -1332,17 +1346,20 @@ namespace gcs::test_innards
      *
      * `specs` and `wraps` must have equal size. Each element is dispatched to
      * the appropriate scalar overload of create_integer_variable_or_constant_with_view.
+     * A name, if given, is subscripted per element the way
+     * Problem::create_integer_variable_vector() does it.
      */
     template <typename Spec_>
-    auto create_integer_variable_or_constant_vector_with_views(
-        Problem & problem, const std::vector<Spec_> & specs, const std::vector<ViewWrap> & wraps) -> std::vector<IntegerVariableID>
+    auto create_integer_variable_or_constant_vector_with_views(Problem & problem, const std::vector<Spec_> & specs,
+        const std::vector<ViewWrap> & wraps, const std::optional<std::string> & name = std::nullopt) -> std::vector<IntegerVariableID>
     {
         if (specs.size() != wraps.size())
             throw UnexpectedException{"create_integer_variable_or_constant_vector_with_views: spec / wrap size mismatch"};
         std::vector<IntegerVariableID> result;
         result.reserve(specs.size());
         for (std::size_t i = 0; i < specs.size(); ++i)
-            result.push_back(create_integer_variable_or_constant_with_view(problem, specs.at(i), wraps.at(i)));
+            result.push_back(create_integer_variable_or_constant_with_view(
+                problem, specs.at(i), wraps.at(i), name.transform([&](const std::string & s) { return s + "[" + std::to_string(i) + "]"; })));
         return result;
     }
 


### PR DESCRIPTION
Closes #903. The diagnosis is in
[this comment](https://github.com/ciaranm/glasgow-constraint-solver/issues/903#issuecomment-5603962241);
the short version is that the 68 red tests were the sweep's own expectation, not
a view bug and not a propagation bug — the same failure reproduces with bare
variables, and `--view-wrap=1` is the identity view that `affine_of()` deviews
straight back to the bare variable.

Two commits, both in test code. Nothing in the solver changes, and Auto's budget
is left alone.

## 1. `constraints_test_utils.hh`: the creators take a name

`create_integer_variable_or_constant()` and its `_with_view()` overloads dropped
the name `Problem::create_integer_variable()` accepts, so moving a test onto them
traded its proof log's `i[x]` / `i[y]` for `i[_3]`. Now they pass it on (the
vector variant subscripts it the way `create_integer_variable_vector()` does).
Default argument, so no caller changes.

## 2. `divide_modulus_test.cc`: GAC only where it is promised, and a sweep that tests something

The branch passed `check_gac = ! is_bc`, demanding GAC of `consistency::Auto`,
whose contract is "tabulates when the domains are small" against
`default_tabulation_threshold()` = 100. Its ranges need 486 and 108 enumeration
nodes for divide, 432 and 144 for modulus. So: GAC-check `consistency::Tabulated`,
hold Auto to soundness and completeness.

Shrinking the ranges instead would not have been a fix. Under an offset wrap
Modulus's aux `|q|` level is sized from `max|x|`, so there is no range whose tree
stays inside 100 for every wrap — an Auto posting is not view-invariant even in
principle, which is why the assertion, not the data, had to go.

The second half of the commit is why the lane went unnoticed. This test (with
`multiply_test` and `power_test`) kept the underlying domain and folded the wrap
into the *predicate* rather than using
`create_integer_variable_or_constant_with_view()`, so its wraps changed the
problem instead of the encoding: **25%** of its uniform-sweep runs, and **every
single run** of the always-on `_view_mixed` lane, had no solutions at all. A lane
that cannot fail is not a gate. With the domains inverted instead, the expected
set is identical under every wrap, Auto's budget stops depending on the wrap, and
the sweep can carry a real Auto GAC lane again — `{0,2}x{1,2}x{-1,2}`, 24 nodes
for divide and 48 for modulus, inside the budget under all 18 wraps.

## Verification

- `ctest` **810/810** with `GCS_WERROR=ON`, both cap settings
  (`GCS_TEST_CAP_DEFAULTS` on and off).
- All **72** `divide_modulus_constraint_view_*` configurations pass at the
  default threshold (previously 68 failed); wraps 1–18 x positions
  all/0/1/2, run directly through the argv flags since the sweep stays off.
- The `_view_mixed` lane goes from 24 runs with no solutions to 36 runs with
  6/18/45 solutions each; solution counts are now identical across wraps.
- Negative controls, because two of the claims here are about a lane having
  teeth: `GCS_TABULATION_THRESHOLD=1` turns the new Auto GAC lane red, so it is
  really checking that Auto took the tabulating arm; and sabotaging
  `invert_view()` to drop the offset is caught by every offset-bearing wrap,
  while being a genuine no-op for wrap 1, as it should be.
- clang 21 `-fsyntax-only` clean on every affected TU (`element.cc`'s three
  `-Wunused-lambda-capture` are the usual local baseline), and the affected test
  binaries pass under clang + `-D_GLIBCXX_ASSERTIONS`.
- Proof logs keep their names: `i[x]`, `i[y]`, `i[out]`, plus
  `p[0_view_of_y_plus_17]` for the view itself.

## Not in this PR

- `multiply_test` and `power_test` have the identical convention problem (57% and
  44% empty sweep runs, 100% empty `_view_mixed` lanes) but are green today, so
  they follow separately rather than making this three test rewrites.
- A full `GCS_ENABLE_VIEW_WRAP_SWEEP=ON` run, which is worth doing once those two
  land rather than now; the sweep stays off by default either way.
- The two stale statements #903 mentions — `dev_docs/view-proof-logging.md`'s
  Status line and the CLAUDE.md sweep note — are #882's, and left alone here so
  they are not fixed twice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
