### PR TITLE
Delete solx and soli constraints once they are spent

### DIFF
--- a/dev_docs/README.md
+++ b/dev_docs/README.md
@@ -209,6 +209,15 @@ library. For an introduction to *using* the solver, start with the top-level
   (entailment-based 2WL), reduced-nld extraction, and the proof lifecycle
   (root-keeps-level-1, deep-first-unwind RUP for reduced clauses, `solx`-enabled
   enumeration). Read when touching restarts, nogoods, or branching heuristics.
+- [Deleting solution clauses from a proof](solution-clause-deletion.md) — why the
+  constraint VeriPB derives from a `solx` or a `soli` lands in its *core* set and
+  stays there, what a deletion check needs before one can be taken away again
+  (and why the check may only propagate over core, which is what forces every
+  variable's encoding across too), how a backtrack clause is made to pay for the
+  blocking clause below it, where the core/derived line is drawn and why it is
+  drawn structurally rather than by need, and the measured cost against a 4x
+  saving on a large enumeration. Read when touching solution logging, proof
+  levels, or `ProofLevel::TopAndCore`.
 - [Refined triggers](refined-triggers.md) — the per-literal watch mechanism that
   lets a propagator wake only when specific literals (`x = v`, `x >= k`, ...)
   become entailed, instead of on every change to a whole variable: the

--- a/dev_docs/solution-clause-deletion.md
+++ b/dev_docs/solution-clause-deletion.md
@@ -1,0 +1,280 @@
+# Deleting solution clauses from a proof
+
+When the solver logs a solution, VeriPB derives a constraint from it and puts
+that constraint in the **core** set:
+
+- `soli`, for an optimisation problem, adds the objective-improving constraint
+  `objective <= value - 1`;
+- `solx`, for an enumeration, adds the blocking clause that forbids the
+  solution's assignment to the preserved variables.
+
+Neither goes away on its own. Without the machinery this note describes, a proof
+that finds *n* solutions ends with *n* extra core constraints, every one of them
+in the way of every unit propagation for the rest of the proof. On a 33k-solution
+enumeration that was 4x the verification time.
+
+Both are deleted now. The two cases are unrelated in every way except the shape
+of the problem, so they are dealt with separately.
+
+## What deleting from core costs
+
+VeriPB splits its constraint database into a **core** set and a **derived** set.
+Everything the solver derives with `pol`, `rup`, `red` or `ia` goes into the
+derived set, and deleting from there is free — which is what lets
+`forget_proof_level` throw away a whole subtree's reasoning with one `del range`.
+
+Deleting from the *core* set is not free. It needs a **deletion check**: a
+demonstration that what remains of the core still implies the constraint being
+removed, checked exactly as redundance-based strengthening is, and — this is the
+part that shapes everything below — able to propagate over **core constraints
+only**.
+
+VeriPB does not fail a proof when that check fails. It logs a warning, downgrades
+to unchecked deletion, and stops making the equi-enumerable / equi-optimal
+guarantees for the rest of the proof; an `s VERIFIED` line still comes out. What
+saves us is that it also stops counting excluded solutions and stops updating the
+best *valid* objective value, so an `ENUMERATION_COMPLETE n` or `BOUNDS` line
+afterwards fails on the count. That is a real backstop but a distant one, so
+every proof the test suite verifies is verified with
+**`--force-checked-deletion`**, which turns the warning into an error where it
+happened (`run_test_and_verify.bash` and `verify_proof_and_dispose` in
+`constraints_test_utils.hh`).
+
+## soli: the next bound deletes the last
+
+An objective-improving constraint is superseded the moment a better solution is
+found: `objective <= v' - 1` for `v' < v` implies `objective <= v - 1` outright.
+So `ProofLogger::solution` remembers the pair of lines each `soli` produces — the
+`soli` itself and the `objective < value` atom emitted beside it — and deletes
+them when the next `soli` arrives. The deletion check is a plain RUP against the
+new bound, which unit propagation over the objective's bits discharges without
+help, for every gap and for a signed objective as well as an unsigned one.
+
+The `soli` line therefore stays at `ProofLevel::Top`: the incumbent bound has to
+outlive the subtree it was found in, because every later branch anywhere in the
+tree prunes against it. Only the arrival of a better one may take it away.
+
+This is close to free, and close to worthless as an optimisation — branch and
+bound finds few incumbents, so there were never many of these. It is here because
+it is right, and because it costs one `del` line per solution to have it.
+
+## solx: the backtrack clause deletes the blocking clause
+
+A blocking clause is not like an incumbent bound. It only has to hold while the
+search is somewhere it could rediscover the same solution — and the backtrack out
+of the leaf that found it says exactly that the search is not there any more. So
+the `solx` line is recorded at `ProofLevel::Current`, which in a solution leaf at
+depth *d* is level *d+1*, and the frame's own tail deletes it:
+
+```
+solx i[_1][eq1] i[_2][eq2];      <- VeriPB adds the blocking clause, in core
+% backtracking
+rup 1 ~i[_1][eq1] 1 ~i[_2][eq2] >= 1;
+core id -1;                      <- the backtrack clause, moved to core
+del id -2;                       <- forget_proof_level takes the blocking clause
+```
+
+The deletion check works because the solution lies under the very guesses the
+backtrack clause forbids: negating the blocking clause fixes every preserved
+variable to the solution's values, propagation reaches each guess literal, and
+the backtrack clause is falsified.
+
+Backtrack clauses then have to be deleted in turn, and they are, by the same
+argument one level up: the clause for a child, over the guesses `g1..g(d+1)`, is
+implied by the parent's, over `g1..gd`, by weakening. The parent emits its own
+clause *before* forgetting the level below, so the witness is always in place by
+the time it is needed.
+
+### Which backtrack clauses go to core
+
+Only the ones that have to. A frame's clause is promoted exactly when the level
+it is about to forget can hold a core constraint, and only two things put one
+there: a `solx` blocking clause, recorded by a solution leaf, and a child's
+promoted clause. Both amount to "a solution was found somewhere under here",
+which is what `this_subtree_contains_solution` already says, so `solve_with_state`
+passes `ClauseSet::Core` on exactly that condition (and only for an enumeration —
+an optimisation logs `soli` and never lands anything core at a search level).
+
+A subtree with no solutions in it pays nothing, and neither does a refutation.
+
+### Restarts
+
+A restart unwind is the one place a frame discards the level below it without
+deriving a backtrack clause of its own. What justifies the deletions there are
+the reduced nld-nogoods the unwind already learns (see
+[restarts, nogoods and weighting](restarts-nogoods-weighting.md)): each is a
+subset of the backtrack clause of the sibling it was learned from — reduction
+drops decisions, it does not add any — and so implies it. A nogood is something
+the search derived rather than part of any variable's encoding, so nothing puts
+it in core on its behalf: it is moved across explicitly, under the same condition
+as the backtrack clauses. One is emitted for every refuted sibling, whatever
+shape its decision has, because skipping one would leave a deletion with nothing
+to check it against.
+
+### Assertion levels
+
+Above `AssertionLevel::Definitions` the proof stops writing the encoding down and
+asserts its links instead, so nothing could carry a blocking clause's
+preserved-variable assignment across to the atoms a backtrack clause is written
+in, and the deletion check could not succeed. Such a proof keeps its blocking
+clauses: `ProofLogger` records them at Top again and promotes no backtrack
+clause. It is not a self-contained proof in the first place, and this is one more
+thing it leaves to whoever consumes its assertions. (Nothing needs suppressing on
+the encoding side — at those levels the definitions are not emitted at all, so
+there is nothing to move.)
+
+The `soli` deletions are unaffected, and stay on at every level: an objective
+bound and its successor are constraints over the same objective bits, and the
+check between them needs no definitions.
+
+## Why the encoding has to be in core too
+
+This is the part that is not obvious. A blocking clause is written over the
+**preserved** variables, which is to say a variable's *bits*. A backtrack clause
+is written over branching decisions, which is to say its *order*, *equality* and
+*interval* atoms. What carries one to the other is the linking constraints — and
+the deletion check may only propagate over the core.
+
+For a literal that already existed when the model was written, the links are OPB
+rows, and the OPB is core, so this is invisible. For a literal first needed
+partway through the search — an interval literal a brancher asks for, an equality
+atom for a value nothing had mentioned yet — the links are `red` lines in the
+proof, and land in the derived set where the deletion check cannot see them. That
+is not a corner case: it is most of them, and the first attempt at this failed on
+essentially every constraint test for exactly this reason.
+
+So a variable's **encoding** goes into core. `ProofLevel::TopAndCore` is how it
+says so: it means what `Top` means — keep this for the whole proof — and
+additionally emits a `core id` for the line. Every one of the tracker's emissions
+names it, and nothing else does, so what is in core is visible at the point each
+constraint is created rather than inferred from surrounding state.
+
+### Where the line is drawn, and why there
+
+Structurally, not by need: *the encoding of a variable is in core; what a
+propagator derives about a problem is not.*
+
+Drawing it by need would be smaller. Deleting a backtrack clause needs no
+encoding at all — negating the child's clause sets its guess literals directly,
+and the parent's clause is a literal-subset of them, so it falsifies by
+subsumption; same for the restart nogoods. The only check that has to cross from
+bits to atoms is the blocking-clause one, and its path today is `bits → gevar →
+eqvar / interval` through those literals' own defining rows. On `langford 7`,
+that would be about a third of what actually goes across.
+
+It is drawn structurally anyway, for two reasons.
+
+The first is that "by need" is not a property anything can rely on. Which rows a
+check needs depends on what the search happened to branch on — nothing stops a
+user's brancher from branching on intervals, which the built-in heuristics other
+than `reject_random_interval` do not — and on which of several shapes a literal
+was given, since `define_plain_invar`, the cell / `not_in_range` route and a
+view's own range literals all reach a range literal differently. Establishing
+that the definitions alone suffice meant reading all three, and it would need
+re-establishing every time the literal machinery moved. A rule that changes with
+either is a poor foundation for anything that reasons about the core, such as a
+redundance-based symmetry break.
+
+The second is that the *converse* — putting more than the encoding in core — is
+not free either. VeriPB's solution check (`get_unsatisfied_core_constraint`)
+requires **every core constraint** to be satisfied by the solution's propagated
+assignment, and does not look at derived ones at all. Sweeping a propagator's
+standing lemmas into core would quietly make every one of them an obligation on
+every later `solx`, with a `SolutionNotSatisfiedConstraint` landing a long way
+from the propagator that caused it.
+
+### Not deferred, and not batched either
+
+The `core id` goes out with the line it names. Two earlier versions of this did
+less work and were both worse.
+
+The first deferred the move to the first excluded solution, which made a
+refutation byte-identical to what it had been. That is not worth having: it makes
+"is this link in core?" answerable only relative to how far the search has got,
+and a core-sensitive step would silently see one core before the first solution
+and another after. For the same reason the move is not conditional on the proof
+being an enumeration either — an encoding that is core when an objective is
+posted and derived when one is not would be just as awkward to reason against.
+
+The second kept an RAII scope over each of the tracker's entry points and flushed
+one `core range` per contiguous run when the outermost scope was released. That
+one is defensible — nothing between entering and leaving a scope can observe core
+membership, so it was batching rather than deferral — but it put the answer to
+"does this constraint go in core?" in ambient state that a caller could not see,
+and it was not paying for itself: emitting the ids eagerly instead costs 1-3% of
+proof size (`langford 6` +3.3%, `langford 7` +1.9%, `langford 8` +0.8%,
+`regular_random -n 6` +0.004%) and, measured on all four, nothing at all in
+checking time.
+
+## What it costs and what it buys
+
+Measured on this machine, against the same solver without any of this:
+
+Enumeration, which is what this is for:
+
+| instance | solutions | proof size | veripb |
+| --- | --- | --- | --- |
+| `langford 6` (refutation) | 0 | +5.3% | unchanged |
+| `langford 7` | 52 | +3.3% | +6% |
+| `langford 8` | 300 | +1.5% | +21% |
+| `regular_random --all --seed 1 -n 6` | 32985 | +6.0% | **4.3x faster** |
+
+The cost is one extra RUP check per backtrack on a path to a solution, paid
+whether or not there are enough solutions for the deletions to earn it back. The
+benefit grows with the number of live blocking clauses avoided, so it is
+superlinear in the solution count and the crossover is somewhere in the low
+thousands. A proof with a handful of solutions is slightly worse off; a proof
+with enough solutions for its verification cost to be a problem in the first
+place is much better off.
+
+The `langford 8` figure was +11% when propagator lemmas were being swept into
+core along with the encoding, and became +23% when they stopped being. Confirmed
+by putting them back, which restores the old figure exactly: the deletion checks
+were using those lemmas as shortcuts, and without them propagate further through
+the encoding instead. That is the price of the narrower rule, taken deliberately
+— see the two reasons above.
+
+### What an optimisation proof pays
+
+An optimisation proof deletes only `soli` constraints, and that check needs no
+encoding at all — an objective bound and its successor are constraints over the
+same objective bits, which are OPB rows. So the encoding being in core buys
+nothing here, and it is not free:
+
+| instance | baseline | with the encoding in core |
+| --- | --- | --- |
+| `table_layout --size 5` | 0.55s | 1.11s |
+| `tour` | 1.38s | 2.47s |
+| `table_layout --size 4` | 0.26s | 0.38s |
+| `talent` | 3.60s | 2.84s |
+| `knapsack`, `p_dispersion`, `colour` | < 0.03s | unchanged |
+
+Isolated: suppressing the `soli` deletions changes none of these, while taking
+the encoding back out of core reproduces the baseline column exactly, so the
+whole swing is VeriPB's per-solution check, which has to find every core
+constraint satisfied by the propagated assignment. Why `talent` moves the other
+way is not established.
+
+This is the price of the encoding being in core unconditionally rather than only
+where a blocking clause could need it. It is paid deliberately: gating it on the
+kind of proof would mean a redundance-based symmetry break seeing the encoding in
+core when enumerating and not when optimising, which is the sort of thing that is
+very hard to be sure about later. But it is a real cost on a real workload, not a
+rounding error, and worth revisiting if optimisation proof checking becomes the
+thing that hurts.
+
+## Testing
+
+Every proof the suite verifies is verified with `--force-checked-deletion`, so
+any deletion whose check does not hold fails the test that produced it, rather
+than silently downgrading the guarantee. Adding that flag on its own left the
+suite green, which is what says it was a no-op before this work.
+
+`gcs/solve_test.cc` has the two shape tests, `Enumeration deletes its
+solution-excluding clauses` and `Optimisation deletes its superseded objective
+bounds`. They exist because losing the deletions leaves every proof still
+verifying — just with a core set that grows once per solution — so nothing else
+in the suite would notice. They compute where the blocking clause has ended up
+relative to the backtrack clause and check that the deletion that follows covers
+it, and they check the `soli` pair. Each was confirmed to fail with the
+corresponding piece of the mechanism disabled.

--- a/gcs/constraints/innards/constraints_test_utils.hh
+++ b/gcs/constraints/innards/constraints_test_utils.hh
@@ -77,6 +77,25 @@ namespace gcs::test_innards
     }
 
     /**
+     * \brief Always ask VeriPB to treat a failed checked deletion as an error.
+     *
+     * Deleting a constraint from VeriPB's *core* set needs a deletion check ---
+     * a proof that the remaining core still implies what is being removed. By
+     * default VeriPB does not fail when that check fails: it logs a warning,
+     * downgrades to unchecked deletion, and stops making the equi-enumerable /
+     * equi-optimal guarantees for the rest of the proof. A `s VERIFIED` line
+     * still comes out, so a proof that quietly lost its guarantees looks exactly
+     * like one that kept them.
+     *
+     * That is the failure mode the solver's `solx` and `soli` deletions are
+     * exposed to, so every test's verification asks for the strict behaviour
+     * instead. It costs nothing when nothing core is deleted, which is the case
+     * for every proof that logs no solution. See
+     * dev_docs/solution-clause-deletion.md.
+     */
+    inline constexpr const char * veripb_checked_deletion_flag = "--force-checked-deletion";
+
+    /**
      * The file extensions a proving run can leave beside its proof. Only .opb
      * and .pbp are always written; .scp and .varmap appear for the runs that ask
      * for them. std::remove and std::rename on an absent file are harmless
@@ -319,7 +338,7 @@ namespace gcs::test_innards
      */
     [[nodiscard]] inline auto verify_proof_and_dispose(const std::string & proof_name) -> bool
     {
-        if (! run_veripb(proof_name + ".opb", proof_name + ".pbp"))
+        if (! run_veripb(veripb_checked_deletion_flag, proof_name + ".opb", proof_name + ".pbp"))
             return false;
         check_scp_writer_reader_symmetry(proof_name);
         cake_probe_chain(proof_name); // PROBE: measure workflow-2 chain (no-op unless GCS_TEST_CAKE)

--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -477,7 +477,7 @@ auto NamesAndIDsTracker::need_constraint_saying_variable_takes_at_least_one_valu
                 for (Integer v = lower; v <= upper; ++v)
                     al1s += 1_i * (var == v);
 
-                auto line = _imp->logger->emit_rup_proof_line(al1s >= 1_i, ProofLevel::Top);
+                auto line = _imp->logger->emit_rup_proof_line(al1s >= 1_i, ProofLevel::TopAndCore);
                 result = _imp->variable_at_least_one_constraints.emplace(var, line).first;
             }
             return result->second;
