### PR TITLE
Two comment fixes from #905 and #909

### DIFF
--- a/dev_docs/large-domains.md
+++ b/dev_docs/large-domains.md
@@ -233,10 +233,11 @@ unreliable.** `Abs`' model is two half-reified rows: `v2 - v1 == 0` under
 
 So the rule to take away is about the *pairing*, not about `Abs`: **the two-lemma
 shape needs a lower bound on one operand and an upper bound on the other, across
-a row that is their difference.** A sign-flipped link does not qualify, and
-`justify_not_in_range.hh`'s suggestion that it just needs "the mirrored pairing"
-is too optimistic — the mirrored pairing is the non-propagating configuration
-above.
+a row that is their difference.** A sign-flipped link does not qualify.
+`justify_not_in_range.hh` used to suggest that it just needs "the mirrored
+pairing"; that was too optimistic — the mirrored pairing *is* the
+non-propagating configuration above — and the header comment was corrected to
+say so.
 
 `pol` is what does not care, which is why `abs/justify.cc` uses it for both
 branches: the model half, plus the defining item of each atom whose arithmetic

--- a/dev_docs/range_literals_spec.md
+++ b/dev_docs/range_literals_spec.md
@@ -255,7 +255,9 @@ Sound under this spec, and either already correct or a strict subset of §3:
   the corrected form of what the superseded analysis believed had to be a
   per-equality global covering. Caveat: this pairing is orientation-sensitive
   (same-sign links only, which is all current callers); a sign-flipped link
-  (Abs) needs the mirrored pairing — see the header comment.
+  (Abs) is *outside* Theorem 2.9's hypotheses rather than a mirrored instance of
+  it, and uses `pol` instead — see the Theorem 2.9 section of
+  [large-domains.md](large-domains.md).
 - The gated consumer in `enforce_equality` (`GCS_RANGE_INFERENCES`, default
   off) with the width-1 guard.
 

--- a/gcs/constraints/divide_modulus/divide_modulus_test.cc
+++ b/gcs/constraints/divide_modulus/divide_modulus_test.cc
@@ -236,9 +236,11 @@ auto main(int argc, char * argv[]) -> int
                 for (const auto & level : vector<DivideConsistency>{consistency::Auto{}, consistency::BC{}, consistency::Tabulated{}}) {
                     bool is_bc = holds_alternative<consistency::BC>(level);
                     bool force_gac = holds_alternative<consistency::Tabulated>(level);
-                    // Inside Auto's budget under every wrap (3 * 2 * 4 = 24 for divide, 3 * 2 * 8 = 48
-                    // for modulus, against default_tabulation_threshold() = 100), so Auto tabulates and
-                    // GAC is checked at every level but BC.
+                    // Inside Auto's budget under every wrap (3 * 2 * 4 = 24 for divide, and 24 for
+                    // modulus too, against default_tabulation_threshold() = 100), so Auto tabulates
+                    // and GAC is checked at every level but BC. Modulus's third factor is the aux
+                    // |q| domain, which for max|x| = 2 is [0, 3] -- not the [0, 7] that the two
+                    // larger cases below get.
                     run_divmod_test(proofs, is_div, level, ! is_bc, {0, 2}, {1, 2}, {-1, 2}, wraps);
                     // Over Auto's budget (486 and 108 for divide, 432 and 144 for modulus), where Auto
                     // is documented to fall back on the decomposition: soundness and completeness at


### PR DESCRIPTION
Three documentation-only fixes, two reported by merger-Claude. No behaviour or test changes.

### 1. `range_literals_spec.md` still forwarded readers to a header that refutes it

#905 retracted the claim that a sign-flipped link (Abs) just needs "the mirrored pairing". It rewrote the header comment in `justify_not_in_range.hh` to say the opposite — the mirrored pairing is precisely the non-propagating configuration, so Abs uses `pol` — and `large-domains.md` calls the old wording "too optimistic".

The spec was the third home of the claim, and it cited the header as corroboration, so a reader following the pointer landed on a refutation. It now points at the Theorem 2.9 section of `large-domains.md` and states that section's conclusion.

### 2. #909's small-case modulus budget was out by a factor of two

The comment said `3 * 2 * 8 = 48` for modulus; the budget is 24.

The `8` is the aux `|q|` domain size for the two *larger* cases, where the comment's 432 and 144 are exactly right. It was never recomputed for the small case: `|q|` is a bit-sum sized by `max|x|` (`prepare_divide_modulus` rounds up to `2^n - 1`), so `max|x| = 2` gives `[0, 3]` — four values, not eight.

Recomputed against `want_tabulation`, which drops the largest-domained determined variable from the product:

| case | divide | modulus |
| --- | --- | --- |
| `{0,2} {1,2} {-1,2}` | `3*2*4` = **24** | `3*2*4` = **24** (aux `[0,3]`, remainder skipped) |
| `{-4,4} {-2,3} {-4,4}` | 486 | 432 |
| `{0,5} {1,3} {0,5}` | 108 | 144 |

Both small-case figures are under `default_tabulation_threshold() = 100`, so the conclusion the comment supports — Auto tabulates, GAC is checked at every level but BC — is unaffected, and the test is correct as it stands.

Confirmed empirically as well as by derivation: merger-Claude bisected `GCS_TABULATION_THRESHOLD` on a modulus-only mutation (tabulates at 24, not at 23), and the whole test passes at `GCS_TABULATION_THRESHOLD=40`, which a 48-budget modulus could not do — the small case's Auto arm would have failed its GAC assertion.

### 3. `large-domains.md` described the header it had just corrected, in the present tense

Noticed while fixing (1). #905 rewrote `justify_not_in_range.hh`'s header to warn against the mirrored pairing and, in the same commit, wrote here that the header "suggests" it — so this file described a suggestion that no longer existed. Same claim and same retraction; only the tense was wrong.

The file's four other references to `justify_not_in_range_across_equality()` (lines 137, 150, 179, 908) all describe the difference configuration correctly and are left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
