### PR TITLE
Documentation review: fix the factual drift, and say how to bring up a constraint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,10 @@ perf.data
 perf.data.old
 html
 build*
+# ... but `build*` is unanchored, so it also swallows this documentation file,
+# which is not a build directory. Anchoring the pattern instead would stop
+# ignoring python/build, which scikit-build really does create.
+!dev_docs/building.md
 # scratch area for local experiments; contents must never be committed
 /tmp/
 Doxyfile

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,26 +53,47 @@ Run a single test binary directly:
 ./build/equals_test
 ```
 
-Run a single test with proof verification (uses `run_test_and_verify.bash`):
+There are two families of test binary, and they are proved differently. The
+data-driven constraint tests have no `--prove` flag: they write and check their
+own proofs, calling `veripb` in-process whenever it is on the `PATH`. Running
+one directly, as above, therefore already verifies its proofs, which is why
+ctest registers them through `run_test_only.bash` — a wrapper that only runs the
+binary. Everything that *does* take `--prove` — the examples, benchmarks and
+frontends, plus the proof-innards tests under `gcs/` — goes through
+`run_test_and_verify.bash`, which runs the binary with `--prove`, checks the
+proof with `veripb`, and reads back any `.scp` it wrote:
 ```shell
-./run_test_and_verify.bash ./build/circuit_disconnected_test
+./run_test_and_verify.bash ./build/reification_test
 ```
-The proof files are deleted once they verify. To keep them for inspection,
-set `GCS_PRESERVE_PROOF_FILES` (see `dev_docs/constraints.md`); they are
-kept automatically when verification fails.
+A third wrapper, `run_test_and_expect_verify_failure.bash`, is the inverse of the
+second: a mutation lane makes a test write a knowingly wrong proof, and the run
+passes only if `veripb` *rejects* it. Mutation lanes are the exception to the
+split above — a handful of constraint tests are driven through these two
+wrappers with `--mutate=` and the wrapper's `--basename`, which is what names
+the one proof the wrapper then checks.
+
+Proof files are deleted once they verify. To keep them for inspection, set
+`GCS_PRESERVE_PROOF_FILES` (see `dev_docs/constraints.md`); they are kept
+automatically when verification fails.
 
 Disable XCSP or MiniZinc support to reduce dependencies:
 ```shell
 cmake -S . -B build -DGCS_ENABLE_XCSP=OFF -DGCS_ENABLE_MINIZINC=OFF
 ```
 
-Enable the view-wrap proof-verification sweep (~3000 extra tests, most
-fail today; opt in when working on view proof logging):
+Enable the view-wrap proof-verification sweep — every wrap × every argument
+position, for each constraint that participates. That is around 7200 extra
+tests (400 without it, 7636 with, in a build with the frontends and executables
+off), and they pass: every constraint registered in the sweep verifies under
+every wrap. `SmartTable` is the one deliberate omission — it over-prunes under
+views, tracked in issue #238. Opt in when working on view proof logging:
 ```shell
 cmake -S . -B build -DGCS_ENABLE_VIEW_WRAP_SWEEP=ON
 ```
-The harness and `--view-wrap=N` / `--view-position=K` argv flags on each
-test are always built; only the ctest registrations are gated.
+The harness and the `--view-wrap=N` / `--view-position=N|all|mixed` argv flags
+on each test are always built, as is the single `--view-position=mixed` test per
+constraint, which is part of the ordinary suite; only the per-wrap ctest
+registrations are gated. See `dev_docs/view-proof-logging.md`.
 
 Enable the large-domain guard, a development tripwire that turns work
 proportional to a variable's domain width into a test failure (issue #833):
@@ -117,18 +138,29 @@ Trusted Publishing configuration are in
 
 ## Compiler and Standard Library Support
 
-The codebase is built with **GCC 15.2.0**, **clang 21**, and **MSVC (Visual Studio
-2022)**. Clang on macOS uses **libc++** (Apple's standard library), not libstdc++.
-This matters for C++23 feature availability: some features are in libstdc++ but not
+Development happens with **GCC 15.2.0** and **clang 21**; **MSVC (Visual Studio
+2022)** is the third supported compiler. The *oldest* supported compiler is **GCC
+13**, which is what the `ubuntu-24.04` lane and the manylinux wheel build use.
+Clang on macOS uses **libc++** (Apple's standard library), not libstdc++. This
+matters for C++23 feature availability: some features are in libstdc++ but not
 yet libc++.
 
+CI runs on every push to `main` and every pull request, over `ubuntu-24.04`
+(default GCC, test caps off), `ubuntu-26.04` (default GCC, test caps off, and the
+one lane that builds with `-DGCS_WERROR=ON`, so a new compiler warning turns the
+lane red), `ubuntu-26.04` with clang, `macos-15` and `macos-26`, plus a
+`ubuntu-26.04` Sanitize lane and the `windows-2022` MSVC lanes. `main` has no
+branch protection, so a lane reports rather than literally gating a merge.
+
 Windows/MSVC support is experimental (see README.md, Platform support), but the
-`windows-2022` CI lanes gate every push and pull request just like the Linux and
+`windows-2022` lanes run on every push and pull request just like the Linux and
 macOS ones, so code must still compile there. In particular, do not use GCC/clang
 extensions or Itanium-ABI-only headers (`<cxxabi.h>`, `abi::__cxa_demangle`, ...).
 
-Known unavailable in libc++ (clang 21):
-- `std::views::enumerate` — use `util/enumerate.hh` instead; do not remove that file
+Known unavailable in libc++ (the Apple Clang on the macOS lanes; last checked
+against clang 21, so re-confirm on CI before relying on a change here):
+- `std::views::enumerate` — use `util/enumerate.hh` instead; do not remove that
+  file, which 46 files include
 
 Known unavailable in libstdc++ on the GitHub Actions Ubuntu 24.04 runner (GCC 13), which
 we still support:
@@ -162,7 +194,7 @@ using std::ranges::any_of;
 using std::ranges::sort;
 ```
 
-Every one of the 48 files that names a `std::ranges::` algorithm does it this way, so
+Every one of the 57 files that names a `std::ranges::` algorithm does it this way, so
 follow it rather than sorting `std::ranges::sort` under 'r' between `std::pair` and
 `std::string` — which is what this section used to say and what nothing in the tree does.
 
@@ -243,8 +275,11 @@ This is a C++23 constraint programming solver with a key focus on **proof loggin
 - `gcs/current_state.hh` — `CurrentState`: read-only view of variable values in solution callbacks
 - `gcs/integer.hh` — `Integer` type wrapper (use `0_i`, `100_i` literals)
 - `gcs/variable_id.hh` — `IntegerVariableID` and related lightweight handle types
-- `gcs/constraints/` — all user-facing constraint types (e.g. `LinearLessThanEqual`, `AllDifferent`, `Table`, etc.)
-- `gcs/gcs.hh` — convenience header including the full public API
+- `gcs/constraints/` — all user-facing constraint types (e.g. `LinearLessThanEqual`, `AllDifferent`, `Table`, etc.), each one a directory plus an umbrella header of the same name
+- `gcs/presolvers/` — the opt-in presolvers (`AutoTable`, `DifferenceLogic`, `CumulativeStrengthening`, `InferredCumulative`, `InferredDisjunctive`), in the same directory-plus-umbrella-header layout; the base class is `gcs/presolver.hh`
+- `gcs/proof.hh` — `ProofOptions` and `ProofFileNames`: the `.opb` model, the `.pbp` proof, the variables map and the `.scp` s-expression definitions
+- `gcs/search_heuristics.hh`, `gcs/restarts.hh`, `gcs/variable_weighting.hh` — branching, restart schedules, and dom/wdeg-style conflict weighting
+- `gcs/gcs.hh` — convenience header for most of the public API. It does **not** pull in `presolver.hh`, `proof_strategy.hh` or `scp_reader.hh`, which have to be included directly
 
 ### Innards (`gcs/innards/`)
 
@@ -253,39 +288,82 @@ Not part of the public API. Key components:
 - **`State`** (`innards/state.hh`) — holds all variable domains as `IntervalSet<Integer>` (a sorted sequence of disjoint closed intervals, with small-buffer optimisation for the common one-or-two-interval case). See `dev_docs/state-and-variables.md` for the full picture: the `IntegerVariableID` family, epoch-based backtracking, and the `change_state_for_*` inference paths.
 - **`Propagators`** (`innards/propagators.hh`) — manages constraint propagators, triggers, and the propagation queue
 - **`InferenceTracker`** (`innards/inference_tracker.hh`) — templated on `SimpleInferenceTracker` or `EagerProofLoggingInferenceTracker`; all domain modifications go through this
-- **`ProofLogger`** (`innards/proofs/proof_logger.hh`) — writes OPB/VeriPB proof files
+- **`ProofModel`** (`innards/proofs/proof_model.hh`) — writes the OPB model: each constraint's definition, emitted during the `define_proof_model` phase
+- **`ProofLogger`** (`innards/proofs/proof_logger.hh`) — writes the VeriPB proof (`.pbp`) during search, tagging each line with a `ProofLevel` and placing it in either the core or the derived constraint set
 
 ### Constraint Pattern
 
-Each constraint in `gcs/constraints/` follows this pattern:
-1. A user-facing struct/class (e.g. `NotEquals`, `AllDifferent`)
-2. An `install` method that registers propagator(s) via `Propagators`
-3. Propagators receive an `InferenceTracker &` and call `infer()` on it with a `Literal`, a `Justification`, and a `Reason` (a declarative reason, materialised on demand)
-4. If `Propagators::want_nonpropagating()` is true, the constraint must also define itself in OPB terms for proof logging
+Each constraint in `gcs/constraints/` is a subclass of `Constraint`
+(`gcs/constraint.hh`). `Constraint::install()` is **not** virtual: `Problem`
+calls it, and it runs up to three phases, which are what a constraint overrides.
+
+1. `prepare(Propagators &, State &, ProofModel * const) -> bool` — argument
+   validation, reading the initial domains, allocating auxiliary variables and
+   backtrackable constraint state, and installing child constraints. It is the
+   only phase holding the propagators, the mutable `State` and the model at
+   once, so it is the only one that can allocate or install a child. Return
+   `false` to say the other two phases must not run.
+2. `define_proof_model(ProofModel &, const State &) -> void` — write the OPB
+   definition, and nothing else. Run only when proofs are being logged. It is
+   `const` because this phase must describe the constraint, never allocate.
+3. `install_propagators(Propagators &) -> void` — register the propagator(s).
+
+Two further overrides are not phases: `constraint_type()` is pure virtual and
+gives the `.scp` keyword stem (`abs`, `lin_less_equal`, `array_min`, ...), and
+`s_expr()` exposes the constraint to the sub-constraint-proof writer (see
+`dev_docs/scp_s_expr_migration.md`).
+
+A propagator receives an `InferenceTracker &` and calls `infer()` on it with a
+`ProofLogger *`, a `Literal`, a `Justification` and a `Reason` (a declarative
+reason, materialised on demand). `dev_docs/constraints.md` has the full pattern;
+`dev_docs/reification.md` covers reified constraints.
 
 ### Justification Types
 
-Every inference must be accompanied by a justification:
+Every inference must be accompanied by a justification. Three of these are the
+alternatives of `using Justification = std::variant<JustifyUsingRUP<NoHint>,
+AssertRatherThanJustifying, NoJustificationNeeded>`; `JustifyExplicitly` is
+dispatched by overload resolution rather than carried in that variant.
 - `NoJustificationNeeded` — the inference needs nothing in the proof: it is neither justified nor asserted (the solver simply trusts it)