@@ -499,7 +499,7 @@ auto NamesAndIDsTracker::need_constraint_saying_variable_takes_at_least_one_valu
                     for (Integer v = lower; v <= upper; ++v)
                         al1s += 1_i * (*v_id == v);
 
-                    auto line = _imp->logger->emit_rup_proof_line(al1s >= 1_i, ProofLevel::Top);
+                    auto line = _imp->logger->emit_rup_proof_line(al1s >= 1_i, ProofLevel::TopAndCore);
                     result = _imp->variable_at_least_one_constraints.emplace(*v_id, line).first;
                 }
                 return result->second;
@@ -765,7 +765,7 @@ auto NamesAndIDsTracker::need_direct_encoding_for(SimpleOrProofOnlyIntegerVariab
             visit(
                 [&](const auto & id) {
                     auto [_f_line, _r_line] =
-                        _imp->logger->emit_red_proof_lines_reifying(WPBSum{} + 1_i * ! (id >= (v + 1_i)) >= 1_i, id == v, ProofLevel::Top);
+                        _imp->logger->emit_red_proof_lines_reifying(WPBSum{} + 1_i * ! (id >= (v + 1_i)) >= 1_i, id == v, ProofLevel::TopAndCore);
                     forwards_line = _f_line;
                     reverse_line = _r_line;
                 },
@@ -787,7 +787,7 @@ auto NamesAndIDsTracker::need_direct_encoding_for(SimpleOrProofOnlyIntegerVariab
             visit(
                 [&](const auto & id) {
                     auto [_f_line, _r_line] =
-                        _imp->logger->emit_red_proof_lines_reifying(WPBSum{} + 1_i * (id >= v) >= 1_i, id == v, ProofLevel::Top);
+                        _imp->logger->emit_red_proof_lines_reifying(WPBSum{} + 1_i * (id >= v) >= 1_i, id == v, ProofLevel::TopAndCore);
                     forwards_line = _f_line;
                     reverse_line = _r_line;
                 },
@@ -809,7 +809,7 @@ auto NamesAndIDsTracker::need_direct_encoding_for(SimpleOrProofOnlyIntegerVariab
             visit(
                 [&](const auto & id) {
                     auto [_f_line, _r_line] = _imp->logger->emit_red_proof_lines_reifying(
-                        WPBSum{} + (1_i * (id >= v)) + (1_i * ! (id > v)) >= 2_i, id == v, ProofLevel::Top);
+                        WPBSum{} + (1_i * (id >= v)) + (1_i * ! (id > v)) >= 2_i, id == v, ProofLevel::TopAndCore);
                     forwards_line = _f_line;
                     reverse_line = _r_line;
                 },
@@ -868,8 +868,8 @@ auto NamesAndIDsTracker::need_direct_encoding_for(SimpleOrProofOnlyIntegerVariab
 
                 auto assert_or_rup =
                     logger->get_assertion_level() == AssertionLevel::Links ? ProofRule(AssertProofRule{}) : ProofRule(RUPProofRule{});
-                logger->emit(assert_or_rup, WPBSum{} + 1_i * ! v_cond + 1_i * x_cond >= 1_i, ProofLevel::Top);
-                logger->emit(assert_or_rup, WPBSum{} + 1_i * ! x_cond + 1_i * v_cond >= 1_i, ProofLevel::Top);
+                logger->emit(assert_or_rup, WPBSum{} + 1_i * ! v_cond + 1_i * x_cond >= 1_i, ProofLevel::TopAndCore);
+                logger->emit(assert_or_rup, WPBSum{} + 1_i * ! x_cond + 1_i * v_cond >= 1_i, ProofLevel::TopAndCore);
             });
         }
     }
@@ -932,7 +932,8 @@ auto NamesAndIDsTracker::need_gevar(SimpleOrProofOnlyIntegerVariableID id, Integ
     }
     else if (_imp->logger) {
         auto def_lines = visit(
-            [&](const auto & id) { return _imp->logger->emit_red_proof_lines_reifying(WPBSum{} + (1_i * id) >= v, id >= v, ProofLevel::Top); }, id);
+            [&](const auto & id) { return _imp->logger->emit_red_proof_lines_reifying(WPBSum{} + (1_i * id) >= v, id >= v, ProofLevel::TopAndCore); },
+            id);
         _imp->atoms_for(id).ge_defs.try_emplace(v.raw_value, def_lines);
     }
     else {
@@ -963,10 +964,10 @@ auto NamesAndIDsTracker::need_gevar(SimpleOrProofOnlyIntegerVariableID id, Integ
             emit_proof_line_now_or_at_start([this, id, v, ge_label](ProofLogger * const logger) {
                 visit(
                     [&](const auto & vid) {
-                        logger->emit(ImpliesProofRule{}, reify(WPBSum{} + (1_i * vid) >= v, {{vid >= v}}), ProofLevel::Top, std::nullopt,
+                        logger->emit(ImpliesProofRule{}, reify(WPBSum{} + (1_i * vid) >= v, {{vid >= v}}), ProofLevel::TopAndCore, std::nullopt,
                             ProofLineLabel{ge_label + "[r]"});
-                        logger->emit(ImpliesProofRule{}, reify(WPBSum{} + (-1_i * vid) >= -v + 1_i, {{vid < v}}), ProofLevel::Top, std::nullopt,
-                            ProofLineLabel{ge_label + "[f]"});
+                        logger->emit(ImpliesProofRule{}, reify(WPBSum{} + (-1_i * vid) >= -v + 1_i, {{vid < v}}), ProofLevel::TopAndCore,
+                            std::nullopt, ProofLineLabel{ge_label + "[f]"});
                     },
                     id);
             });
@@ -996,7 +997,8 @@ auto NamesAndIDsTracker::need_gevar(SimpleOrProofOnlyIntegerVariableID id, Integ
             auto annotation = AssertionAnnotation{.hint_name = hints::InitialBound::hint_name};
             auto line = visit(
                 [&](auto vid) {
-                    return logger->emit(assert_or_rup, WPBSum{} + 1_i * (negated ? ! (vid >= v) : (vid >= v)) >= 1_i, ProofLevel::Top, annotation);
+                    return logger->emit(
+                        assert_or_rup, WPBSum{} + 1_i * (negated ? ! (vid >= v) : (vid >= v)) >= 1_i, ProofLevel::TopAndCore, annotation);
                 },
                 id);
             // Remembered so that a step wanting this fact can cite it instead of
@@ -1049,7 +1051,7 @@ auto NamesAndIDsTracker::need_gevar(SimpleOrProofOnlyIntegerVariableID id, Integ
                         return;
                     ProofRule assert_or_rup =
                         logger->get_assertion_level() == AssertionLevel::Links ? ProofRule(AssertProofRule{}) : ProofRule(RUPProofRule{});
-                    logger->emit(assert_or_rup, c, ProofLevel::Top, link_hint);
+                    logger->emit(assert_or_rup, c, ProofLevel::TopAndCore, link_hint);
                 });
             }, //
             [&](const SimpleIntegerVariableID & id) {
@@ -1058,12 +1060,13 @@ auto NamesAndIDsTracker::need_gevar(SimpleOrProofOnlyIntegerVariableID id, Integ
                 }
                 else if (_imp->assertion_level == AssertionLevel::Links) {
                     auto chain_con = WPBSum{} + (1_i * (id >= v)) + (1_i * ! (id >= *higher_gevar)) >= 1_i;
-                    emit_proof_line_now_or_at_start(
-                        [c = chain_con, link_hint](ProofLogger * const logger) { logger->emit(AssertProofRule{}, c, ProofLevel::Top, link_hint); });
+                    emit_proof_line_now_or_at_start([c = chain_con, link_hint](ProofLogger * const logger) {
+                        logger->emit(AssertProofRule{}, c, ProofLevel::TopAndCore, link_hint);
+                    });
                 }
                 else {
                     auto pol = make_pol_chain_line(id >= v, ! (id >= *higher_gevar));
-                    emit_proof_line_now_or_at_start([pol](ProofLogger * const logger) { pol->emit(*logger, ProofLevel::Top); });
+                    emit_proof_line_now_or_at_start([pol](ProofLogger * const logger) { pol->emit(*logger, ProofLevel::TopAndCore); });
                 }
             } //
         }
@@ -1080,7 +1083,7 @@ auto NamesAndIDsTracker::need_gevar(SimpleOrProofOnlyIntegerVariableID id, Integ
                         return;
                     ProofRule assert_or_rup =
                         logger->get_assertion_level() == AssertionLevel::Links ? ProofRule(AssertProofRule{}) : ProofRule(RUPProofRule{});
-                    logger->emit(assert_or_rup, c, ProofLevel::Top, link_hint);
+                    logger->emit(assert_or_rup, c, ProofLevel::TopAndCore, link_hint);
                 });
             }, //
             [&](const SimpleIntegerVariableID & id) {
@@ -1090,12 +1093,12 @@ auto NamesAndIDsTracker::need_gevar(SimpleOrProofOnlyIntegerVariableID id, Integ
                 else if (_imp->assertion_level == AssertionLevel::Links) {
                     auto chain_con = WPBSum{} + (1_i * (id >= *prev(this_gevar))) + (1_i * ! (id >= v)) >= 1_i;
                     emit_proof_line_now_or_at_start([c = chain_con, link_hint = link_hint](ProofLogger * const logger) {
-                        logger->emit(AssertProofRule{}, c, ProofLevel::Top, link_hint);
+                        logger->emit(AssertProofRule{}, c, ProofLevel::TopAndCore, link_hint);
                     });
                 }
                 else {
                     auto pol = make_pol_chain_line(id >= *prev(this_gevar), ! (id >= v));
-                    emit_proof_line_now_or_at_start([pol](ProofLogger * const logger) { pol->emit(*logger, ProofLevel::Top); });
+                    emit_proof_line_now_or_at_start([pol](ProofLogger * const logger) { pol->emit(*logger, ProofLevel::TopAndCore); });
                 }
             } //
         }
