### PR TITLE
Element: pick the result-union rule's form by width, not by variable kind (#924)

### DIFF
--- a/dev_docs/large-domains.md
+++ b/dev_docs/large-domains.md
@@ -952,8 +952,8 @@ separately, because they mean different things:
 Re-measured over all 75 probes after the interval rewrites landed for
 `ArrayMinMax`, `Table`, `Among`, `Element`, `In`, `GlobalCardinality` and
 `AllEqual/holes`, and again after #878, #875, #877 and #874 — which moved nothing
-but their own rows: `Element/holey` is flat at 41 rows and 51 steps, `Abs/hole` at
-30 and 46, `Abs/hole-preimage` at 26 and 64, `GlobalCardinality/closed` at 24 and
+but their own rows: `Element/holey` is flat at 41 rows and 78 steps, `Abs/hole` at
+30 and 78, `Abs/hole-preimage` at 26 and 113, `GlobalCardinality/closed` at 24 and
 83, and none of the rewrites changes which values get removed, so no other row
 could have moved either. (Checked, for #877, by diffing a whole survey run against
 one from `main`: identical bar the new row.) The figures move, so re-run the
@@ -962,7 +962,7 @@ loop — that is how the previous version of it went stale, and how the
 `GlobalCardinality/hall` figures below came to be corrected.
 
 **#874's two rows are the case for running this survey and not just the audit
-lane.** With the propagation fixed, `In/vars` was flat at 50 steps but
+lane.** With the propagation fixed, `In/vars` was flat at 88 steps but
 `In/vars-single-support` read 7048 → **70048**: the rule's proof was still
 per-value even though its inferences were not, because the scaffolding that rules
 out the non-supporting sources' selectors emitted one line per value of
@@ -970,7 +970,7 @@ out the non-supporting sources' selectors emitted one line per value of
 The guard cannot see either — a reason is only materialised with proofs on, and
 the lane runs without them — so the survey was the only thing that showed it.
 The walk that fixes it is the same one the conclusions use, one interval at a
-time, and the row is now flat at 53.
+time, and the row is now flat at 93.
 
 | | growth (opb / steps) | constraints |
 |---|---|---|

--- a/dev_docs/large-domains.md
+++ b/dev_docs/large-domains.md
@@ -671,14 +671,14 @@ is the part worth reading carefully:
 
 ### Where we stand
 
-77 constraint probes, plus 20 heuristic ones in the second table. The lane
+78 constraint probes, plus 20 heuristic ones in the second table. The lane
 itself is the authority — run it rather than trusting this table, which is a
 snapshot for orientation.
 
 | | constraints |
 |---|---|
 | **KnownTrip** (19) | `Power`, `PowerTable`, `AllDifferent`, `AllDifferentExcept`, `Count`, `NValue`, `AtMostOne`, `AtMostOneSmartTable`, `GlobalCardinality/hall`, `ArrayMinMax`, `LexSmartTable`, `SmartTable`, `Regular`, `RegularLegacy`, `RegularBacchus`, `MDD`, `Cumulative`, `Disjunctive`, `Knapsack` |