+- `AssertRatherThanJustifying` — the inference is emitted under VeriPB's assertion rule and taken on trust rather than checked. This is also what every other justification degrades to when the logger is running at an `AssertionLevel` other than `Off`
 - `JustifyUsingRUP{}` — reverse unit propagation suffices (optionally `JustifyUsingRUP{hints::Foo{...}}` to carry a typed assertion hint)
 - `JustifyExplicitly{emit, ThenRUP::Yes}` — `emit` is a `(const ReasonLiterals &) -> void` callback (or a named fat-witness struct, for a reification verdict) that writes explicit VeriPB proof steps. `ThenRUP` is mandatory: `Yes` RUPs the inferred literal after the steps, `No` lets the steps conclude it. An optional third argument is a typed assertion hint, shared with `JustifyUsingRUP`.
 
 ### Testing Pattern
 
-Constraint tests (e.g. `constraints/equals_test.cc`) use the `gcs::test_innards` utilities in `constraints/constraints_test_utils.hh`. The test pattern:
+Constraint tests live beside the constraint they test (e.g.
+`gcs/constraints/equals/equals_test.cc`) and use the `gcs::test_innards`
+utilities in `gcs/constraints/innards/constraints_test_utils.hh`. The test
+pattern:
 1. Generate all expected solutions using a pure C++ satisfiability check
 2. Run the solver and collect actual solutions
 3. Compare expected vs actual (optionally checking GAC at each search node)
-4. Optionally run VeriPB on the proof output
+4. Prove and check: these tests write their own proofs and call `veripb`
+   in-process whenever it is on the `PATH` (`can_run_veripb()`,
+   `verify_proof_and_clean_up()`), so they need no `--prove` flag and no
+   verifying wrapper — which is why ctest registers them with
+   `run_test_only.bash`
 
-Tests that call `run_test_and_verify.bash` run the test binary with `--prove`, then invoke `veripb` to check the proof. Tests using `run_test_only.bash` skip proof verification.
+`run_test_and_verify.bash` is for the *other* kind of test binary: those that
+take `--prove` and leave the checking to the wrapper — the examples, benchmarks
+and frontends, plus the proof-innards tests under `gcs/` (`reification_test`,
+`invar_test`, the `range_witness_*` set, and so on).
 
 Some tests use Catch2 (linked with `Catch2::Catch2WithMain`); others are standalone programs.
 
-### External Dependencies (fetched via CMake FetchContent)
+### External Dependencies
 
-- **Catch2** — unit test framework
-- **fmt** — string formatting
+Fetched at configure time with CMake `FetchContent`:
+
+- **Catch2** — unit test framework (only when `GCS_BUILD_TESTS`)
+- **cxxopts** — command-line parsing for the executables and the MiniZinc frontend
 - **nlohmann/json** — JSON parsing (MiniZinc support)
-- **generator** — `<generator>` polyfill if compiler lacks it (C++23)
-- **VeriPB** — external proof checker, installed separately via `cargo install`
+- **gch/small_vector** — the small-buffer vector that backs `IntervalSet`, and so sits on the solver's hottest path
+- **fmt** — string formatting, only when the compiler has no `<format>`/`<print>`
+- **pybind11** — only for the Python bindings (`GCS_ENABLE_PYTHON`, via `python/CMakeLists.txt`)
+
+Not `FetchContent`:
+
+- **generator** — `<generator>` polyfill if the compiler lacks it (C++23); fetched with `ExternalProject_Add`, headers only
+- **XCSP3-CPP-Parser** — vendored in-tree, and excluded from clang-format
+- **VeriPB** — external proof checker, not fetched by CMake at all: install it separately with `cargo install --path .` from a VeriPB checkout

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,369 +1,97 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file provides guidance to Claude Code (claude.ai/code) when working with
+code in this repository.
 
-## Build Commands
+It is deliberately short. Nearly everything a developer needs here is project
+documentation rather than agent guidance, and it lives in `dev_docs/`,
+`README.md` or `CONTRIBUTING.md`. A fact copied into two files goes stale in
+one of them, so this file routes rather than restates: what to read, the
+mistakes that have actually been made in this tree, and what to run before
+committing.
 