@@ -1141,8 +1144,8 @@ auto NamesAndIDsTracker::need_gevar(SimpleOrProofOnlyIntegerVariableID id, Integ
                 auto d1 = WPBSum{} + 1_i * ! v_atom + 1_i * x_cond >= 1_i;
                 auto d2 = WPBSum{} + 1_i * ! x_cond + 1_i * v_atom >= 1_i;
                 emit_proof_line_now_or_at_start([d1, d2, link_hint](ProofLogger * const logger) {
-                    logger->emit(AssertProofRule{}, d1, ProofLevel::Top, link_hint);
-                    logger->emit(AssertProofRule{}, d2, ProofLevel::Top, link_hint);
+                    logger->emit(AssertProofRule{}, d1, ProofLevel::TopAndCore, link_hint);
+                    logger->emit(AssertProofRule{}, d2, ProofLevel::TopAndCore, link_hint);
                 });
                 return;
             }
@@ -1165,8 +1168,8 @@ auto NamesAndIDsTracker::need_gevar(SimpleOrProofOnlyIntegerVariableID id, Integ
                 auto b2 = make_shared<PolBuilder>();
                 b2->add(*v_rev_line).add(link.second).add(d2_x).saturate();
                 emit_proof_line_now_or_at_start([b1, b2](ProofLogger * const logger) {
-                    b1->emit(*logger, ProofLevel::Top);
-                    b2->emit(*logger, ProofLevel::Top);
+                    b1->emit(*logger, ProofLevel::TopAndCore);
+                    b2->emit(*logger, ProofLevel::TopAndCore);
                 });
             }
         }
