### PR TITLE
Replay a watchless model's round without the watch index (#895)

### DIFF
--- a/dev_docs/benchmarking.md
+++ b/dev_docs/benchmarking.md
@@ -211,6 +211,29 @@ doing different amounts of work, and no per-unit figure can be read off them.
 `propagator-performance.md` ("Is it the propagator, the strength, or the
 search?") is the separation to do first.
 
+### The null-change control, for a change inside a hot function
+
+That reproducibility makes it tempting to read any instruction-count difference as
+a result. For a change *inside* a function the size of `Propagators::propagate`, it
+often is not: adding code to such a function changes what the compiler does with
+the code around it, and the executed count moves even where the executed path is
+identical. The extra instructions are spills and reloads around untouched calls,
+not anything the change added.
+
+Measured on issue #895: a lambda added to `propagate()` that is **never called** —
+reachable only through a `volatile bool` that is always false — cost **+0.24% of
+`tsp`'s instructions, +0.52% of `magic_square --size=5`'s and +0.15% of
+`ortho_latin --size=6 --all`'s**, at identical `recursions` and `propagations`,
+with not one added instruction executed.
+
+So when a change goes inside a hot function, **build the null change too** — the
+same code added, with the new path made unreachable — and read the real change
+against that rather than against the unmodified build. A difference smaller than
+the null change's own figure is not a result. Try more than one arrangement of the
+same change for the same reason: on #895, moving a new lambda from inside the
+enclosing one to beside it, and taking a parameter instead of capturing, was worth
+0.2% of `tsp` at identical behaviour.
+
 ### "Search is unchanged" is a claim about the corpus, not about the change
 
 When a change touches something every search reads — variable degree, trigger or

--- a/dev_docs/propagator-performance.md
+++ b/dev_docs/propagator-performance.md
@@ -182,6 +182,20 @@ and only the per-item body is cheaper (a `test_literal` against a full propagato
 call). Reach for one when the propagator's whole verdict turns on a *literal*,
 not when it merely reads a few values.
 
+They are free to a model that arms *none*, though, which is most models. The round
+boundary asks once whether the watch index has anything in it at all, and a model
+that has armed nothing replays the round through a body with no firing block in
+it, instead of testing an index that will never have anything in it once for every
+inference of every round (issue #895). On the benchmarking.md set that is worth
+1.28% of `tsp`'s instructions, 0.83% of `magic_square --size=5`'s, 0.57% of
+`n_queens --size=14 --all`'s and about 0.2% of `qap` and `langford`, at identical
+search — and those are against an unmodified build, where the null-change control
+for touching `propagate()` at all is itself +0.15% to +0.52% (see
+benchmarking.md), so the change is worth more than the figures say.
+`ortho_latin --size=6 --all` is the exception and stays where it was: it is the
+one benchmark that does arm watches, since its `Equals` against a constant watches
+a literal as of #889, so it has nothing to hoist.
+
 **A `_micros` share is not necessarily wake cost.** `GCS_PROPAGATOR_STATS=time`
 brackets the propagator call, so a contradiction's `throw
 TrackedPropagationFailed` unwinds inside the sample. `lin_not_equals` on `tpp`

--- a/dev_docs/refined-triggers.md
+++ b/dev_docs/refined-triggers.md
@@ -121,6 +121,23 @@ is replayed exactly once and a watch not fired against it is never offered it
 again. Getting this wrong is invisible in everything but the node count; see
 issue #889, where it turned nmseq/100 from 767 nodes into 1,089,375.
 
+**Whether to look at the index at all is decided once per boundary, not once per
+inference.** A model that has armed no watch — most models — replays through
+`replay_inferences_of_watchless_model`, a separate body that wakes the coarse
+triggers and does nothing else: no firing block, and no test of an index that will
+never have anything in it. A model that has armed one replays through the body
+above, unchanged. The empty-index question is asked once, where the boundary picks
+between them (issue #895).
+
+Once per *boundary* is the load-bearing part. A propagator can arm the model's
+first watch in one round and need it fired at the next boundary of the same
+`propagate()` call, so an answer cached at entry to `propagate()` would drop that
+watch — silently, since a lost wake costs only pruning. Within a single replay the
+answer cannot go stale, because nothing can arm a watch while a replay is running:
+only a propagator arms one, and no propagator runs between the start of a replay
+and its end. The watchless path checks that rather than trusting it; see the
+invariants below.
+
 ### Trigger masks
 
 A literal can only *become* entailed on certain kinds of change, mirroring the
@@ -279,11 +296,21 @@ For anyone changing this code:
 - **Trigger masks must over-approximate.** A mask must include *every* `Inference`
   granularity that could make the literal newly entailed; too narrow a mask drops
   a fire (a missed inference). The differential catches this.
-- **Every replay path must fire watches.** A watch is a one-shot subscription and
-  each inference is replayed once, so any path that walks the round's inferences
-  and skips the watch index loses the wake permanently. `requeue` and
-  `requeue_unless_already_seen` share `fire_refined_watches` for exactly this
-  reason; a new variant must call it too.
+- **Every replay path must fire watches, unless the model has none to fire.** A
+  watch is a one-shot subscription and each inference is replayed once, so any path
+  that walks the round's inferences and skips the watch index loses the wake
+  permanently. There are two such paths and they are not interchangeable:
+  `requeue_honouring`, instantiated on `HonourClaims_`, which fires watches, and
+  `requeue_coarse_only`, which has no firing block at all and is reachable only
+  when the index is empty. A new variant must be one or the other deliberately.
+- **The watchless replay must only run against an empty index.** It was chosen
+  against the index as it stood when the boundary started, and a watch armed on a
+  variable it has already walked past would never be offered the inference that
+  entails it. The boundary re-tests `refined_watches_by_var.empty()` after the
+  watchless replay returns and throws if it is not, so an engine change that ran a
+  propagator mid-replay fails loudly instead of silently losing pruning. The test
+  is on that side of the branch only: a model with watches does not depend on the
+  answer and pays nothing for the question.
 - **Catch-up runs at root re-propagation only**, keyed off an empty fired set.
   That is where new clauses appear (after a restart unwind) and where the edits
   land in the persistent root epoch, keeping the non-backtrackable `set_up`
@@ -311,7 +338,11 @@ refined path must behave byte-for-byte like the scan oracle:
 - `gcs/innards/propagators_test.cc` — a watch must fire whether or not the round
   has an idempotence claimant. Neither vehicle above co-registers a claiming
   propagator, which is how the claim-path gap in the replay survived (#889), so
-  this one is a pair of unit cases rather than a differential.
+  this one is a pair of unit cases rather than a differential. A third case arms a
+  watch *during* a round rather than at install, which is what says the empty-index
+  question is re-asked at every boundary and not cached for the `propagate()` call
+  (#895); every other test here arms at install, where the distinction is
+  invisible.
 
 Each load-bearing piece has a **mutation test** recorded in the relevant PR:
 inject the bug, confirm a differential catches it, before trusting the check.

--- a/gcs/innards/propagators.cc
+++ b/gcs/innards/propagators.cc
@@ -853,6 +853,23 @@ auto Propagators::propagate(const Literals & guesses, State & state, ProofLogger
         }
     };
 
+    // The same wake for a model that has armed no refined watch at all: the coarse
+    // triggers and nothing else, with no firing block and no test of the watch index.
+    //
+    // A separate body rather than an `if constexpr (AnyWatches_)` inside the one
+    // above, which is what issue #895 proposed and what was tried first. Giving the
+    // shared body a second template parameter also changes what the compiler does
+    // with the watch-carrying instantiations, and on the one benchmark here that
+    // arms watches that cost more than the hoist saved. Written out separately, a
+    // model with watches goes on executing the body it executed before, instruction
+    // for instruction, and only the watchless path is new code.
+    auto requeue_coarse_only = [&]<bool HonourClaims_>(const SimpleIntegerVariableID & v, const Inference inf) {
+        if (v.index < _imp->iv_triggers.size())
+            for (auto & [p, mask] : _imp->iv_triggers[v.index].ids_and_masks)
+                if ((mask & (1 << to_underlying(inf))) && (! HonourClaims_ || ! _imp->claim_protected[p]))
+                    enqueue_if_idle(p);
+    };
+
     auto requeue = [&](const SimpleIntegerVariableID & v, const Inference inf) { requeue_honouring.template operator()<false>(v, inf); };
 
     auto requeue_unless_already_seen = [&](const SimpleIntegerVariableID & v, const Inference inf) {
@@ -966,6 +983,49 @@ auto Propagators::propagate(const Literals & guesses, State & state, ProofLogger
     auto orig_idle_end = _imp->idle_end;
     state.on_backtrack([&, orig_idle_end = orig_idle_end]() { _imp->idle_end = orig_idle_end; });
 
+    // The round boundary's replay, for a model whose watch index is empty: the
+    // coarse triggers alone, with no firing block and no test of an index with
+    // nothing in it.
+    //
+    // Written here rather than inside run(), and taking the tracker as a parameter
+    // rather than capturing it, because where this sits is worth instructions: with
+    // run() owning the closure, the code around the propagator dispatch grew enough
+    // to eat a third of what the hoist saved on tsp and all of it on qap. Whether it
+    // is then inlined is left to the compiler, which does inline it -- the call
+    // would be once per round boundary, not once per inference, so it is not worth
+    // pinning either way.
+    //
+    // The claims bookkeeping below is the same cursor walk as the one at the
+    // boundary itself, and the two have to stay in step: what differs between them
+    // is only which wake they call. Factoring the walk out and handing it the wake
+    // to use is what was tried first, and it is what costs the instructions -- the
+    // shared per-inference body then has to serve both, and the compiler's handling
+    // of the watch-carrying instantiation changes with it.
+    auto replay_inferences_of_watchless_model = [&](auto & tracker) {
+        if (_imp->idempotent_run_claims.empty()) {
+            for (const auto & [v, inf] : tracker.each_inference())
+                requeue_coarse_only.template operator()<false>(v, inf);
+        }
+        else {
+            for (const auto & c : _imp->idempotent_run_claims)
+                _imp->claim_protected[c.propagator_id] = 1;
+            auto claim = _imp->idempotent_run_claims.begin();
+            const auto claims_end = _imp->idempotent_run_claims.end();
+            std::size_t inference_index = 0;
+            for (const auto & [v, inf] : tracker.each_inference()) {
+                while (claim != claims_end && claim->end_inference_index <= inference_index) {
+                    _imp->claim_protected[claim->propagator_id] = 0;
+                    ++claim;
+                }
+                requeue_coarse_only.template operator()<true>(v, inf);
+                ++inference_index;
+            }
+            for (; claim != claims_end; ++claim)
+                _imp->claim_protected[claim->propagator_id] = 0;
+            _imp->idempotent_run_claims.clear();
+        }
+    };
+
     // The loop body is identical for either tracker (it only uses the shared base
     // interface plus the dual-overloaded propagation-function call), so run it on a
     // generic lambda. With no logger we use the lean SimpleInferenceTracker, whose
@@ -1006,9 +1066,38 @@ auto Propagators::propagate(const Literals & guesses, State & state, ProofLogger
                 // monotone, so the fixpoint is unique and the search tree identical --
                 // but inference attribution, and hence proof lines, the total and
                 // effectful propagation counts, can differ in either direction.)
+                //
+                // Which replay to walk them with is decided here, once per boundary.
+                // A model that has armed no refined watch at all -- most models, and
+                // five of the six in benchmarking.md -- takes a body with no firing
+                // block in it, rather than testing an index that will never have
+                // anything in it once for every inference of every round (#895).
+                //
+                // The question is asked at every boundary rather than once per
+                // propagate(), because a propagator can arm the model's first watch
+                // in one round and need it fired at the next boundary of the same
+                // call. Within one replay the answer cannot go stale: only a
+                // propagator arms a watch, from Triggers::refined at install or
+                // ctx.watch while propagating, and no propagator runs between the
+                // start of a replay and its end. That is a temporal fact about the
+                // hottest loop in the solver, though, and what rests on it is a
+                // watch armed on a variable the replay has already walked past: it
+                // would never be offered the inference that entails it, and a watch
+                // is a one-shot subscription replayed exactly once, so never offered
+                // it again. That costs pruning and nothing else, so it fails no test
+                // and shows up only in a node count -- which is how the wake loss in
+                // issue #889 stayed hidden. So the watchless path checks its
+                // assumption instead of asserting it in a comment. The check is on
+                // this side of the branch only: a model that does have watches is
+                // not relying on the answer, and pays nothing for the question.
                 _imp->enqueued_begin = 0;
                 _imp->enqueued_end = 0;
-                if (_imp->idempotent_run_claims.empty()) {
+                if (_imp->refined_watches_by_var.empty()) {
+                    replay_inferences_of_watchless_model(tracker);
+                    if (! _imp->refined_watches_by_var.empty()) [[unlikely]]
+                        throw UnexpectedException{"the refined watch index grew during a round boundary's inference replay"};
+                }
+                else if (_imp->idempotent_run_claims.empty()) {
                     for (const auto & [v, inf] : tracker.each_inference())
                         requeue(v, inf);
                 }

--- a/gcs/innards/propagators_test.cc
+++ b/gcs/innards/propagators_test.cc
@@ -364,6 +364,57 @@ TEST_CASE("A refined watch fires when the round has no idempotence claimant")
     CHECK(watcher_runs == 2);
 }
 
+// The round boundary asks once, before walking the round's inferences, whether the
+// model has armed any watch at all, and replays through a body with the firing
+// block compiled out when it has not (issue #895). That question has to be asked
+// again at every boundary: a propagator can arm the model's very first watch in
+// one round and need it fired at the next boundary of the same propagate() call,
+// so an answer cached at entry to propagate() would drop it --- silently, since a
+// lost wake costs only pruning.
+
+namespace
+{
+    // Arms its first watch on its first run rather than at install, so the watch
+    // index is empty when propagate() is entered and non-empty by the time the
+    // boundary replays. scope_only keeps x in scope while arming no coarse
+    // trigger, so any later run of it is its watch and nothing else.
+    auto install_late_arming_propagator(Propagators & propagators, SimpleIntegerVariableID x, int & runs, int & payloads_seen) -> void
+    {
+        Triggers triggers;
+        triggers.scope_only = {x};
+        propagators.install(
+            ConstraintID{NumberedConstraint{3}},
+            [&runs, &payloads_seen, x](const State &, auto &, ProofLogger * const, const RefinedWatchContext & ctx) -> PropagatorState {
+                ++runs;
+                payloads_seen += static_cast<int>(ctx.fired_payloads().size());
+                if (runs == 1)
+                    ctx.watch(x != 7_i, 42u);
+                return PropagatorState::Enable;
+            },
+            triggers);
+    }
+}
+
+TEST_CASE("A watch armed during a round fires at that propagate()'s next boundary")
+{
+    State state;
+    Stats stats;
+    Propagators propagators{stats};
+    auto x = state.allocate_integer_variable_with_state(0_i, 10_i);
+
+    int arming_runs = 0, payloads_seen = 0, puncher_runs = 0;
+    // Registration order is first-pass order: the arming propagator runs, and arms,
+    // before the puncher makes the hole its watch is waiting for.
+    install_late_arming_propagator(propagators, x, arming_runs, payloads_seen);
+    install_hole_punching_propagator(propagators, x, PropagatorState::Enable, puncher_runs);
+
+    REQUIRE(propagators.propagate(Literals{}, state, nullptr));
+    CHECK(! state.in_domain(x, 7_i));
+
+    CHECK(arming_runs == 2);
+    CHECK(payloads_seen == 1);
+}
+
 // Propagators::shared_derived_data: the store that lets several constraints
 // over one shared input derive something from it once between them. Keyed by
 // (input address, type), created empty on the first ask, and the same object


### PR DESCRIPTION
Part 1 of #895: the watch-index test on the inference-frequency path. Part 2
(indexing equality watches by value) is not here — it needs the inference record
to carry the removed value, which is a hot-path change wanting its own
measurement.

## What this does

#889 had to make the round-boundary replay fire refined watches on the
already-seen path as well as the claim-free one, which put
`if (v.index < refined_watches_by_var.size())` on a path that runs once per
inference. Most models have nothing in that index.

The question is now asked **once per boundary**: a model whose index is empty
replays through a second body that wakes the coarse triggers and does nothing
else, and a model that has armed a watch replays through exactly the code it did
before.

Once per boundary and not once per `propagate()`, because a propagator can arm
the model's first watch in one round and need it fired at the next boundary of
the same call. The watchless path re-tests the index when it returns and throws
if it grew, so the invariant is checked rather than asserted in a comment — on
that side of the branch only, so a model with watches pays nothing for the
question. `propagators_test` gains a case that arms a watch *during* a round,
which is what distinguishes the two; it fails on the cached form.

## Not the shape the issue proposed

The issue suggests an `if constexpr` second template parameter beside
`HonourClaims_`. That was tried first. Giving the shared wake body a second
parameter also changes what the compiler does with the watch-carrying
instantiations, and that cost `ortho_latin` more than the hoist saved anywhere.
A separate body leaves that instantiation alone — 443 instructions either side —
at the price of one duplicated claims-cursor walk, which the code says out loud.

## Measurements

Instructions, `perf stat`, medians of three, pinned, boost off. `recursions` and
`propagations` are identical in every row.

| | null change | this change |
|---|---|---|
| `tsp` | +0.235% | **−1.284%** |
| `magic_square --size=5` | +0.520% | **−0.834%** |
| `n_queens --size=14 --all` | +0.204% | **−0.569%** |
| `qap --size=12` | +0.146% | **−0.212%** |
| `langford --size=11` | +0.207% | **−0.147%** |
| `ortho_latin --size=6 --all` | +0.153% | +0.188% |

The **null change** column is a build with the same code added and the new path
made unreachable behind an always-false `volatile bool`. Not one added
instruction executes, and the count still moves that much — adding code to
`propagate()` changes inlining and register allocation around the code that was
already there. So the second column should be read against the first, not
against zero. `benchmarking.md` gains that as a method note.

## One correction to the issue

The issue says every model in the benchmarking.md set has an empty watch index.
That holds for five of them; **`ortho_latin` arms 18 watches** (91 index vars),
because it posts `Equals` against a constant and that has watched a literal
since #889. So it has nothing to hoist, and lands inside its own null-change
band. Its +0.69% in #889 was the fix doing its job, not overhead.

## Testing

- 829/829 on `release`, `sanitize`, and `-DGCS_TEST_CAP_DEFAULTS=OFF`, with
  `minizinc` and `cake_pb_cp` on `PATH` (so the MiniZinc cases and the verified
  scp chain actually run, 169 full workflow-2 chains).
- `langford --size=11 --restarts=100` explores the same 258,670 recursions,
  169,350 failures, 348 restarts and 2,746 learned nogoods on the refined and
  the scan path, before and after — the differential #889 was caught by.
- Mutation tested: hoisting the decision to `propagate()` entry fails the new
  unit case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LwP4aznqMKhCH8PLBmCdNi