-| **Clean** (43) | the arithmetic family (with two rows of its own for `Abs`' interior holes), comparison, equality, linear, `AllDifferent` under `VC`, `Element` in both arms and with a holey entry, `AllEqual` with holes and without, `Among`, `In` in three rows (a constant candidate list, and a variable one in each of its two rules), `GlobalCardinality` open and closed, `Table` (both shapes), `ValuePrecede`, `SeqPrecedeChain`, `IncreasingChain`, `Lex`, `Sort`, `ArgSort`, `NegativeTable`, `Disjunctive2D`, `BinPacking`, `MinDistance`, `DifferenceConstraints`, `Nogoods` |
+| **Clean** (44) | the arithmetic family (with two rows of its own for `Abs`' interior holes), comparison, equality, linear, `AllDifferent` under `VC`, `Element` in both arms, with a holey entry and with a *view* on the result, `AllEqual` with holes and without, `Among`, `In` in three rows (a constant candidate list, and a variable one in each of its two rules), `GlobalCardinality` open and closed, `Table` (both shapes), `ValuePrecede`, `SeqPrecedeChain`, `IncreasingChain`, `Lex`, `Sort`, `ArgSort`, `NegativeTable`, `Disjunctive2D`, `BinPacking`, `MinDistance`, `DifferenceConstraints`, `Nogoods` |
 | **NoWidePosition** (15) | the graph and permutation family, and the Boolean constraints |
 
 `Among`, `In`, `AllEqual/holes`, `GlobalCardinality` (open and closed), `Table`
@@ -693,6 +693,20 @@ which is two range removals however wide the domain is. **A second per-value sit
 remains** in its Hall reasoning, which the original probe could not reach — one
 cover value means there is no multi-value hall — so it now has a row of its own
 rather than being covered by association.
+
+**Every probe in this lane wraps nothing, and that is an axis of its own.**
+`Element/view-result` is the first row to put a view on anything. It is the GAC
+`Element` row with the result wrapped and nothing else changed, and before #924
+it walked 10^9 values while the bare row beside it removed two ranges: the
+result-union rule answered "can I say a range about these?" with a *type* test,
+so a view anywhere sent the whole rule down a per-value walk of the remainder.
+Nothing in this file could have caught that, because nothing in this file wraps.
+
+The general question is open and is not really about `Element`. Every constraint
+whose proof reasons about intervals has the same question to answer, and #904
+changed the answer for all of them at once; a lane that only ever asks it about
+bare variables cannot tell which ones were updated. One row is a start, not a
+policy.
 
 It has a **third** site, and finding it was a lesson about the axes a row covers
 rather than about the constraint. `with_closed()` installs a propagator of its
@@ -963,7 +977,7 @@ time, and the row is now flat at 53.
 | **Both** grow | 10x / 10x | `Power`, `PowerTable`, `NValue`, `Regular`, `RegularLegacy`, `RegularBacchus`, `MDD` |
 | **OPB only** | 10x / 1.0x | `Cumulative` (19046 → 190046 rows; one capacity line per time point, so it is H3 on the encoding side) |
 | **Steps only** | 1.0x / 10x | `GlobalCardinality/hall` (34-row OPB fixed, 43988 → 439988 steps) |
-| neither | 1.0x / 1.0x | everything else, 68 of 77 |
+| neither | 1.0x / 1.0x | everything else, 69 of 78 |
 
 The last row means "does not grow with the width", not "identical at both widths",
 and three entries in it are worth naming so nobody reads them as a promise.

--- a/gcs/constraints/element/element.cc
+++ b/gcs/constraints/element/element.cc
@@ -4,7 +4,6 @@
 #include <gcs/constraints/equals.hh>
 #include <gcs/exception.hh>
 #include <gcs/innards/inference_tracker.hh>
-#include <gcs/innards/large_domain_guard.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/proofs/proof_model.hh>
@@ -51,7 +50,6 @@ using std::stringstream;
 using std::unique_ptr;
 using std::vector;
 using std::ranges::adjacent_find;
-using std::ranges::all_of;
 using std::ranges::sort;
 
 #if defined(__cpp_lib_print) && defined(__cpp_lib_format)
@@ -643,18 +641,15 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators_impl(Prop
                 // -- and the search does not change, only how many inferences it
                 // takes to get there.
                 //
-                // Views keep the per-value path. The range justification below has
-                // to carry an order atom from result_var across the model's
-                // half-reified equality to the array entry, and a view's atoms are
-                // spelled through the view; that crossing has not been shown to
-                // bridge one. Same restriction, and the same reason, as
-                // min_max.cc's range path. (Among's range path needs no such
-                // restriction, because its lines stay within one variable.)
-                auto all_simple = holds_alternative<SimpleIntegerVariableID>(IntegerVariableID{result_var}) &&
-                    all_of(considered_vars, [](const IntegerVariableID & v) { return holds_alternative<SimpleIntegerVariableID>(v); });
-
-                if (all_simple) {
-                    for (auto [range_lo, range_hi] : still_to_find_support_for.each_interval()) {
+                // A view operand needs nothing extra here. The bound lemmas below
+                // name no bit vector, only order conditions on result_var and the
+                // entry, so they are emitted over whichever encoded variable each
+                // one resolves to -- a registered view's own, which since #904 is
+                // where its range literals live and is also the representation the
+                // model states this equality in. What decides the form is the width
+                // of the run, not the kind of the variables (#924).
+                for (auto [range_lo, range_hi] : still_to_find_support_for.each_interval()) {
+                    if (range_lo < range_hi) {
                         Reason reason;
                         if (inference.want_reasons()) {
                             ReasonLiterals extra;
@@ -690,7 +685,14 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators_impl(Prop
                                                     elem.push_back((v - index_starts.at(d)).as_index());
                                                     auto array_var = get_array_var<dimensions_>(elem, *array);
                                                     elem.pop_back();
-                                                    if (holds_alternative<SimpleIntegerVariableID>(array_var)) {
+                                                    // A constant entry needs no lemmas:
+                                                    // result = c pins every bit of
+                                                    // result under the guard, which
+                                                    // decides both halves of the range
+                                                    // disjunction outright. Anything
+                                                    // else -- bare variable or view --
+                                                    // needs the pair.
+                                                    if (! holds_alternative<ConstantIntegerVariableID>(array_var)) {
                                                         logger->emit_rup_proof_line_under_reason(reason,
                                                             guard + 1_i * (result_var < range_lo) + 1_i * (array_var >= range_lo) >= 1_i,
                                                             ProofLevel::Temporary);
@@ -719,22 +721,16 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators_impl(Prop
                                 },
                                 ThenRUP::Yes, hints::Element{owner}},
                             reason);
+                        continue;
                     }
 
-                    return scope_has_aliasing ? PropagatorState::Enable : PropagatorState::EnableButIdempotent;
-                }
-
-                // A view keeps the per-value walk, and so keeps the guard: this
-                // walks an IntervalSet the propagator built for itself, which
-                // State's iterators never see, and a walk of that shape is the
-                // same #833 hazard however the values were obtained. Without it
-                // the probe's outcome is decided by how much memory the machine
-                // happens to have -- 16 GB and 81 s here, a bad_alloc somewhere
-                // smaller -- which is not a test result.
-                LargeDomainIterationCounter unsupported_guard{"the number of unsupported result values one Element propagation has walked"};
-
-                for (auto value : still_to_find_support_for.each()) {
-                    unsupported_guard.step();
+                    // A run of one value. The range form would buy nothing --
+                    // not_in_range canonicalises to this same != literal -- and
+                    // would cost two bound lemmas per feasible index tuple, so it
+                    // stays on the single-value form. No iteration counter: the
+                    // branch above takes every run of two or more values, so this
+                    // is reached once per interval and never once per value.
+                    auto value = range_lo;
                     // index_vars stay a declarative generic_reason, concatenated with
                     // the per-considered-var literals; assembled only when a reason
                     // will be read.

--- a/gcs/large_domain_audit_test.cc
+++ b/gcs/large_domain_audit_test.cc
@@ -485,6 +485,21 @@ namespace
             auto result = wide_var(p);
             p.post(Element{result, p.create_integer_variable(0_i, 2_i), narrow(p, 3, 1_i, 3_i)});
         });
+        add("Element/view-result", Expect::Clean, [](Problem & p) {
+            // The GAC row above with the result wrapped, and nothing else changed.
+            // It is the first probe in this file to wrap anything, and it exists
+            // because the rule used to answer the question "can I say a range about
+            // these?" with a *type* test: a view anywhere sent the whole rule down
+            // a per-value walk of the remainder, so this shape walked 10^9 values
+            // while the bare one beside it removed two ranges (#924). Nothing else
+            // here would have caught that, because nothing else here wraps.
+            //
+            // Worth generalising rather than leaving as one row: every constraint
+            // whose proof reasons about intervals has the same question to answer,
+            // and every probe in this file answers it about bare variables only.
+            auto result = wide_var(p);
+            p.post(Element{result + 1_i, p.create_integer_variable(0_i, 2_i), narrow(p, 3, 1_i, 3_i)});
+        });
         add("Element/BC", Expect::Clean, [](Problem & p) {
             // The same instance as the GAC probe above, so the pair is
             // comparable: the weaker arm is what makes it clean, not an easier


### PR DESCRIPTION
The rule removed the result values no array entry supports, and asked whether it
could state a removal as a range by testing whether every operand was a bare
SimpleIntegerVariableID. A view anywhere sent the whole rule down a per-value
walk of the remainder, which is width-proportional: the audit's `Element` row is
Clean at 0..10^9 because the remainder goes in as the two ranges it is, and the
same instance with the result wrapped walked 100001 values and tripped the guard.

The reason the test gave stopped being true with #904, which gave a registered
view its own range literals over its own encoded variable, linked to the
underlying one -- and that is the representation the model states this equality
in, so the two bound lemmas cross on whichever encoding each operand resolves to.
(#904 retired the same test in equals, all_equal and min_max; #912 retires In's.)

What replaces it is the question that was actually being asked: is this run wide
enough to be worth stating as a range? The range form costs two bound lemmas per
feasible index tuple and the per-value form costs one line per value per tuple,
so a one-value run is pure loss -- not_in_range canonicalises to the same !=
literal there anyway. `In` draws the line in the same place.

A constant entry keeps its exemption, and now says why: `result = c` under the
tuple's guard pins every bit of result, which decides both halves of the range
disjunction outright, so it needs no lemmas. That is the one case a view is not
like a bare variable, and the inner test now names it directly rather than
catching it by accident through `holds_alternative<SimpleIntegerVariableID>`.

The per-value loop over `still_to_find_support_for.each()` is gone with the type
test. What is left is reached only when `range_lo == range_hi`, so its
`LargeDomainIterationCounter` would have been counting intervals rather than
values, and a guard that describes work it is not doing reads as coverage.

## Measured

`large_domain_audit_test` gains `Element/view-result`: the GAC `Element` row with
the result wrapped and nothing else changed. It **trips on `main`** (100001
values walked, over the limit of 100000) and survives here. It is the first probe
in that file to wrap anything, which is why nothing caught this; the lane is 192
assertions green.

Proof-scaling survey: the new row is flat (36 OPB rows, 171 steps at both 10^3
and 10^4). `Element` moves 190 -> 184 steps and `Element/holey` 84 -> 78, which
is the two lemmas per tuple that the width test stops paying on one-value runs.

`element_test var --seed=1`, whole-run proof size:

| lane | main | here |
|---|---|---|
| bare | 52147 | **50833** |
| mixed views | 57412 | 58079 |

The bare lane is 2.5% smaller for the same reason the survey rows moved. The
view lane is 1.2% larger, and that is the honest cost: at these widths a
two-value run is three lines per tuple as a range against two per value, so the
crossover is a run of three or four. The point is not the 1.2% -- it is that the
per-value form has no upper bound and this one does.

## Checks

* `ctest` 829/829, caps on and with `-DGCS_TEST_CAP_DEFAULTS=OFF`.
* `element_test` in all five modes (`var`, `const`, `constgac`, `const2d`,
  `var2d`) x {bare, mixed, `--view-wrap=8 --view-position=all`,
  `--view-wrap=10 --view-position=all`, `--view-wrap=17 --view-position=1`}: no
  VeriPB rejection.
* Sabotage: dropping the two bound lemmas is rejected bare
  (`element_test_var_w0_pall.pbp:12999`) and under views
  (`element_test_var_mixed.pbp:530`, `element_test_var_w8_pall.pbp:530`).
* Forcing the range form onto one-value runs as well still verifies, which is
  what says the width test is a size choice and not a soundness one.


## Note for whoever merges this

`dev_docs/large-domains.md`'s probe counts move here and in #912, so whichever
lands second gets a one-line conflict in the table: this branch adds one row
(76 probes, Clean 42), #912 adds two (77 probes, Clean 43). Together they are 78
and 44. The `ArrayMinMax` paragraph that says "Views keep the per-value path" is
left alone here deliberately — it is about `min_max.cc`, whose guards #904 had
already retired, and #912 rewrites it. This branch only stops `element.cc` from
citing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