@@ -1211,7 +1214,7 @@ auto NamesAndIDsTracker::link_immediate_containment(SimpleOrProofOnlyIntegerVari
                 else
                     edge += 1_i * not_in_range(id, clo, chi);
                 edge += 1_i * in_range(id, plo, phi);
-                _imp->logger->emit_rup_proof_line(move(edge) >= 1_i, ProofLevel::Top);
+                _imp->logger->emit_rup_proof_line(move(edge) >= 1_i, ProofLevel::TopAndCore);
             },
             id);
     };
@@ -1269,7 +1272,7 @@ auto NamesAndIDsTracker::define_plain_invar(SimpleOrProofOnlyIntegerVariableID i
         ? visit(
               [&](const auto & id) {
                   return _imp->logger->emit_red_proof_lines_reifying(
-                      WPBSum{} + (1_i * (id >= lo)) + (1_i * ! (id > hi)) >= 2_i, in_range(id, lo, hi), ProofLevel::Top);
+                      WPBSum{} + (1_i * (id >= lo)) + (1_i * ! (id > hi)) >= 2_i, in_range(id, lo, hi), ProofLevel::TopAndCore);
               },
               id)
         : make_pair(ProofLine{}, ProofLine{});
@@ -1340,7 +1343,7 @@ auto NamesAndIDsTracker::ensure_partition_cut(SimpleOrProofOnlyIntegerVariableID
     visit([&](const auto & id) { covering += 1_i * not_in_range(id, a, b); }, id);
     append_cell_literal_to(covering, id, a, p - 1_i);
     append_cell_literal_to(covering, id, p, b);
-    _imp->logger->emit_rup_proof_line(move(covering) >= 1_i, ProofLevel::Top);
+    _imp->logger->emit_rup_proof_line(move(covering) >= 1_i, ProofLevel::TopAndCore);
 }
 
 auto NamesAndIDsTracker::init_interval_partition(SimpleOrProofOnlyIntegerVariableID id, Integer request_lo, Integer request_hi) -> void
@@ -1378,7 +1381,7 @@ auto NamesAndIDsTracker::init_interval_partition(SimpleOrProofOnlyIntegerVariabl
             define_plain_invar(id, cell_lo, cell_hi);
         append_cell_literal_to(root_covering, id, cell_lo, cell_hi);
     }
-    _imp->logger->emit_rup_proof_line(move(root_covering) >= 1_i, ProofLevel::Top);
+    _imp->logger->emit_rup_proof_line(move(root_covering) >= 1_i, ProofLevel::TopAndCore);
 }
 
 auto NamesAndIDsTracker::need_invar(SimpleOrProofOnlyIntegerVariableID id, Integer lo, Integer hi) -> ProofLiteral
@@ -1437,7 +1440,7 @@ auto NamesAndIDsTracker::need_invar(SimpleOrProofOnlyIntegerVariableID id, Integ
     visit([&](const auto & id) { covering += 1_i * not_in_range(id, lo, hi); }, id);
     for (auto it = boundaries.find(span_lo); *it != span_hi + 1_i; ++it)
         append_cell_literal_to(covering, id, *it, *next(it) - 1_i);
-    _imp->logger->emit_rup_proof_line(move(covering) >= 1_i, ProofLevel::Top);
+    _imp->logger->emit_rup_proof_line(move(covering) >= 1_i, ProofLevel::TopAndCore);
     return as_literal();
 }
 
@@ -1624,7 +1627,7 @@ auto NamesAndIDsTracker::derive_deviewed_form_for(const ProofLine & v_form_line,
     }
 
     emit_proof_line_now_or_at_start([this, v_form_line, pol](ProofLogger * const logger) {
-        auto deview_line = pol->emit(*logger, ProofLevel::Top);
+        auto deview_line = pol->emit(*logger, ProofLevel::TopAndCore);
         register_deviewed_line(v_form_line, deview_line);
     });
 }

--- a/gcs/innards/proofs/proof_logger-fwd.hh
+++ b/gcs/innards/proofs/proof_logger-fwd.hh
@@ -18,7 +18,30 @@ namespace gcs::innards
     {
         Current,
         Top,
-        Temporary
+        Temporary,
+        /**
+         * As Top --- kept for the whole proof --- and additionally moved into
+         * VeriPB's core set with a `core id`.
+         *
+         * Used for one thing: a variable's *encoding*.
+         *
+         * The deletion check that lets a `solx` blocking clause go away has to
+         * get from the preserved variables the clause is written over (a
+         * variable's bits) to the atoms the backtrack clause justifying it is
+         * written over (its order, equality and interval literals), and only
+         * core constraints count towards that check. The rows that make that
+         * crossing are a variable's encoding. They are OPB rows, hence already
+         * core, for anything that existed when the model was written; a literal
+         * first needed partway through the search is defined by a `red` in the
+         * proof instead, and without this would land in the derived set where
+         * the check cannot see it.
+         *
+         * Emitted by NamesAndIDsTracker, and only by it: the line is drawn
+         * structurally, at a variable's encoding rather than at whatever a check
+         * turns out to need, so a propagator's standing lemma stays derived.
+         * See dev_docs/solution-clause-deletion.md.
+         */
+        TopAndCore
     };
 }
 

--- a/gcs/innards/proofs/proof_logger.cc
+++ b/gcs/innards/proofs/proof_logger.cc
@@ -177,6 +177,11 @@ struct ProofLogger::Imp
     int active_proof_level = 0;
     deque<IntervalSet<long long>> proof_lines_by_level;
 
+    // The `soli` line, and the objective-improving atom line beside it, for the
+    // most recent solution of an optimisation problem. Kept so that the next,
+    // strictly better solution can delete both: see ProofLogger::solution.
+    optional<pair<ProofLine, ProofLine>> previous_soli_lines;
+
     string proof_file;
     fstream proof;
     // A proof is many short lines; the default stream buffer makes for a
@@ -184,6 +189,11 @@ struct ProofLogger::Imp
     // via pubsetbuf before open in start_proof.
     vector<char> proof_stream_buffer;
     int current_indent = 0;
+    // How many `subproof` blocks deep we are. Constraints derived inside one do
+    // not survive its `qed;`, so a line recorded at Top from in there must not
+    // be moved to core: `core id` inside a subproof addresses something the
+    // outer database has never seen.
+    int subproof_depth = 0;
     AssertionLevel assertion_level;
 
     // Scratch buffers for assembling proof lines before they are written out,
@@ -295,14 +305,44 @@ auto ProofLogger::solution(const vector<pair<IntegerVariableID, Integer>> & all_
     }
 
     _imp->proof << ";\n";
