### PR TITLE
Write down the facts that only existed in a notebook

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,7 @@ reasoning behind them.
 | changing an existing constraint | the rest of [`dev_docs/constraints.md`](dev_docs/constraints.md), then [`reification.md`](dev_docs/reification.md) if it is reified |
 | touching domains, backtracking, or the inference paths | [`state-and-variables.md`](dev_docs/state-and-variables.md) |
 | writing or debugging a justification | `constraints.md` (Justifications), [`infer-redesign.md`](dev_docs/infer-redesign.md), and the per-constraint proof notes in the index |
+| wondering what the checker will accept, or why a proof is slow to check | [`veripb-facts.md`](dev_docs/veripb-facts.md) |
 | creating an auxiliary variable for a proof | [`variable-encodings.md`](dev_docs/variable-encodings.md) |
 | touching views | [`view-proof-logging.md`](dev_docs/view-proof-logging.md) |
 | making a propagator faster | [`propagator-performance.md`](dev_docs/propagator-performance.md), then [`benchmarking.md`](dev_docs/benchmarking.md) |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -143,6 +143,36 @@ installed clang-format is what makes it a check at all. It also only sees what
 is staged, whereas CI formats the whole tree; the two agree on a clean tree, but
 run the command above by hand if you are unsure.
 
+Branches and History
+====================
+
+A pull request's MERGED status is **not** a reliable signal that its content is
+in `main`, and stacked pull requests are how that goes wrong. A PR based on
+another branch rather than on `main` is merged *into that branch*, and GitHub
+marks it MERGED at that point — whether or not the parent ever carries it the
+rest of the way. If the parent is then merged from a commit that predates the
+child, or is merged and the stack is not re-pushed, the child's content never
+reaches `main` while its PR page says it did. PR #261 is the worked example: it
+read MERGED while the example it added was absent from `main` entirely, because
+`main`'s merge of its parent stopped one commit short of it.
+
+To decide whether a branch's content has landed, ask the content rather than the
+PR status:
+
+```shell
+git merge-base --is-ancestor origin/<branch> origin/main   # exit 0: it is in
+git cherry origin/main origin/<branch>                     # no '+' lines: it is in
+```
+
+A branch that GitHub calls merged but that still has `+` lines needs its unique
+commits diffing against `main` by hand: it may have been squash-merged (fine) or
+it may be carrying commits that were dropped along the way.
+
+Before deleting a remote branch, check that no open pull request is based on it
+(`gh pr list --base <branch> --state open`). Deleting a branch that is an open
+PR's base **closes that PR**; GitHub does not retarget it, and the close is not
+reversible by recreating the branch.
+
 Developer Documentation
 =======================
 

--- a/dev_docs/README.md
+++ b/dev_docs/README.md
@@ -52,6 +52,15 @@ library. For an introduction to *using* the solver, start with the top-level
   types, the `install_reified_dispatcher` helper, the OPB encoding pattern,
   and the conventions for writing new reified constraints. Read
   `constraints.md` first.
+- [What VeriPB checks, and what it does not](veripb-facts.md) — the checker at
+  the other end of everything we emit: the two ways a proof can exit 0 while
+  establishing less than you meant, what RUP can and cannot derive without a
+  `pol` (and the case where a `pol` is not needed at all), why a `pol` only has
+  to get close and what that does to mutation lanes, what a RUP step costs and
+  therefore what may live at `Top`, why deletion checking follows where the
+  target lives rather than which rule you wrote, and what the proof system can
+  express at all. Read when a proof verifies and you are not sure it should, or
+  when one is slow to check.
 - [MiniZinc bindings](minizinc.md) — how the `minizinc/` directory plugs into
   the MiniZinc / FlatZinc ecosystem: `fzn-glasgow`, the `mznlib/` predicate
   overrides, `.msc` solver-config files, the cross-solver test harness, and

--- a/dev_docs/benchmarking.md
+++ b/dev_docs/benchmarking.md
@@ -174,6 +174,102 @@ dominated by `n_queens_88` (~20 minutes alone).
   external wall is much larger than `solve time`, the difference is setup
   / proof I/O / output, which is usually outside the change being measured.
 
