### PR TITLE
GlobalCardinality: subtract the closed cover as intervals, not value by value (#877)

### DIFF
--- a/dev_docs/large-domains.md
+++ b/dev_docs/large-domains.md
@@ -618,7 +618,7 @@ is the part worth reading carefully:
 
 ### Where we stand
 
-74 constraint probes, plus 20 heuristic ones in the second table. The lane
+75 constraint probes, plus 20 heuristic ones in the second table. The lane
 itself is the authority — run it rather than trusting this table, which is a
 snapshot for orientation.
 
@@ -867,7 +867,7 @@ separately, because they mean different things:
 
 ### Results at 10^3 → 10^4
 
-Re-measured over all 74 probes after the interval rewrites landed for
+Re-measured over all 75 probes after the interval rewrites landed for
 `ArrayMinMax`, `Table`, `Among`, `Element`, `In`, `GlobalCardinality` and
 `AllEqual/holes`, and again after #878, #875 and #877 — which moved nothing but
 their own rows: `Element/holey` is flat at 41 rows and 51 steps, `Abs/hole` at 30
@@ -884,7 +884,7 @@ loop — that is how the previous version of it went stale, and how the
 | **Both** grow | 10x / 10x | `Power`, `PowerTable`, `NValue`, `Regular`, `RegularLegacy`, `RegularBacchus`, `MDD` |
 | **OPB only** | 10x / 1.0x | `Cumulative` (19046 → 190046 rows; one capacity line per time point, so it is H3 on the encoding side) |
 | **Steps only** | 1.0x / 10x | `GlobalCardinality/hall` (34-row OPB fixed, 43988 → 439988 steps) |
-| neither | 1.0x / 1.0x | everything else, 65 of 74 |
+| neither | 1.0x / 1.0x | everything else, 66 of 75 |
 
 The last row means "does not grow with the width", not "identical at both widths",
 and three entries in it are worth naming so nobody reads them as a promise.
@@ -946,7 +946,7 @@ whose steps grow at a fixed encoding is a propagator that has an interval and
 spells it out. That is a real conclusion rather than a gap in the survey, and it
 should be re-tested after stage 4 rather than assumed to stay true — a genuine
 candidate would be a growing row whose removed set provably is not an interval,
-and none of the 73 probes produces one today.
+and none of the 75 probes produces one today.
 
 Two things kept this table wrong for longer than it should have been. The probe
 sharpening of PR #849 turned exactly these three rows from `HazardNotReached` into

--- a/dev_docs/large-domains.md
+++ b/dev_docs/large-domains.md
@@ -352,6 +352,49 @@ worth reaching for before wall time: identical search makes it reproducible to
 0.002% here, where wall time and cycles move ±1% between batches and about 3%
 between one hour and the next.
 
+**A fourth, on `GlobalCardinality`'s closed propagator (#877): ask the cheap
+question before reaching for a new primitive, not after.** The closed restriction
+removes every value outside the cover from every variable, and it is idempotent
+— once a domain is inside the cover it stays there, since domains only shrink —
+so the number that matters is not what the removal costs but what the *no-op* run
+costs, which is every run but the first. Four shapes over two searches whose
+recursion and propagation counts are identical throughout: seven variables over
+`[0,5]` with the whole of it covered (`flat`, one interval per domain), and the
+same with the cover `{0,2,4}` (`holey`, three intervals per domain, one more than
+`IntervalSet`'s inline capacity, so the copy allocates). Instructions retired,
+median of five pinned runs:
+
+| how the non-cover runs are found | flat | holey |
+|---|---|---|
+| walk the domain grouping runs — before | 4.7313e9 | 156.98e6 |
+| `copy_of_values()` + `each_interval_minus()` | 4.5750e9 (−3.30%) | 146.86e6 (−6.45%) |
+| **`domain_is_subset_of()` first, else the above** | **4.4653e9 (−5.62%)** | **138.94e6 (−11.5%)** |
+| a new callback `IntervalSet::for_each_interval_minus()` | 4.4984e9 (−4.93%) | 141.36e6 (−9.95%) |
+| both | 4.4655e9 (−5.62%) | 138.97e6 (−11.5%) |
+
+The shape that wins is an existing `State` query rather than a new primitive, and
+it wins for a reason worth stating separately from the numbers: it answers the
+whole question without copying anything, and it can be false **at most once per
+variable**, because this propagator's own run is what makes the domain a subset.
+So the merge walk it duplicates on that one call is paid once, against a copy
+saved on every later call.
+
+The new primitive is then *subsumed*: with the early-out in, the generator form
+and the callback form agree to three figures, because the code they differ over
+is what almost never runs. That is `Element`'s finding arrived at from the other
+side — there the question was whether to avoid the copy in the inner loop and the
+answer was no; here the copy is worth avoiding, and the way to avoid it is a
+query that already exists. **Measure the new primitive against the cheap
+early-out, not against the code you are replacing.**
+
+One further step was measured and not taken. The propagator is not merely
+idempotent but *entailed* once every domain is inside the cover, so it could
+return `PropagatorState::DisableUntilBacktrack` and not run again in the subtree
+at all: another −0.70% / −1.74% on the two shapes, and half the propagation
+count (102474 → 51246 on `flat`). That is a claim about the engine rather than
+about domain width, and it changes a reported statistic, so it is left as a
+separate question.
+
 **Where the equality is guarded by a conjunction, the same lemmas take a longer
 guard.** `Element`'s model is `result - array[i] == 0` half-reified on the
 conjunction of index conditions, so it is `ArrayMinMax`'s shape with the selector
@@ -575,19 +618,20 @@ is the part worth reading carefully:
 
 ### Where we stand
 
-73 constraint probes, plus 20 heuristic ones in the second table. The lane
+74 constraint probes, plus 20 heuristic ones in the second table. The lane
 itself is the authority — run it rather than trusting this table, which is a
 snapshot for orientation.
 
 | | constraints |
 |---|---|
 | **KnownTrip** (19) | `Power`, `PowerTable`, `AllDifferent`, `AllDifferentExcept`, `Count`, `NValue`, `AtMostOne`, `AtMostOneSmartTable`, `GlobalCardinality/hall`, `ArrayMinMax`, `LexSmartTable`, `SmartTable`, `Regular`, `RegularLegacy`, `RegularBacchus`, `MDD`, `Cumulative`, `Disjunctive`, `Knapsack` |
-| **Clean** (40) | the arithmetic family (with two rows of its own for `Abs`' interior holes), comparison, equality, linear, `AllDifferent` under `VC`, `Element` in both arms and with a holey entry, `AllEqual` with holes and without, `Among`, `In`, `GlobalCardinality`, `Table` (both shapes), `ValuePrecede`, `SeqPrecedeChain`, `IncreasingChain`, `Lex`, `Sort`, `ArgSort`, `NegativeTable`, `Disjunctive2D`, `BinPacking`, `MinDistance`, `DifferenceConstraints`, `Nogoods` |
+| **Clean** (41) | the arithmetic family (with two rows of its own for `Abs`' interior holes), comparison, equality, linear, `AllDifferent` under `VC`, `Element` in both arms and with a holey entry, `AllEqual` with holes and without, `Among`, `In`, `GlobalCardinality` open and closed, `Table` (both shapes), `ValuePrecede`, `SeqPrecedeChain`, `IncreasingChain`, `Lex`, `Sort`, `ArgSort`, `NegativeTable`, `Disjunctive2D`, `BinPacking`, `MinDistance`, `DifferenceConstraints`, `Nogoods` |
 | **NoWidePosition** (14) | the graph and permutation family, and the Boolean constraints |
 
-`Among`, `In`, `AllEqual/holes`, `GlobalCardinality`, `Table` and `Element` started
-as `KnownTrip` and are now `Clean`, by the interval rewrites rather than by a
-weaker arm: all of them still propagate at their original strength.
+`Among`, `In`, `AllEqual/holes`, `GlobalCardinality` (open and closed), `Table`
+and `Element` started as `KnownTrip` and are now `Clean`, by the interval
+rewrites rather than by a weaker arm: all of them still propagate at their
+original strength.
 
 `GlobalCardinality` mattered most of the six, because it was the rule's own
 counterexample: already the bounds arm, and still enumerating, so it had nothing
@@ -596,6 +640,21 @@ which is two range removals however wide the domain is. **A second per-value sit
 remains** in its Hall reasoning, which the original probe could not reach — one
 cover value means there is no multi-value hall — so it now has a row of its own
 rather than being covered by association.
+
+It has a **third** site, and finding it was a lesson about the axes a row covers
+rather than about the constraint. `with_closed()` installs a propagator of its
+own — the one that restricts every variable to the cover — and nothing in the
+lane called `with_closed`, in either consistency arm, so neither of the rows
+above could reach it (#877). It is the same shape `In` had: the conclusions were
+always intervals, and what was per-value was *finding* them, by walking the
+domain and grouping maximal runs the cover misses. `GlobalCardinality/closed` is
+that row, and the fix is `each_interval_minus()` against the cover with a
+`domain_is_subset_of()` early-out in front of it. Linear in the width before
+(35 ms at 10^6, 351 at 10^7, 3505 at 10^8, **35088 at 10^9**), and 0 ms at every
+one of those widths after. The default
+BC level on purpose: the closed propagator is installed identically whichever
+level is chosen, so the row is about that propagator alone, where a GAC row would
+trip on the GAC arm's own sites (#876) and say nothing about this one.
 
 **`In` is worth more than its own row.** `create_integer_variable` over a vector
 posts an `In` to carve the holes, so any probe that builds a sparse variable that
@@ -679,6 +738,25 @@ not selected by the width at all — it is selected by
 contiguous one satisfies too. Before adding a row, read the *condition* on the
 branch and pick the probe from that, rather than reasoning about the axis the
 issue is named after. `Element/holey` is that row.
+
+**And an option that installs a propagator of its own needs a row for the
+option, not just for the constraint.** `GlobalCardinality`'s two rows were both
+about the propagator `with_consistency` selects; `with_closed` installs a
+*third* propagator alongside whichever of those runs, nothing in the lane called
+it, and so no row reached that code at all (#877). The question to ask when
+adding a constraint to the lane is not how many consistency arms it has but **how
+many propagators it can install**, and an option that adds one rather than
+choosing between them is the case a row per arm silently misses. Whether any
+other constraint has the same gap has not been checked here; #876 proposes that
+sweep — a row per arm and a row per `with_` option throughout — as its own piece
+of work.
+
+Where a constraint has both kinds of choice, keep the rows separate. The closed
+propagator is installed identically whichever consistency level is chosen, so
+`GlobalCardinality/closed` uses the default BC arm and is about that propagator
+alone. A closed row on the GAC arm would also trip, on the GAC arm's own unfixed
+sites (#876), and would then have gone on tripping after this fix — pinning a
+`KnownTrip` that says nothing about either site.
 
 One deliberate non-axis: the lane runs **without proof logging**. `NValue`'s
 H2′ is caught anyway, because its per-value work is in `prepare()`, but a
@@ -789,22 +867,24 @@ separately, because they mean different things:
 
 ### Results at 10^3 → 10^4
 
-Re-measured over all 73 probes after the interval rewrites landed for
+Re-measured over all 74 probes after the interval rewrites landed for
 `ArrayMinMax`, `Table`, `Among`, `Element`, `In`, `GlobalCardinality` and
-`AllEqual/holes`, and again after #878 and #875 — which moved nothing but their
-own rows: `Element/holey` is flat at 41 rows and 51 steps, `Abs/hole` at 30 and
-46, `Abs/hole-preimage` at 26 and 64, and none of the three rewrites changes
-which values get removed, so no other row could have moved either. The
-figures move, so re-run the survey rather than quoting this table after touching
-any propagator's removal loop — that is how the previous version of it went
-stale, see below.
+`AllEqual/holes`, and again after #878, #875 and #877 — which moved nothing but
+their own rows: `Element/holey` is flat at 41 rows and 51 steps, `Abs/hole` at 30
+and 46, `Abs/hole-preimage` at 26 and 64, `GlobalCardinality/closed` at 24 and
+83, and none of the four rewrites changes which values get removed, so no other
+row could have moved either. (Checked, for #877, by diffing a whole survey run
+against one from `main`: identical bar the new row.) The figures move, so re-run
+the survey rather than quoting this table after touching any propagator's removal
+loop — that is how the previous version of it went stale, and how the
+`GlobalCardinality/hall` figures below came to be corrected.
 
 | | growth (opb / steps) | constraints |
 |---|---|---|
 | **Both** grow | 10x / 10x | `Power`, `PowerTable`, `NValue`, `Regular`, `RegularLegacy`, `RegularBacchus`, `MDD` |
 | **OPB only** | 10x / 1.0x | `Cumulative` (19046 → 190046 rows; one capacity line per time point, so it is H3 on the encoding side) |
-| **Steps only** | 1.0x / 10x | `GlobalCardinality/hall` (34-row OPB fixed, 33984 → 339984 steps) |
-| neither | 1.0x / 1.0x | everything else, 64 of 73 |
+| **Steps only** | 1.0x / 10x | `GlobalCardinality/hall` (34-row OPB fixed, 43988 → 439988 steps) |
+| neither | 1.0x / 1.0x | everything else, 65 of 74 |
 
 The last row means "does not grow with the width", not "identical at both widths",
 and three entries in it are worth naming so nobody reads them as a promise.
@@ -853,7 +933,7 @@ work rather than evidence:
   others; what resists is the *justification*, whose `pol` builds an at-most-one
   over the hall values plus the single removed value, so the removed value is
   named in the derivation rather than merely concluded. It has its own probe and
-  its own survey row now (33984 → 339984), and it is the most interesting
+  its own survey row now (43988 → 439988), and it is the most interesting
   remaining candidate for exactly that reason.
 * `Element` walked the result values its array does not support (`element.cc`),
   which for a narrow array over a wide result is mostly intervals. **Done**, and it

--- a/gcs/constraints/global_cardinality/bounds_global_cardinality_test.cc
+++ b/gcs/constraints/global_cardinality/bounds_global_cardinality_test.cc
@@ -49,7 +49,11 @@ using fmt::println;
 using namespace gcs;
 using namespace gcs::test_innards;
 
-using Range = variant<int, pair<int, int>>;
+// A test variable is a constant, a lo/hi interval, or an explicit list of
+// values -- the third shape being the only one that gives a variable holes,
+// which is what the closed propagator's domain-difference needs to be run
+// against (#877).
+using Range = variant<int, pair<int, int>, vector<int>>;
 
 auto run_bgcc_test(bool proofs, const vector<Range> & vars_range, const vector<int> & values, const vector<Range> & counts_range, bool closed) -> void
 {
@@ -119,6 +123,23 @@ auto main(int argc, char * argv[]) -> int
         {{pair{1, 2}, pair{1, 2}}, {1, 2}, {pair{0, 2}, pair{0, 2}}, false},
         // Closed.
         {{pair{1, 3}, pair{1, 3}, pair{2, 3}}, {1, 2, 3}, {pair{0, 3}, pair{0, 3}, pair{0, 3}}, true},
+        // Closed over a domain with a hole in it (#877). The closed propagator
+        // removes each run of non-cover values in one go, and the runs it has to
+        // find are bounded by three different things at once here: the first
+        // ends where the domain's own hole starts (0, then 2 is missing), the
+        // second starts after a cover value inside an interval (3 covered, so
+        // 4..5 is what is left of [3,5]). Nothing else posts a variable with a
+        // hole in it under with_closed, so before this row every domain reaching
+        // that propagator was one contiguous interval, and the case where
+        // "group consecutive values" and "subtract one interval set from
+        // another" could disagree was untested. The second variable is the same
+        // instance without the hole, so the pair says the hole is what differs.
+        {{vector<int>{0, 1, 3, 4, 5}, pair{0, 5}}, {1, 3}, {pair{0, 2}, pair{0, 2}}, true},
+        // The mirror image: a *cover* value that falls inside the domain's hole
+        // (3 is covered, the first variable does not have it). The subtraction
+        // then has to step over an interval of the cover that matches nothing at
+        // all, which is a different position in the merge from the row above.
+        {{vector<int>{0, 1, 2, 4, 5, 6}, pair{0, 6}}, {0, 3, 6}, {pair{0, 2}, pair{0, 2}, pair{0, 2}}, true},
         // Cover values spanning zero, with a bit-aliased {0,1}-domain variable in
         // the Hall set (issue #557): the aliased variable's (== 0)/(== 1) atoms are
         // ~b0/b0, a complementary pair, which made the demand-aggregate at-most-one

--- a/gcs/constraints/global_cardinality/gac_global_cardinality_test.cc
+++ b/gcs/constraints/global_cardinality/gac_global_cardinality_test.cc
@@ -49,7 +49,11 @@ using fmt::println;
 using namespace gcs;
 using namespace gcs::test_innards;
 
-using Range = variant<int, pair<int, int>>;
+// A test variable is a constant, a lo/hi interval, or an explicit list of
+// values -- the third shape being the only one that gives a variable holes,
+// which is what the closed propagator's domain-difference needs to be run
+// against (#877).
+using Range = variant<int, pair<int, int>, vector<int>>;
 
 auto run_gacgcc_test(bool proofs, const vector<Range> & vars_range, const vector<int> & values, const vector<Range> & counts_range, bool closed)
     -> void
@@ -116,6 +120,23 @@ auto main(int argc, char * argv[]) -> int
         {{pair{1, 2}, pair{1, 2}}, {1, 2}, {pair{0, 2}, pair{0, 2}}, false},
         // Closed.
         {{pair{1, 3}, pair{1, 3}, pair{2, 3}}, {1, 2, 3}, {pair{0, 3}, pair{0, 3}, pair{0, 3}}, true},
+        // Closed over a domain with a hole in it (#877). The closed propagator
+        // removes each run of non-cover values in one go, and the runs it has to
+        // find are bounded by three different things at once here: the first
+        // ends where the domain's own hole starts (0, then 2 is missing), the
+        // second starts after a cover value inside an interval (3 covered, so
+        // 4..5 is what is left of [3,5]). Nothing else posts a variable with a
+        // hole in it under with_closed, so before this row every domain reaching
+        // that propagator was one contiguous interval, and the case where
+        // "group consecutive values" and "subtract one interval set from
+        // another" could disagree was untested. The second variable is the same
+        // instance without the hole, so the pair says the hole is what differs.
+        {{vector<int>{0, 1, 3, 4, 5}, pair{0, 5}}, {1, 3}, {pair{0, 2}, pair{0, 2}}, true},
+        // The mirror image: a *cover* value that falls inside the domain's hole
+        // (3 is covered, the first variable does not have it). The subtraction
+        // then has to step over an interval of the cover that matches nothing at
+        // all, which is a different position in the merge from the row above.
+        {{vector<int>{0, 1, 2, 4, 5, 6}, pair{0, 6}}, {0, 3, 6}, {pair{0, 2}, pair{0, 2}, pair{0, 2}}, true},
         // Cover values spanning zero, with a bit-aliased {0,1}-domain variable in
         // the Hall set (issue #557): its (== 0)/(== 1) atoms are the complementary
         // pair ~b0/b0, which made the demand-aggregate at-most-one loose and broke

--- a/gcs/constraints/global_cardinality/global_cardinality.cc
+++ b/gcs/constraints/global_cardinality/global_cardinality.cc
@@ -25,11 +25,10 @@ using namespace gcs::innards;
 using std::holds_alternative;
 using std::make_unique;
 using std::move;
-using std::pair;
 using std::unique_ptr;
 using std::vector;
-using std::ranges::binary_search;
 using std::ranges::sort;
+using std::ranges::unique;
 
 GlobalCardinality::GlobalCardinality(vector<IntegerVariableID> vars, vector<Integer> values, vector<IntegerVariableID> counts) :
     _vars(move(vars)), _values(move(values)), _counts(move(counts))
@@ -121,28 +120,55 @@ auto GlobalCardinality::install_propagators(Propagators & propagators) -> void
     // the disjunction. This is also what lets the GAC propagator hand it the
     // no-cover-value-left case rather than raising an unjustified contradiction.
     if (_closed) {
-        // sort_cover_values() only runs on the BC path, so sort a copy rather
-        // than assume _values is ordered.
+        // The cover as intervals, built once: it is fixed for the life of the
+        // constraint, and every call takes each variable's domain difference
+        // against it. insert_at_end() needs its input ascending *and distinct*,
+        // and _values is neither in general -- sort_cover_values() only runs on
+        // the BC path, and nothing rejects a repeated cover value -- so sort and
+        // unique a copy here rather than assume either. Dedup on the copy only:
+        // _values stays as posted, since _counts is indexed alongside it and the
+        // proof model's per-value rows are numbered by that index.
         auto sorted_cover = _values;
         sort(sorted_cover);
+        sorted_cover.erase(unique(sorted_cover).begin(), sorted_cover.end());
+        IntervalSet<Integer> cover_set;
+        for (const auto & value : sorted_cover)
+            cover_set.insert_at_end(value);
 
         Triggers closed_triggers;
         closed_triggers.on_change.insert(closed_triggers.on_change.end(), _vars.begin(), _vars.end());
         propagators.install(
             constraint_id(),
-            [vars = _vars, cover = sorted_cover, owner = constraint_id()](
+            [vars = _vars, cover_set = move(cover_set), owner = constraint_id()](
                 const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
                 for (const auto & var : vars) {
-                    vector<pair<Integer, Integer>> runs;
-                    for (auto v : state.each_value_immutable(var)) {
-                        if (binary_search(cover, v))
-                            continue;
-                        if (! runs.empty() && runs.back().second + 1_i == v)
-                            runs.back().second = v;
-                        else
-                            runs.emplace_back(v, v);
-                    }
-                    for (const auto & [lo, hi] : runs)
+                    // Nothing to remove, asked without copying anything: this is
+                    // by far the common case, because the answer is yes for the
+                    // whole of the rest of the search once it is yes once. It can
+                    // be no at most once per variable -- this propagator's own
+                    // run is what makes the domain a subset, and domains only
+                    // shrink -- so the walk it duplicates when it says no is paid
+                    // once, against a copy on every later call that it saves.
+                    if (state.domain_is_subset_of(var, cover_set))
+                        continue;
+
+                    // The conclusions were already interval-level; what was
+                    // per-value was finding them, by walking the domain and
+                    // grouping maximal runs of values the cover misses. The runs
+                    // a merge against the cover yields are the same intervals: a
+                    // run breaks exactly where the domain has a hole or a cover
+                    // value intervenes, which is where each_interval_minus() ends
+                    // one too. So this emits the identical inferences, in the
+                    // same order, and changes nothing in the proof -- it just
+                    // stops taking O(|D(var)|) to find them (#877).
+                    //
+                    // Named local: each_interval_minus() hands out a generator
+                    // borrowing both sets, which must outlive it (see
+                    // IntervalSet's class documentation). It also means the
+                    // domain may be modified as we go, which is what the old
+                    // code's separate collection pass was for.
+                    auto var_values = state.copy_of_values(var);
+                    for (auto [lo, hi] : var_values.each_interval_minus(cover_set))
                         inference.infer_not_in_range(logger, var, lo, hi, JustifyUsingRUP{hints::GlobalCardinality{owner}}, NoReason{});
                 }
                 return PropagatorState::Enable;

--- a/gcs/constraints/innards/constraints_test_utils.hh
+++ b/gcs/constraints/innards/constraints_test_utils.hh
@@ -464,6 +464,10 @@ namespace gcs::test_innards
 
     template <typename ResultsSet_, typename IsSatisfying_, typename... Accumulated_, typename... RestOfArgs_>
     auto generate_expected(ResultsSet_ & expected, IsSatisfying_ is_satisfying, const std::tuple<Accumulated_...> & acc,
+        const std::vector<std::variant<int, std::pair<int, int>, std::vector<int>>> & range_arg_vec, RestOfArgs_... rest_of_args) -> void;
+
+    template <typename ResultsSet_, typename IsSatisfying_, typename... Accumulated_, typename... RestOfArgs_>
+    auto generate_expected(ResultsSet_ & expected, IsSatisfying_ is_satisfying, const std::tuple<Accumulated_...> & acc,
         std::pair<int, int> range_arg, RestOfArgs_... rest_of_args) -> void
     {
         for (int n = range_arg.first; n <= range_arg.second; ++n)
@@ -558,6 +562,50 @@ namespace gcs::test_innards
                     }, //
                     [&](std::pair<int, int> p) {
                         for (int n = p.first; n <= p.second; ++n) {
+                            sol.push_back(n);
+                            build(pos + 1, sol);
+                            sol.pop_back();
+                        }
+                    } //
+                }
+                    .visit(range_arg_vec.at(pos));
+            }
+        };
+        std::vector<int> sol;
+        build(0, sol);
+    }
+
+    /* As above, for a list of specs that may also name an explicitly enumerated
+     * domain. A variable built from a value list has holes in it, which is a
+     * shape a lo/hi pair cannot express and which several propagators treat
+     * differently from a contiguous domain; create_integer_variable_or_constant
+     * already accepts the same three shapes, so a test widens its spec type and
+     * needs nothing else.
+     */
+    template <typename ResultsSet_, typename IsSatisfying_, typename... Accumulated_, typename... RestOfArgs_>
+    auto generate_expected(ResultsSet_ & expected, IsSatisfying_ is_satisfying, const std::tuple<Accumulated_...> & acc,
+        const std::vector<std::variant<int, std::pair<int, int>, std::vector<int>>> & range_arg_vec, RestOfArgs_... rest_of_args) -> void
+    {
+        std::function<auto(std::size_t, std::vector<int>)->void> build = [&](std::size_t pos, std::vector<int> sol) -> void {
+            if (pos == range_arg_vec.size()) {
+                generate_expected(expected, is_satisfying, std::tuple_cat(acc, std::tuple{sol}), rest_of_args...);
+            }
+            else {
+                overloaded{
+                    [&](int n) {
+                        sol.push_back(n);
+                        build(pos + 1, sol);
+                        sol.pop_back();
+                    }, //
+                    [&](std::pair<int, int> p) {
+                        for (int n = p.first; n <= p.second; ++n) {
+                            sol.push_back(n);
+                            build(pos + 1, sol);
+                            sol.pop_back();
+                        }
+                    }, //
+                    [&](const std::vector<int> & vs) {
+                        for (int n : vs) {
                             sol.push_back(n);
                             build(pos + 1, sol);
                             sol.pop_back();

--- a/gcs/large_domain_audit_test.cc
+++ b/gcs/large_domain_audit_test.cc
@@ -404,6 +404,28 @@ namespace
             auto v = wide(p, 2);
             p.post(GlobalCardinality{v, {1_i, 2_i}, {p.create_integer_variable(1_i, 1_i), p.create_integer_variable(1_i, 1_i)}});
         });
+        add("GlobalCardinality/closed", Expect::Clean, [](Problem & p) {
+            // The third per-value site, and the only one neither row above can
+            // reach: with_closed() installs a propagator of its own, which used
+            // to restrict every variable to the cover by walking its domain and
+            // grouping the runs the cover does not contain, and now takes that
+            // difference at interval level (#877). Nothing else in the lane
+            // calls with_closed, in either arm.
+            //
+            // The default BC level on purpose. The closed propagator is
+            // installed identically whichever level is chosen, so this row is
+            // about that propagator alone; a GAC row would trip on the GAC arm's
+            // own sites (#876) and say nothing about this one.
+            //
+            // The count is left as a range so that the closed restriction is
+            // the only thing in the probe that can remove a value. Pinning it at
+            // 2 reaches this site too -- checked, it trips before the fix and
+            // survives after, exactly as this row does -- but it also puts the
+            // bounds arm's just-met-demand branch within reach, and a row two
+            // sites can satisfy says less about either.
+            auto v = wide(p, 2);
+            p.post(GlobalCardinality{v, {1_i}, {p.create_integer_variable(0_i, 2_i)}}.with_closed(true));
+        });
         add("In", Expect::Clean, [](Problem & p) {
             // Its conclusions were always interval-level; what was per-value was
             // finding them, by walking the domain to group maximal runs. A merge


### PR DESCRIPTION
Closes #877.

`GlobalCardinality::with_closed(true)` installs a propagator that restricts every
variable to the cover values. Its *conclusions* were always intervals — that is
what the `runs` vector was for — but finding them walked the domain grouping
maximal runs of non-cover values, so root propagation was linear in the width.
On two variables and a cover of one value:

| `w` | before | after |
|---|---|---|
| 10^6 | 35 ms | 0 ms |
| 10^7 | 351 ms | 0 ms |
| 10^8 | 3505 ms | 0 ms |
| 10^9 | **35088 ms** | 0 ms |

This is the shape #859 removed from `In`, and the same rewrite applies: the runs
a merge against the cover yields are the same intervals, because a run breaks
exactly where the domain has a hole or a cover value intervenes, which is where
`each_interval_minus()` ends one too.

### Does this want a new `State` or `IntervalSet` operation?

No, and the interesting part is *why not*. Five shapes were measured on two
searches whose recursion and propagation counts are identical throughout — seven
variables over `[0,5]` with the whole of it covered (`flat`), and the same with
the cover `{0,2,4}` (`holey`, where each domain ends up as three intervals, one
more than `IntervalSet`'s inline capacity, so the copy allocates). Instructions
retired, median of five pinned runs:

| how the non-cover runs are found | flat | holey |
|---|---|---|
| walk the domain grouping runs — before | 4.7313e9 | 156.98e6 |
| `copy_of_values()` + `each_interval_minus()` | 4.5750e9 (−3.30%) | 146.86e6 (−6.45%) |
| **`domain_is_subset_of()` first, else the above** | **4.4653e9 (−5.62%)** | **138.94e6 (−11.5%)** |
| a new callback `IntervalSet::for_each_interval_minus()` | 4.4984e9 (−4.93%) | 141.36e6 (−9.95%) |
| both | 4.4655e9 (−5.62%) | 138.97e6 (−11.5%) |

The shape that wins is an existing `State` query. It answers the whole question
without copying anything, and it can be false **at most once per variable**,
because this propagator's own run is what makes the domain a subset and domains
only shrink — so the merge walk it duplicates on that one call is paid once,
against a copy saved on every later one. The new primitive is then *subsumed*:
with the early-out in, the generator and callback forms agree to three figures,
because the code they differ over is what almost never runs. So it was written,
measured, and thrown away. That is `Element`'s #878 finding arrived at from the
other side, and `dev_docs/large-domains.md` gains it as a fourth maxim: **measure
a new primitive against the cheap early-out, not against the code you are
replacing.**

One further step was measured and *not* taken: the propagator is not merely
idempotent but entailed once every domain is inside the cover, so it could return
`DisableUntilBacktrack` and not run again in the subtree (another −0.70% /
−1.74%, and half the propagation count). That is a claim about the engine rather
than about domain width, and it changes a reported statistic, so it is left as a
separate question.

### The lane row, and the gap it came from

Nothing in the audit lane called `with_closed`, in either consistency arm, so
this propagator was never probed. The general lesson is not about
`GlobalCardinality`: the question to ask when adding a row is **how many
propagators the constraint can install**, not how many consistency arms it has,
and an option that *adds* one rather than choosing between them is exactly what a
row per arm misses. Whether any other constraint has the same gap is not claimed
here — #876 proposes that sweep as its own piece of work.

`GlobalCardinality/closed` uses the default BC arm on purpose: the closed
propagator is installed identically whichever level is chosen, so the row is
about that propagator alone, where a closed row on the GAC arm would trip on the
GAC arm's own sites (#876) and go on tripping after this fix.

### Verification

* **Proof unchanged, checked rather than argued.** With *only* the propagator
  file's change applied to `main`, so the test data is identical on both sides,
  1700 artefacts across both consistency arms and five pinned seeds are
  byte-identical.
* **810/810 GCC, 814/814 clang, zero skips** (MiniZinc, `cake_pb_cp` and
  `opbdiff` all on `PATH`), caps off. Both cardinality tests also run directly
  and uncapped across six seeds on each compiler, and clean under
  ASan+UBSan (`-fsanitize=address,undefined` confirmed in `flags.make`).
  `-Werror` build clean.
* **Negative control**: suppress the propagator change and exactly the new lane
  row fails, nothing else (exit 42).
* **Proof scaling survey re-run in full** and diffed against one from `main`:
  identical bar the new row, which is flat at 24 OPB rows and 83 steps at both
  widths.

Two incidental things fell out and are in their own commits. The constraint test
harness could not give a variable a domain with a hole in it — `build_expected()`
had no overload for a spec list naming its values outright, though
`create_integer_variable_or_constant()` has accepted one all along. That was
worth fixing because instrumenting the closed propagator across both tests and
eight seeds showed **every domain that reached the subtraction was a single
interval**, so the case where "group consecutive values" and "subtract one
interval set from another" could disagree was untested; there are now two rows
for it. And the survey run shows `GlobalCardinality/hall` at 43988 → 439988
steps, not the 33984 → 339984 the doc has carried since #860, so those figures
are corrected — stale on `main`, and a good illustration of the instruction three
paragraphs above them to re-run the survey rather than quote the table.

One thing found while checking that the rewrite could not corrupt an
`IntervalSet` on a repeated cover value: `GlobalCardinality` is **already
unsound** on that input, on both arms, losing solutions and emitting a step
VeriPB rejects. Filed as #922. This PR does not change that behaviour — verified
identical before and after on the repro there — it only makes sure the interval
form does not add a second problem on top of it, which is what the `unique()` is
for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EidEnS39QnX36W6agaJZCZ
