### PR TITLE
Let the proof stream buffer outlive the stream that writes through it

### DIFF
--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -860,6 +860,12 @@ if(GCS_BUILD_TESTS)
     target_link_libraries(duplicate_label_test PRIVATE glasgow_constraint_solver)
     add_test(NAME duplicate_label_test COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_verify.bash $<TARGET_FILE:duplicate_label_test>)
 
+    add_executable(proof_flush_on_throw_test innards/proofs/proof_flush_on_throw_test.cc)
+    target_link_libraries(proof_flush_on_throw_test PRIVATE glasgow_constraint_solver)
+    # The proof it leaves behind is deliberately incomplete, so there is nothing
+    # for the verifier to check: it inspects and cleans up the file itself.
+    add_test(NAME proof_flush_on_throw_test COMMAND $<TARGET_FILE:proof_flush_on_throw_test>)
+
     add_executable(eqvar_polarity_test innards/proofs/eqvar_polarity_test.cc)
     target_link_libraries(eqvar_polarity_test PRIVATE glasgow_constraint_solver)
     add_test(NAME eqvar_polarity_test COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_verify.bash $<TARGET_FILE:eqvar_polarity_test>)

--- a/gcs/innards/proofs/proof_flush_on_throw_test.cc
+++ b/gcs/innards/proofs/proof_flush_on_throw_test.cc
@@ -1,0 +1,119 @@
+#include <gcs/constraints/comparison.hh>
+#include <gcs/constraints/innards/constraints_test_utils.hh>
+#include <gcs/current_state.hh>
+#include <gcs/problem.hh>
+#include <gcs/proof.hh>
+#include <gcs/solve.hh>
+
+#include <cstdlib>
+#include <exception>
+#include <fstream>
+#include <iterator>
+#include <optional>
+#include <string>
+#include <version>
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+#include <print>
+#else
+#include <fmt/core.h>
+#endif
+
+using namespace gcs;
+using namespace gcs::test_innards;
+
+using std::ifstream;
+using std::istreambuf_iterator;
+using std::make_optional;
+using std::string;
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+using std::print;
+#else
+using fmt::print;
+#endif
+
+// The proof stream writes through a 1MB buffer that ProofLogger::Imp owns and
+// installs with pubsetbuf, so the bytes of a .pbp live in that buffer until
+// something flushes them. end_proof() flushes explicitly, which is why a proof
+// that runs to completion is always whole; a solve that throws part-way through
+// never reaches end_proof, and the only flush left is the one ~fstream does when
+// it closes the file.
+//
+// That flush must still be able to read the buffer, which makes the declaration
+// order of those two members load-bearing: members are destroyed in reverse, so
+// the buffer has to be declared first to outlive the stream. It was not, and the
+// consequence was invisible --- the final write read freed memory, and where the
+// 1MB block had been handed back to the kernel the write failed with EFAULT and
+// dropped the whole unflushed tail of the .pbp on the floor without a word.
+//
+// So: throw out of a solve that is writing a proof, and check the proof written
+// so far actually reached the disk.
+namespace
+{
+    struct ThrowFromSolution final : std::exception
+    {
+    };
+}
+
+auto main() -> int
+{
+    const string base = "proof_flush_on_throw_test";
+
+    Problem p;
+    auto x = p.create_integer_variable(0_i, 3_i, "x");
+    auto y = p.create_integer_variable(0_i, 3_i, "y");
+    p.post(LessThan{x, y});
+
+    auto threw = false;
+    try {
+        static_cast<void>(solve_with(p, SolveCallbacks{.solution = [](const CurrentState &) -> bool { throw ThrowFromSolution{}; }},
+            make_optional<ProofOptions>(ProofFileNames{base})));
+    }
+    catch (const ThrowFromSolution &) {
+        threw = true;
+    }
+
+    auto ok = true;
+
+    if (! threw) {
+        print(stderr, "the solution callback's exception did not escape solve_with\n");
+        ok = false;
+    }
+
+    // Read after the solve, so the ProofLogger --- and with it the stream whose
+    // destructor does the flush --- has been destroyed.
+    ifstream proof{base + ".pbp"};
+    const string contents{istreambuf_iterator<char>{proof}, istreambuf_iterator<char>{}};
+
+    if (! proof) {
+        print(stderr, "could not read {}.pbp\n", base);
+        ok = false;
+    }
+    else if (contents.empty()) {
+        // What the lost-tail bug looked like: everything written before the throw
+        // fitted in the buffer, and none of it survived the close.
+        print(stderr, "{}.pbp is empty: the buffered proof never reached the disk\n", base);
+        ok = false;
+    }
+    else {
+        // A partially-written proof is expected and fine. Corrupt bytes at the
+        // front are not: freeing the buffer before the flush leaves the
+        // allocator's own bookkeeping in the first few bytes of it.
+        const string header = "pseudo-Boolean proof version 3.0\n";
+        if (! contents.starts_with(header)) {
+            print(stderr, "{}.pbp does not begin with the version header: {:?}\n", base, contents.substr(0, header.size()));
+            ok = false;
+        }
+        // Nothing writes a partial line, so a whole flush ends at a line ending.
+        if (contents.back() != '\n') {
+            print(stderr, "{}.pbp does not end at a line ending\n", base);
+            ok = false;
+        }
+    }
+
+    proof.close();
+    dispose_of_proof_files(base);
+
+    return ok ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/gcs/innards/proofs/proof_logger.cc
+++ b/gcs/innards/proofs/proof_logger.cc
@@ -183,11 +183,19 @@ struct ProofLogger::Imp
     optional<pair<ProofLine, ProofLine>> previous_soli_lines;
 
     string proof_file;
-    fstream proof;
     // A proof is many short lines; the default stream buffer makes for a
     // write syscall every few KB, which shows up at this volume. Installed
     // via pubsetbuf before open in start_proof.
+    //
+    // Declared before `proof`, and that order is load-bearing: members are
+    // destroyed in reverse, and ~fstream closes the file, which flushes
+    // whatever is still buffered. If the buffer went first, that final write
+    // would read freed memory. It only bites when the last flush is the
+    // destructor's --- end_proof() flushes explicitly, so a proof that runs to
+    // completion never notices --- but a solve that throws part-way through
+    // does, and silently lost the whole unflushed tail of the .pbp.
     vector<char> proof_stream_buffer;
+    fstream proof;
     int current_indent = 0;
     // How many `subproof` blocks deep we are. Constraints derived inside one do
     // not survive its `qed;`, so a line recorded at Top from in there must not


### PR DESCRIPTION
The `.pbp` goes out through a 1MB buffer that `ProofLogger::Imp` owns and hands to
the filebuf with `pubsetbuf`, so a proof's bytes sit in that buffer until something
flushes them. `Imp` declared the buffer *after* the stream:

```cpp
fstream proof;
// ...
vector<char> proof_stream_buffer;
```

Members are destroyed in reverse, so the buffer goes first, and then `~fstream`
closes the file — which flushes whatever is still pending, reading a block that has
already been freed.

## Why nothing had hit it

`end_proof()` is the only explicit flush in the file. A proof that runs to
completion therefore empties the buffer before anything is destroyed, and the bad
read never happens. A solve that **throws** part-way through never reaches
`end_proof`, and the destructor's flush is the only one left.

Nothing in the tree threw out of a solve with a proof open until #915's new
`scp_writer_test`, whose Sanitize lane is where this turned up:

```
ERROR: AddressSanitizer: heap-use-after-free
READ of size 33 at 0x78c6c9be6800
    #0 write
    #1 std::__basic_file<char>::xsputn(char const*, long)
    ...
    #5 std::basic_filebuf<...>::close()
    #8 gcs::innards::ProofLogger::Imp::~Imp() proof_logger.cc:172
```

33 bytes is exactly `pseudo-Boolean proof version 3.0\n`. #915 does not touch
`proof_logger.cc`, `proof.cc` or `solve.cc`; it only made the path reachable.

## Not only a sanitizer finding

On `main` at 78d2af7b, Release, no sanitizers, throwing from a solution callback:

| | `.pbp` written |
| --- | --- |
| before | 0 bytes |
| after | 1590 bytes |

1MB is over glibc's mmap threshold, so `free` hands the block back to the kernel
and the `write` fails with `EFAULT`. Silently: the stream's `exceptions()` mask is
irrelevant, because `~basic_filebuf` swallows what its own close reports. So any
solve that throws while a proof is open loses the whole unflushed tail of the
`.pbp` — for a small model, the entire file — and says nothing about it. Which is
exactly the proof you wanted to look at, since the solve went wrong.

## The fix

Declare the buffer before the stream. Members are then destroyed stream-first and
the final flush has something to read. The order is load-bearing and nothing about
the struct suggests it, so there is a comment saying so.

An explicit `close()` in a hand-written `~Imp` would be the other way to do it, but
`start_proof` sets `exceptions(failbit | badbit)`, so a close that failed there
would throw from a destructor and terminate. `~fstream`'s own close is the one that
is allowed to fail quietly; it just has to be able to read the buffer.

## Test

`proof_flush_on_throw_test` throws out of a solution callback and checks the proof
written before the throw actually reached the disk: non-empty, starting with the
version header, ending at a line ending. Those cover both shapes of the bad read —
an empty file where the block was unmapped, and clobbered leading bytes where the
allocator reused it in place — and a partial proof is otherwise expected, so
nothing else is asserted about the contents. Registered without a verify wrapper:
the proof is deliberately incomplete, so there is nothing for VeriPB to check, and
the test disposes of the files itself through `dispose_of_proof_files`.

It fails on the unfixed tree in a plain Release build, not only under the
sanitizers:

```
proof_flush_on_throw_test.pbp is empty: the buffered proof never reached the disk
```

Present since c4ed8c18 (2026-07-16), which introduced the buffer.

## Verified

ctest 811/811 Release and 811/811 Sanitize with g++ 15.2.0, zero skips (VeriPB and
MiniZinc both present) and no ASan or UBSan output in the sanitize run. The new
test file is clang 21 syntax-clean and the tree is clang-format 21.1.8 clean.
#915's `scp_writer_test` passes under ASan with this cherry-picked into its branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WeCSig4HzZ8nRZ6t3bDdYy