-    record_proof_line(advance_proof_line_number(), ProofLevel::Top);
+
+    // Both rules put the constraint they derive into VeriPB's *core* set, where
+    // it stays until something explicitly takes it away, and where it is a drag
+    // on every later unit propagation. Which is to say: both want deleting, and
+    // they want deleting in different ways.
+    //
+    // A `solx` blocking clause is only needed while the search is still
+    // somewhere that could rediscover the same solution, so it is recorded at
+    // the *current* proof level. The backtrack out of the leaf that found the
+    // solution then deletes it along with everything else at that level, and
+    // that frame's backtrack clause --- which we have moved to core for exactly
+    // this purpose --- is what passes VeriPB's deletion check for it.
+    //
+    // A `soli` objective-improving constraint has to outlive its subtree: it is
+    // the incumbent bound, and every later branch anywhere in the tree prunes
+    // against it. So it stays at Top and is deleted below instead, at the point
+    // where a strictly better one has replaced it.
+    // A `soli` constraint stays at Top and is deleted below, when a better one
+    // replaces it. So does a `solx` blocking clause in a proof that cannot
+    // delete it: above AssertionLevel::Definitions the encoding is not written
+    // down, so nothing could carry the clause's preserved-variable assignment
+    // across to the atoms a backtrack clause is written in, and the deletion
+    // check would have to fail.
+    auto solution_level =
+        (optional_minimise_variable_and_value || _imp->assertion_level > AssertionLevel::Definitions) ? ProofLevel::Top : ProofLevel::Current;
+    auto solution_line = record_proof_line(advance_proof_line_number(), solution_level);
+
+    // The objective-improving constraint's line, and the atom line beside it,
+    // both of which the next solution supersedes.
+    optional<pair<ProofLine, ProofLine>> soli_lines;
 
     if (optional_minimise_variable_and_value && _imp->assertion_level > AssertionLevel::Definitions)
         // soli and no links => have to assert the objective improving constraint
         visit(
             [&](const auto & id) {
-                emit(AssertProofRule{}, WPBSum{} + 1_i * (id < optional_minimise_variable_and_value->second) >= 1_i, ProofLevel::Top,
+                auto atom_line = emit(AssertProofRule{}, WPBSum{} + 1_i * (id < optional_minimise_variable_and_value->second) >= 1_i, ProofLevel::Top,
                     AssertionAnnotation{.hint_name = hints::SoliImprove::hint_name});
+                soli_lines.emplace(solution_line, atom_line);
             },
             optional_minimise_variable_and_value->first);
     else if (optional_minimise_variable_and_value)
@@ -313,17 +353,34 @@ auto ProofLogger::solution(const vector<pair<IntegerVariableID, Integer>> & all_
                 emit_inequality_to(names_and_ids_tracker(), WPBSum{} + 1_i * id <= optional_minimise_variable_and_value->second - 1_i, _imp->proof);
                 _imp->proof << ":" << relative_proof_line(_imp->proof_line, _imp->proof_line.number) << ";\n";
 
-                emit_rup_proof_line(WPBSum{} + 1_i * (id < optional_minimise_variable_and_value->second) >= 1_i, ProofLevel::Top);
+                auto atom_line = emit_rup_proof_line(WPBSum{} + 1_i * (id < optional_minimise_variable_and_value->second) >= 1_i, ProofLevel::Top);
+                soli_lines.emplace(solution_line, atom_line);
             },
             optional_minimise_variable_and_value->first);
     else if (_imp->assertion_level > AssertionLevel::Definitions) {
-        // solx and no links => have to assert the blocking constraint
-        emit(AssertProofRule{}, blocking_sum >= 1_i, ProofLevel::Top, AssertionAnnotation{.hint_name = hints::SolxBlock::hint_name});
+        // solx and no links => have to assert the blocking constraint. At the
+        // same level as the solx itself: it is the same fact said in literals
+        // rather than in bits, so it goes when the solx goes, and stays when the
+        // solx stays.
+        emit(AssertProofRule{}, blocking_sum >= 1_i, solution_level, AssertionAnnotation{.hint_name = hints::SolxBlock::hint_name});
     }
     // nothing needs done for solx below AssertionLevel::Links
+
+    if (soli_lines) {
+        // The constraint we have just added is `objective <= value - 1` for a
+        // strictly smaller value than the one it replaces, so it implies the
+        // older constraint outright and VeriPB's deletion check for the older
+        // one is a plain RUP against what remains of the core. Likewise for the
+        // `objective < value` atom beside it, which is merely derived and so
+        // costs nothing to delete. Without this the proof carries one live
+        // objective bound per solution found rather than one in total.
+        if (_imp->previous_soli_lines)
+            delete_proof_lines({_imp->previous_soli_lines->first, _imp->previous_soli_lines->second});
+        _imp->previous_soli_lines = soli_lines;
+    }
 }
 
