### PR TITLE
Do not assemble a comparison reason when nothing reads it (#907)

### DIFF
--- a/dev_docs/propagator-performance.md
+++ b/dev_docs/propagator-performance.md
@@ -230,6 +230,58 @@ If the reason is materialised eagerly against the current state
 it is per-call by nature and must not be hoisted. (`lex` is the in-tree example
 that is *not* hoisted for exactly this reason.)
 
+### Don't build a reason nothing is going to read
+
+`InferenceTrackerBase::want_reasons()` says whether a `Reason` handed to an
+`infer*` method will actually be consumed. It reports a `static constexpr` on
+the tracker type — `false` for the proofs-off `SimpleInferenceTracker` — so the
+branch folds away and a reason behind it costs nothing at all on the path where
+nothing reads it:
+
+```cpp
+inference.infer_less_than_or_stop(logger, v1, bound, JustifyUsingRUP{hint},
+    inference.want_reasons() ? Reason{ExplicitReason{ReasonLiterals{{cond, v2 <= ub}}}} : Reason{});
+```
+
+The declarative reasons of the previous lever mostly do not need this: they
+capture a scope and defer the domain walk, so building one unmaterialised is
+already cheap. The ones that do need it are the eager kinds. `ReasonLiterals`
+is a `gch::small_vector` over a nested variant, so even a two-literal
+`ExplicitReason` is a real `memcpy` at every inference site, and a
+`ConcatReason` or a per-value walk is far worse.
+
+Two shapes have turned up in-tree, and they need different detectors:
+
+- **Wide** — the assembly is O(domain width), so it shows up as memory.
+  `equals`' no-overlap rule built one literal per value and reached
+  `std::bad_alloc` at 10^9 (#864 / #873). [large-domains.md](large-domains.md)
+  has the audit lane for this shape, and the warning that its `bad_alloc`
+  fallback is a fact about the box rather than about the code.
+- **Hot** — the reason is two literals and looks far too cheap to be worth a
+  branch, but the propagator runs tens of millions of times, so the constant
+  factor is the whole cost. This one does not show up as memory at all and a
+  large-domain audit will not find it. `comparison` had nine unguarded reasons;
+  guarding them took `difference_chain --donor=comparison -n 500` from 12.91 s
+  to 8.55 s at a byte-identical search tree, removing 30% of the instructions
+  and taking `__memmove_avx_unaligned_erms` from 4.4% of cycles to 0.1% (#907).
+
+Guarding cannot change what a proof says: `want_reasons()` is true whenever a
+reason is going to be logged, so the guard is unreachable on a proving run.
+Confirm that by diffing preserved artefacts under `GCS_PRESERVE_PROOF_FILES=all`
+rather than by argument, as #873 and #907 both did.
+
+Nor can it change the search *today*, but that is the one thing here with an
+expiry date. The query is deliberately keyed on the tracker's needs rather than
+on whether a logger exists, because conflict-directed search will want reasons
+without one, and a contradiction already hands its reason to the conflict
+observers with proofs off (`Propagators::propagate`). No observer reads it yet —
+all three weighting schemes leave the parameter unnamed — so when one starts to,
+every guarded site becomes a behaviour change and wants re-checking.
+
+Finally: guard every reason in a file, not just the hot ones. `comparison` was
+found by a family audit rather than by a profile, and "some of them are guarded"
+is exactly what made the file look finished.
+
 ### Don't throw from a propagator that fails in bulk
 
 `inference.contradiction(...)` signals failure by throwing

--- a/gcs/constraints/comparison/comparison.cc
+++ b/gcs/constraints/comparison/comparison.cc
@@ -134,6 +134,16 @@ auto innards::ConstraintProofModelData<ReifiedCompareLessThanOrMaybeEqual>::prim
 
 auto ReifiedCompareLessThanOrMaybeEqual::install_propagators(Propagators & propagators) -> void
 {
+    // Every reason below is guarded on inference.want_reasons(), and they all
+    // have to be: a comparison's reason is only two or three literals, which
+    // looks too cheap to be worth a branch, but ReasonLiterals is a small_vector
+    // over a nested variant, so an element is large and building one is a
+    // memcpy. With proofs off SimpleInferenceTracker never reads it (see the
+    // query's own comment in inference_tracker.hh), and at the propagation rates
+    // this family runs at that assembly was 30% of instructions and a third of
+    // runtime -- see issue #907, and #864 / #873 for the same defect in equals.
+    // Keep the guard on any reason added here, including the cold ones: a file
+    // where only some reasons are guarded is the state that let this survive.
     if (_v1_is_constant && _v2_is_constant) {
         /* special case: both values are constant, so we're potentially forcing
          * the reification condition, or just giving contradiction, but will never
@@ -145,8 +155,10 @@ auto ReifiedCompareLessThanOrMaybeEqual::install_propagators(Propagators & propa
                     propagators.install_initialiser(
                         [v1 = _v1, v2 = _v2, v1_is_constant = _v1_is_constant, v2_is_constant = _v2_is_constant, cond = reif.cond,
                             owner = constraint_id()](const State &, auto & inference, ProofLogger * const logger) -> void {
-                            inference.infer(logger, ! cond, JustifyUsingRUP{hints::Comparison{owner}},
-                                ExplicitReason{ReasonLiterals{{cond, v1 == *v1_is_constant, v2 == *v2_is_constant}}});
+                            const Reason reason = inference.want_reasons()
+                                ? Reason{ExplicitReason{ReasonLiterals{{cond, v1 == *v1_is_constant, v2 == *v2_is_constant}}}}
+                                : Reason{};
+                            inference.infer(logger, ! cond, JustifyUsingRUP{hints::Comparison{owner}}, reason);
                         });
             }, //
             [&](const evaluated_reif::MustNotHold & reif) {
@@ -154,8 +166,10 @@ auto ReifiedCompareLessThanOrMaybeEqual::install_propagators(Propagators & propa
                     propagators.install_initialiser(
                         [v1 = _v1, v2 = _v2, v1_is_constant = _v1_is_constant, v2_is_constant = _v2_is_constant, cond = reif.cond,
                             owner = constraint_id()](const State &, auto & inference, ProofLogger * const logger) -> void {
-                            inference.infer(logger, ! cond, JustifyUsingRUP{hints::Comparison{owner}},
-                                ExplicitReason{ReasonLiterals{{cond, v1 == *v1_is_constant, v2 == *v2_is_constant}}});
+                            const Reason reason = inference.want_reasons()
+                                ? Reason{ExplicitReason{ReasonLiterals{{cond, v1 == *v1_is_constant, v2 == *v2_is_constant}}}}
+                                : Reason{};
+                            inference.infer(logger, ! cond, JustifyUsingRUP{hints::Comparison{owner}}, reason);
                         });
             }, //
             [&](const evaluated_reif::Undecided & reif) {
@@ -164,8 +178,10 @@ auto ReifiedCompareLessThanOrMaybeEqual::install_propagators(Propagators & propa
                     propagators.install_initialiser(
                         [v1 = _v1, v2 = _v2, v1_is_constant = _v1_is_constant, v2_is_constant = _v2_is_constant, lit = *lit, owner = constraint_id()](
                             const State &, auto & inference, ProofLogger * const logger) -> void {
-                            inference.infer(logger, lit, JustifyUsingRUP{hints::Comparison{owner}},
-                                ExplicitReason{ReasonLiterals{{v1 == *v1_is_constant, v2 == *v2_is_constant}}});
+                            const Reason reason = inference.want_reasons()
+                                ? Reason{ExplicitReason{ReasonLiterals{{v1 == *v1_is_constant, v2 == *v2_is_constant}}}}
+                                : Reason{};
+                            inference.infer(logger, lit, JustifyUsingRUP{hints::Comparison{owner}}, reason);
                         });
             },                                         //
             [](const evaluated_reif::Deactivated &) {} //
@@ -177,10 +193,11 @@ auto ReifiedCompareLessThanOrMaybeEqual::install_propagators(Propagators & propa
                                                 ProofLogger * const logger, const Literal & cond) -> PropagatorState {
             auto v1_bounds = state.bounds(v1), v2_bounds = state.bounds(v2);
             if (! inference.infer_less_than_or_stop(logger, v1, v2_bounds.second + (or_equal ? 1_i : 0_i), JustifyUsingRUP{hints::Comparison{owner}},
-                    ExplicitReason{ReasonLiterals{{cond, v2 <= v2_bounds.second}}}))
+                    inference.want_reasons() ? Reason{ExplicitReason{ReasonLiterals{{cond, v2 <= v2_bounds.second}}}} : Reason{}))
                 return PropagatorState::Enable; // contradiction: loop sees tracker.contradicted()
             if (! inference.infer_greater_than_or_equal_or_stop(logger, v2, v1_bounds.first + (or_equal ? 0_i : 1_i),
-                    JustifyUsingRUP{hints::Comparison{owner}}, ExplicitReason{ReasonLiterals{{cond, v1 >= v1_bounds.first}}}))
+                    JustifyUsingRUP{hints::Comparison{owner}},
+                    inference.want_reasons() ? Reason{ExplicitReason{ReasonLiterals{{cond, v1 >= v1_bounds.first}}}} : Reason{}))
                 return PropagatorState::Enable;
             return v1_bounds.second < (v2_bounds.first + (or_equal ? 1_i : 0_i)) ? PropagatorState::DisableUntilBacktrack : PropagatorState::Enable;
         };
@@ -189,15 +206,17 @@ auto ReifiedCompareLessThanOrMaybeEqual::install_propagators(Propagators & propa
                                                     auto & inference, ProofLogger * const logger, const Literal & cond) -> PropagatorState {
             auto v1_bounds = state.bounds(v1), v2_bounds = state.bounds(v2);
             if (! inference.infer_less_than_or_stop(logger, v2, v1_bounds.second + (! or_equal ? 1_i : 0_i),
-                    JustifyUsingRUP{hints::Comparison{owner}}, ExplicitReason{ReasonLiterals{{cond, v1 <= v1_bounds.second}}}))
+                    JustifyUsingRUP{hints::Comparison{owner}},
+                    inference.want_reasons() ? Reason{ExplicitReason{ReasonLiterals{{cond, v1 <= v1_bounds.second}}}} : Reason{}))
                 return PropagatorState::Enable; // contradiction: loop sees tracker.contradicted()
             if (! inference.infer_greater_than_or_equal_or_stop(logger, v1, v2_bounds.first + (! or_equal ? 0_i : 1_i),
-                    JustifyUsingRUP{hints::Comparison{owner}}, ExplicitReason{ReasonLiterals{{cond, v2 >= v2_bounds.first}}}))
+                    JustifyUsingRUP{hints::Comparison{owner}},
+                    inference.want_reasons() ? Reason{ExplicitReason{ReasonLiterals{{cond, v2 >= v2_bounds.first}}}} : Reason{}))
                 return PropagatorState::Enable;
             return v2_bounds.second < (v1_bounds.first + (! or_equal ? 1_i : 0_i)) ? PropagatorState::DisableUntilBacktrack : PropagatorState::Enable;
         };
 
-        auto infer_cond_when_undecided = [v1 = _v1, v2 = _v2, or_equal = _or_equal, owner = constraint_id()](const State & state, auto &,
+        auto infer_cond_when_undecided = [v1 = _v1, v2 = _v2, or_equal = _or_equal, owner = constraint_id()](const State & state, auto & inference,
                                              ProofLogger * const,
                                              const IntegerVariableCondition &) -> ReificationVerdictFor<JustifyUsingRUP<hints::Comparison>> {
             // Aliased non-constant operands: v1<v2 never (when strict),
@@ -220,15 +239,17 @@ auto ReifiedCompareLessThanOrMaybeEqual::install_propagators(Propagators & propa
             if (or_equal ? (v1_bounds.second <= v2_bounds.first) : (v1_bounds.second < v2_bounds.first)) {
                 // v1 has to be less than (or equal): constraint must hold.
                 return reification_verdict::MustHold<JustifyUsingRUP<hints::Comparison>>{
-                    .justification = JustifyUsingRUP{hints::Comparison{owner}},                               //
-                    .reason = ExplicitReason{ReasonLiterals{{v1 <= v1_bounds.second, v2 >= v2_bounds.first}}} //
+                    .justification = JustifyUsingRUP{hints::Comparison{owner}}, //
+                    .reason = inference.want_reasons() ? Reason{ExplicitReason{ReasonLiterals{{v1 <= v1_bounds.second, v2 >= v2_bounds.first}}}}
+                                                       : Reason{} //
                 };
             }
             else if (or_equal ? (v1_bounds.first > v2_bounds.second) : (v1_bounds.first >= v2_bounds.second)) {
                 // v1 has to be greater than (or equal): constraint cannot hold.
                 return reification_verdict::MustNotHold<JustifyUsingRUP<hints::Comparison>>{
-                    .justification = JustifyUsingRUP{hints::Comparison{owner}},                               //
-                    .reason = ExplicitReason{ReasonLiterals{{v1 >= v1_bounds.first, v2 <= v2_bounds.second}}} //
+                    .justification = JustifyUsingRUP{hints::Comparison{owner}}, //
+                    .reason = inference.want_reasons() ? Reason{ExplicitReason{ReasonLiterals{{v1 >= v1_bounds.first, v2 <= v2_bounds.second}}}}
+                                                       : Reason{} //
                 };
             }
             else


### PR DESCRIPTION
Two commits: the fix for #907, and the `propagator-performance.md` lever it belongs under.

## The fix

`comparison.cc` builds nine reasons and not one of them was guarded on `inference.want_reasons()`. `SimpleInferenceTracker::materialises_reasons` is `false`, so with proofs off each of the nine was built, never read, and thrown away on the propagation path. The neighbouring linear family routes *every* reason through that query; this family routed none.

Two literals looks far too cheap to be worth a branch. But `ReasonLiterals` is a `gch::small_vector` over a nested variant, so an element is large and building one is a real `memcpy`, and this family runs tens of millions of times.

`difference_chain --variant=decomposed --donor=comparison -n 500` is the purpose-built benchmark. One core of an otherwise idle EPYC 7643, boost off, `numactl --cpunodebind=0 --membind=0 taskset -c 4 setarch -R`, min of three:

| | Time | Recursions | Propagations | Effectful |
|---|---|---|---|---|
| as on `main` | 12.91 s | 503 | 63 004 752 | 375 751 |
| all nine guarded | **8.56 s** | 503 | 63 004 752 | 375 751 |

**1.51x at a byte-identical search tree** — same recursions, same propagation count, same effectful count.

`perf stat`, deterministic, at n=300:

| Arm | Instructions | Cycles | IPC |
|---|---|---|---|
| `--donor=comparison`, as on `main` | 1.107e10 | 6.547e9 | 1.69 |
| `--donor=comparison`, guarded | 7.710e9 | 4.767e9 | 1.62 |
| `--donor=linear` (already guarded) | 7.220e9 | 2.265e9 | 3.19 |

So the guard removes 30% of instructions and 27% of cycles. `perf record` says where they went: `__memmove_avx_unaligned_erms` falls from 4.4% of cycles to 0.1%, and `memcpy@plt` from 0.70% to nothing. That is the `small_vector` construction inside `ExplicitReason{ReasonLiterals{...}}`, which is exactly what the guard removes.

Against the linear spelling of the same edge, at n=500, the comparison spelling goes from 2.99x to 1.98x.

Numbers here are lower than the issue's (1.74x, -43% cycles) because that was measured on a 9950X3D at `76bfd836`; this is an EPYC 7643 at 2.3 GHz with boost off, at `78d2af7b`. The shape is the same and the tree is identical either way.

## All nine, not four

The four on the two enforce passes are the hot ones and are what the table measures. The other five — the two reified verdicts and the three both-constant initialiser arms — are cold, and are guarded anyway: a file where some reasons are guarded and some are not is the state that let this survive an earlier pass, and the file now says so at the top of `install_propagators`.

`infer_cond_when_undecided` had left its tracker parameter unnamed, which is why the query was not to hand there. That is the same detail that hid the `equals` site in #873.

The three initialisers take the guard as a local rather than inline only because the inline form pushes those lines past the column limit, at which point clang-format wraps the enclosing lambda's *capture list* instead of the ternary. The six others use `equals`' inline spelling.

## Proofs are untouched, by measurement

3459 proofs (13754 files: `.opb`, `.pbp`, `.scp`, `.varmap`) preserved under `GCS_PRESERVE_PROOF_FILES=all` at a pinned `--seed=907`, across `comparison_test` and twenty other lanes that reach a comparison, are **byte-identical** before and after — `diff -rq` over the two trees is empty.

| lane | proofs | | lane | proofs |
|---|---|---|---|---|
| `comparison_test` | 1356 | | `smart_table_test` | 84 |
| `linear_test` | 925 | | `element_test` | 76 |
| `equals_test` | 298 | | `inferred_cumulative_presolver_test` | 47 |
| `difference_logic_presolver_test proofs` | 270 | | `cumulative_optional_test enumerate` | 35 |
| `lex_test` | 184 | | `derived_cumulative_test` | 26 |
| `min_max_test` | 88 | | 10 further lanes | 70 |

Reasons are materialised whenever one is being written, so the guard is unreachable on a proving run; this confirms it rather than arguing it, as #873 did.

## The search is untouched too, which is the less obvious half

`want_reasons()` is deliberately keyed on the *tracker's* needs rather than on whether there is a logger, because a contradiction hands its reason to the conflict observers with proofs off (`Propagators::propagate`, both the throwing and the `_or_stop` paths). So a guard here could in principle change conflict-directed search.

It does not today: all three weighting schemes (`ClassicDomWDeg`, `ConflictHistorySearch`, `RefinedWeighting`) leave that parameter unnamed and read nothing from it. Measured as well as read — 21 `table_layout --branch dom-wdeg:VARIANT` arms (seven schemes x three sizes, 617–1832 failures each) report identical `recursions`, `failures`, `propagations`, effectful count, depth and solution count before and after.

That is a fact with an expiry date rather than a property of the design, and the new documentation says so.

## No new test

There is nothing to pin: with proofs off the reason was already never read, so this changes no answer, and with proofs on the guard cannot fire. #873 could add a test because there the unguarded reason was O(domain width) and reached `std::bad_alloc`; here the cost is a constant factor times the propagation count, which no test asserts. The regression guards are the benchmark (`--donor` exists to compare exactly these two spellings) and the note at the top of `install_propagators`.

## Documentation

`dev_docs/propagator-performance.md` had a lever for *reusing* a declarative reason but nothing about not building an eager one at all. It gains one, naming the two shapes apart: the wide one (#864 / #873, O(domain width), shows up as memory, [large-domains.md](dev_docs/large-domains.md) has the audit lane) and the hot one (#907, two literals, no measurable memory, invisible to a large-domain audit).

## Verification

- **GCC 15.2.0, `GCS_WERROR=ON`, `GCS_TEST_CAP_DEFAULTS=OFF`** (the strict CI lane, full-enumeration checking): 810/810, no failures (334 s).
- **clang 21.1.8** (no `-Werror`, matching the CI clang lane, which is not the `-Werror` one): 814/814, no failures (116 s).
- No tests skipped in either: MiniZinc 2.9.7, `cake_pb_cp`, `veripb` 3.0.2 and `opbdiff` 0.3.0 all on `PATH`.
- clang-format 21.1.8 clean over the whole tree.

One note on the issue: the working patch it says is preserved at `~/claude/tmp/famdocs-findings/` is not there any more, so this was written from the issue's description rather than applied from it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018s5Rxd5qtz8CRHe53cFzLy