+## Choosing the metric
+
+The list above is what to capture. Which of those numbers carries the answer
+depends on what the change did to the search, and getting that wrong has
+produced more retracted results here than measurement noise ever has.
+
+### When the search is identical, count instructions, not seconds
+
+If two builds run the same search — same `recursions`, same `propagations`, so
+that the only difference is how the same work gets executed — compare
+**instructions retired**. On one machine `langford --size=11` retires 47.587e9
+instructions with a spread of 0.002% across five runs, while wall time and
+cycles for the *same* binary move about 1% within a single interleaved batch and
+about 3% between one hour and the next. A 1% effect is invisible to wall time and
+unmissable in instructions.
+
+```shell
+perf stat -e instructions,cycles,branch-misses,L1-icache-load-misses -x, \
+    taskset -c 4 ./build/langford --size=11
+```
+
+Read cycles *alongside* instructions rather than instead of them — the pair is
+what diagnoses. On #878 the variant that retired **fewer** instructions burned
+2–3% **more** cycles, and that is what rejected it; a wall-time-only run would
+have called the whole thing noise. The first wall-time batch on that issue (five
+repeats, pinned, interleaved) reported the variant 0.8% *slower*, where the
+instruction count said +0.11% and a reversed-order batch then agreed with the
+instruction count.
+
+Instructions are load-insensitive; cycles are not. Interleave the variants within
+each repeat, and check what else is running before believing a cycles figure.
+
+If the search shape *does* change, none of this applies: the two runs are then
+doing different amounts of work, and no per-unit figure can be read off them.
+`propagator-performance.md` ("Is it the propagator, the strength, or the
+search?") is the separation to do first.
+
+### "Search is unchanged" is a claim about the corpus, not about the change
+
+When a change touches something every search reads — variable degree, trigger or
+scope accounting, wake order — "all N tests pass and the search is unchanged" is
+evidence about the shapes the corpus happens to contain.
+
+Commit `d9a8dc93` (#506) switched degree accounting from per-trigger-slot to
+per-distinct-scope-variable, justified in its own commit message with "no real
+constraint does that". `ReifiedCompareLessThanOrMaybeEqual` does exactly that
+whenever the reified expression mentions its own condition variable, because the
+dispatcher appends an `on_change` trigger to the propagator's own `on_bounds`
+one. On CPMpy's `p <-> (p <= BV113)` the root branch flipped and the model went
+from 25 to 7,085,707 nodes. All 517 tests still passed.
+
+Before claiming the search is unchanged, name the shape the change *could* alter
+and go and find one. Grepping for constructs that add triggers **implicitly**
+(reification dispatchers, umbrella installers) is the cheap version.
+Frontend-generated models are the good hunting ground, because CPMpy and MiniZinc
+flattening alias variables in ways hand-written tests never do. Note that the
+change above was kept — it is the principled accounting — so the lesson is about
+the justification, not the change.
+
+### Nothing that divides by time means anything on a capped row
+
+On a row where the run hit a timeout, both configurations ran the same wall time,
+so anything divided by time is a constant away from the node count. That kills
+two figures, and #788 published both before spotting either: "throughput falls
+10× to 30×" was the node count divided by 60 s, and — less obviously — the *node
+ratio* between two configurations was the same quantity wearing the other hat.
+"Node counts fall 34.8× at n=100" was two runs that had both hit the cap; across
+the instances where both arms actually finished, the reduction was 1.09× to
+1.38×. Those two numbers lead to completely different decisions, and the wrong
+one is the exciting-looking one.
+
+- On a capped row, only the **objective reached** and the **absolute node count**
+  mean anything. Nodes/s, node ratios, per-node cost and speed-ups all need every
+  configuration in the comparison to have finished.
+- If too few finish, shorten the instances rather than the reasoning: a cut-down
+  family that finishes beats a real one that caps.
+- Say in the table which rows are capped, and put derived columns only on the
+  uncapped ones. A footnote is not enough.
+- Declare the selection effect: the instances both arms finish are the easy ones,
+  so "1.09–1.38×" is not evidence that the reduction is small on the hard ones.
+  It is evidence that there is no *measured* support for a large one.
+- The giveaway is a "throughput ratio" or "node reduction" that equals the node
+  ratio to two significant figures on every capped row. That is not a striking
+  finding, it is arithmetic.
+
+### A per-node figure is a product of two independent things
+
+Calls per node and cost per call vary independently, so a per-node cost can move
+without either one behaving the way you read it. #788's walk looked "1.0× on
+`tpp` at n=35 but 10× on `mario` at n=30", which reads as "the cost is not a
+function of n". It is: per *call* it is 7.7 µs at n=15 and 30.7 µs at n=35 on the
+same family, and `tpp` merely wakes the propagator 676 times in a 7.5-million-node
+search. Never conclude anything about per-call cost from a per-node figure; split
+it with `GCS_PROPAGATOR_STATS` first (see
+[propagator-performance.md](propagator-performance.md)).
+
 ## Benchmarking proof-shape changes
 
 The set above is for *solver* performance. Proof-logging work — a new
@@ -379,11 +475,64 @@ from a destructor) will tell you a call-count distribution in one run —
 crude, but enough to distinguish "expensive once" from "cheap but called a
 billion times".
 
+## Reporting the numbers
+
+Every defect in this section was caught by review of a numbers-heavy document
+that was otherwise correct, and each one survived because it sat *next to* the
+evidence rather than in it.
+
+- **Quote rows that are printed.** A figure whose instance appears in no table
+  cannot be checked by anyone, and drifts out of agreement with the set as the
+  set changes underneath it. `proof-benchmarks.md` once headlined a
+  cost-per-byte range with an instance that was in no group, and took the other
+  end of the range from a different campaign's artefacts. If you state a range
+  over a selection, either print the whole selection or say what the selection
+  rule was: "every group A and B row except the four measured after the pilot" is
+  checkable, "twenty of the rows" with eight shown is not.
+- **A superlative next to a table is a claim about that table.** Read the column
+  and confirm the row is the one you named. Where only a tendency exists, say so,
+  give the coefficient, and name the concrete pair that makes it vivid.
+- **A "mean" is a division.** Compute it (`awk '{s+=$1} END {print s/NR}'`),
+  never eyeball it from a sorted listing — that samples the large end. Where a
+  per-item measurement is all you have, either keep it labelled as that one item
+  or convert it to a fraction and apply that to a measured total. Cross-check any
+  derived figure against another number in the same table before it lands
+  anywhere permanent: one such figure, multiplied back out, came to more than the
+  whole tree it was describing.
+- **An "X out of Y" must count one unit.** Write both as products and check they
+  share a factor set. `large-domains.md` once said a run over 31 instances leaves
+  "six artefacts to compare out of 124", where 124 was 31 instances × 4 extensions
+  and six was 3 basenames × 2 extensions; the real answer was twelve.
+- **Name the population, especially when an older draw is still around.** Two
+  numbers for one quantity with no populations attached read as a contradiction.
+  If the prose keeps quoting a ratio the table only implies, make it a column so
+  it is read off rather than remembered — that is how a figure from stage zero's
+  30,000-instance draw ended up quoted in a section whose own table reported a
+  20,000-instance one, in five places including two class comments.
+- **Fix the commit message too.** The same sentence usually lives in both.
+
 ## Reproducibility caveats
 
 - Pin CPU governor to `performance` if available; thermal throttling on
   longer runs (`n_queens_88`) can produce 5–10 % drift between trials.
-- Don't run other CPU-heavy work in parallel.
+- Don't run other CPU-heavy work in parallel. This is not only about core
+  contention, and `taskset` does not protect you from it: figures taken while a
+  9 GB-RSS run was in flight on another core read **2× slow** (21.3 s against
+  10.8 s idle) for a deep enumeration with allocation churn, while cache-resident
+  workloads measured alongside it reproduced within 1%. Adding a spinning burner
+  on another core changed nothing, so the variable was memory bandwidth. The
+  cheap discriminator: repeat the measurement three times on an idle machine, and
+  if it moves by 2×, load was the variable rather than the code.
+- **Put exact counts in a comment, never in an assertion.** Recursion counts and
+  per-rule counters are deterministic for a given build and *not* across
+  toolchains — different standard libraries break ties differently, so sweep order
+  and intermediate work differ even where the fixpoint does not. A ctest pinning
+  `recursions: 963` and another pinning a counter triple both failed on macOS and
+  on ubuntu-24.04 (#776); `examples/rcpsp/CMakeLists.txt` has exact counts all
+  through it and not one of them is an assertion. Assert an invariant that
+  travels instead: for a counter, "switched off reports four zeroes" plus
+  "switched on reports firings" pins each counter to the rule it is named after,
+  which is the failure worth catching, and holds everywhere.
 - Don't include proof verification (`--prove`) in performance numbers —
   proof I/O dominates and is not what the change usually targets. Keep
   proof verification for correctness checks via `ctest`.

--- a/dev_docs/constraints.md
+++ b/dev_docs/constraints.md
@@ -179,6 +179,25 @@ for a real variable, `@po[index][...]` for a proof-only one) are out of
 scope deliberately: those rows may be deleted and re-emitted to keep the
 proof database small, so a repeat there is by design.
 
+That rule puts a **ceiling on how many children one constraint can
+install**, and the limit is the labels rather than the propagation. A
+child builds its label out of *its own* id and *its own* role, so a
+parent that has given several children its own id cannot rename them
+apart, and the second row under a name is refused. Since
+`LinearLessThanEqual` (as `MustHold`) uses the **empty** role while
+`LinearEquality` uses `le`/`ge`, two linear children under one parent id
+collide, whereas a `Reachable` child plus one `LinearEquality` child is
+fine and verifies. Confirmed by probe against a real build, not by
+reading the code. Roughly one child per role namespace is the ceiling,
+and anything past it has to be rows the parent writes itself with
+`add_labelled_constraint(id, role, ...)`, picking roles that name what
+varies (`indeg7`, `startdeg7`), plus its own propagator —
+`gcs/constraints/innards/graph_rules.{hh,cc}` is that pattern for the
+tree/path family. Giving children derived ids instead would mean growing
+`ConstraintID`, which is on the hot path (it is a `string_view` into the
+`Problem` name pool precisely so that it stays trivially copyable), so it
+has not been done.
+
 ## The header
 
 ```cpp
@@ -290,6 +309,20 @@ auto Foo::install_propagators(Propagators & propagators) -> void
         triggers);
 }
 ```
+
+Argument validation splits across the constructor and `prepare()`, and the
+half that is easy to forget is the second one. A "size"-like parameter — a
+rectangle's width, a task's duration or demand, a capacity — that may be either
+a constant or an `IntegerVariableID` can only be checked in the constructor for
+the constant cases, because a variable's domain does not exist yet. Do not leave
+the variable case as an unchecked modelling assumption: check
+`initial_state.lower_bound(v) < 0_i` in `prepare()` and throw
+`InvalidProblemDefinitionException`, mirroring the constructor's constant check.
+A negative size has no sensible interpretation and otherwise produces nonsense
+silently. Both `Disjunctive2D` and `Cumulative` shipped with a constructor check,
+a comment saying the variable case was "checked in prepare()", and a `prepare()`
+that never did; `cumulative_test.cc`'s `expect_negative_size_throws` is the
+regression test shape to copy.
 
 State that needs to flow between phases (filtered task lists, proof-flag
 handles, cached line numbers) goes on the class as private members.
@@ -754,6 +787,50 @@ without proof verification (always), once with `--prove` if `veripb`
 is on `PATH`. The CMake test target points at `run_test_only.bash`
 which handles this.
 
+### Forcing a particular propagation situation
+
+When a test or probe needs to provoke one specific situation — a chosen
+inference, a Hall band, a particular matching commitment — post `In` constraints
+rather than trying to coax initial domains into the configuration or
+hand-building a search. `In` pins each variable to an explicit, possibly
+non-contiguous value set, so the propagator sees exactly the domains you meant,
+and the instance stays small and deterministic.
+
+### When the solution callback throws `VariableDoesNotHaveUniqueValue`
+
+`s(v)` in a solution callback is `optional_single_value(v)` unwrapped: it asserts
+that `v` is uniquely determined. The solver calls the callback on every feasible
+assignment to the **branch** set, not to every variable in the problem, so if the
+branch heuristic fixes every branch variable and the active propagators do not
+then force `v`, the read throws. It is the normal outcome for a derived or
+objective variable constrained only by inequalities (`makespan >= start[i] +
+length[i]`) when the propagator that ought to pin it is weak or, during
+bring-up, is still a checker that does not propagate at all.
+
+The fix is **not** to read `s.lower_bound(v)` instead. That papers over the gap
+and hides whichever propagator should have done the work. Either drop the custom
+branch so the default branches over every variable, or extend the branch variable
+list to cover every derived and objective variable the callback reads. Reach for
+`s.lower_bound` / `s.upper_bound` only when you genuinely want to display a
+bound, such as printing intermediate state from a debug callback.
+
+### Porting a reproduction program in
+
+When a standalone bug-reproduction program turns up, the preferred outcome is
+that the data-driven test for that constraint gains equivalent coverage and the
+repro is **deleted** — not registered with ctest, and not kept as a documented
+manual tool. Programs that are built but never run rot silently: one was
+unrunnable for eight months after an options-library conversion and nobody
+noticed. The data-driven framework also checks strictly more, since it
+brute-forces the expected solution set and verifies the proof rather than only
+observing that VeriPB accepted one.
+
+Before deciding anything about a repro, audit what it actually guards — the
+constraint shape, the argument kinds (views, constants), the bound ranges — and
+check each ingredient appears in the corresponding `*_test.cc`. Port the exact
+originally-failing instance as one of the new test instances, and size instances
+against the default caps so that most still check completeness when capped.
+
 ### Splitting a slow test for parallelism
 
 If a test takes a long time, it becomes a parallelism bottleneck —
@@ -917,6 +994,63 @@ repo root, which they source relative to their own `$0`. Changing what the
 wrappers delete — adding a sixth proof artifact, say — means changing that one
 file, and its extension list should stay in step with `proof_file_extensions`
 in `constraints_test_utils.hh`.
+
+### Pinning the random seed
+
+Every test main calls `establish_and_announce_seed(argc, argv)`, which takes a
+seed from the command line, invents one from `std::random_device` if there was
+none, and announces it:
+
+```
+./build/equals_test: random seed is 4262523410 (reproduce with --seed=4262523410)
+```
+
+The flag form is **`--seed=12345`**, parsed by prefix. Writing `--seed 12345`
+does not fail: the argument is simply not recognised, so the run picks a fresh
+random seed and announces a different one each time. Read the announced line back
+to confirm the flag took — that line is the only thing that makes the mistake
+visible.
+
+**Which artefacts depend on the seed.** Measured across 274 instances of
+`difference_logic_presolver_test`:
+
+| Artefact | Seed-dependent? |
+|---|---|
+| `.opb`, `.scp` | **No** — byte-identical across two *different* seeds |
+| `.pbp`, `.varmap` | **Yes** — search order decides which inferences get logged, in what order, and which literals get minted |
+
+So a "no new OPB content" claim can be checked with an unseeded diff, and is the
+strongest statement about the *model*; a `.pbp` or `.varmap` diff means nothing
+unless the seed is pinned identically on both sides. Say which you did. An
+unseeded run of that test showed 225 of 274 `.pbp` and `.varmap` files
+differing — all of it seed noise — where with the seed pinned all 1096 artefacts
+came out byte-identical and the evidence meant something.
+
+Proof **size** is seed noise at a scale that looks like a result: measuring the
+`.pbp` cost of one substitution unseeded gave −4.5%, +14.2% and −19.2% on three
+constraints, and with `--seed=1` on both sides the same three came out +0.02%,
++0.21% and +0.77%. Treat any unpinned proof-size delta as unmeasured, however
+large.
+
+**A mutation probe on a randomising test is not a probe without `--seed=N`.**
+`subcircuit_test` randomises its view-wrap configuration, so replacing a
+certificate with a plain `JustifyUsingRUP` came out *passing* on two of three
+unseeded runs — the wrap it happens to pick decides whether unit propagation
+reaches the conflict unaided. With `--seed=1` it rejects at n=5 every time, and
+n=3 and n=4 still pass, so the scenario *size* is the second half of the same
+trap. A probe that can silently come out the wrong way is worse than no probe,
+because it licenses deleting the thing it was supposed to protect.
+
+If a test does not call `establish_and_announce_seed`, `--seed=N` is silently
+ignored and its enumeration proof differs between two runs of the same binary.
+`cumulative_kaoc_test` was the one test in its family missing the call, and it
+looked harmless because the file draws no random data: every fixture is written
+out, and the randomness is in the *branching*, because `solve_for_tests` goes
+through `random_branch_with_optional_seed`, which falls back to `random_device`
+when no seed was stored. Every test that solves needs the call. The diagnostic
+order that settles this quickly is to run the same binary twice (which rules out
+the change under test), then `setarch -R` (which rules out ASLR), then grep the
+test for `establish_and_announce_seed`.
 
 ### Mutation testing: showing a derivation is tight
 

--- a/dev_docs/infer-redesign.md
+++ b/dev_docs/infer-redesign.md
@@ -124,6 +124,48 @@ Still deferred (consistent with the body's "open questions"):
   hint-aware, Table is ready. (`arithmetic` / `seq_precede_chain` post no inferences
   of their own and inherit the hints of what they delegate to.)
 
+### Naming a hint, and reading one back
+
+Two rules, which look contradictory apart and are clear together.
+
+**Choosing a name.** `hints::Foo::hint_name` is the **user-facing constraint
+type** — `tree`, `path`, `reachable`, `abs`, `count` — never the internal API or
+the shared helper that happens to emit the step. The annotation is vocabulary an
+*external* justifier reads in assertion mode, so it has to say which constraint
+that justifier must reason about, not how this repository factors its
+implementation. (Naming one after the shared rule machinery, `graphrules`, is the
+mistake that established this.) The only names that do not follow it are the
+framework-level ones in `gcs/innards/proofs/hints.hh` — `initial_bound`,
+`backtrack`, … — which belong to no model constraint at all. A shared helper
+therefore owns no hint: it takes one from its caller by templating on the hint
+type. One hint per *family* is fine and is the precedent — `hints::Reachable`
+covers `Reachable` and `DReachable`, `hints::Tree` covers `Tree`/`DTree` —
+because `originator` pins down which constraint it was and the `.scp` says which
+spelling; separate structs are for genuinely separate constraints
+(`sort`/`arg_sort`, `table`/`negative_table`).
+
+**Reading one back.** An assertion in a gcs proof looks like
+`a <clause> >= 1::equals:((constraint_id _23));` — and `equals` there **does not
+mean the constraint is an `Equals`**. The hint names the derivation's shape; the
+constraint id names the owner, and the two disagree exactly when a family calls
+exported shared inference code. `Element` calls `innards::enforce_equality`,
+exported from `gcs/constraints/equals/equals.hh`, which hints
+`hints::Equals{owner}` with the `owner` argument its *caller* passed. Measured on
+`langford --size=8` at `GCS_ASSERTION_LEVEL=inferences`: 6,545 assertions carry
+the `equals` hint and **every one of them is owned by an `Element`**, against 485
+carrying `element` — and `langford` posts `AllDifferent`, `Element` and `Plus`,
+with no `Equals` anywhere in the model.
+
+That is not a bug: the derivation genuinely is that shape and the owner genuinely
+is the `Element`, so a justifier is given both of the facts it needs. What it
+must not do is resolve the id expecting the hint's family — looking up `_23` for
+`Equals`'s two equality rows finds an `Element`'s per-cell half-reified pair
+instead, and what it wants is the cell, which the reason's index literals name.
+So never build a cross-family table by counting hint names; resolve each
+constraint id against the `.opb`'s own `* constraint <family> <id>` provenance
+comments. When auditing one family, grep for calls to exported inference helpers
+(`enforce_equality` is the one that exists today) and check which hint they emit.
+
 ## The abstraction
 
 Every inference has three layers with a strict one-way dependency:

--- a/dev_docs/minizinc.md
+++ b/dev_docs/minizinc.md
@@ -139,6 +139,32 @@ The general recipe (see `gcs/constraints/lex/lex.cc` and the
    `.mzn` test, all set to `SKIP_RETURN_CODE 66` (which means
    "MiniZinc isn't installed, skip").
 
+### Never shift a `var` array inside a comprehension
+
+A redefinition that rebases an array of *variables* — `[x[i] - min(index_set(x))
+| i in index_set(x)]`, to hand a zero-based copy to a propagator that wants one —
+looks free and is not. The comprehension introduces a fresh FlatZinc variable per
+element, tied to the original by an `int_lin_eq`, and `LinearEquality` is bounds
+consistent by default, so a **hole** punched in the shifted copy never reaches
+the model's array; only its bounds do. Every value-pruning propagator behind such
+a redefinition is silently downgraded, and the damage lands on the search
+heuristic too, because a search annotation names the model's array: `first_fail`
+then reads stale domain sizes and `indomain_min` tries values already ruled out.
+
+Pass the **offset** instead and let `fzn_glasgow.cc` apply it as a view
+(`operator+(IntegerVariableID, Integer)`), which shares the domain outright and
+costs nothing to propagate. On `subcircuit` this was worth optimal-in-cap 4/15 →
+9/15 across the MiniZinc Challenge mario family;
+[subcircuit-proof-logging.md](subcircuit-proof-logging.md) has the measurements,
+the probe that separates cause from fix, and the list of redefinitions that still
+have the pattern (issue #803). Two details come with the change: the guard the
+comprehension used to make unnecessary (`if length(x) = 0 then true`) has to come
+back, and the constraint now gets views on every MiniZinc model, so it needs
+`add_view_tests` coverage.
+
+Shifting *parameters* in a comprehension costs nothing; this is only about arrays
+of `var`.
+
 ## When no predicate is the right answer
 
 Not every gcs feature wants an `mznlib/` override. The difference-logic

--- a/dev_docs/veripb-facts.md
+++ b/dev_docs/veripb-facts.md
@@ -1,0 +1,289 @@
+# What VeriPB checks, and what it does not
+
+The rest of `dev_docs/` is about how to write a proof for a propagator. This
+document is about the checker at the other end: what `veripb` actually does with
+what we emit, where its cost goes, and what it can and cannot be asked to
+establish.
+
+Everything here was established empirically, against the Rust VeriPB that CI
+installs — Cargo version `3.0.2`, built from a fresh `--depth 1` clone of
+upstream `main` (see [building.md](building.md), which also explains why that
+clone is deliberately unpinned). That makes these observations about a moving
+target: they were each re-checked at the date given, and if the checker
+surprises you, re-check rather than assume. Every one of them cost somebody a
+session to learn.
+
+Read this when a proof verifies and you are not sure it should, when a proof is
+slow to check, or when you are deciding whether a derivation can be certified at
+all.
+
+## A green exit status is not a checked proof
+
+There are two independent ways for `veripb` to exit 0 on a proof that
+establishes less than you meant it to. Neither is a bug in the checker.
+
+### The `s` line, not the exit code
+
+A proof containing unchecked assertions (VeriPB's `a` rule, which the solver
+emits for `AssertRatherThanJustifying`) verifies with exit status 0 and prints
+`s UNDER ASSERTIONS …` instead of `s VERIFIED …`. Since `run_veripb` in
+`constraints_test_utils.hh` reads only the exit status, a full green `ctest` is
+exactly as green with cheats in it as without.
+
+[constraints.md](constraints.md) ("Bringing up a new constraint", stages 3–5)
+covers the staged bring-up this enables and the never-merge-an-assertion rule.
+Two things to add to what it says: `--elaborate` is **not** a second gate —
+3.0.2 takes `-e/--elaborate [<PATH>]` and, on an asserted proof, merely warns
+that unchecked assertions have been written to the elaborated proof, exit 0
+(re-checked 2026-09-10; the older hard refusal was a behaviour of the
+`CP2026-enumeration` tag of the development checker, not of anything shipped).
+And there is no `--force-…` flag for assertions the way there is for deletions,
+so the burn-down count on a preserved proof is the only mechanical check there
+is.
+
+### A valid proof is not the proof you meant
+
+A hand-built certificate for disjunctive edge-finding verified end to end —
+`s VERIFIED UNSATISFIABLE` — while **every** order-ladder row in it had the
+wrong coefficients.
+
+The mechanism: a `pol` that ends `+ s` where the running degree is `d > 1`
+saturates to `d·l₁ + d·l₂ ≥ d`, not to the unit clause, because saturation caps
+a coefficient *at the degree*. Every row downstream of that is then correct but
+slack, and a proof full of slack rows still closes whenever the wrapping
+reason-carrying RUP can finish the job. Nothing in the exit code distinguishes
+"the certificate did the work" from "the RUP did".
+
+So for any hand-generated proof — a prototype, a simulation of a rule you have
+not implemented yet, anything you are about to take a measurement off — run
+`veripb --trace` and check every load-bearing row against a written-down
+expected shape before believing conclusions drawn from it. The line counts of a
+mangled certificate are not the line counts of the real one, so a cost model
+taken from it is wrong too. [constraints.md](constraints.md) (Mutation testing)
+is the complementary check for a proof the solver emits.
+
+## What RUP can and cannot do
+
+RUP unit-propagates one constraint at a time, including bit-level propagation
+through bit-encoded integers — enough to fix individual bits of `a` when
+`result` and `b` are known. It does **not** perform the cross-variable linear
+combination "`a + b = result`, plus `b ≤ b_ub`, plus `result = v`, therefore
+`a ≥ v - b_ub`". Combining several PB constraints into a tighter one is `pol`'s
+job.
+
+So when designing a stronger-than-bounds proof for an arithmetic constraint,
+assume that any "narrow `X` using `Y` and `Z`'s bounds" deduction needs an
+explicit `pol` step, and that the trailing RUP can only close *after* the bound
+has been materialised. `Plus`'s bound inferences are the worked example
+(`gcs/constraints/plus_minus/plus.cc`, which builds the `pol` and hands it to a
+`JustifyExplicitly`); issue #192 is the case study where missing this made
+per-value `result ≠ v` proofs fail verification. A
+per-pair lemma like `(a ≠ a_v) ∨ (b = v - a_v) ∨ (result ≠ v)` *is* RUP-derivable
+and useful, but it does not substitute for the bound-materialisation step.
+
+The converse trap is real too, so check before reaching for `pol`. Converting a
+`Cumulative`'s `cge` row plus a height's lower bound into
+`Σ 2ᵏ cc_k + L·~active ≥ L` closes as a plain **hinted RUP**, always: negating it
+forces `~active` to zero, leaving two power-of-two bit counters that unit
+propagation walks down one bit at a time, every step single-constraint. Two
+sweeps (1504 and 968 shapes, including contribution bits narrower than the
+height's and non-power-of-two upper bounds), with negative controls that do fail,
+confirmed it (#686). That is one line instead of O(bits) addends, and unlike a
+`pol` it can carry hints. Before writing a saturate-and-restore `pol`, try the
+RUP.
+
+### A `pol` only has to get close
+
+**The `pol` is not the certificate; the wrapping RUP is.** A firing emits a `pol`
+and then RUPs its conclusion under the reason, so the `pol`'s result is just
+another line in the database when that RUP runs. It only has to get close enough
+that unit propagation can finish — not all the way to a contradiction.
+
+Concretely, in `Cumulative`'s energy `pol`s, leaving a task's `active_{i,t}` terms
+uncancelled produces a valid but weaker line, and UP then assigns those flags
+from the reason's own bound literals (the reifications are full) and the line
+goes violated. TTEF's certificate pins the non-contained tasks' mandatory load
+for exactly that cancellation, and **dropping every one of those pins still
+verifies on 235 of 248 searched instances**.
+
+Two consequences, and the second is the more interesting one.
+
+1. **A mutation that only removes energy from a `pol` is usually not a test.** It
+   is a corruption VeriPB is right to accept. What bites instead is corrupting
+   the *claim*, and only where the claim is **tight** — where some solution sits
+   exactly on the bound being pushed to. Where a push is merely valid,
+   one-too-far is valid too. A fixture therefore has to satisfy two conditions at
+   once, and a hand-built one usually satisfies at most one.
+
+   There is a second absorber, found on #746's published not-first/not-last
+   (PR #772): **the detection's own margin**. Dropping a contiguity row costs the
+   `pol` `lb(h_k)` units of degree, and a rule that fires at `> supply` has at
+   least one to spare and usually many. Dropping those rows — the rows carrying
+   the whole of what makes that rule stronger than window energy — could not be
+   made to fail in either a one-row or an every-row form on any of ~1,700 firing
+   instances, while `emit_nothing` was rejected on 171 of 238. A mutation lane
+   for such a row needs a fixture whose margin is narrower than the smallest
+   height involved, which for unit heights is impossible. When that happens, say
+   so in the mutations header as *deliberately absent* rather than shipping a lane
+   that always passes — and **keep the rows**: a `pol` that stops short of its own
+   claim is not a certificate of the rule, however VeriPB finishes it.
+
+2. **A cheaper certificate may be available by deliberately leaving work to UP.**
+   Every term a `pol` cancels costs lines; the ones UP can reach from the reason
+   are free. Nobody has measured how far this goes — the 13 of 248 above say it
+   does not go all the way, and there is no cheap test for which firing needs
+   what, so TTEF emits its pins unconditionally. "Which `pol` terms are
+   load-bearing" is an open question about proof size, not just about mutation
+   lanes.
+
+### What a RUP step costs
+
+A **hinted** `rup` unit-propagates over only the cited lines: cost O(|hints|). A
+**hint-free** `rup` propagates over the entire live constraint database: cost
+O(standing constraints). That asymmetry drives both hint emission and what may
+be left living at `ProofLevel::Top`.
+
+Two symmetric traps follow from it:
+
+- **Hints must cover the whole conflict path.** Hints *restrict* propagation;
+  there is no fallback to a full-database search when they turn out to be
+  incomplete. `RUPProofRule{}` with an engaged-but-empty vector renders `: ;`,
+  which restricts propagation to nothing. (One exception, found later: an empty
+  hint vector does check when the negated claim is contradictory on its face,
+  i.e. degree > Σ coefficients.)
+- **Lines that never leave the database tax every later hint-free RUP.** A
+  value-keyed cache that pushed ~45k lines to `Top` made a modulus proof check
+  **9× slower** while being 7× smaller.
+
+**How much hinting is worth is set by what is standing, not by what you are
+emitting.** Hinting the lifted cover cut replay against a bare model — one
+capacity row per time point, all scaffolding deleted — bought 25% of checking
+time. The same change against a real RCPSP model, where the standing database is
+the whole model, bought **6–14×** (`pack043`, 17.69 s → 1.24 s; #676 / PR #681).
+Deleting your own scaffolding cannot touch the model underneath it. So a
+derivation benchmarked in isolation and found not to need hints may well need
+them inside a real proof, and a scaling harness built on a toy model will tell
+you the opposite.
+
+When choosing a proof level for a cache, go by key churn: keys that repeat
+heavily across the search (a few hundred distinct values) can live at `Top`;
+churning keys such as per-node bounds belong in a per-pass cache at `Current`,
+where backtracking cleans them up.
+
+Debugging aids, in rough order of usefulness:
+
+- To tell an incomplete hint set from a wrong claim, `sed`-strip the hints and
+  re-verify: if it then passes, the hints were incomplete; if it still fails, the
+  claim is wrong.
+- Claims emitted under a reason render `>= K:` with no space before the colon,
+  which matters when grepping a proof.
+- Unit propagation cannot cross `[v ≥ 5] → [v ≥ 1]` via the bit definitions.
+  Derive the ladder clause from the two atoms' definition rows with a `pol` and
+  hint that; the tracker's own ladder lines are not recorded as citable.
+- `ia`'s implication check is itself "literal axioms, one saturation, literal
+  axioms", so pinning with `ia` gets a saturate-and-restore for free.
+
+[decision-diagram-proof-strategies.md](decision-diagram-proof-strategies.md)
+turns this cost model into the `displacement × DB-tax` rule for deciding between
+upfront and per-call scaffolding.
+
+## Deletion is checked by where the target lives
+
+The natural reading of "`del` is the unchecked rule, `delc` is the checked one"
+is wrong. `DeletionChecker::check` enters the checked path according to whether
+the deleted **IDs are in the core set**; `DeletionOrigin` only decides which
+origins are *permitted*. So a `del` aimed at a core constraint is checked exactly
+as a `delc` is, and rejects under `--force-checked-deletion` if the autoproof
+fails.
+
+What `delc` buys is therefore the **origin assertion**, not the check: `delc` on
+a derived constraint is rejected outright ("Deletion of derived constraint ID N
+using deletion from core set"). That is worth having for an emitter that deletes
+by remembered line number, because getting the two the wrong way round then fails
+loudly instead of silently. Relative (negative) ids work in `delc` and resolve
+exactly — confirmed by aiming one a line further on and watching the autoproof
+reject.
+
+For a gcs `soli`, the `soli` line itself produces the objective-improvement
+constraint in **core**, while a `rup` line — including the `~ge(v) >= 1` unit
+emitted right after it — is **derived**.
+
+[solution-clause-deletion.md](solution-clause-deletion.md) covers what happens
+when a deletion check fails (a warning and a downgrade, not a rejection) and why
+the suite passes `--force-checked-deletion` everywhere. The flag is a
+**diagnostic, not a soundness requirement**: without it the downgrade is still
+enforced at the conclusions that need it, but the error arrives at a distant
+conclusion instead of at the deletion that caused it.
+
+One more asymmetry to know about: **VeriPB polices the order encoding only at a
+point of use, not at deletion.** Deleting definitions out from under a
+still-resident line that names them also verifies. Eviction ordering is a
+solver-side invariant, and a green proof is not evidence that the discipline
+held.
+
+## What the proof system can express
+
+Background rather than day-to-day practice, but it settles a class of question
+that keeps coming up — "can this be logged at all?" — and it has already stopped
+one bad idea.
+
+**Strength.** The redundance rule (substitution redundancy — the `red` lines
+that `emit_red_proof_lines_reifying` writes behind
+`create_proof_flag_reifying`; `create_proof_flag` alone only mints a name and
+emits nothing) is *equivalent to extended resolution*. Dominance
+lifts that to G₁, one level above, plausibly but **not provably** strictly
+stronger; the hierarchy is not known to be strict. A single symmetry is
+ER-simulable; multiple symmetries need the full rule. (Kołodziejczyk & Thapen,
+"The Strength of the Dominance Rule", SAT 2024, Theorems 4 and 5.)
+
+**Essentially no superpolynomial lower bounds are known** for anything at this
+strength. So when we say we cannot log something, that almost always means *no
+compact construction has been found yet*, not *it is proven hard*. The frontier
+is constructive, not complexity-theoretic, and treating it as the latter talks
+us out of things that are merely unbuilt.
+
+**There is no general "derive once, cite many times" facility, and there cannot
+be one here.** Cutting planes + such a facility is sound, and cutting planes +
+dominance is sound, but cutting planes + dominance + it is **unsound**. Since we
+rely on dominance, the facility is off the table in general, and the fallback is
+to re-derive the fact per use and pay for it. (This is why "derive `v` is in no
+`k`-clique once, then reuse it across pattern vertices" cannot be a generic move
+in subgraph-isomorphism proofs.) The loophole, if anyone wants to chase it: the
+unsoundness argument needs *strengthening inside the body* of the reusable step,
+so inferences that never strengthen there may be a safe special case. That is an
+open question, not a known construction.
+
+Two corrections worth not relapsing into:
+
+- **Parity / XOR is not a wall.** Gocht & Nordström certify XOR reasoning and
+  Gaussian elimination efficiently: reify each XOR with a fresh variable via the
+  redundance rule, then combine by cutting planes. It is a known construction,
+  merely unimplemented here. (The barrier that does exist is for *plain* cutting
+  planes without redundance, which is a different system from ours.)
+- **Multiplication is the current frontier, not a proven barrier.** Bit
+  decomposition gives a polynomial-size encoding, but bounds reasoning over it
+  blows up. Whether a compact certificate exists is open — the same epistemic
+  status as everything else above. [view-proof-logging.md](view-proof-logging.md)
+  records the one case where a suspected "bit-composition wall" turned out to
+  have an ordinary cause.
+
+## Names and labels
+
+VeriPB 3.0.2 allows `-` in **both** variable names and `@labels`. Earlier
+versions allowed it in names only, and because the solver derives labels from
+names, a negative value leaking into a label was illegal — which is why the tree
+once spelled negatives `minusN`. PR #367 switched to rendering `-N` everywhere a
+value goes into a proof name: `eq`/`ge` literals, interval literals, and
+value-indexed flags. The old "must spell minus" rule is gone; do not reintroduce
+it.
+
+## See also
+
+- [constraints.md](constraints.md) — justifications, mutation testing, and the
+  staged bring-up that the `a` rule exists for.
+- [decision-diagram-proof-strategies.md](decision-diagram-proof-strategies.md) —
+  the upfront-vs-per-call cost model built on the RUP cost facts above.
+- [solution-clause-deletion.md](solution-clause-deletion.md) — deletion in
+  practice, and the core-set check from the solver's side.
+- [variable-encodings.md](variable-encodings.md) — which encodings exist to be
+  reasoned over in the first place.


### PR DESCRIPTION
I went over the notes I keep on this machine and pulled out the things that are durable facts about the project rather than status, and that dev_docs does not already say. This is that set. It is documentation only — no code changes, nothing to build.

The largest piece is a new `dev_docs/veripb-facts.md`. Everything else in dev_docs is about how to write a proof for a propagator; nothing covered the checker at the other end. It has the two ways a proof can exit 0 while establishing less than intended, what RUP can and cannot derive without a `pol` (and the case where a hinted RUP closes what a `pol` was about to be written for), why a `pol` only has to get close enough for the wrapping RUP to finish and what that does to mutation lanes, what a RUP step costs and therefore what may live at `Top`, why deletion checking follows where the target lives rather than which rule was written, and the strength results that say a reusable-lemma facility cannot be sound alongside dominance.

The rest is additions to documents that already exist:

- **`benchmarking.md`** gains a section on which metric answers which question — instructions retired when the search is identical, why nothing that divides by time means anything on a capped row, and why a per-node figure is a product of two things that vary independently — and one on reporting, since every defect it lists was caught by review of a document whose tables were correct.
- **`constraints.md`** gains the ceiling on child constraints that the role-label rule implies, the `prepare()`-time check a variable-valued size argument needs, the seed rules (`--seed=N`, which artefacts depend on it, and why a mutation probe without it is worse than no probe), posting `In` to force a chosen propagation situation, and what to do about `VariableDoesNotHaveUniqueValue`.
- **`infer-redesign.md`** gains the two hint-naming rules, which look contradictory apart.
- **`minizinc.md`** gains the general form of the comprehension trap whose measurements live in `subcircuit-proof-logging.md`.
- **`CONTRIBUTING.md`** gains a note on why a MERGED pull request may not be in main.

Every symbol, path and environment variable named was checked against the tree rather than taken from my notes, which caught two that had gone stale (`mult_bc.cc` and `create_proof_flag`). The `CONTRIBUTING.md` note originally said main is periodically rebased; ciaranm pointed out that is not what happens, and the history agrees — main carries 322 merge commits — so it now describes the stacked-PR mechanism that actually caused it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)