### PR TITLE
Give multiply's and power's view sweeps the domains they claim to test (#910)

### DIFF
--- a/gcs/constraints/divide_modulus/divide_modulus_test.cc
+++ b/gcs/constraints/divide_modulus/divide_modulus_test.cc
@@ -64,17 +64,6 @@ namespace
             .visit(level);
     }
 
-    auto wrap_label(const vector<ViewWrap> & wraps) -> string
-    {
-        string s = "(";
-        for (const auto & w : wraps) {
-            if (s.size() > 1)
-                s += ", ";
-            s += std::to_string(w.bare ? 1 : (w.negate ? -1 : 1)) + ", " + std::to_string(w.bare ? 0 : w.offset);
-        }
-        return s + ")";
-    }
-
     auto post_divmod(Problem & p, bool is_div, IntegerVariableID x, IntegerVariableID y, IntegerVariableID out, const DivideConsistency & level)
         -> void
     {
@@ -95,7 +84,7 @@ auto run_divmod_test(bool proofs, bool is_div, const DivideConsistency & level, 
     pair<int, int> out_range, vector<ViewWrap> wraps = {view_none(), view_none(), view_none()}) -> void
 {
     print(cerr, "{} {} {} {} {} {} views {} {}", is_div ? "divide" : "modulus", level_name(level), check_gac ? "gac-checked" : "plain", x_range,
-        y_range, out_range, wrap_label(wraps), proofs ? " with proofs:" : ":");
+        y_range, out_range, view_wraps_label(wraps), proofs ? " with proofs:" : ":");
     cerr << flush;
     set<tuple<int, int, int>> expected, actual;
 

--- a/gcs/constraints/innards/constraints_test_utils.hh
+++ b/gcs/constraints/innards/constraints_test_utils.hh
@@ -1481,6 +1481,26 @@ namespace gcs::test_innards
     }
 
     /**
+     * \brief The per-position (multiplier, offset) rendering of a wrap list, for
+     * a test's log line.
+     *
+     * Reads as the view spec the arithmetic tests used to pass around by hand:
+     * `(1, 0, -1, 5)` is a first position that is bare or identity-viewed, and a
+     * second that is `-v + 5`. A bare position and an identity view read the
+     * same, since they describe the same values.
+     */
+    inline auto view_wraps_label(const std::vector<ViewWrap> & wraps) -> std::string
+    {
+        std::string s = "(";
+        for (const auto & w : wraps) {
+            if (s.size() > 1)
+                s += ", ";
+            s += std::to_string(w.bare ? 1 : (w.negate ? -1 : 1)) + ", " + std::to_string(w.bare ? 0 : w.offset);
+        }
+        return s + ")";
+    }
+
+    /**
      * \brief Whether this config would produce no actual wrapping.
      *
      * True when wrap_index = 0 (view_none) or when single_position is set but

--- a/gcs/constraints/multiply/multiply_test.cc
+++ b/gcs/constraints/multiply/multiply_test.cc
@@ -55,37 +55,30 @@ namespace
     }
 }
 
-// Three distinct variables, optionally through views: constrain
-// (m1 * v1 + o1) * (m2 * v2 + o2) = (m3 * v3 + o3) and enumerate over the
-// underlying variables. With all multipliers 1 and offsets 0 this is the plain
-// case.
+// Three distinct variables, optionally through views. The wraps invert the
+// underlying domain, so the VISIBLE domains stay v1_range / v2_range / v3_range
+// and the expected solution set is the same under every wrap -- only the
+// constraint-side encoding differs, which is what the view sweep is for.
 string test_proof_suffix = "";
 
 auto run_multiply_test(bool proofs, const MultiplyConsistency & level, bool check_gac, pair<int, int> v1_range, pair<int, int> v2_range,
-    pair<int, int> v3_range, tuple<int, int, int, int, int, int> view_spec = {1, 0, 1, 0, 1, 0}) -> void
+    pair<int, int> v3_range, vector<ViewWrap> wraps = {view_none(), view_none(), view_none()}) -> void
 {
-    const auto & [m1, o1, m2, o2, m3, o3] = view_spec;
     print(cerr, "multiply {} {} {} {} {} views {} {}", level_name(level), check_gac ? "gac-checked" : "plain", v1_range, v2_range, v3_range,
-        view_spec, proofs ? " with proofs:" : ":");
+        view_wraps_label(wraps), proofs ? " with proofs:" : ":");
     cerr << flush;
     set<tuple<int, int, int>> expected, actual;
 
-    auto is_satisfying = [&](int a, int b, int c) { return (m1 * a + o1) * (m2 * b + o2) == (m3 * c + o3); };
+    auto is_satisfying = [&](int a, int b, int c) { return a * b == c; };
     build_expected(expected, is_satisfying, v1_range, v2_range, v3_range);
     println(cerr, " expecting {} solutions", expected.size());
 
     Problem p;
-    auto v1 = p.create_integer_variable(Integer(v1_range.first), Integer(v1_range.second), "v1");
-    auto v2 = p.create_integer_variable(Integer(v2_range.first), Integer(v2_range.second), "v2");
-    auto v3 = p.create_integer_variable(Integer(v3_range.first), Integer(v3_range.second), "v3");
+    auto v1 = create_integer_variable_or_constant_with_view(p, v1_range, wraps.at(0), "v1");
+    auto v2 = create_integer_variable_or_constant_with_view(p, v2_range, wraps.at(1), "v2");
+    auto v3 = create_integer_variable_or_constant_with_view(p, v3_range, wraps.at(2), "v3");
 
-    auto wrap = [&](SimpleIntegerVariableID v, int m, int o) -> IntegerVariableID {
-        IntegerVariableID result = v;
-        if (m == -1)
-            result = -result;
-        return result + Integer{o};
-    };
-    p.post(Multiply{wrap(v1, m1, o1), wrap(v2, m2, o2), wrap(v3, m3, o3)}.with_consistency(level));
+    p.post(Multiply{v1, v2, v3}.with_consistency(level));
 
     auto proof_name = proofs ? make_optional("multiply_test" + test_proof_suffix) : nullopt;
 
@@ -223,22 +216,18 @@ auto main(int argc, char * argv[]) -> int
     if (! view_wrap_config_is_effectively_bare(view_cfg, n_positions)) {
         test_proof_suffix = "_" + view_wrap_config_label(view_cfg);
         auto wraps = wraps_for_positions(view_cfg, n_positions);
-        auto spec_of = [&](int pos) -> pair<int, int> {
-            if (wraps[static_cast<size_t>(pos)].bare)
-                return {1, 0};
-            return {wraps[static_cast<size_t>(pos)].negate ? -1 : 1, wraps[static_cast<size_t>(pos)].offset};
-        };
-        auto [m1, o1] = spec_of(0);
-        auto [m2, o2] = spec_of(1);
-        auto [m3, o3] = spec_of(2);
         for (bool proofs : {false, true}) {
             if (proofs && ! can_run_veripb())
                 break;
             for (const auto & level : vector<MultiplyConsistency>{consistency::Auto{}, consistency::BC{}, consistency::Tabulated{}}) {
                 bool is_bc = holds_alternative<consistency::BC>(level);
-                run_multiply_test(proofs, level, ! is_bc, {1, 3}, {1, 3}, {1, 9}, tuple{m1, o1, m2, o2, m3, o3});
-                run_multiply_test(proofs, level, ! is_bc, {-2, 2}, {1, 2}, {-4, 4}, tuple{m1, o1, m2, o2, m3, o3});
-                run_multiply_test(proofs, level, ! is_bc, {-3, 2}, {-2, 3}, {-6, 7}, tuple{m1, o1, m2, o2, m3, o3});
+                // The product slot is a DeterminedVariable, so want_tabulation() skips its level
+                // and Auto's budget is 3 * 3, 5 * 2 and 6 * 6 here, well inside
+                // default_tabulation_threshold() = 100 whatever the wraps do. GAC is checked at
+                // every level but BC.
+                run_multiply_test(proofs, level, ! is_bc, {1, 3}, {1, 3}, {1, 9}, wraps);
+                run_multiply_test(proofs, level, ! is_bc, {-2, 2}, {1, 2}, {-4, 4}, wraps);
+                run_multiply_test(proofs, level, ! is_bc, {-3, 2}, {-2, 3}, {-6, 7}, wraps);
             }
         }
         return EXIT_SUCCESS;
@@ -257,9 +246,10 @@ auto main(int argc, char * argv[]) -> int
         generate_random_data(rand, random_bc_data, random_bounds(-10, 10, 3, 12), random_bounds(-10, 10, 3, 12), random_bounds(-80, 80, 10, 60));
         generate_random_data(rand, random_bc_data, random_bounds(0, 20, 2, 8), random_bounds(-6, 6, 2, 8), random_bounds(-60, 60, 20, 80));
     }
-    auto random_view_spec = [&]() -> tuple<int, int, int, int, int, int> {
-        uniform_int_distribution<int> sign(0, 1), offset(-3, 3);
-        return {sign(rand) ? 1 : -1, offset(rand), sign(rand) ? 1 : -1, offset(rand), sign(rand) ? 1 : -1, offset(rand)};
+    auto random_wraps = [&]() -> vector<ViewWrap> {
+        uniform_int_distribution<int> negate(0, 1), offset(-3, 3);
+        auto one = [&]() { return ViewWrap{false, negate(rand) == 1, offset(rand)}; };
+        return {one(), one(), one()};
     };
 
     for (bool proofs : {false, true}) {
@@ -271,11 +261,11 @@ auto main(int argc, char * argv[]) -> int
             // Small domains: Auto tabulates (3 * 3 * 9 = 81 <= threshold) and GAC
             // is forced, so both are GAC; BC is checked for soundness only.
             run_multiply_test(proofs, level, ! is_bc, {1, 3}, {1, 3}, {1, 9});
-            run_multiply_test(proofs, level, ! is_bc, {-2, 2}, {1, 2}, {-4, 4}, {1, 0, 1, 0, 1, 0});
+            run_multiply_test(proofs, level, ! is_bc, {-2, 2}, {1, 2}, {-4, 4}, {view_offset(0), view_offset(0), view_offset(0)});
 
             // Views, negatives, zero. 5 * 3 * 5 = 75 <= threshold.
-            run_multiply_test(proofs, level, ! is_bc, {-2, 2}, {0, 2}, {-2, 2}, {1, 2, -1, 1, 1, -1});
-            run_multiply_test(proofs, level, ! is_bc, {1, 3}, {1, 3}, {1, 5}, {-1, 0, 1, 0, -1, 2});
+            run_multiply_test(proofs, level, ! is_bc, {-2, 2}, {0, 2}, {-2, 2}, {view_offset(2), view_neg_offset(1), view_offset(-1)});
+            run_multiply_test(proofs, level, ! is_bc, {1, 3}, {1, 3}, {1, 5}, {view_neg(), view_offset(0), view_neg_offset(2)});
 
             // Aliased shapes, small: 7 * 10 = 70 and similar.
             run_alias_test(proofs, level, ! is_bc, "xxy", {-3, 3}, {0, 9});
@@ -304,7 +294,7 @@ auto main(int argc, char * argv[]) -> int
         // Wider domains: Auto falls back on bounds consistency; soundness and
         // completeness are still checked, per-node consistency is not.
         run_multiply_test(proofs, consistency::Auto{}, false, {-10, 10}, {-10, 10}, {-100, 100});
-        run_multiply_test(proofs, consistency::Auto{}, false, {2, 20}, {-8, 8}, {-160, 160}, {1, 0, 1, 1, 1, 0});
+        run_multiply_test(proofs, consistency::Auto{}, false, {2, 20}, {-8, 8}, {-160, 160}, {view_offset(0), view_offset(1), view_offset(0)});
         // A wide product with a small operand: the quotient estimate for the small operand can
         // fall outside its bit-encoding, so filter_quotient reports an inconsistent (empty)
         // quotient range on an infeasible node. Regression for a prove_quotient_bounds crash on
@@ -319,7 +309,7 @@ auto main(int argc, char * argv[]) -> int
             run_multiply_test(proofs, consistency::BC{}, false, r1, r2, r3);
         for (std::size_t x = 0; x < 4; ++x) {
             const auto & [r1, r2, r3] = random_bc_data.at(x);
-            run_multiply_test(proofs, consistency::BC{}, false, r1, r2, r3, random_view_spec());
+            run_multiply_test(proofs, consistency::BC{}, false, r1, r2, r3, random_wraps());
         }
     }
 

--- a/gcs/constraints/power/power_test.cc
+++ b/gcs/constraints/power/power_test.cc
@@ -106,30 +106,26 @@ auto run_power_var_exp_test(bool proofs, pair<int, int> base_range, pair<int, in
 
 // A structurally constant exponent, which dispatches on its value: linear for
 // 0 and 1, a Multiply chain for small positive, a case analysis for negative
-// or enormous ones.
+// or enormous ones. The wraps invert the underlying domain, so the VISIBLE
+// domains stay base_range / result_range and the expected solution set is the
+// same under every wrap -- only the constraint-side encoding differs, which is
+// what the view sweep is for.
 auto run_power_const_exp_test(bool proofs, const PowerConsistency & level, bool check_gac, pair<int, int> base_range, long long exp,
-    pair<int, int> result_range, tuple<int, int, int, int> view_spec = {1, 0, 1, 0}) -> void
+    pair<int, int> result_range, vector<ViewWrap> wraps = {view_none(), view_none()}) -> void
 {
-    const auto & [m1, o1, m3, o3] = view_spec;
     print(cerr, "power {} {} {} ^ {} = {} views {} {}", level_name(level), check_gac ? "gac-checked" : "plain", base_range, exp, result_range,
-        view_spec, proofs ? " with proofs:" : ":");
+        view_wraps_label(wraps), proofs ? " with proofs:" : ":");
     cerr << flush;
     set<tuple<int, int>> expected, actual;
 
-    build_expected(expected, [&](int a, int c) { return power_is_satisfying(m1 * a + o1, exp, m3 * c + o3); }, base_range, result_range);
+    build_expected(expected, [&](int a, int c) { return power_is_satisfying(a, exp, c); }, base_range, result_range);
     println(cerr, " expecting {} solutions", expected.size());
 
     Problem p;
-    auto v1 = p.create_integer_variable(Integer(base_range.first), Integer(base_range.second), "b");
-    auto v3 = p.create_integer_variable(Integer(result_range.first), Integer(result_range.second), "r");
+    auto v1 = create_integer_variable_or_constant_with_view(p, base_range, wraps.at(0), "b");
+    auto v3 = create_integer_variable_or_constant_with_view(p, result_range, wraps.at(1), "r");
 
-    auto wrap = [&](SimpleIntegerVariableID v, int m, int o) -> IntegerVariableID {
-        IntegerVariableID result = v;
-        if (m == -1)
-            result = -result;
-        return result + Integer{o};
-    };
-    p.post(Power{wrap(v1, m1, o1), constant_variable(Integer{exp}), wrap(v3, m3, o3)}.with_consistency(level));
+    p.post(Power{v1, constant_variable(Integer{exp}), v3}.with_consistency(level));
 
     auto proof_name = proofs ? make_optional("power_test" + test_proof_suffix) : nullopt;
     if (check_gac)
@@ -286,20 +282,17 @@ auto main(int argc, char * argv[]) -> int
     if (! view_wrap_config_is_effectively_bare(view_cfg, n_positions)) {
         test_proof_suffix = "_" + view_wrap_config_label(view_cfg);
         auto wraps = wraps_for_positions(view_cfg, n_positions);
-        auto spec_of = [&](int pos) -> pair<int, int> {
-            if (wraps[static_cast<size_t>(pos)].bare)
-                return {1, 0};
-            return {wraps[static_cast<size_t>(pos)].negate ? -1 : 1, wraps[static_cast<size_t>(pos)].offset};
-        };
-        auto [m1, o1] = spec_of(0);
-        auto [m3, o3] = spec_of(1);
         for (bool proofs : {false, true}) {
             if (proofs && ! can_run_veripb())
                 break;
             for (const auto & level : vector<PowerConsistency>{consistency::Auto{}, consistency::BC{}, consistency::Tabulated{}}) {
                 bool is_bc = holds_alternative<consistency::BC>(level);
-                run_power_const_exp_test(proofs, level, ! is_bc, {-3, 3}, 2, {-2, 9}, tuple{m1, o1, m3, o3});
-                run_power_const_exp_test(proofs, level, ! is_bc, {-2, 3}, 3, {-8, 27}, tuple{m1, o1, m3, o3});
+                // The result slot is a DeterminedVariable, so want_tabulation() skips its level
+                // and Auto's budget is the base's 7 and 6 here, well inside
+                // default_tabulation_threshold() = 100 whatever the wraps do. GAC is checked at
+                // every level but BC.
+                run_power_const_exp_test(proofs, level, ! is_bc, {-3, 3}, 2, {-2, 9}, wraps);
+                run_power_const_exp_test(proofs, level, ! is_bc, {-2, 3}, 3, {-8, 27}, wraps);
             }
         }
         return EXIT_SUCCESS;
@@ -333,8 +326,8 @@ auto main(int argc, char * argv[]) -> int
             run_power_const_exp_test(proofs, level, ! is_bc, {-2, 2}, -3, {-2, 2});
 
             // Views on the base and the result.
-            run_power_const_exp_test(proofs, level, ! is_bc, {-2, 2}, 2, {-1, 8}, {1, 1, 1, -1});
-            run_power_const_exp_test(proofs, level, ! is_bc, {1, 3}, 3, {-8, 8}, {-1, 1, 1, 0});
+            run_power_const_exp_test(proofs, level, ! is_bc, {-2, 2}, 2, {-1, 8}, {view_offset(1), view_offset(-1)});
+            run_power_const_exp_test(proofs, level, ! is_bc, {1, 3}, 3, {-8, 8}, {view_neg_offset(1), view_offset(0)});
         }
 
         // Wider domains fall back on the chain without tabulation.


### PR DESCRIPTION
Closes #910. **Stacked on #909** — base is `issue903-divide-modulus-view-sweep`,
since this uses the name parameter that PR adds to the helpers. Merge that first.

`multiply_test` and `power_test` were the other two tests building their view
sweep with a local `wrap` lambda: they kept the underlying domain and folded the
wrap into the *predicate*, so a wrap changed the problem rather than the
encoding, and most of what it changed it into had no solutions at all. Now they
use `create_integer_variable_or_constant_with_view()` like the other 41 tests in
the sweep, with the names it takes as of #909.

Three commits: the shared log label (divide_modulus grew a local copy in #909,
and a third caller is the point at which it should live in the utils), then one
test each.

## What changes, and what deliberately does not

The **GAC expectations are untouched** in both, unlike #903's. Multiply's product
slot and Power's result slot are `DeterminedVariable`s, so `want_tabulation()`
skips that level and their Auto budgets here are 3\*3, 5\*2, 6\*6 (multiply) and
the base's 7 and 6 (power), all well inside the threshold of 100 — and, unlike
Modulus, neither has a magnitude-derived aux level for a wrap's offset to
inflate, so those budgets are wrap-invariant. Their sweeps could always have
GAC-checked `Auto` safely; they just weren't checking it against anything.

The main body's hand-written view cases move to wraps too, so the file has one
convention rather than two, and multiply's random BC lane draws a random wrap
triple instead of a random view spec.

## Verification

- `ctest` **810/810** with `GCS_WERROR=ON`, both `GCS_TEST_CAP_DEFAULTS`
  settings.
- **72/72** multiply and **54/54** power sweep configurations pass (18 wraps x
  pall/p0/p1/p2 and pall/p0/p1), run through the argv flags with the sweep off.
- **No empty run left**: zero `expecting 0 solutions` across all 126
  configurations, against 57% (multiply) and 44% (power) before. Solution counts
  are now identical at every wrap.
- The always-on `_view_mixed` lanes go from 18 and 12 runs of nothing to 9/10/35
  and 6/7 solutions.
- Negative control: sabotaging `invert_view()` to drop the offset is caught by
  every offset-bearing wrap in both tests, and is a genuine no-op at wrap 1
  (offset 0), as it should be.
- clang 21 `-fsyntax-only` clean on every changed TU, and both binaries pass
  under clang + `-D_GLIBCXX_ASSERTIONS`.

Worth saying explicitly: this newly-real GAC coverage found **nothing**. Both
constraints achieve GAC through every wrap in the sweep, which is what should
have been on record for them all along.

## Next

With this and #909 in, one full `GCS_ENABLE_VIEW_WRAP_SWEEP=ON` run to put a
number on what the sweep actually says. The sweep stays off by default either
way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
