### PR TITLE
Count the audit lane's NoWidePosition rows as 15 too (#833)

### DIFF
--- a/dev_docs/large-domains.md
+++ b/dev_docs/large-domains.md
@@ -626,7 +626,7 @@ snapshot for orientation.
 |---|---|
 | **KnownTrip** (19) | `Power`, `PowerTable`, `AllDifferent`, `AllDifferentExcept`, `Count`, `NValue`, `AtMostOne`, `AtMostOneSmartTable`, `GlobalCardinality/hall`, `ArrayMinMax`, `LexSmartTable`, `SmartTable`, `Regular`, `RegularLegacy`, `RegularBacchus`, `MDD`, `Cumulative`, `Disjunctive`, `Knapsack` |
 | **Clean** (41) | the arithmetic family (with two rows of its own for `Abs`' interior holes), comparison, equality, linear, `AllDifferent` under `VC`, `Element` in both arms and with a holey entry, `AllEqual` with holes and without, `Among`, `In`, `GlobalCardinality` open and closed, `Table` (both shapes), `ValuePrecede`, `SeqPrecedeChain`, `IncreasingChain`, `Lex`, `Sort`, `ArgSort`, `NegativeTable`, `Disjunctive2D`, `BinPacking`, `MinDistance`, `DifferenceConstraints`, `Nogoods` |
-| **NoWidePosition** (14) | the graph and permutation family, and the Boolean constraints |
+| **NoWidePosition** (15) | the graph and permutation family, and the Boolean constraints |
 
 `Among`, `In`, `AllEqual/holes`, `GlobalCardinality` (open and closed), `Table`
 and `Element` started as `KnownTrip` and are now `Clean`, by the interval


### PR DESCRIPTION
One character. `be55b02e` corrected the audit lane's headline counts for the
`Dag` row that #918 added after the #877 branch was cut, but not the breakdown
table immediately under them, which still added up to the old 74:

> `KnownTrip (19)` + `Clean (41)` + `NoWidePosition (14)` = **74**, under a line
> saying 75.

`Dag` is an `Expect::NoWidePosition`, so that is the count that moves.

Both numbers re-derived from a run rather than read off the page, which is what
the table's own preamble asks for ("the lane itself is the authority — run it
rather than trusting this table"). Off this commit:

* the lane is green (190 assertions) and prints **75** constraint rows, **41
  Clean / 19 KnownTrip / 15 NoWidePosition**, with `Dag` as
  `NoWidePosition survives`;
* the proof scaling survey is **75** rows and **63** strictly flat, which with
  `Multiply`, `Divide` and `Modulus` counted as the logarithmic cases the row's
  own footnote describes gives the **66 of 75** already recorded. So that half of
  `be55b02e` was right and only this one line was left behind. `Dag` is flat
  there too: 47 OPB rows and 4 proof steps at both widths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012iUaXT5G9VBE3cJeVXvtzx