-auto ProofLogger::backtrack(const vector<Literal> & guesses) -> void
+auto ProofLogger::backtrack(const vector<Literal> & guesses, ClauseSet destination) -> void
 {
     _imp->proof << "% backtracking\n";
     // The backtrack clause is `at least one guess is false': exactly a
@@ -335,17 +392,39 @@ auto ProofLogger::backtrack(const vector<Literal> & guesses) -> void
     for (const auto & guess : guesses)
         guesses_as_reason.emplace_back(ProofLiteral{guess});
     auto assert_or_rup = (_imp->assertion_level >= AssertionLevel::Inferences) ? ProofRule(AssertProofRule{}) : ProofRule(RUPProofRule{});
-    emit_under_reason(
+    auto line = emit_under_reason(
         assert_or_rup, WPBSum{} >= 1_i, ProofLevel::Current, guesses_as_reason, AssertionAnnotation{.hint_name = hints::Backtrack::hint_name});
+
+    // The caller asks for core when the level it is about to forget can hold a
+    // blocking clause. Whether such a clause is deletable at all turns on the
+    // assertion level, which is the logger's to know: see solution() above.
+    if (ClauseSet::Core == destination && _imp->assertion_level <= AssertionLevel::Definitions)
+        move_to_core(line);
 }
 
-auto ProofLogger::emit_learned_nogood(const vector<Literal> & decisions) -> ProofLine
+auto ProofLogger::move_to_core(const ProofLine & line) -> void
+{
+    // `core id` is unconditional --- anything the proof has derived could have
+    // been derived into the core in the first place --- and does not itself
+    // produce a constraint, so the line counter does not move.
+    write_indent();
+    _imp->proof << "core id " << relative_proof_line(line, _imp->proof_line.number) << ";\n";
+}
+
+auto ProofLogger::emit_learned_nogood(const vector<Literal> & decisions, ClauseSet destination) -> ProofLine
 {
     _imp->proof << "% learned nogood\n";
     WPBSum clause;
     for (const auto & lit : decisions)
         clause += 1_i * ! lit;
-    return emit_rup_proof_line(move(clause) >= 1_i, ProofLevel::Top);
+    auto line = emit_rup_proof_line(move(clause) >= 1_i, ProofLevel::Top);
+
+    // A nogood is something the search derived rather than part of any
+    // variable's encoding, so nothing puts it in core on its behalf.
+    if (ClauseSet::Core == destination && _imp->assertion_level <= AssertionLevel::Definitions)
+        move_to_core(line);
+
+    return line;
 }
 
 auto ProofLogger::end_proof() -> void
@@ -707,6 +786,15 @@ auto ProofLogger::record_proof_line(ProofLineNumber line, ProofLevel level) -> P
 {
     switch (level) {
     case ProofLevel::Top: _imp->proof_lines_by_level.at(0).insert_at_end(line.number); break;
+    case ProofLevel::TopAndCore:
+        _imp->proof_lines_by_level.at(0).insert_at_end(line.number);
+        // Into VeriPB's core set as well: see ProofLevel::TopAndCore. Not from
+        // inside a subproof, where the constraint does not survive the `qed;`
+        // and `core id` would be addressing something the outer database has
+        // never seen.
+        if (0 == _imp->subproof_depth)
+            move_to_core(line);
+        break;
     case ProofLevel::Current: _imp->proof_lines_by_level.at(_imp->active_proof_level).insert_at_end(line.number); break;
     case ProofLevel::Temporary: _imp->proof_lines_by_level.at(_imp->active_proof_level + 1).insert_at_end(line.number); break;
     }
@@ -729,6 +817,7 @@ auto ProofLogger::emit_subproofs(const map<ProofGoal, Subproof> & subproofs)
     _imp->proof << " : subproof\n";
     advance_proof_line_number();
     _imp->current_indent += INDENT_WIDTH;
+    ++_imp->subproof_depth;
     for (const auto & [proofgoal, proof] : subproofs) {
         // A ProofLine proofgoal (naming a specific constraint, as circuit does)
         // is a reference and must be relativised like any other -- but VeriPB
@@ -755,6 +844,7 @@ auto ProofLogger::emit_subproofs(const map<ProofGoal, Subproof> & subproofs)
         write_indent();
         _imp->proof << "qed;\n";
     }
+    --_imp->subproof_depth;
     _imp->current_indent -= INDENT_WIDTH;
     write_indent();
     _imp->proof << "qed;\n";

--- a/gcs/innards/proofs/proof_logger.hh
+++ b/gcs/innards/proofs/proof_logger.hh
@@ -39,6 +39,33 @@ namespace gcs::innards
 
     using ProofRule = std::variant<RUPProofRule, AssertProofRule, ImpliesProofRule>;
 
+    /**
+     * \brief Which of VeriPB's two constraint sets a clause the search derives
+     * should end up in.
+     *
+     * VeriPB splits its constraint database into a *core* set and a *derived*
+     * set. Deleting a derived constraint is free; deleting a core constraint
+     * needs a deletion check first --- a demonstration that what is left of the
+     * core still implies the constraint being removed --- and only constraints
+     * in the core count towards that check.
+     *
+     * Everything the solver derives lands in the derived set, which is what we
+     * want: the search deletes an enormous number of lines, and each one being
+     * free to delete is why forget_proof_level can do it with a `del range`.
+     * The exception is a clause we intend to *use* as the reason a core
+     * constraint may go away. The blocking clause a `solx` adds is core, so
+     * deleting it needs something in the core that implies it, and the
+     * backtrack clause for the subtree that solution was found in is exactly
+     * such a clause.
+     *
+     * \sa ProofLogger::backtrack, and dev_docs/solution-clause-deletion.md
+     */
+    enum class ClauseSet
+    {
+        Derived, ///< Leave it in the derived set: free to delete, no use as a deletion witness.
+        Core     ///< Move it to the core set, so it can justify deleting a solution-excluding clause.
+    };
+
     using ProofGoal = std::variant<ProofLine, std::string>;
     // No ostream operator for ProofGoal: a ProofLine goal is a constraint
     // reference and must be emitted relative to the current line, which needs
@@ -59,6 +86,8 @@ namespace gcs::innards
         auto emit_subproofs(const std::map<ProofGoal, Subproof> & subproofs) -> auto;
 
         auto log_stacktrace() -> void;
+
+        auto move_to_core(const ProofLine & line) -> void;
 
     public:
         /**
@@ -92,8 +121,16 @@ namespace gcs::innards
 
         /**
          * Log that we are backtracking.
+         *
+         * Pass \c ClauseSet::Core when the subtree being left behind had a
+         * solution excluded anywhere inside it. The backtrack clause is then
+         * moved into VeriPB's core set, where it can serve as the deletion
+         * check for every `solx` blocking clause and every deeper backtrack
+         * clause recorded at the level this frame is about to forget: it
+         * implies all of them, the solutions and subtrees they speak about
+         * lying under the very guesses it forbids.
          */
-        auto backtrack(const std::vector<Literal> & guesses) -> void;
+        auto backtrack(const std::vector<Literal> & guesses, ClauseSet = ClauseSet::Derived) -> void;
 
         /**
          * Derive a learned nogood --- the clause forbidding the given conjunction
@@ -101,8 +138,16 @@ namespace gcs::innards
          * its proof line. Used when restart learning records a nogood as the stack
          * unrolls: the clause is RUP from the refutation still in scope, and being
          * at Top it survives the restart's forget. Like backtrack() but kept.
+         *
+         * A restart unwind is the one place a frame discards the level below it
+         * without deriving a backtrack clause of its own, so when that level
+         * holds core clauses these nogoods are what has to justify deleting
+         * them: each is a subset of the backtrack clause of the sibling it was
+         * learned from, and so implies it. Pass \c ClauseSet::Core to put them
+         * where that check can see them: a nogood is something the search
+         * derived, not part of any variable's encoding, so nothing else does it.
          */
-        auto emit_learned_nogood(const std::vector<Literal> & decisions) -> ProofLine;
+        auto emit_learned_nogood(const std::vector<Literal> & decisions, ClauseSet = ClauseSet::Derived) -> ProofLine;
 
         /**
          * Log that we have reached an unsatisfiable conclusion at the end of the proof.

--- a/gcs/solve.cc
+++ b/gcs/solve.cc
@@ -221,6 +221,19 @@ namespace
             }
         }
 
+        // Whether the clause refuting this subtree has to go into VeriPB's core
+        // set. It does exactly when the level we are about to forget can hold a
+        // core constraint of its own, and there are only two things that put one
+        // there: a `solx` blocking clause, recorded by a solution leaf at the
+        // level it was found at, and the backtrack clause of a child that
+        // needed to be in core for the same reason. Both happen if and only if a
+        // solution was found somewhere under here, which is what
+        // this_subtree_contains_solution says. An optimisation problem logs
+        // `soli` rather than `solx` and deletes its superseded bounds by hand,
+        // so nothing core ever lands at a search level and no clause here needs
+        // promoting.
+        auto backtrack_clause_set = (this_subtree_contains_solution && ! problem.optional_minimise_variable()) ? ClauseSet::Core : ClauseSet::Derived;
+
         // Restart-nogood learning: each sibling refuted at this frame before the
         // cutoff yields a reduced nld-nogood --- the positive decisions on the path
         // to here (reduced_prefix) plus that refuted decision. The clause drops the
@@ -231,21 +244,32 @@ namespace
         // and the whole restart, and feed it to the store for the next pass.
         if (learned_nogoods && result == SearchResult::RestartCutoffHit && ! refuted_siblings.empty()) {
             for (const auto & sibling : refuted_siblings) {
-                // The refuted sibling heads the nogood; if it is not a plain
-                // condition (a proof-scaffolding literal) skip it.
-                auto sibling_cond = std::get_if<IntegerVariableCondition>(&sibling);
-                if (! sibling_cond)
-                    continue;
-                Nogood nogood = reduced_prefix;
-                nogood.push_back(*sibling_cond);
+                // The proof line goes out for every refuted sibling, whatever
+                // shape its decision has. On this path the frame is about to
+                // throw away the level below it without deriving a backtrack
+                // clause of its own, so when that level holds a core constraint
+                // --- a `solx` blocking clause, or a child's promoted backtrack
+                // clause --- this nogood is the only thing left that implies it,
+                // and skipping one would leave a deletion with nothing to check
+                // it against. It does imply it: dropping the refutation-flip
+                // decisions makes the nogood a subset of that sibling's
+                // backtrack clause.
                 if (logger) {
                     vector<Literal> decisions;
                     decisions.reserve(reduced_prefix.size() + 1);
                     for (const auto & cond : reduced_prefix)
                         decisions.push_back(cond);
-                    decisions.push_back(*sibling_cond);
-                    logger->emit_learned_nogood(decisions);
+                    decisions.push_back(sibling);
+                    logger->emit_learned_nogood(decisions, backtrack_clause_set);
                 }
+
+                // The store holds plain conditions, so a sibling that is not one
+                // (a proof-scaffolding literal) is not something it can record.
+                auto sibling_cond = std::get_if<IntegerVariableCondition>(&sibling);
+                if (! sibling_cond)
+                    continue;
+                Nogood nogood = reduced_prefix;
+                nogood.push_back(*sibling_cond);
                 learned_nogoods->add(move(nogood));
             }
         }
@@ -269,7 +293,7 @@ namespace
                 vector<Literal> guesses;
                 for (const auto & g : state.guesses())
                     guesses.push_back(g);
-                logger->backtrack(guesses);
+                logger->backtrack(guesses, backtrack_clause_set);
                 logger->forget_proof_level(depth + 1);
             }
         }

--- a/gcs/solve_test.cc
+++ b/gcs/solve_test.cc
@@ -20,10 +20,13 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include <algorithm>
 #include <cstdlib>
+#include <fstream>
 #include <map>
 #include <memory>
 #include <optional>
+#include <ranges>
 #include <set>
 #include <sstream>
 #include <string>
@@ -35,6 +38,7 @@ using namespace gcs::innards;
 using namespace gcs::test_innards;
 
 using std::function;
+using std::getline;
 using std::nullopt;
 using std::optional;
 using std::string;
@@ -456,6 +460,194 @@ TEST_CASE("Enumerate all solutions with restarts")
     CHECK(stats.solutions == 6);
     CHECK(stats.restarts > 0); // restarts actually fired during enumeration
     CHECK(stats.learned_nogoods > 0);
+    CHECK(verify_proof_and_dispose(proof_name));
+}
+
+namespace
+{
+    // The lines of a proof the solver has just written, for a test that wants to
+    // assert on its shape rather than only on whether VeriPB accepts it.
+    [[nodiscard]] auto read_proof_lines(const string & proof_name) -> vector<string>
+    {
+        std::ifstream proof{proof_name + ".pbp"};
+        REQUIRE(proof);
+        vector<string> lines;
+        for (string line; getline(proof, line);)
+            lines.push_back(line);
+        return lines;
+    }
+
+    // A proof line with its leading indent (subproofs indent theirs) removed.
+    [[nodiscard]] auto undented(const string & line) -> string
+    {
+        return line.substr(std::min(line.find_first_not_of(' '), line.size()));
+    }
+
+    // Whether this line is a rule that adds exactly one constraint, and so moves
+    // VeriPB's id counter on by one. Deletions, `core` moves, the `e` sanity
+    // check and comments do not.
+    [[nodiscard]] auto adds_a_constraint(const string & line) -> bool
+    {
+        auto text = undented(line);
+        for (const auto & rule : {"pol ", "rup ", "rup;", "rup>", "ia ", "a ", "red ", "solx ", "solx;", "soli "})
+            if (text.starts_with(rule))
+                return true;
+        return false;
+    }
+
+    // Whether a `del id X;` or `del range A B;` command --- with X, A and B the
+    // negative, relative ids the solver always emits --- takes out constraint
+    // `relative_id`. `range` is half-open.
+    [[nodiscard]] auto deletion_covers(const string & line, long long relative_id) -> bool
+    {
+        std::istringstream parse{undented(line)};
+        string del, kind;
+        if (! (parse >> del >> kind) || del != "del")
+            return false;
+        if (kind == "id") {
+            long long id{};
+            return (parse >> id) && id == relative_id;
+        }
+        else if (kind == "range") {
+            long long from{}, to{};
+            return (parse >> from >> to) && from <= relative_id && relative_id < to;
+        }
+        return false;
+    }
+}
+
+// The blocking clause a `solx` adds is a *core* constraint in VeriPB, so it stays
+// live --- slowing every later unit propagation down --- until something deletes
+// it, which needs a deletion check, which needs a core constraint that implies
+// it. The solver arranges one: the backtrack clause for the subtree the solution
+// was found in, moved across with `core id`. Losing any part of that leaves every
+// proof still verifying, just with a core set that grows once per solution, so
+// nothing else in the suite would notice. This pins the shape.
+TEST_CASE("Enumeration deletes its solution-excluding clauses")
+{
+    const auto proof_name = "solve_test_enumeration_deletes_solx";
+
+    Problem p;
+    auto a = p.create_integer_variable(1_i, 3_i);
+    auto b = p.create_integer_variable(1_i, 3_i);
+    p.post(NotEquals{a, b});
+
+    unsigned long long solutions = 0;
+    solve(
+        p,
+        [&](const CurrentState &) -> bool {
+            ++solutions;
+            return true;
+        },
+        ProofOptions{proof_name});
+    CHECK(solutions == 6);
+
+    auto lines = read_proof_lines(proof_name);
+
+    // A variable's encoding goes into core as it is written, not once some
+    // solution has shown up to need it: there are `core id` lines before the
+    // first solution is even logged, and each sits directly after the line that
+    // produced the constraint it names, rather than being batched up behind
+    // state saying what a later flush should sweep.
+    bool cored_before_any_solution = false;
+    for (std::size_t i = 1; i != lines.size(); ++i) {
+        if (lines[i].starts_with("solx"))
+            break;
+        if (undented(lines[i]).starts_with("core id"))
+            cored_before_any_solution = true;
+    }
+    CHECK(cored_before_any_solution);
+
+    for (std::size_t i = 1; i != lines.size(); ++i)
+        if (undented(lines[i]).starts_with("core id"))
+            CHECK(adds_a_constraint(lines[i - 1]));
+
+    unsigned long long excluded = 0;
+    for (std::size_t i = 0; i != lines.size(); ++i) {
+        if (! lines[i].starts_with("solx"))
+            continue;
+        ++excluded;
+
+        // Rendering the backtrack clause can introduce literals, whose
+        // definitions land between the solution and the clause; count them, so
+        // we know how far back the blocking clause has ended up by the time the
+        // clause is out. A subproof in there would consume ids of its own and
+        // throw the count off --- there is no reason for one, so require its
+        // absence rather than quietly miscount.
+        long long constraints_after_solx = 0;
+        std::size_t clause = i + 1;
+        for (; clause != lines.size() && ! undented(lines[clause]).starts_with("core id"); ++clause) {
+            REQUIRE(! lines[clause].contains("subproof"));
+            if (adds_a_constraint(lines[clause]))
+                ++constraints_after_solx;
+        }
+        REQUIRE(clause != lines.size());
+
+        // The backtrack clause is the last of those, and sits at -1, so the
+        // blocking clause is one further back for every definition in between.
+        auto blocking_clause = -1 - constraints_after_solx;
+
+        // The deletions the clause pays for follow it immediately, one of them
+        // taking the blocking clause out.
+        bool deleted = false;
+        for (auto del = clause + 1; del != lines.size() && undented(lines[del]).starts_with("del "); ++del)
+            if (deletion_covers(lines[del], blocking_clause))
+                deleted = true;
+        CHECK(deleted);
+    }
+    CHECK(excluded == solutions);
+
+    CHECK(verify_proof_and_dispose(proof_name));
+}
+
+// The counterpart for optimisation. A `soli` objective-improving constraint is
+// core too, and one accumulates per solution found; each is implied outright by
+// the next, strictly better one, so the next one's arrival is where the old one
+// goes. Largest-first values make the incumbent improve once per value rather
+// than landing on the optimum straight away.
+TEST_CASE("Optimisation deletes its superseded objective bounds")
+{
+    const auto proof_name = "solve_test_optimisation_deletes_soli";
+
+    Problem p;
+    auto v = p.create_integer_variable(1_i, 5_i);
+    p.minimise(v);
+
+    unsigned long long solutions = 0;
+    solve_with(p,
+        SolveCallbacks{.solution = [&](const CurrentState &) -> bool {
+                           ++solutions;
+                           return true;
+                       },
+            .branch = branch_with(variable_order::dom_then_deg(p), value_order::largest_first())},
+        ProofOptions{proof_name});
+    CHECK(solutions == 5);
+
+    auto lines = read_proof_lines(proof_name);
+
+    // Each `soli` is followed by the `e` line the proof trimmer wants and the
+    // `objective < value` atom, and then --- for every solution but the first ---
+    // by the deletion of the pair the previous solution left behind: its
+    // objective-improving constraint and its atom.
+    unsigned long long improved = 0, superseded = 0;
+    for (std::size_t i = 0; i != lines.size(); ++i) {
+        if (! lines[i].starts_with("soli"))
+            continue;
+        REQUIRE(i + 4 < lines.size());
+        CHECK(lines[i + 1].starts_with("e "));
+        CHECK(lines[i + 2].starts_with("rup "));
+        if (improved++ == 0) {
+            // Nothing to supersede yet.
+            CHECK(! undented(lines[i + 3]).starts_with("del "));
+            continue;
+        }
+        CHECK(undented(lines[i + 3]).starts_with("del id "));
+        CHECK(undented(lines[i + 4]).starts_with("del id "));
+        ++superseded;
+    }
+    CHECK(improved == solutions);
+    CHECK(superseded == solutions - 1);
+
     CHECK(verify_proof_and_dispose(proof_name));
 }
 

--- a/minizinc/run_fzn_json_test.bash
+++ b/minizinc/run_fzn_json_test.bash
@@ -35,9 +35,15 @@ if ! diff -u <(sort < "$jsondir/$testname.expected") "$testname.fzn.sols" ; then
     exit 2
 fi
 
+# --force-checked-deletion: a failed core deletion check is only a warning by
+# default -- VeriPB downgrades to unchecked deletion, drops its
+# equi-enumerable / equi-optimal guarantees and still prints `s VERIFIED`.
+# The solver deletes `solx` and `soli` constraints, which are exactly the
+# deletions that check applies to, so ask for the strict behaviour.
+# See dev_docs/solution-clause-deletion.md.
 if veripb --help >/dev/null 2>&1 ; then
     "$fznglasgow" -a --prove --proof-files-basename "$testname" "$infile" || exit 3
-    if ! veripb "$testname.opb" "$testname.pbp" ; then
+    if ! veripb --force-checked-deletion "$testname.opb" "$testname.pbp" ; then
         echo "Rerunning last 100 lines of proof verification in trace mode..."
         echo '$ ' veripb --trace "$(readlink -f "$testname.opb")" "$(readlink -f "$testname.pbp")"
         # the trace rerun fails again by construction; we still want exit 4

--- a/minizinc/run_minizinc_test.bash
+++ b/minizinc/run_minizinc_test.bash
@@ -140,10 +140,16 @@ for reference in ${reference_solvers[@]+"${reference_solvers[@]}"} ; do
     fi
 done
 
+# --force-checked-deletion: a failed core deletion check is only a warning by
+# default -- VeriPB downgrades to unchecked deletion, drops its
+# equi-enumerable / equi-optimal guarantees and still prints `s VERIFIED`.
+# The solver deletes `solx` and `soli` constraints, which are exactly the
+# deletions that check applies to, so ask for the strict behaviour.
+# See dev_docs/solution-clause-deletion.md.
 if [[ "$doproofs" == "true" ]] && veripb --help >/dev/null ; then
     minizinc --solver "$solver_msc" -a ${solverflags[@]+"${solverflags[@]}"} "$minizincdir/tests/$testname.mzn" \
         --prove --proof-files-basename "$testname" | tee "$testname.glasgow.out" || exit 7
-    if ! veripb "$testname.opb" "$testname.pbp" ; then
+    if ! veripb --force-checked-deletion "$testname.opb" "$testname.pbp" ; then
         echo "Rerunning last 100 lines of proof verification in trace mode..."
         echo '$ ' veripb --trace "$(readlink -f "$testname.opb")" "$(readlink -f "$testname.pbp")"
         # the trace rerun fails again by construction; we still want exit 8

--- a/run_test_and_verify.bash
+++ b/run_test_and_verify.bash
@@ -52,7 +52,13 @@ else
     "$prog" --prove "$@" || exit 1
 fi
 
-veripb "${proofname}.opb" "${proofname}.pbp" || exit 1
+# --force-checked-deletion: deleting a constraint from VeriPB's core set needs a
+# deletion check, and by default a failed check is only a warning -- VeriPB
+# downgrades to unchecked deletion, drops its equi-enumerable / equi-optimal
+# guarantees, and still prints `s VERIFIED`. The solx and soli deletions the
+# solver emits are exactly the deletions that check applies to, so ask for the
+# strict behaviour. It is free for a proof that deletes nothing from core.
+veripb --force-checked-deletion "${proofname}.opb" "${proofname}.pbp" || exit 1
 
 # Writer/reader symmetry: whatever .scp the run wrote must be one gcs::read_scp
 # can rebuild. The chain harness re-solves the .scp as its first step, so a

--- a/verified_encodings/run_scp_chain.bash
+++ b/verified_encodings/run_scp_chain.bash
@@ -70,7 +70,7 @@ if ! have "$CAKE_PB_CP"; then
     # cake_pb_cp unavailable -- fall back to a workflow-1 self-verify so the case
     # still gets checked (the solver's proof is valid against its own OPB).
     echo "[fallback] cake_pb_cp not on PATH (set CAKE_PB_CP to override); workflow-1 self-verify only"
-    out=$(veripb "${base}.opb" "${base}.pbp" 2>&1)
+    out=$(veripb --force-checked-deletion "${base}.opb" "${base}.pbp" 2>&1)
     if ! verified "$out"; then echo "FAIL: self-verify"; tail -5 <<< "$out"; exit 1; fi
     check_bounds "$out"
     grep -E '^s VERIFIED' <<< "$out"
@@ -83,8 +83,14 @@ echo "[2] cake_pb_cp: re-derive OPB from ${base}.scp"
 "$CAKE_PB_CP" "${base}.scp" > "${base}.verifiedopb"
 [[ -s "${base}.verifiedopb" ]] || { echo "FAIL: cake_pb_cp produced no OPB"; exit 1; }
 
+# --force-checked-deletion: a failed core deletion check is only a warning by
+# default -- VeriPB downgrades to unchecked deletion, drops its
+# equi-enumerable / equi-optimal guarantees and still prints `s VERIFIED`.
+# The solver deletes `solx` and `soli` constraints, which are exactly the
+# deletions that check applies to, so ask for the strict behaviour.
+# See dev_docs/solution-clause-deletion.md.
 echo "[3] veripb --elaborate: solver proof against cake's OPB -> core"
-out=$(veripb "${base}.verifiedopb" "${base}.pbp" --elaborate "${base}.corepb" 2>&1)
+out=$(veripb --force-checked-deletion "${base}.verifiedopb" "${base}.pbp" --elaborate "${base}.corepb" 2>&1)
 if ! verified "$out"; then echo "FAIL: veripb did not verify"; tail -5 <<< "$out"; exit 1; fi
 
 echo "[4] cake_pb_cp: re-check the elaborated core (the verified step)"

--- a/xcsp/run_xcsp_test.bash
+++ b/xcsp/run_xcsp_test.bash
@@ -104,7 +104,13 @@ for pattern in ${required_patterns[@]+"${required_patterns[@]}"}; do
     fi
 done
 
-veripb "$testname".{opb,pbp} || exit 4
+# --force-checked-deletion: a failed core deletion check is only a warning by
+# default -- VeriPB downgrades to unchecked deletion, drops its
+# equi-enumerable / equi-optimal guarantees and still prints `s VERIFIED`.
+# The solver deletes `solx` and `soli` constraints, which are exactly the
+# deletions that check applies to, so ask for the strict behaviour.
+# See dev_docs/solution-clause-deletion.md.
+veripb --force-checked-deletion "$testname".{opb,pbp} || exit 4
 
 # Verification passed, so dispose of the proof unless asked to preserve it; the
 # failure paths above all exit first, leaving a failing proof to inspect.


### PR DESCRIPTION
VeriPB puts the constraint it derives from a logged solution into its **core** set: the
objective-improving constraint for a `soli`, the solution-excluding blocking clause for a
`solx`. Neither went away, so a proof that found *n* solutions ended with *n* extra core
constraints in the way of every later unit propagation. On a 33k-solution enumeration that
was 4x the verification time.

Design note: [`dev_docs/solution-clause-deletion.md`](dev_docs/solution-clause-deletion.md).

## soli

Superseded outright by the next, better one, so it is deleted when that arrives, along
with the `objective < value` atom beside it. The deletion check is a plain RUP against the
new bound, which unit propagation over the objective's bits discharges unaided — verified
for gap-1 steps and for signed objectives.

## solx

A blocking clause only has to hold while the search could still rediscover the solution,
so it is recorded at the current proof level and the backtrack out of the leaf that found
it takes it away:

```
solx i[_1][eq1] i[_2][eq2];
% backtracking
rup 1 ~i[_1][eq1] 1 ~i[_2][eq2] >= 1;
core id -1;                     <- the backtrack clause, moved to core
del id -2;                      <- forget_proof_level takes the blocking clause
```

Backtrack clauses are then deleted in turn by the one a level up, which implies them by
weakening. A frame promotes its clause exactly when a solution was found beneath it, so a
refuted subtree pays nothing. On a restart unwind — the one place a frame discards the
level below without deriving a clause of its own — the reduced nld-nogoods do the same
job, each being a subset of its sibling's backtrack clause.

## Why a variable's encoding has to be in core

A blocking clause is written over the *preserved* variables, which is to say a variable's
bits; a backtrack clause is written over branching decisions, which is to say its order,
equality and interval atoms. Only the linking constraints carry one to the other — and a
deletion check may propagate over **core constraints only**. Those links are OPB rows,
hence core, for a literal that existed when the model was written, but a `red` in the
proof, hence derived and invisible to the check, for one first needed partway through the
search. That is most of them: the first attempt at this failed on essentially every
constraint test for exactly this reason.

So a variable's encoding goes into core. `ProofLevel::TopAndCore` is how it says so: it
means what `Top` means — keep this for the whole proof — and additionally emits a
`core id` for the line. Every one of the tracker's 27 emissions names it, and nothing else
does, so what is in core is visible at the point each constraint is created rather than
inferred from surrounding state.

The line is drawn **structurally** — the encoding of a variable is in core, what a
propagator derives about a problem is not — rather than around what a check turns out to
need, which would be about a third as much. Two reasons:

- Which rows a check needs depends on what the search happened to branch on (nothing stops
  a user's brancher branching on intervals) and on which of several shapes a literal was
  given. Neither is something a propagator author should have to know, and a rule that
  changed with either would be a poor foundation for anything reasoning about the core,
  such as a redundance-based symmetry break.
- Sweeping propagator lemmas in as well is not free either: VeriPB's
  `get_unsatisfied_core_constraint` requires **every** core constraint to be satisfied by a
  logged solution's propagated assignment and ignores derived ones, so each swept-in lemma
  would quietly become an obligation on every later `solx`.

The `core id` goes out with the line it names — not deferred, not batched, and not
conditional on the kind of proof. Two earlier versions did less work and were both worse:
deferring the move to the first excluded solution made "is this link in core?" answerable
only relative to how far the search had got, and an RAII scope with one `core range` per
contiguous run put the answer in ambient state a caller could not see, for 1-3% of proof
size and no measurable checking time.

## Checked deletion is only a warning by default

A failed deletion check does not fail a proof: VeriPB downgrades to unchecked deletion,
drops its equi-enumerable / equi-optimal guarantees, and still prints `s VERIFIED`. Every
script and helper that verifies a solver proof now passes `--force-checked-deletion` so
that becomes an error where it happened. Adding that flag on its own left the suite green,
which is what says it was a no-op before this work.

Above `AssertionLevel::Definitions` the proof stops writing the encoding down, so no
deletion check could succeed; such a proof keeps its blocking clauses. `soli` deletion is
unaffected at every level.

## Measured

Enumeration, which is what this is for:

| instance | proof size | veripb |
| --- | --- | --- |
| `langford 6` (refutation) | +5.3% | unchanged |
| `langford 7` (52 solutions) | +3.3% | +6% |
| `langford 8` (300 solutions) | +1.5% | +21% |
| `regular_random --all --seed 1 -n 6` (32985 solutions) | +6.0% | **4.3x faster** |

The cost is one extra RUP check per backtrack on a path to a solution, paid whether or not
there are enough solutions for the deletions to earn it back. The benefit is superlinear
in the solution count, with the crossover somewhere in the low thousands.

`langford 8` was +11% while propagator lemmas were being swept into core alongside the
encoding, and became +23% when they stopped being. Confirmed by putting them back, which
restores the old figure exactly: the deletion checks were using those lemmas as shortcuts
and now propagate further through the encoding instead. That is the price of the narrower
rule, taken deliberately.

### What an optimisation proof pays

An optimisation proof deletes only `soli` constraints, and that check needs no encoding at
all — an objective bound and its successor are constraints over the same objective bits,
which are OPB rows. So the encoding being in core buys nothing here, and it is not free:

| instance | baseline | now |
| --- | --- | --- |
| `table_layout --size 5` | 0.55s | 1.11s |
| `tour` | 1.38s | 2.47s |
| `table_layout --size 4` | 0.26s | 0.38s |
| `talent` | 3.60s | 2.84s |
| `knapsack`, `p_dispersion`, `colour` | < 0.03s | unchanged |

Isolated: suppressing the `soli` deletions changes none of these, while taking the
encoding back out of core reproduces the baseline column exactly — so the whole swing is
VeriPB's per-solution check, which has to find every core constraint satisfied by the
propagated assignment, rather than anything to do with the deletions. Why `talent` moves
the other way is not established.

This is the price of the encoding being in core unconditionally rather than only where a
blocking clause could need it, and it is paid deliberately: gating it on the kind of proof
would mean a redundance-based symmetry break seeing the encoding in core when enumerating
and not when optimising. But it is a real cost on a real workload, and the design note
flags it as worth revisiting if optimisation proof checking becomes the thing that hurts.

## Testing

810/810 release, 810/810 uncapped (`-DGCS_TEST_CAP_DEFAULTS=OFF`, so full enumeration
rather than capped), 814/814 under clang — all with `--force-checked-deletion`, and with
MiniZinc and `cake_pb_cp` on `PATH` so nothing skipped and the workflow-2 chain actually
ran.

Two new `solve_test.cc` cases, `Enumeration deletes its solution-excluding clauses` and
`Optimisation deletes its superseded objective bounds`. They exist because losing the
deletions leaves every proof still verifying — just with a core set that grows once per
solution — so nothing else in the suite would notice. Each was confirmed to fail with the
corresponding piece of the mechanism disabled (five mutations tried, five caught).

## Not in this PR

`GCS_ASSERTION_LEVEL=Links` on an optimisation problem (`build/talent --prove`) emits a
backtrack clause that is not RUP. Pre-existing — `origin/main` fails identically at the
same rule — and left alone as assertion-level work in progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018s5Rxd5qtz8CRHe53cFzLy