-Three build types are supported: `Release` (default), `Debug`, and `Sanitize`.
-All keep debug information, but scaled to purpose: `Release` (with `/Z7` as the
-MSVC equivalent) and `Sanitize` use `-g1` — function names plus line tables,
-enough for backtraces, for the `GCS_VERBOSE_LOGGING` stacktrace annotation, and
-for an ASan or UBSan report to name a function and a `file:line` — while `Debug`
-uses `-g3` for full interactive debugging. `Sanitize` is `-g1` for size: every
-test binary links the solver statically and so carries its own copy of the same
-DWARF, which at `-g3` made a 93 GiB build tree and ran the CI runner out of
-disk; at `-g1` it is 56 GiB. Build `Debug` when you are going to attach a
-debugger. Use named presets from `CMakePresets.json` for convenience:
+## Read the relevant document first
+
+The solver is a C++23 constraint programming solver whose defining feature is
+**proof logging**: every inference it makes can be checked externally by
+VeriPB. That constraint shapes almost every design decision in the tree, and
+very little of it is guessable from the code alone. `dev_docs/README.md` is the
+index; read the document that covers what you are about to change *before* you
+change it. It is the most efficient way to absorb the conventions and the
+reasoning behind them.
+
+| If you are... | Start with |
+|---------------|------------|
+| adding or changing a constraint | [`dev_docs/constraints.md`](dev_docs/constraints.md), then [`reification.md`](dev_docs/reification.md) if it is reified |
+| touching domains, backtracking, or the inference paths | [`state-and-variables.md`](dev_docs/state-and-variables.md) |
+| writing or debugging a justification | `constraints.md` (Justifications), [`infer-redesign.md`](dev_docs/infer-redesign.md), and the per-constraint proof notes in the index |
+| creating an auxiliary variable for a proof | [`variable-encodings.md`](dev_docs/variable-encodings.md) |
+| touching views | [`view-proof-logging.md`](dev_docs/view-proof-logging.md) |
+| making a propagator faster | [`propagator-performance.md`](dev_docs/propagator-performance.md), then [`benchmarking.md`](dev_docs/benchmarking.md) |
+| changing the build, an option, or a toolchain assumption | [`building.md`](dev_docs/building.md) |
+| writing C++ that clang-format does not settle | [`code-style.md`](dev_docs/code-style.md) |
+| working on a frontend | [`minizinc.md`](dev_docs/minizinc.md), [`xcsp.md`](dev_docs/xcsp.md), [`frontend-support-matrix.md`](dev_docs/frontend-support-matrix.md) |
+| releasing the Python bindings | [`releasing-gcspy.md`](dev_docs/releasing-gcspy.md) |
+
+For orientation in the source itself, `README.md` (Navigating the Source Code)
+covers the public API in `gcs/`; `gcs/innards/` is everything that is not part
+of it, and `dev_docs/constraints.md` (The big picture) is the map of how a
+constraint, its propagators, its OPB definition and its proof fit together.
+
+## Mistakes that have been made here before
+
+Each of these is a real regression or a real wasted afternoon, not a
+hypothetical. The reasoning is in the linked document; the instruction is here
+so that it is visible without following the link.
+
+- **Do not "tidy" the per-configuration flags in `CMakeLists.txt` into cache
+  variables.** A cached `set()` there is a silent no-op, and that is how the
+  Sanitize build spent months containing no sanitizers (issue #597). Nor does
+  grepping `CMakeCache.txt` tell you which flags are in use — read
+  `flags.make`. See [`building.md`](dev_docs/building.md).
+- **Do not delete `util/enumerate.hh`.** `std::views::enumerate` is missing
+  from libc++, so 46 files depend on it. Same for anything else the tree
+  hand-rolls: check [`building.md`](dev_docs/building.md) before replacing it
+  with the standard-library spelling.
+- **Do not reformat an `overloaded{...}` block by hand.** The empty `//` after
+  the opening brace is load-bearing; add it and re-run clang-format. See
+  [`code-style.md`](dev_docs/code-style.md), which also has the `using`
+  ordering that the tree follows and that is easy to guess wrong.
+- **A capped test run does not check completeness.** The data-driven constraint
+  tests run with per-solve caps by default, which check soundness and a partial
+  proof only. When you have changed a propagator, configure with
+  `-DGCS_TEST_CAP_DEFAULTS=OFF` and re-run.
+- **A proof that verifies is not the same as a derivation that is tight.**
+  If you are claiming an inference is justified, sabotage the justification and
+  check that VeriPB then rejects it — see `constraints.md` (Mutation testing).
+- **Removing work is not automatically saving time.** Dropping 9.9M of 17.8M
+  propagator calls on `tpp` moved the wall clock by nothing measurable, while
+  the same change on a different model was a reproducible 6.9%. Counts, proof
+  sizes and wall clock move independently here, and a ratio means nothing
+  unless the search shape is identical either side of it. See
+  [`propagator-performance.md`](dev_docs/propagator-performance.md) for what to
+  measure and [`benchmarking.md`](dev_docs/benchmarking.md) for how.
+
+## Before committing
+
+`CONTRIBUTING.md` is the contract: it covers the policy on AI-assisted
+contributions (declare it, with a `Co-Authored-By:` trailer naming the tool),
+the clang-format requirement, and what a contribution should pass. Work on a
+branch and open a pull request; do not commit to `main`.
 
 ```shell
-cmake --preset release  && cmake --build --preset release   # optimised (default)
-cmake --preset debug    && cmake --build --preset debug     # -O0, full debug info
-cmake --preset sanitize && cmake --build --preset sanitize  # ASan + UBSan
-```
-
-Or explicitly without presets (release equivalent):
-```shell
-cmake -S . -B build
-cmake --build build --parallel $(nproc 2>/dev/null || sysctl -n hw.logicalcpu)
-```
-
-The per-configuration flags at the top of `CMakeLists.txt` are plain `set()` calls,
-not `set(... CACHE ...)`, and must stay that way: a cached `set()` there is a silent
-no-op, because `project()` has already created those cache entries. That is how the
-Sanitize build spent months containing no sanitizers (issue #597). Do not "tidy" them
-back into cache variables — `sanitizers_enabled_test` and a configure-time check will
-both object, and `-DCMAKE_CXX_FLAGS_SANITIZE=...` on the command line has no effect
-either way. `grep`ping `CMakeCache.txt` for these tells you nothing; check
-`build-sanitize/gcs/CMakeFiles/*.dir/flags.make` instead.
-
-Use `--parallel N` for parallel builds. The expression `$(nproc 2>/dev/null || sysctl -n
-hw.logicalcpu)` gives the CPU count on both Linux and macOS. Omitting the count causes
-`make` to spawn unlimited jobs, which exhausts memory. If the build fails and the error
-output is hard to read, re-run without `--parallel` to get clean sequential output.
-For `ctest`, use `-j $(nproc 2>/dev/null || sysctl -n hw.logicalcpu)`.
-
-Run all tests (requires `veripb` installed):
-```shell
-ctest --preset release      # with presets
-cd build && ctest           # without presets
-```
-
-Run a single test binary directly:
-```shell
-./build/equals_test
-```
-
-There are two families of test binary, and they are proved differently. The
-data-driven constraint tests have no `--prove` flag: they write and check their
-own proofs, calling `veripb` in-process whenever it is on the `PATH`. Running
-one directly, as above, therefore already verifies its proofs, which is why
-ctest registers them through `run_test_only.bash` — a wrapper that only runs the
-binary. Everything that *does* take `--prove` — the examples, benchmarks and
-frontends, plus the proof-innards tests under `gcs/` — goes through
-`run_test_and_verify.bash`, which runs the binary with `--prove`, checks the
-proof with `veripb`, and reads back any `.scp` it wrote:
-```shell
-./run_test_and_verify.bash ./build/reification_test
-```
-A third wrapper, `run_test_and_expect_verify_failure.bash`, is the inverse of the
-second: a mutation lane makes a test write a knowingly wrong proof, and the run
-passes only if `veripb` *rejects* it. Mutation lanes are the exception to the
-split above — a handful of constraint tests are driven through these two
-wrappers with `--mutate=` and the wrapper's `--basename`, which is what names
-the one proof the wrapper then checks.
-
-Proof files are deleted once they verify. To keep them for inspection, set
-`GCS_PRESERVE_PROOF_FILES` (see `dev_docs/constraints.md`); they are kept
-automatically when verification fails.
-
-Disable XCSP or MiniZinc support to reduce dependencies:
-```shell
-cmake -S . -B build -DGCS_ENABLE_XCSP=OFF -DGCS_ENABLE_MINIZINC=OFF
-```
-
-Enable the view-wrap proof-verification sweep — every wrap × every argument
-position, for each constraint that participates. That is around 7200 extra
-tests (400 without it, 7636 with, in a build with the frontends and executables
-off), and they pass: every constraint registered in the sweep verifies under
-every wrap. `SmartTable` is the one deliberate omission — it over-prunes under
-views, tracked in issue #238. Opt in when working on view proof logging:
-```shell
-cmake -S . -B build -DGCS_ENABLE_VIEW_WRAP_SWEEP=ON
-```
-The harness and the `--view-wrap=N` / `--view-position=N|all|mixed` argv flags
-on each test are always built, as is the single `--view-position=mixed` test per
-constraint, which is part of the ordinary suite; only the per-wrap ctest
-registrations are gated. See `dev_docs/view-proof-logging.md`.
-
-Enable the large-domain guard, a development tripwire that turns work
-proportional to a variable's domain width into a test failure (issue #833):
-```shell
-cmake -S . -B build-guard -DGCS_LARGE_DOMAIN_GUARD=ON
-```
-Off by default, and deliberately not user-facing: what protects a user is a
-constraint having somewhere cheap to fall back to, not an exception thrown from
-the middle of propagation. Turning it on also registers `large_domain_audit_test`,
-which probes every constraint class over a `0..10^9` domain against a table of
-expected outcomes. See `dev_docs/large-domains.md`.
-
-By default the data-driven constraint tests run with generous per-solve
-solution/recursion caps (`GCS_TEST_CAP_DEFAULTS=ON`) so a pathological
-random instance can't dominate the parallel suite. A capped run checks
-soundness and the partial proof only, **not** completeness — so when
-working on a propagator, turn the caps off to get full enumeration
-checking:
-```shell
-cmake -S . -B build -DGCS_TEST_CAP_DEFAULTS=OFF
-```
-See `dev_docs/constraints.md` (Testing) for details.
-
-Format code with clang-format; all source is formatted this way. Use
-**clang-format 21** to match CI (formatting output differs between major
-releases). Format the whole tree with:
-```shell
+# format (clang-format 21, matching CI)
 git ls-files '*.cc' '*.hh' | grep -v '^XCSP3-CPP-Parser/' | xargs clang-format -i
-```
-The `clang-format` CI workflow enforces this on every push and pull request. To
-catch violations before CI, enable the tracked pre-commit hook once per clone
-with `git config core.hooksPath .githooks` (see CONTRIBUTING.md).
 
-## Releasing the Python bindings
+# jobs for ctest; the build presets already parallelise on their own
+j=$(nproc 2>/dev/null || sysctl -n hw.logicalcpu)
 
-`gcspy` (the pybind11 module in `python/`) is published to PyPI. The version
-lives in `python/pyproject.toml`; a tag push matching `gcspy-v*` builds the
-sdist plus macOS/manylinux wheels and publishes via the `release-gcspy.yml`
-workflow. Full procedure, the compiler-floor wheel setup, and the one-time PyPI
-Trusted Publishing configuration are in
-[`dev_docs/releasing-gcspy.md`](dev_docs/releasing-gcspy.md).
-
-## Compiler and Standard Library Support
-
-Development happens with **GCC 15.2.0** and **clang 21**; **MSVC (Visual Studio
-2022)** is the third supported compiler. The *oldest* supported compiler is **GCC
-13**, which is what the `ubuntu-24.04` lane and the manylinux wheel build use.
-Clang on macOS uses **libc++** (Apple's standard library), not libstdc++. This
-matters for C++23 feature availability: some features are in libstdc++ but not
-yet libc++.
-
-CI runs on every push to `main` and every pull request, over `ubuntu-24.04`
-(default GCC, test caps off), `ubuntu-26.04` (default GCC, test caps off, and the
-one lane that builds with `-DGCS_WERROR=ON`, so a new compiler warning turns the
-lane red), `ubuntu-26.04` with clang, `macos-15` and `macos-26`, plus a
-`ubuntu-26.04` Sanitize lane and the `windows-2022` MSVC lanes. `main` has no
-branch protection, so a lane reports rather than literally gating a merge.
-
-Windows/MSVC support is experimental (see README.md, Platform support), but the
-`windows-2022` lanes run on every push and pull request just like the Linux and
-macOS ones, so code must still compile there. In particular, do not use GCC/clang
-extensions or Itanium-ABI-only headers (`<cxxabi.h>`, `abi::__cxa_demangle`, ...).
-
-Known unavailable in libc++ (the Apple Clang on the macOS lanes; last checked
-against clang 21, so re-confirm on CI before relying on a change here):
-- `std::views::enumerate` — use `util/enumerate.hh` instead; do not remove that
-  file, which 46 files include
-
-Known unavailable in libstdc++ on the GitHub Actions Ubuntu 24.04 runner (GCC 13), which
-we still support:
-- `std::vector::append_range` (and the other P1206 `*_range` container members) —
-  `__cpp_lib_containers_ranges` is undefined there. Use
-  `vec.insert(vec.end(), src.begin(), src.end())` instead. Reconfirmed unavailable on the
-  Ubuntu 24.04 lane via CI on 2026-07-03; libc++ (macOS) and GCC 15 both have it.
-
-Confirmed available on **all** supported toolchains (including GCC 13 and macOS libc++),
-verified via CI on 2026-07-03 — prefer them where they read more clearly than a hand-rolled
-`if`/ternary:
-- `std::optional` monadic operations: `.transform()`, `.and_then()`, `.or_else()`, and
-  `.value_or()`.
-
-When adding a new C++23 feature, build with GCC and clang before committing, and check
-MSVC availability (CI is the backstop there).
-
-## Code Style
-
-### `using` declarations
-
-The `using` declarations block near the top of each `.cc` file is sorted **alphabetically
-by name**, with the `std::ranges::` names in a group of their own **after** all the plain
-`std::` ones, themselves alphabetical. Example:
-
-```cpp
-using std::pair;
-using std::string;
-using std::vector;
-using std::ranges::any_of;
-using std::ranges::sort;
+cmake --preset release  && cmake --build --preset release  && ctest --preset release  -j $j
+cmake --preset sanitize && cmake --build --preset sanitize && ctest --preset sanitize -j $j
 ```
 
-Every one of the 57 files that names a `std::ranges::` algorithm does it this way, so
-follow it rather than sorting `std::ranges::sort` under 'r' between `std::pair` and
-`std::string` — which is what this section used to say and what nothing in the tree does.
-
-The `#if defined(__cpp_lib_print)` block that picks `std::print`/`fmt::print` is a
-separate block and stays where it is, below.
-
-### Ranges algorithms
-
-When replacing a classic algorithm with its `std::ranges::` equivalent:
-- Remove `using std::foo;`
-- Add `using std::ranges::foo;` to the `std::ranges::` group below the plain `std::` ones,
-  in alphabetical order within that group (see `using` declarations, above)
-- Leave the call site **unqualified** — do not write `std::ranges::sort(v)` at the call site
-
-### `using enum`
-
-Place `using enum SomeEnum;` on the **first line inside the switch body**, indented one
-level past the `switch` keyword, before the first `case` label:
-
-```cpp
-switch (x) {
-    using enum SomeEnum;
-case Value1:
-```
-
-This pattern is already used in the codebase; follow it consistently.
-
-### `overloaded{...}` visitor blocks
-
-Format `overloaded{...}` visitors like a `switch`: nothing after the opening brace, each
-lambda starting on its own line at one indent level, all lambdas indented equally. Pin the
-layout with an empty `//` comment straight after the opening brace:
-
-```cpp
-overloaded{//
-    [&](const consistency::GAC &) {
-        // ...
-    },
-    [&](const consistency::VC &) {
-        // ...
-    }}
-    .visit(_level);
-```
-
-The pin is load-bearing. clang-format's penalty optimiser will otherwise pull the first
-lambda up onto the `overloaded{` line whenever the content happens to make that layout
-score better, and it re-mangles a previously-clean block when the lambda bodies change —
-so an unpinned block that looks stable today is one edit away from being reflowed. When
-you meet an already-mangled block, add the `//` and re-run clang-format rather than
-re-indenting by hand. (Same trick as the trailing `//` that keeps cxxopts `add_options`
-blocks one option per line.)
-
-### `std::format` / `fmt::format`
-
-Files that use `format()` for string building must use the conditional pattern:
-
-```cpp
-#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
-#include <format>
-using std::format;
-#else
-#include <fmt/core.h>
-using fmt::format;
-#endif
-```
-
-Add `#include <format>` in the same `#if` block as `#include <print>` where both are
-needed.
-
-## Architecture Overview
-
-This is a C++23 constraint programming solver with a key focus on **proof logging** — every inference can be verified externally by VeriPB.
-
-### Public API (`gcs/`)
-
-- `gcs/problem.hh` — `Problem` class: create variables, post constraints, set objective
-- `gcs/solve.hh` — `solve()` and `solve_with()` entry points; `SolveCallbacks` struct for solution/branch callbacks
-- `gcs/current_state.hh` — `CurrentState`: read-only view of variable values in solution callbacks
-- `gcs/integer.hh` — `Integer` type wrapper (use `0_i`, `100_i` literals)
-- `gcs/variable_id.hh` — `IntegerVariableID` and related lightweight handle types
-- `gcs/constraints/` — all user-facing constraint types (e.g. `LinearLessThanEqual`, `AllDifferent`, `Table`, etc.), each one a directory plus an umbrella header of the same name
-- `gcs/presolvers/` — the opt-in presolvers (`AutoTable`, `DifferenceLogic`, `CumulativeStrengthening`, `InferredCumulative`, `InferredDisjunctive`), in the same directory-plus-umbrella-header layout; the base class is `gcs/presolver.hh`
-- `gcs/proof.hh` — `ProofOptions` and `ProofFileNames`: the `.opb` model, the `.pbp` proof, the variables map and the `.scp` s-expression definitions
-- `gcs/search_heuristics.hh`, `gcs/restarts.hh`, `gcs/variable_weighting.hh` — branching, restart schedules, and dom/wdeg-style conflict weighting
-- `gcs/gcs.hh` — convenience header for most of the public API. It does **not** pull in `presolver.hh`, `proof_strategy.hh` or `scp_reader.hh`, which have to be included directly
-
-### Innards (`gcs/innards/`)
-
-Not part of the public API. Key components:
-
-- **`State`** (`innards/state.hh`) — holds all variable domains as `IntervalSet<Integer>` (a sorted sequence of disjoint closed intervals, with small-buffer optimisation for the common one-or-two-interval case). See `dev_docs/state-and-variables.md` for the full picture: the `IntegerVariableID` family, epoch-based backtracking, and the `change_state_for_*` inference paths.
-- **`Propagators`** (`innards/propagators.hh`) — manages constraint propagators, triggers, and the propagation queue
-- **`InferenceTracker`** (`innards/inference_tracker.hh`) — templated on `SimpleInferenceTracker` or `EagerProofLoggingInferenceTracker`; all domain modifications go through this
-- **`ProofModel`** (`innards/proofs/proof_model.hh`) — writes the OPB model: each constraint's definition, emitted during the `define_proof_model` phase
-- **`ProofLogger`** (`innards/proofs/proof_logger.hh`) — writes the VeriPB proof (`.pbp`) during search, tagging each line with a `ProofLevel` and placing it in either the core or the derived constraint set
-
-### Constraint Pattern
-
-Each constraint in `gcs/constraints/` is a subclass of `Constraint`
-(`gcs/constraint.hh`). `Constraint::install()` is **not** virtual: `Problem`
-calls it, and it runs up to three phases, which are what a constraint overrides.
-
-1. `prepare(Propagators &, State &, ProofModel * const) -> bool` — argument
-   validation, reading the initial domains, allocating auxiliary variables and
-   backtrackable constraint state, and installing child constraints. It is the
-   only phase holding the propagators, the mutable `State` and the model at
-   once, so it is the only one that can allocate or install a child. Return
-   `false` to say the other two phases must not run.
-2. `define_proof_model(ProofModel &, const State &) -> void` — write the OPB
-   definition, and nothing else. Run only when proofs are being logged. It is
-   `const` because this phase must describe the constraint, never allocate.
-3. `install_propagators(Propagators &) -> void` — register the propagator(s).
-
-Two further overrides are not phases: `constraint_type()` is pure virtual and
-gives the `.scp` keyword stem (`abs`, `lin_less_equal`, `array_min`, ...), and
-`s_expr()` exposes the constraint to the sub-constraint-proof writer (see
-`dev_docs/scp_s_expr_migration.md`).
-
-A propagator receives an `InferenceTracker &` and calls `infer()` on it with a
-`ProofLogger *`, a `Literal`, a `Justification` and a `Reason` (a declarative
-reason, materialised on demand). `dev_docs/constraints.md` has the full pattern;
-`dev_docs/reification.md` covers reified constraints.
-
-### Justification Types
-
-Every inference must be accompanied by a justification. Three of these are the
-alternatives of `using Justification = std::variant<JustifyUsingRUP<NoHint>,
-AssertRatherThanJustifying, NoJustificationNeeded>`; `JustifyExplicitly` is
-dispatched by overload resolution rather than carried in that variant.
-- `NoJustificationNeeded` — the inference needs nothing in the proof: it is neither justified nor asserted (the solver simply trusts it)
-- `AssertRatherThanJustifying` — the inference is emitted under VeriPB's assertion rule and taken on trust rather than checked. This is also what every other justification degrades to when the logger is running at an `AssertionLevel` other than `Off`
-- `JustifyUsingRUP{}` — reverse unit propagation suffices (optionally `JustifyUsingRUP{hints::Foo{...}}` to carry a typed assertion hint)
-- `JustifyExplicitly{emit, ThenRUP::Yes}` — `emit` is a `(const ReasonLiterals &) -> void` callback (or a named fat-witness struct, for a reification verdict) that writes explicit VeriPB proof steps. `ThenRUP` is mandatory: `Yes` RUPs the inferred literal after the steps, `No` lets the steps conclude it. An optional third argument is a typed assertion hint, shared with `JustifyUsingRUP`.
-
-### Testing Pattern
-
-Constraint tests live beside the constraint they test (e.g.
-`gcs/constraints/equals/equals_test.cc`) and use the `gcs::test_innards`
-utilities in `gcs/constraints/innards/constraints_test_utils.hh`. The test
-pattern:
-1. Generate all expected solutions using a pure C++ satisfiability check
-2. Run the solver and collect actual solutions
-3. Compare expected vs actual (optionally checking GAC at each search node)
-4. Prove and check: these tests write their own proofs and call `veripb`
-   in-process whenever it is on the `PATH` (`can_run_veripb()`,
-   `verify_proof_and_clean_up()`), so they need no `--prove` flag and no
-   verifying wrapper — which is why ctest registers them with
-   `run_test_only.bash`
-
-`run_test_and_verify.bash` is for the *other* kind of test binary: those that
-take `--prove` and leave the checking to the wrapper — the examples, benchmarks
-and frontends, plus the proof-innards tests under `gcs/` (`reification_test`,
-`invar_test`, the `range_witness_*` set, and so on).
-
-Some tests use Catch2 (linked with `Catch2::Catch2WithMain`); others are standalone programs.
-
-### External Dependencies
-
-Fetched at configure time with CMake `FetchContent`:
-
-- **Catch2** — unit test framework (only when `GCS_BUILD_TESTS`)
-- **cxxopts** — command-line parsing for the executables and the MiniZinc frontend
-- **nlohmann/json** — JSON parsing (MiniZinc support)
-- **gch/small_vector** — the small-buffer vector that backs `IntervalSet`, and so sits on the solver's hottest path
-- **fmt** — string formatting, only when the compiler has no `<format>`/`<print>`
-- **pybind11** — only for the Python bindings (`GCS_ENABLE_PYTHON`, via `python/CMakeLists.txt`)
-
-Not `FetchContent`:
-
-- **generator** — `<generator>` polyfill if the compiler lacks it (C++23); fetched with `ExternalProject_Add`, headers only
-- **XCSP3-CPP-Parser** — vendored in-tree, and excluded from clang-format
-- **VeriPB** — external proof checker, not fetched by CMake at all: install it separately with `cargo install --path .` from a VeriPB checkout
+Run a single test binary directly (`./build/equals_test`); the data-driven
+constraint tests verify their own proofs whenever `veripb` is on the `PATH`.
+[`building.md`](dev_docs/building.md) has the rest: the build options, which
+wrapper runs which kind of test, the supported toolchains and their gaps, and
+what each CI lane covers.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,8 @@ reasoning behind them.
 
 | If you are... | Start with |
 |---------------|------------|
-| adding or changing a constraint | [`dev_docs/constraints.md`](dev_docs/constraints.md), then [`reification.md`](dev_docs/reification.md) if it is reified |
+| adding a constraint that does not exist yet | [`dev_docs/constraints.md`](dev_docs/constraints.md), "Bringing up a new constraint" — the order to do the work in, before anything else |
+| changing an existing constraint | the rest of [`dev_docs/constraints.md`](dev_docs/constraints.md), then [`reification.md`](dev_docs/reification.md) if it is reified |
 | touching domains, backtracking, or the inference paths | [`state-and-variables.md`](dev_docs/state-and-variables.md) |
 | writing or debugging a justification | `constraints.md` (Justifications), [`infer-redesign.md`](dev_docs/infer-redesign.md), and the per-constraint proof notes in the index |
 | creating an auxiliary variable for a proof | [`variable-encodings.md`](dev_docs/variable-encodings.md) |
@@ -37,6 +38,30 @@ For orientation in the source itself, `README.md` (Navigating the Source Code)
 covers the public API in `gcs/`; `gcs/innards/` is everything that is not part
 of it, and `dev_docs/constraints.md` (The big picture) is the map of how a
 constraint, its propagators, its OPB definition and its proof fit together.
+
+## When to ask for a second opinion
+
+Reproducing a proof shape this tree already uses is reliable. Inventing one is
+where things go wrong, and the failure mode is quiet: a derivation that verifies
+but is needlessly baroque, or that leans on something which happens to hold for
+the instance in front of you.
+
+Two triggers. Either the constraint needs a proof technique that is not already
+somewhere in `dev_docs/`, or the technique you did use looks inelegant or
+suspicious *to you* — treat that feeling as evidence rather than as fussiness.
+
+When either fires, spawn a subagent on the **Fable** model as a critical proofs
+consultant, and keep its instructions narrow. Give it one derivation and one
+question; tell it what the encoding provides and what the reason contains; ask
+it to attack the argument, not to write code. A broad "review my proof logging"
+gets a vague answer, whereas "here is the `pol`, here is why I think each step
+is sound, find the case where it is not" gets a useful one. This is a good use
+of tokens: much cheaper than meeting the same problem as a rejected VeriPB line
+three stages later, and much cheaper than not meeting it.
+
+The staged method in `dev_docs/constraints.md` ("Bringing up a new constraint")
+is what makes this cheap to act on — each stage's gate localises the problem
+before you go asking about it.
 
 ## Mistakes that have been made here before
 
@@ -61,6 +86,13 @@ so that it is visible without following the link.
   tests run with per-solve caps by default, which check soundness and a partial
   proof only. When you have changed a propagator, configure with
   `-DGCS_TEST_CAP_DEFAULTS=OFF` and re-run.
+- **Never leave an `AssertRatherThanJustifying` in code you commit.** It emits
+  VeriPB's `a` rule, which puts an *unchecked* claim into the proof, so the
+  inference is not verified and the proof establishes nothing about it. It is
+  legitimate as temporary scaffolding while bringing a propagator up, and
+  nothing but you will catch it if it stays: `veripb` exits 0 on an asserted
+  proof, so the whole suite stays green. The only signal is `s UNDER ASSERTIONS`
+  instead of `s VERIFIED` on a real run. See `constraints.md`, stages 3 and 5.
 - **A proof that verifies is not the same as a derivation that is tight.**
   If you are claiming an inference is justified, sabotage the justification and
   check that VeriPB then rejects it — see `constraints.md` (Mutation testing).

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,7 +120,16 @@ endif()
 option(GCS_ENABLE_EXECUTABLES "Build the example, benchmark and verified-encoding programs" ${_gcs_enable_executables_default})
 unset(_gcs_enable_executables_default)
 option(GCS_BUILD_TESTS "Build GCS tests" ${PROJECT_IS_TOP_LEVEL})
-option(GCS_ENABLE_VIEW_WRAP_SWEEP "Register the view-wrap proof-verification sweep (many tests, most failing today; opt in when working on view proof logging)" OFF)
+# The view-wrap proof-verification sweep: every wrap x every argument position,
+# for each constraint that threads a ViewWrapConfig through its test. That is
+# around 7200 extra tests, which is why it is opt-in -- not because they fail.
+# Every constraint registered in the sweep verifies under every wrap; SmartTable
+# is the one deliberate omission, because it over-prunes under views (#238).
+# This gates only the per-wrap registrations: the one --view-position=mixed test
+# per constraint is registered either way and is part of the ordinary suite, as
+# are the --view-wrap / --view-position flags on each test binary. Turn this on
+# when working on view proof logging. See dev_docs/view-proof-logging.md.
+option(GCS_ENABLE_VIEW_WRAP_SWEEP "Register the full per-wrap view proof-verification sweep (~7200 extra tests; opt in when working on view proof logging)" OFF)
 
 # The large-domain guard (issue #833). A development tripwire, not a user-facing
 # safety net: it turns work proportional to a variable's domain width -- a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,11 +18,6 @@ should be able to see at a glance that AI was involved and which tool was used.
 change is correct---not merely that it compiles and passes tests. Rubber-stamping
 AI output without understanding it is not acceptable.
 
-Have particular care when working with logic. Our experience to date with
-Claude is that it knows the C++ libraries and language well, but that it can
-make subtle mistakes when dealing with complicated conditions (which show up
-quite a lot in propagators). The proof logging code is similarly high-risk.
-
 All contributions should pass both the `release` and `sanitize` build and tests
 before submission, including the full test suite (with VeriPB installed) in
 both modes. See `README.md` for the build and test commands, and
@@ -32,6 +27,67 @@ per-solve caps to the data-driven constraint tests, which check soundness and a
 partial proof but not completeness; when you have changed a propagator,
 configure with `-DGCS_TEST_CAP_DEFAULTS=OFF` so that they enumerate fully, as
 the two default-GCC Ubuntu CI lanes do.
+
+What agents are currently good and bad at here
+----------------------------------------------
+
+If you want a global constraint this solver does not have, this section is aimed
+at you: the answer to "could I get an agent to write it, and would that be worth
+anyone's time?" has changed recently enough to be worth writing down. It is not
+an invitation to send us unsupervised output --- what makes a contribution like
+that reviewable is the supervision described here, not the model that wrote it.
+
+This is a moving target, so it is dated, and it is one project's experience
+rather than a study. As of September 2026:
+
+**Implementing a global constraint is now a reasonable thing to attempt with an
+agent, under supervision.** We have found that Claude Opus 5, run at the `xhigh`
+reasoning effort, is generally able to implement a propagator from the
+literature --- read the paper, get the algorithm right, encode it in PB, and
+certify it --- provided two things hold.
+
+The first is that it works in *stages* rather than trying to land a whole
+constraint at once. `dev_docs/constraints.md` ("Bringing up a new constraint")
+sets out the staging we have found works: the encoding certified on its own
+before any propagation exists, the intended consistency level written into the
+tests before anything can pass it, then propagation, then the proofs. The gate
+at the end of each stage is what keeps a mistake attributable to the piece that
+caused it, which is most of the value.
+
+The second is that it actually reads the developer documentation for whatever it
+is touching. Most of what goes wrong when it does not is a convention or an
+invariant that *is* written down in `dev_docs/` and was not read. This is the
+single biggest lever, and it is why those documents exist in the form they do.
+
+**The weak spot is novel proof technique.** Reproducing a proof shape the tree
+already uses is reliable. Devising a new one is not: that is where you get
+derivations which verify but are needlessly baroque, or which lean on a step
+that happens to hold for the instance in front of them. Two triggers to watch
+for --- the constraint needs a technique that is not already somewhere in
+`dev_docs/`, or the technique it did use looks inelegant or suspicious to you.
+
+When either fires, what we have found effective is to tell Opus to **spawn a
+subagent on the Fable model as a critical proofs consultant, with narrow
+instructions**: one derivation, one question, and an instruction to attack the
+argument rather than to write code. It is good at that, and it is a good use of
+tokens --- considerably cheaper than finding the same problem from a rejected
+VeriPB line three stages later, and much cheaper than not finding it.
+
+**The older warning still holds where it always did.** Claude knows the C++
+language and libraries well, but makes subtle mistakes in complicated
+conditions, which propagators are full of. Read the branch structure yourself,
+particularly around the edge cases a paper glosses over.
+
+**Two things to check by hand, because nothing else will.** That no
+`AssertRatherThanJustifying` survives into the submission: an asserted proof
+still exits successfully, so the test suite passes with the cheats in, and only
+the `s UNDER ASSERTIONS` line on a real run gives it away (see
+`dev_docs/constraints.md`, "Bringing up a new constraint", stage 5). And that
+the consistency level claimed in the class comment is the one the tests
+actually check, with the caps off.
+
+None of this changes what you take on by submitting the work: you still have to
+be able to explain why each change is correct.
 
 Licensing
 =========

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,9 @@ quite a lot in propagators). The proof logging code is similarly high-risk.
 
 All contributions should pass both the `release` and `sanitize` build and tests
 before submission, including the full test suite (with VeriPB installed) in
-both modes. See `README.md` for details. Note that a default build applies
+both modes. See `README.md` for the build and test commands, and
+`dev_docs/building.md` for the build options, the supported toolchains, and
+what each CI lane covers. Note that a default build applies
 per-solve caps to the data-driven constraint tests, which check soundness and a
 partial proof but not completeness; when you have changed a propagator,
 configure with `-DGCS_TEST_CAP_DEFAULTS=OFF` so that they enumerate fully, as
@@ -70,6 +72,11 @@ check over the staged C++ is tracked in `.githooks/`. Enable it once per clone:
 ```shell
 git config core.hooksPath .githooks
 ```
+
+`clang-format` settles only the mechanical questions. The conventions it does
+not enforce --- the ordering of the `using` block, `using enum` placement, the
+`//` that pins an `overloaded{...}` visitor, the `#if` guard around `format()`
+--- are written down in `dev_docs/code-style.md`.
 
 It rejects a commit whose staged files are not formatted, printing the exact
 `clang-format -i` command to fix them; `git commit --no-verify` bypasses it for

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,11 @@ quite a lot in propagators). The proof logging code is similarly high-risk.
 
 All contributions should pass both the `release` and `sanitize` build and tests
 before submission, including the full test suite (with VeriPB installed) in
-both modes. See `README.md` for details.
+both modes. See `README.md` for details. Note that a default build applies
+per-solve caps to the data-driven constraint tests, which check soundness and a
+partial proof but not completeness; when you have changed a propagator,
+configure with `-DGCS_TEST_CAP_DEFAULTS=OFF` so that they enumerate fully, as
+the two default-GCC Ubuntu CI lanes do.
 
 Licensing
 =========
@@ -70,7 +74,11 @@ git config core.hooksPath .githooks
 It rejects a commit whose staged files are not formatted, printing the exact
 `clang-format -i` command to fix them; `git commit --no-verify` bypasses it for
 a one-off. The hook uses `clang-format-21` if present, otherwise `clang-format`,
-so install version 21 (CI pins 21.1.8) for results that match CI.
+so install version 21 (CI pins 21.1.8) for results that match CI --- and note
+that if neither is on `PATH` the hook warns and lets the commit through, so an
+installed clang-format is what makes it a check at all. It also only sees what
+is staged, whereas CI formats the whole tree; the two agree on a clean tree, but
+run the command above by hand if you are unsure.
 
 Developer Documentation
 =======================

--- a/README.md
+++ b/README.md
@@ -149,6 +149,12 @@ cmake --build build --parallel $(nproc 2>/dev/null || sysctl -n hw.logicalcpu)
 cmake --build build --target docs
 ```
 
+There are more switches than these — ones that change what the test suite
+checks, a large-domain tripwire, a warnings-as-errors setting for one CI lane.
+Those are developer-facing rather than user-facing, and are catalogued in
+[`dev_docs/building.md`](dev_docs/building.md), along with the reasoning behind
+each build type's flags and the supported-toolchain matrix.
+
 Using the XCSP Solver
 ---------------------
 
@@ -415,7 +421,9 @@ Developer Documentation
 
 In-depth notes on individual subsystems live in the ``dev_docs/`` directory. These are aimed at
 developers (human or AI) working on the solver itself, not at end users. See ``dev_docs/README.md``
-for an index.
+for an index; [`dev_docs/building.md`](dev_docs/building.md) and
+[`dev_docs/code-style.md`](dev_docs/code-style.md) are the two to read before making any change,
+whatever it touches.
 
 Before submitting a contribution, please read ``CONTRIBUTING.md``. It covers the policy on
 AI-assisted contributions and the formatting (clang-format), build, and test requirements.

--- a/dev_docs/README.md
+++ b/dev_docs/README.md
@@ -40,9 +40,13 @@ library. For an introduction to *using* the solver, start with the top-level
 - [Implementing a constraint](constraints.md) — the structural pattern every
   constraint follows: class shape, the three install phases, the propagator
   framework, triggers, the inference and justification APIs, OPB encoding
-  building blocks, and the testing pattern. Start here when adding any new
-  constraint — and for the umbrella-header directory layout, which presolvers
-  under `gcs/presolvers/` share.
+  building blocks, and the testing pattern. Also the *order* to build a new
+  constraint in ("Bringing up a new constraint"): encoding first behind a
+  check-only propagator, then the consistency level stated in the tests, then
+  propagation with every inference cheated, then the cheats discharged one at a
+  time — and why none of those cheats may ever be merged. Start here when
+  adding any new constraint — and for the umbrella-header directory layout,
+  which presolvers under `gcs/presolvers/` share.
 - [Reification](reification.md) — additional machinery for *reified* constraints:
   the `ReificationCondition` static and `EvaluatedReificationCondition` runtime
   types, the `install_reified_dispatcher` helper, the OPB encoding pattern,

--- a/dev_docs/README.md
+++ b/dev_docs/README.md
@@ -10,6 +10,20 @@ library. For an introduction to *using* the solver, start with the top-level
 
 ## Contents
 
+- [Building, build options, and toolchains](building.md) — the developer's side
+  of the build: why each build type carries the debug information it does, why
+  the per-configuration flags must stay plain `set()` calls (issue #597), the
+  full option catalogue and what each one changes about what the tests
+  *check*, which test wrapper runs which kind of binary, the supported
+  compilers and standard libraries and their known gaps, and what each CI lane
+  covers. `README.md` has the user-facing version. Read before editing
+  `CMakeLists.txt` or relying on a C++23 library feature.
+- [Code style](code-style.md) — the conventions clang-format does not enforce:
+  the ordering of the `using` block and its `std::ranges::` group, how a
+  classic algorithm is replaced with its ranges equivalent, `using enum`
+  placement, the load-bearing `//` that pins an `overloaded{...}` visitor, and
+  the `#if` guard a file using `format()` must carry. `CONTRIBUTING.md` covers
+  clang-format itself.
 - [State and variables](state-and-variables.md) — how variables and their
   state are represented inside the solver: the `IntegerVariableID` family,
   the `State` class, the `IntervalSet` domain representation, chronological
@@ -123,6 +137,9 @@ library. For an introduction to *using* the solver, start with the top-level
   W1–W5 witness suite as the regression defence against re-simplification.
   Read when touching range/interval reasons, branching, or `infer_not_in_range`.
 - [View proof logging](view-proof-logging.md) — how the proof layer handles
+  views (`ViewOfIntegerVariableID`): the V↔X link constraints that tie a view's
+  proof variable to its underlying variable, and how literals over views are
+  deviewed for emission. Read when touching view handling in proofs.
 - [arithmetic-proofs.md](arithmetic-proofs.md) — how Multiply/Divide/Modulus/Power propagate and justify against cake's encoding: the slot-keyed emitters, the ConditionalBound justification layer, the sign-case driver, and the hard-won RUP/pol rules.
 - [Decision-diagram proof strategies](decision-diagram-proof-strategies.md) — for
   the layered/partial-sum propagators (`Regular`, `MDD`, `Knapsack`,
@@ -132,9 +149,6 @@ library. For an introduction to *using* the solver, start with the top-level
   measured verdicts and defaults, a predictive rule to apply before implementing,
   and why scaffold deletion is unsafe while hinting the propagator's own RUPs is
   the high-value lever. Read when adding or tuning a diagram-shaped constraint.
-  views (`ViewOfIntegerVariableID`): the V↔X link constraints that tie a view's
-  proof variable to its underlying variable, and how literals over views are
-  deviewed for emission. Read when touching view handling in proofs.
 - [Proof logging for `Sort` / `ArgSort`](sortedness.md) — the fully-certified
   Mehlhorn–Thiel sortedness propagator proof: the permutation/root argument and
   the Hall-band pigeonhole over ranks. A worked companion to `constraints.md`.
@@ -152,6 +166,16 @@ library. For an introduction to *using* the solver, start with the top-level
   `glasgow_scp_solver` binary and the SCP chain test harness
   (`run_scp_chain.bash`, `scp_cases/`) for verifying constraint encodings
   against an external checker.
+- [`BinPacking`: design and staging](bin-packing.md) — the working-design note
+  for the `BinPacking` propagator (#148): the two forms (variable loads,
+  constant capacities) that share one propagator, the staging plan, and the
+  context for the extraction towards the unified path-DAG framework (#200).
+- [Slack-based waking for linear inequalities](linear-slack-waking.md) — waking
+  `ReifiedLinearInequality` only when a *covering* subset of its terms moves,
+  via the refined-watch API, instead of on every bound change of every term:
+  the per-term potential, the margin that decides how many to watch, and what
+  it is measured to be worth. Companion to
+  [refined-triggers.md](refined-triggers.md).
 - [`Knapsack`](knapsack.md) — the default per-call DP `Knapsack` (chosen
   for fastest proof verification) and the opt-in upfront-DAG
   `KnapsackUpfront` (#200), the *k*-coordinate generalisation of

--- a/dev_docs/building.md
+++ b/dev_docs/building.md
@@ -1,0 +1,251 @@
+# Building, build options, and toolchains
+
+`README.md` has what a *user* of the solver needs: dependencies, the three
+presets, and how to run `ctest`. This document is the developer's side of the
+same ground — why the build is configured the way it is, the full option
+catalogue, which toolchains have to keep working, and which test wrapper runs
+what. Read it before editing `CMakeLists.txt` or adding a build option.
+
+## Build types
+
+Three build types are supported: `Release` (default), `Debug`, and `Sanitize`,
+with a named preset each in `CMakePresets.json` and its own build directory
+(`build/`, `build-debug/`, `build-sanitize/`), so all three can coexist:
+
+```shell
+cmake --preset release  && cmake --build --preset release   # optimised (default)
+cmake --preset debug    && cmake --build --preset debug     # -O0, full debug info
+cmake --preset sanitize && cmake --build --preset sanitize  # ASan + UBSan
+```
+
+Or explicitly, without presets — this is the release build:
+
+```shell
+cmake -S . -B build
+cmake --build build --parallel $(nproc 2>/dev/null || sysctl -n hw.logicalcpu)
+```
+
+### Debug information is scaled to purpose
+
+All three keep debug information, but not the same amount. `Release` (with
+`/Z7` plus linker `/DEBUG` as the MSVC equivalent) and `Sanitize` use `-g1`;
+`Debug` uses `-g3`.
+
+`-g1` is function names plus line tables — what GCC documents as "enough for
+making backtraces". That is all `ProofLogger::log_stacktrace` needs for the
+`GCS_VERBOSE_LOGGING` proof annotation, and all an ASan or UBSan report needs
+to name a function and a `file:line`, so keeping it in Release means crash
+reports and verbose proofs stay useful in optimised builds.
+`stacktrace_logging_test` fails if a Release build ever drops it.
+
+`Sanitize` is `-g1` for size, and that is a deliberate trade. Every test binary
+statically links the whole solver, so each carries its own copy of the same
+DWARF: at `-g3` the tree's 173 programs came to 84.6 GiB of a 93 GiB build
+tree, which is more than a GitHub runner has — the Sanitize lane died mid-test
+with "No space left on device" when the tests went to write their proof files.
+At `-g1` the same programs come to 52.1 GiB and the tree to 56 GiB. What is
+given up is macros and local-variable DWARF, and those want a debugger — which
+is what the `Debug` configuration is for. Build `Debug` when you are going to
+attach one.
+
+### The per-configuration flags must stay plain `set()`
+
+The `CMAKE_CXX_FLAGS_<CONFIG>` assignments near the top of `CMakeLists.txt` are
+plain `set()` calls, not `set(... CACHE ...)`, and must stay that way.
+
+`set(FOO "value" CACHE STRING "help")` is a *defaulting* operation: it does
+nothing at all, without a word of warning, when the cache entry already exists.
+By the time `CMakeLists.txt` runs, `project()` has already created a
+`CMAKE_CXX_FLAGS_<CONFIG>` cache entry for every configuration — the standard
+ones get CMake's defaults, and since CMake 4.2 the custom `Sanitize`
+configuration gets an *empty* one. So every cached `set()` there was a no-op.
+For Release and Debug that went unnoticed, because CMake's defaults are close
+to what was wanted; for Sanitize it meant compiling with no flags whatsoever,
+and a CI lane that reported "sanitize clean" for months without ever running a
+sanitizer (issue #597).
+
+So: do not "tidy" these back into cache variables. A configure-time check and
+`sanitizers_enabled_test` will both object if the flags go missing again,
+however that happens. The trade-off is that `-DCMAKE_CXX_FLAGS_SANITIZE=...` on
+the command line does not reach the compiler — but it never did. To add flags
+to every configuration, use `CMAKE_CXX_FLAGS`, which is applied ahead of these
+and is unaffected; to change what a build type *means*, edit it there.
+
+One consequence when checking a build: `CMakeCache.txt` still holds CMake's own
+(for Sanitize, empty) entries, because nothing writes to the cache any more, so
+grepping the cache tells you nothing about the flags actually in use. The build
+files are the truth:
+
+```shell
+grep CXX_FLAGS build-sanitize/gcs/CMakeFiles/*.dir/flags.make
+```
+
+### Parallelism
+
+Use `--parallel N`. The expression `$(nproc 2>/dev/null || sysctl -n
+hw.logicalcpu)` gives the CPU count on both Linux and macOS. Omitting the count
+lets `make` spawn unlimited jobs, which exhausts memory. If a build fails and
+the error output is hard to read, re-run without `--parallel` for clean
+sequential output. For `ctest`, use `-j $(nproc 2>/dev/null || sysctl -n
+hw.logicalcpu)`.
+
+## Build options
+
+| Option | Default | What it does |
+|--------|---------|--------------|
+| `GCS_ENABLE_XCSP` | on at top level | XCSP3 frontend; needs libxml2 |
+| `GCS_ENABLE_MINIZINC` | on at top level | MiniZinc / FlatZinc frontend |
+| `GCS_ENABLE_PYTHON` | `OFF` | `gcspy` bindings; needs Python and pybind11. `python/pyproject.toml` turns it on |
+| `GCS_ENABLE_EXECUTABLES` | on at top level | Everything that is a program rather than the library: `examples/`, `benchmarks/`, `verified_encodings/`, `scp/`, `minicp_benchmarks/`. Formerly `GCS_ENABLE_EXAMPLES`, which still supplies the default |
+| `GCS_BUILD_TESTS` | on at top level | Build the tests, and fetch Catch2 |
+| `GCS_ENABLE_DOXYGEN` | `OFF` | Adds the `docs` target |
+| `GCS_NATIVE_ARCH` | `ON` | `-march=native` on Release. Turn off for redistributable binaries such as wheels |
+| `GCS_WERROR` | `OFF` | `-Werror`. One CI lane only — see below |
+| `GCS_ENABLE_VIEW_WRAP_SWEEP` | `OFF` | The full view-wrap proof sweep; see [view-proof-logging.md](view-proof-logging.md) |
+| `GCS_LARGE_DOMAIN_GUARD` | `OFF` | Development tripwire for width-proportional work, plus the audit lane; see [large-domains.md](large-domains.md) |
+| `GCS_TEST_CAP_DEFAULTS` | `ON` | Per-solve caps on the data-driven constraint tests; see [constraints.md](constraints.md) |
+| `GCS_TEST_MAX_SOLUTIONS` | `300` | The solution cap those defaults apply |
+| `GCS_TEST_MAX_RECURSIONS` | `1500` | The search-node cap those defaults apply |
+
+Two of these change what the test suite *checks*, rather than merely what gets
+built, and are the ones to reach for when working on a propagator:
+
+```shell
+cmake -S . -B build -DGCS_TEST_CAP_DEFAULTS=OFF      # full-enumeration completeness checking
+cmake -S . -B build -DGCS_ENABLE_VIEW_WRAP_SWEEP=ON  # ~7200 extra view-wrap proof tests
+```
+
+A capped run checks soundness and a partial proof only, **not** completeness.
+The caps exist so a pathological random instance cannot dominate the parallel
+suite; turning them off is what makes the tests enumerate fully, as the two
+default-GCC Ubuntu CI lanes do.
+
+`GCS_WERROR` is a CI lane rather than a normal build setting: GCC's warning
+baseline has been zero since #710, whereas clang and Apple Clang each still
+have a few hundred pre-existing warnings, so only the `ubuntu-26.04` default-GCC
+lane can afford `-Werror`. Build with it before pushing if you want to know
+what that lane will say.
+
+## Which wrapper runs which test
+
+There are two families of test binary, and ctest drives them differently.
+
+The **data-driven constraint tests** have no `--prove` flag. They write and
+check their own proofs, calling `veripb` in-process whenever it is on the
+`PATH`, so running one directly already verifies its proofs. ctest registers
+them with `run_test_only.bash`, which only runs the binary:
+
+```shell
+./build/equals_test
+```
+
+**Binaries that take `--prove`** — the examples, benchmarks and frontends, plus
+the proof-innards tests under `gcs/` (`reification_test`, `invar_test`, the
+`range_witness_*` set) — leave the checking to `run_test_and_verify.bash`, which
+runs the binary with `--prove`, checks the proof with `veripb`, and then reads
+back any `.scp` it wrote with `glasgow_scp_solver --parse-only`, so that a
+constraint whose keyword `read_scp` cannot handle is reported by the program
+that posted it:
+
+```shell
+./run_test_and_verify.bash ./build/reification_test
+```
+
+`run_test_and_expect_verify_failure.bash` is the inverse, for mutation testing:
+the binary writes a knowingly wrong proof and the run passes only if `veripb`
+*rejects* it. Mutation lanes are the exception to the split above — a handful of
+constraint tests are driven through these wrappers with `--mutate=` and the
+wrapper's `--basename`, which names the one proof the wrapper then checks. See
+[constraints.md](constraints.md) (Mutation testing).
+
+The frontends have their own wrappers — `xcsp/run_xcsp_test.bash`,
+`minizinc/run_minizinc_test.bash`, `minizinc/run_fzn_json_test.bash` — as does
+the SCP chain harness, `verified_encodings/run_scp_chain.bash` (see
+[workflow2_testing.md](workflow2_testing.md)).
+
+All of them dispose of proof files through one `dispose_proof` in
+`proof_file_disposal.bash` at the repo root, and all honour
+`GCS_PRESERVE_PROOF_FILES`; [constraints.md](constraints.md) (What happens to
+the proof files) has the policy.
+
+## Compilers and standard libraries
+
+Development happens with **GCC 15.2.0** and **clang 21**. **MSVC (Visual Studio
+2022)** is the third supported compiler. The *oldest* supported compiler is
+**GCC 13**, which is what the `ubuntu-24.04` lane and the manylinux wheel build
+use, so a C++23 feature that GCC 13 lacks cannot be used unconditionally.
+
+Clang on macOS uses **libc++** (Apple's standard library) rather than libstdc++,
+which is the other axis of feature availability: some C++23 library features are
+in libstdc++ but not yet in libc++, and vice versa.
+
+Windows/MSVC support is experimental (see README.md, Platform support), but the
+`windows-2022` lanes run on every push and pull request just like the Linux and
+macOS ones, so code must still compile there. In particular, do not use
+GCC/clang extensions or Itanium-ABI-only headers (`<cxxabi.h>`,
+`abi::__cxa_demangle`, ...).
+
+### Known gaps
+
+Unavailable in libc++ (the Apple Clang on the macOS lanes; last checked against
+clang 21, so re-confirm on CI before relying on a change here):
+
+- `std::views::enumerate` — use `util/enumerate.hh` instead. Do not remove that
+  file; 46 files include it.
+
+Unavailable in libstdc++ on the GitHub Actions Ubuntu 24.04 runner (GCC 13),
+which we still support:
+
+- `std::vector::append_range` and the other P1206 `*_range` container members —
+  `__cpp_lib_containers_ranges` is undefined there. Use `vec.insert(vec.end(),
+  src.begin(), src.end())` instead. Reconfirmed unavailable on the Ubuntu 24.04
+  lane via CI on 2026-07-03; libc++ (macOS) and GCC 15 both have it.
+
+Confirmed available on **all** supported toolchains, including GCC 13 and macOS
+libc++, verified via CI on 2026-07-03 — prefer them where they read more clearly
+than a hand-rolled `if` or ternary:
+
+- `std::optional` monadic operations: `.transform()`, `.and_then()`,
+  `.or_else()`, `.value_or()`
+
+Three features are probed at configure time rather than assumed, and a fallback
+is fetched or disabled when absent: `<format>`/`<print>` (libfmt is fetched
+instead), `<generator>` (a polyfill is fetched), and `<stacktrace>` (without it,
+`GCS_VERBOSE_LOGGING` is unavailable). See [code-style.md](code-style.md) for
+the `#if` pattern a file using `format()` must follow.
+
+When adding a new C++23 feature, build with GCC and clang before committing, and
+check MSVC availability — CI is the backstop there.
+
+## CI
+
+Every push to `main` and every pull request runs:
+
+| Lane | Notes |
+|------|-------|
+| `ubuntu-24.04`, default GCC | GCC 13, the compiler floor; test caps off |
+| `ubuntu-26.04`, default GCC | Test caps off, and the only lane with `-DGCS_WERROR=ON` |
+| `ubuntu-26.04`, clang | clang + libstdc++, including the lifetime-annotation probe tests |
+| `macos-15`, `macos-26` | Apple Clang + libc++ |
+| `ubuntu-26.04` Sanitize | ASan + UBSan, through the `sanitize` test preset |
+| `windows-2022` | MSVC: library and ctest, then the XCSP3 / MiniZinc / Python frontends, then VeriPB |
+| `clang-format` | `--dry-run --Werror` over the whole tree |
+
+Every lane that runs tests installs VeriPB with `cargo install` from a fresh
+`--depth 1` clone of upstream, so CI tracks VeriPB's `main` rather than a pinned
+version — which means an upstream change can turn a lane red without anything
+here having moved. The lanes that exercise the MiniZinc frontend install it too
+— the official bundle on Linux and Windows, brew on macOS — without which every
+`minizinc-*` test skips rather than failing.
+
+`main` has no branch protection, so a lane reports rather than literally gating
+a merge — read the results, do not assume a red lane blocked anything.
+
+## See also
+
+- `README.md` — dependencies, user-facing build and test instructions
+- `CONTRIBUTING.md` — clang-format, the pre-commit hook, what a contribution
+  should pass before submission
+- [code-style.md](code-style.md) — the conventions clang-format does not enforce
+- [releasing-gcspy.md](releasing-gcspy.md) — cutting a Python bindings release
+- [benchmarking.md](benchmarking.md) — measuring a performance change

--- a/dev_docs/code-style.md
+++ b/dev_docs/code-style.md
@@ -1,0 +1,113 @@
+# Code style
+
+`clang-format` settles the mechanical questions — indentation, wrapping,
+spacing — and `CONTRIBUTING.md` covers how to run it and the pre-commit hook
+that checks it. This document covers the conventions it does *not* enforce:
+things the formatter is happy either way about, but which the tree does
+consistently one way.
+
+Each of these is a convention the whole tree already follows, so the right move
+when in doubt is to copy the nearest existing file rather than to reason from
+first principles.
+
+## `using` declarations
+
+The `using` declarations block near the top of each `.cc` file is sorted
+**alphabetically by name**, with the `std::ranges::` names in a group of their
+own **after** all the plain `std::` ones, themselves alphabetical:
+
+```cpp
+using std::pair;
+using std::string;
+using std::vector;
+using std::ranges::any_of;
+using std::ranges::sort;
+```
+
+Every one of the 57 files that names a `std::ranges::` algorithm does it this
+way. In particular, do not sort `std::ranges::sort` under 'r', between
+`std::pair` and `std::string`: nothing in the tree does that.
+
+The `#if defined(__cpp_lib_print)` block that picks `std::print` / `fmt::print`
+is a separate block and stays where it is, below.
+
+## Ranges algorithms
+
+When replacing a classic algorithm with its `std::ranges::` equivalent:
+
+- Remove `using std::foo;`
+- Add `using std::ranges::foo;` to the `std::ranges::` group below the plain
+  `std::` ones, in alphabetical order within that group (see above)
+- Leave the call site **unqualified** — do not write `std::ranges::sort(v)` at
+  the call site
+
+## `using enum`
+
+Place `using enum SomeEnum;` on the **first line inside the switch body**,
+indented one level past the `switch` keyword, before the first `case` label:
+
+```cpp
+switch (x) {
+    using enum SomeEnum;
+case Value1:
+```
+
+Watch for an enumerator that shadows a class of the same name once it is
+unqualified; `search_heuristics.cc` has a case label qualified for exactly that
+reason, with a comment saying so.
+
+## `overloaded{...}` visitor blocks
+
+Format `overloaded{...}` visitors like a `switch`: nothing after the opening
+brace, each lambda starting on its own line at one indent level, all lambdas
+indented equally. Pin the layout with an empty `//` comment straight after the
+opening brace:
+
+```cpp
+overloaded{//
+    [&](const consistency::GAC &) {
+        // ...
+    },
+    [&](const consistency::VC &) {
+        // ...
+    }}
+    .visit(_level);
+```
+
+The pin is load-bearing. clang-format's penalty optimiser will otherwise pull
+the first lambda up onto the `overloaded{` line whenever the content happens to
+make that layout score better, and it re-mangles a previously-clean block when
+the lambda bodies change — so an unpinned block that looks stable today is one
+edit away from being reflowed. When you meet an already-mangled block, add the
+`//` and re-run clang-format rather than re-indenting by hand.
+
+The same trick keeps cxxopts `add_options` blocks one option per line: a
+trailing `//` on each line.
+
+## `std::format` / `fmt::format`
+
+The compiler's own `<format>` and `<print>` are used where available, and
+libfmt is fetched as a fallback where they are not (see
+[building.md](building.md)). A file that uses `format()` for string building
+must therefore use the conditional pattern:
+
+```cpp
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+#include <format>
+using std::format;
+#else
+#include <fmt/core.h>
+using fmt::format;
+#endif
+```
+
+**Both** macros, not just `__cpp_lib_print`: all 348 guards in the tree test
+both, and a guard that tests only one will break on a standard library that has
+one and not the other. Add `#include <format>` in the same `#if` block as
+`#include <print>` where both are needed.
+
+## See also
+
+- `CONTRIBUTING.md` — clang-format version, how to run it, the pre-commit hook
+- [building.md](building.md) — which standard-library features are available on
+  which supported toolchain

--- a/dev_docs/constraints.md
+++ b/dev_docs/constraints.md
@@ -34,6 +34,10 @@ solver starts, each constraint is installed once, in three phases:
 After installing, the constraint object itself is gone — only the
 propagators (with their captured state) and the OPB definition remain.
 
+Those three phases are what a constraint *is*. The order in which to build them
+for a constraint that does not exist yet is a separate question, and an
+important one: see Bringing up a new constraint, below, before starting.
+
 ## File layout
 
 Every constraint lives in its own directory. For a constraint named
@@ -512,12 +516,22 @@ an external justifier rather than fully justified. In normal proofs-off mode
 the hint is inert and the output is byte-identical. See `abs/hints.hh` for
 the minimal shape.
 
-**Debug aid only:** `AssertRatherThanJustifying` exists as a "trust me"
-step that bypasses the justification. Use it temporarily during
-development to isolate whether a VeriPB failure is in the OPB
-encoding (still fails with `Assert*`) or the justification (passes
-with `Assert*`, fails with the real one). Never commit code that uses
-it.
+**Development scaffolding only --- never merge it:**
+`AssertRatherThanJustifying` is a "trust me" step that bypasses the
+justification entirely, emitting VeriPB's `a` rule, which adds the
+constraint to the proof *without checking it*. An inference justified this
+way is not verified, and a proof containing one verifies nothing about it.
+
+It has two legitimate uses, both temporary. As a bisection aid, it isolates
+whether a VeriPB failure is in the OPB encoding (still fails with `Assert*`)
+or in the justification (passes with `Assert*`, fails with the real one). And
+as stage 3 of Bringing up a new constraint, below, it lets a new propagator's
+algorithm be developed and tested before any of its proofs exist.
+
+Both are borrowed time. **Never commit code that uses it**, and be aware that
+nothing will catch you if you do: `veripb` exits successfully on an asserted
+proof, so the test suite stays green. The only signal is the `s UNDER
+ASSERTIONS` line and the accompanying warning, which you have to go and read.
 
 ### When RUP isn't enough: explicit `pol`
 
@@ -943,6 +957,206 @@ Arrange for the fact to arrive under a decision (a reified constraint whose
 condition the search sets, say, with a fixed branching order so it is set first),
 or mutate an emitted lemma instead. `equals_mutations.hh` records two instances
 that accept the mutation for this reason before the third one bites.
+
+## Bringing up a new constraint
+
+The checklist below says what files a new constraint touches. This section says
+what order to do the work in, which matters more: it is the difference between
+one hard problem and three easy ones.
+
+A finished proof-logged constraint has three things that can be wrong — the OPB
+encoding, the propagation algorithm, and the justification of each inference —
+and a VeriPB failure looks much the same whichever it is. So bring them up one
+at a time, in that order, with a gate after each that can only be failed by the
+piece you just added.
+
+One warning up front, because it is the part of this method that can do real
+damage if it is half-remembered. Stage 3 has you cheat — deliberately, with
+`AssertRatherThanJustifying`, which puts unchecked claims into the proof — and
+stages 4 and 5 exist to take every one of those cheats back out again. **Not a
+single one of them may ever be merged**, and nothing in the test suite or CI
+will stop you, so the discipline has to come from you. If you are going to
+follow only part of this section, follow that part.
+
+### Stage 1: the encoding, with a check-only propagator
+
+Write `define_proof_model` and a propagator that does no pruning at all: it
+waits until the variables its semantics need are assigned, checks the
+requirement, and contradicts if it is violated. Every inference such a
+propagator makes is `JustifyUsingRUP{}` — no `pol`, no explicit steps, because
+a fully assigned scope is exactly the case unit propagation can close on its
+own.
+
+Then run the data-driven tests with proofs on.
+
+**The gate: the whole suite verifies.** That is a much stronger statement than
+it looks. It says the encoding is *definitionally correct* — its solutions are
+the constraint's solutions, on every instance the test generates — and that it
+is *strong enough* that RUP alone certifies every consequence reachable from a
+complete assignment. Once it passes, the encoding is settled, and every later
+failure is about propagation or justification rather than about the model. Both
+of the worked examples below record reaching this point as the thing that
+licensed building everything else without revisiting the encoding.
+
+**The catch: a check-only propagator does not prune, so the solver enumerates.**
+Search is exponential in the number of variables, and the proof grows with it.
+Keep the instances at this stage very small — small domains, few variables — and
+expect to shrink them further if a proof gets slow. This is the one stage where
+the test data is chosen for the *search* rather than for coverage of interesting
+cases; you get those back in stage 2, once there is a propagator to make them
+cheap. Turning the caps off (`-DGCS_TEST_CAP_DEFAULTS=OFF`) is what makes the
+gate mean "on every instance" rather than "on a prefix of every instance", so
+this stage wants them off and wants instances that can afford it.
+
+### Stage 2: state the consistency level in the tests
+
+Before writing any pruning, change the tests to demand it: switch
+`solve_for_tests` to `solve_for_tests_checking_gac` if the constraint is meant
+to achieve GAC, or add the directed cases that pin the bounds you intend to
+reach if it is bounds-consistent (see Testing, above).
+
+The tests now fail. That is the point — they fail for the reason you are about
+to fix, and they will keep failing until the propagator actually reaches the
+strength you claimed, rather than until it stops crashing. Writing this rung
+before the propagator is what stops "it passes" quietly becoming the definition
+of the strength, and it is the same discipline as
+[large-domains.md](large-domains.md)'s audit table: say what you promise, then
+make a test hold you to it.
+
+### Stage 3: propagate, with every inference cheated (temporarily)
+
+Now write the real propagation, and justify every inference with
+`AssertRatherThanJustifying`.
+
+**Be clear about what that is: it is cheating.** It emits VeriPB's `a` rule,
+which adds a constraint to the proof *with no check whatsoever* — the solver
+says "this follows" and the checker writes it down and believes it. Every
+inference so justified is unverified. This is temporary development
+scaffolding, borrowed against work you have not done yet, and it is repaid in
+stage 4. It is the one thing in this whole document that must never reach
+`main`.
+
+Used that way, it is genuinely valuable: the suite verifies *subject to the
+cheats*, so you can develop and debug the algorithm without paying for a single
+proof step, and a failure at this stage can only be the algorithm.
+
+**The gate: the stage 2 tests pass, and VeriPB still accepts.** Passing means
+the algorithm reaches the strength you claimed and prunes nothing it shouldn't;
+the enumeration check catches unsoundness whether or not anything is proved.
+What it deliberately does *not* tell you is whether any of it is justifiable —
+that is stage 4's job, and separating the two is the whole point, because
+"my propagator is wrong" and "my proof is wrong" want completely different
+debugging.
+
+Assert each inference's own unit consequence, not a whole node failure: one
+assertion per propagator firing keeps the search-tree refutation honest RUP from
+the start, so what you discharge later is one self-contained claim at a time.
+
+**Nothing will catch a cheat you leave behind. That is why this is dangerous.**
+`veripb` exits 0 whether or not the proof used assertions, and `run_veripb` only
+looks at the exit status, so a green `ctest` is exactly as green with cheats in
+it as without. No CI lane, no test, and no reviewer reading a test log will tell
+you. The only oracle is the `s` line, and you have to go and look at it:
+
+```
+s VERIFIED COMPLETE ENUMERATION OF 8 SOLUTIONS               <- honest
+Warning: The proof used unchecked assertions.
+s UNDER ASSERTIONS COMPLETE ENUMERATION OF 8 SOLUTIONS       <- cheats remain
+```
+
+`s UNDER ASSERTIONS` is not a verification. It is the checker telling you it was
+asked to take things on faith, and it says nothing about the inferences that were
+asserted — nor, strictly, about a proof whose later steps were derived from them.
+There is no `--force-...` flag to turn this into an error, the way
+`--force-checked-deletion` exists for the analogous deletion problem. So watch
+the `s` line whenever you run a test binary directly during stages 3 and 4, and
+count what is left with `GCS_PRESERVE_PROOF_FILES=1` and
+`grep -c '^a ' foo.pbp`.
+
+### Stage 4: discharge the cheats, one at a time
+
+Take each inference-producing site in turn and ask, in words, before writing any
+proof steps:
+
+> *Precisely what is the general nature of what is being inferred here, and why
+> is it true?*
+
+The answer has to be a general argument about the constraint — the kind of thing
+you would say to a colleague — not a restatement of what the code does. Insist
+on it being general: "because `D[a][b] < T` for every `b` still in `x_j`'s
+domain" is an argument; "because the loop found no support" is the code. When
+the answer comes out sharp, the proof usually falls straight out of it, because
+a `pol` is a formal transcription of exactly this kind of argument and RUP is
+what you use when the argument is "unit propagation can see it". When it does
+not come out sharp, you have found the real work, stated as a question you can
+go and answer — which is a far better position than staring at a rejected proof
+line.
+
+Replace one assertion, re-run, and only then move to the next. One at a time
+keeps every failure attributable, and the burn-down (`grep -c '^a '`) is a
+progress bar.
+
+If an argument turns out to need something RUP cannot do — a cross-variable
+linear combination, most often — that is When RUP isn't enough, above. If it
+needs a fact that is true but not stated anywhere in the encoding, you have
+found the one legitimate reason to reopen stage 1.
+
+### Stage 5: zero assertions, and no exceptions
+
+**`AssertRatherThanJustifying` must not appear in merged code. Ever, for any
+reason.** Not behind a flag, not "just this one inference", not with a `TODO`
+next to it, not in a mode nobody enables by default. Delete every one of them
+before the pull request.
+
+This is not tidiness, and it is not a style rule. This solver has exactly one
+claim to make — that you do not have to trust it, because everything it infers
+can be checked by something else. A merged assertion is that claim being false
+while continuing to look true: the proof still ships, VeriPB still prints a
+green-looking `s` line, and the one inference nobody has checked is the one
+someone got wrong. It is worse than having no proof at all, because a
+constraint with no proof logging is honest about it and this is not.
+
+So the finished constraint's proofs say `s VERIFIED`, with no assertion
+warning. Check it yourself, on a real run, and say so in the pull request
+description — "zero assertions", as the min-distance and global-cardinality
+work both did — because nothing in the test suite or CI will say it for you.
+
+If one inference genuinely resists after stage 4 has been honest about it, the
+answer is never to leave the cheat in. Weaken the *inference* to something you
+can justify: prune less, say so in the class comment, and record what a stronger
+propagator would need, so that someone can pick the gap up later. A constraint
+that prunes less and tells the truth is worth having; one that prunes more and
+lies is not.
+
+`NoJustificationNeeded` is not a way round this either, and it is worth
+understanding why it is nonetheless the *safe* one of the two. It puts nothing
+in the proof at all, so any later step that depends on the unjustified inference
+simply fails to verify — you get a loud, honest failure. An assertion puts a
+line in that VeriPB accepts unconditionally, so everything downstream sails
+through. That is the whole difference: one of them breaks when you are wrong.
+
+### Worked examples
+
+Two constraints have written this up from their own side, each in detail on the
+stage that was hardest for them:
+
+- [min-distance-proofs.md](min-distance-proofs.md), "Check-only first:
+  validating the encoding" — stage 1 on `MinDistance`. Shows what a check-only
+  propagator looks like (act only once a pair's endpoints are both assigned;
+  tighten `z`; pin it exactly once everything is fixed), and states the gate in
+  its strongest form.
+- [sortedness.md](sortedness.md), "Proof logging plan" — stages 3 and 4 on
+  `Sort` / `ArgSort`, where no certifying sortedness propagator existed and the
+  proofs had to be designed from scratch. Records the question above in its
+  original wording, and what it turned up: the permutation/surjectivity of the
+  stable rank, and then a single Hall pigeonhole shared by every bound and the
+  contradiction.
+
+`CheckOnly` is not a shared facility — `MinDistance` has its own
+`install_check_only_propagator` and a mode enum to select it, and that is the
+pattern to copy rather than something to call. Keeping the mode after bring-up
+is worth considering: `MinDistance` still ships it, and it is the encoding's
+standing regression test.
 
 ## Adding a new constraint: checklist
 


### PR DESCRIPTION
A review-and-revise pass over `CLAUDE.md` and `CONTRIBUTING.md`, which had drifted a long way from the tree, plus the documentation the review turned out to be missing. Five commits, each self-contained; documentation and build comments only, no behaviour change.

## 1. Factual corrections (`63c42fbb`)

Things that were simply wrong, each checked rather than reasoned about:

- **The worked `run_test_and_verify.bash` example exits 1.** Constraint tests self-verify now and name their proofs after the view configuration, so the wrapper's own `veripb` call looked for a file that was never written. `run_test_only.bash` "skips proof verification" was the same misunderstanding stated directly — those tests call `veripb` in-process whenever it is on the `PATH`.
- **The view-wrap sweep is ~7200 extra tests, not ~3000** (measured: 400 → 7636 with the frontends and executables off), **and they pass** rather than mostly failing. Spot-checked equals/abs/all\_different across four wraps.
- **`Propagators::want_nonpropagating()` does not exist** — `CLAUDE.md` was the only occurrence of the identifier in the tree. The Constraint Pattern around it still described a single virtual `install()`; replaced with the three phases plus `constraint_type()` and `s_expr()`.
- **`ProofLogger` does not write the OPB**; `ProofModel` does.
- `AssertRatherThanJustifying` was missing from the justification list despite being one of the three arms of the variant; 48 files naming a `std::ranges::` algorithm is 57 (the rule itself holds in all of them); the test paths predated the per-constraint directory layout; the dependency list was missing cxxopts, gch/small\_vector and pybind11, and filed `generator` and VeriPB under FetchContent.

## 2. `CLAUDE.md` → `dev_docs/` (`d6c8d81f`)

Most of `CLAUDE.md` was project documentation wearing an agent's hat, and keeping it there meant maintaining a second copy of things that already had a canonical home — which is how the errors above got in. Two new documents take what had none:

- **`dev_docs/building.md`** — why each build type carries the debug information it does, why the per-configuration flags must stay plain `set()` calls (#597), the full option catalogue including the two that change what the tests *check*, which wrapper runs which kind of test binary, the supported toolchains and their gaps, and what each CI lane covers.
- **`dev_docs/code-style.md`** — the conventions clang-format does not enforce.

The architecture summary was deleted rather than moved: `constraints.md`, `state-and-variables.md` and the README already cover it, in more depth. `CLAUDE.md` is now 121 lines and routes rather than restates.

## 3. The view-wrap option's help string (`128ab0c5`)

Same stale claim as above, in `CMakeLists.txt`, where it read as a warning not to turn the option on.

## 4. How to bring up a new constraint (`54a4b7db`)

The one that matters most. This method has been used on at least four constraints and written down twice — both times inside one constraint's own proof document, each covering the half that was hard for it, and neither reachable from `constraints.md`, whose checklist is purely structural. It is now a section there, with those two write-ups as worked examples:

1. **Encoding first, behind a check-only propagator.** Gate: the whole suite verifies, which says the encoding is definitionally correct *and* RUP-complete for anything reachable from a complete assignment. Costs exponential search, so instances stay small.
2. **State the intended consistency level in the tests**, before anything can pass it.
3. **Propagate with every inference cheated.**
4. **Discharge the cheats one at a time**, each starting from *precisely what is the general nature of what is being inferred here, and why is it true?*
5. **Zero assertions.**

The section is emphatic that stage 3's cheating must never be merged, and says so wherever it comes up, because **nothing enforces it**: verified against veripb 3.0.2 that one `a` line turns `s VERIFIED` into `s UNDER ASSERTIONS` plus a warning, but **the exit status is 0 either way**, and `run_veripb` only reads the exit status. A green `ctest` is exactly as green with cheats in it as without, and there is no `--force-...` flag for this the way there is for checked deletion.

Two corrections fell out of that: the Justifications note called `AssertRatherThanJustifying` a debug aid, which reads as "do not build with this" — the opposite of the staging advice — and nothing recorded the distinction that makes `NoJustificationNeeded` the safe one of the two trapdoors (it puts nothing in the proof, so a dependent step fails loudly; an assertion is accepted unconditionally and everything downstream sails through).

## 5. The AI guidance (`9f609bbf`)

The policy's technical assessment was one out-of-date paragraph that read as a reason not to try. Replaced with a dated assessment aimed at someone who wants a global constraint the solver does not have: implementing a propagator from the literature with an agent, under supervision, is now a reasonable thing to attempt, provided it works in stages and reads the developer documentation — both things a supervisor can check are happening. The weak spot is named (reproducing a proof shape the tree uses is reliable, devising a new one is not), along with the two triggers and the response, and the two things a supervisor must check by hand because nothing else will.

## Incidental

`dev_docs/README.md`'s "View proof logging" entry had been cut in half, its tail stranded several entries below where two documents were inserted into the middle of it; `bin-packing.md` and `linear-slack-waking.md` were present but unindexed. Both fixed, so everything in `dev_docs/` is now listed. `.gitignore` needed a negation: `build*` is unanchored and was silently swallowing `dev_docs/building.md` — anchoring the pattern instead would stop ignoring `python/build`, which scikit-build really does create.

## Checking

Documentation, one CMake comment and help string, and a `.gitignore` line. No C++ changed, so clang-format is not in play. CMake reconfigures clean and still registers 7636 tests with the sweep on. Every intra-doc link resolves. The measured claims above (test counts, the sweep spot-checks, the veripb assertion behaviour, the 57 files) were each run rather than recalled.

Written with Claude Code (Claude Opus 5); reviewed and directed by @ciaranm throughout, as per the policy in `CONTRIBUTING.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)