### PR TITLE
Abs: pick both hole rules' form by width, not by variable kind (#931)

### DIFF
--- a/dev_docs/large-domains.md
+++ b/dev_docs/large-domains.md
@@ -314,6 +314,20 @@ Two shapes come out of it, and their asymmetry is the useful part:
 
 Neither count depends on the range's width, which is the property that matters.
 
+**And neither depends on the operands being bare variables.** The resolutions
+name only order atoms of `v1` and `v2` and the two half-reified halves, so they
+are emitted over whichever encoded variable each operand resolves to — a
+registered view's own since #904. That had to be checked here rather than
+inherited from the `Element` and `In` retirements, because those rest on two
+ge-layer RUP bound lemmas "naming no bit vector", and these are `pol` steps that
+work by the operands' bit coefficients *cancelling*, which is exactly what a view
+could have broken. It does not: all five `abs_test` view lanes verify, the hole
+proofs under `--view-position=mixed` carry their runs as range literals on view
+proof variables (`p[0_neg_view_of__2_plus_13][in2_7]`), and dropping either
+direction's bound resolutions is rejected under views as well as bare (#931). The
+one operand that still keeps the per-value path is a **constant**, which has no
+order-encoding atom to resolve against at all.
+
 ### Sabotaging proof lines one at a time under-reports
 
 The same work produced a methodology result worth having, because the obvious way
@@ -515,15 +529,26 @@ The count goes from `|voi|` lines per removed *value* to `|voi|` per removed
 Measured: `Among`'s survey row falls from 32996 → 329996 steps across a 10x width
 to a flat 98.
 
-**And unlike `ArrayMinMax`, this one bridges views**, so `Among` needs no
-plain-variable restriction: 259 range removals on view variables under proofs,
-all verified. The difference is that every atom in these lines is on the *same*
-variable — its order atoms against its own eq atoms — and `need_gevar` pol-derives
-a view's chain links from the underlying variable's. `ArrayMinMax`'s lemmas have
-to carry an atom on `result` across a row to an atom on `var_i`, and it is the
-crossing, not the range, that views break. So "does this constraint's range
-justification stay within one variable" is the question to ask before restricting
-a rewrite to `SimpleIntegerVariableID`.
+**This one bridges views**, so `Among` needs no plain-variable restriction: 259
+range removals on view variables under proofs, all verified. Every atom in these
+lines is on the *same* variable — its order atoms against its own eq atoms — and
+`need_gevar` pol-derives a view's chain links from the underlying variable's.
+
+It was for a while the *only* one, and "does this constraint's range
+justification stay within one variable" was the question to ask before
+restricting a rewrite to `SimpleIntegerVariableID`: `ArrayMinMax`'s lemmas carry
+an atom on `result` across a row to an atom on `var_i`, and the crossing, not the
+range, was what views broke. **That question is retired.** #904 gave a registered
+view its own range literals over its own encoded variable, so an atom is taken
+over whichever encoding its operand resolves to, and the crossing lands in the
+same representation the model states its rows in. The guards went with it, in
+`equals`, `all_equal` and `min_max` (#904), `In` (#912), `Element` (#925) and
+`Abs` (#931), and there is no site left in the tree holding the old shape.
+
+What is left in its place is a *width* test — is this run wide enough to be worth
+stating as a range at all — and one genuine kind test, for a **constant**
+operand, which pins every bit and so has no order-encoding atom for a lemma or a
+resolution to name. Test for the constant, never for the view.
 
 **The related trap.** The *hull bound* `result <= max_i ub(var_i)`, which #815
 proposes as a small first fix, is a different problem and is still open. There the
@@ -615,6 +640,15 @@ Two kinds of check, and the difference matters:
   trips its own counter and not the other's — with two counters in one propagator,
   a row that trips *a* guard proves nothing about which loop it exercised.
 
+  Then **four**, because a third axis turned up later: both loops answered "can I
+  say a range about these?" with a *type* test, so a view on either operand sent
+  both of them down the per-value path the counters were watching. The two rows
+  above are bare on both sides and could not see it; `Abs/view-hole` and
+  `Abs/view-hole-preimage` are those rows with one operand wrapped and nothing
+  else changed, and they trip before #931 (100001 values walked) and survive
+  after it. Same finding as `Element/view-result` one family down, and the reason
+  for the standing rule below.
+
   What the counter at that site now counts is *moves of an interval walk*, not
   values (#867). A reason that says "these two domains do not overlap" one value
   at a time is width-proportional by construction, and the guard is then the only
@@ -671,14 +705,14 @@ is the part worth reading carefully:
 
 ### Where we stand
 
-79 constraint probes, plus 20 heuristic ones in the second table. The lane
+81 constraint probes, plus 20 heuristic ones in the second table. The lane
 itself is the authority — run it rather than trusting this table, which is a
 snapshot for orientation.
 
 | | constraints |
 |---|---|
 | **KnownTrip** (19) | `Power`, `PowerTable`, `AllDifferent`, `AllDifferentExcept`, `Count`, `NValue`, `AtMostOne`, `AtMostOneSmartTable`, `GlobalCardinality/hall`, `ArrayMinMax`, `LexSmartTable`, `SmartTable`, `Regular`, `RegularLegacy`, `RegularBacchus`, `MDD`, `Cumulative`, `Disjunctive`, `Knapsack` |
-| **Clean** (45) | the arithmetic family (with two rows of its own for `Abs`' interior holes), comparison, equality, linear, `AllDifferent` under `VC`, `Element` in both arms, on the index side, with a holey entry and with a *view* on the result, `AllEqual` with holes and without, `Among`, `In` in three rows (a constant candidate list, and a variable one in each of its two rules), `GlobalCardinality` open and closed, `Table` (both shapes), `ValuePrecede`, `SeqPrecedeChain`, `IncreasingChain`, `Lex`, `Sort`, `ArgSort`, `NegativeTable`, `Disjunctive2D`, `BinPacking`, `MinDistance`, `DifferenceConstraints`, `Nogoods` |
+| **Clean** (47) | the arithmetic family (with four rows of its own for `Abs`' interior holes, two of them view-wrapped), comparison, equality, linear, `AllDifferent` under `VC`, `Element` in both arms, on the index side, with a holey entry and with a *view* on the result, `AllEqual` with holes and without, `Among`, `In` in three rows (a constant candidate list, and a variable one in each of its two rules), `GlobalCardinality` open and closed, `Table` (both shapes), `ValuePrecede`, `SeqPrecedeChain`, `IncreasingChain`, `Lex`, `Sort`, `ArgSort`, `NegativeTable`, `Disjunctive2D`, `BinPacking`, `MinDistance`, `DifferenceConstraints`, `Nogoods` |
 | **NoWidePosition** (15) | the graph and permutation family, and the Boolean constraints |
 
 `Among`, `In`, `AllEqual/holes`, `GlobalCardinality` (open and closed), `Table`
@@ -694,19 +728,27 @@ remains** in its Hall reasoning, which the original probe could not reach — on
 cover value means there is no multi-value hall — so it now has a row of its own
 rather than being covered by association.
 
-**Every probe in this lane wraps nothing, and that is an axis of its own.**
-`Element/view-result` is the first row to put a view on anything. It is the GAC
-`Element` row with the result wrapped and nothing else changed, and before #924
-it walked 10^9 values while the bare row beside it removed two ranges: the
-result-union rule answered "can I say a range about these?" with a *type* test,
-so a view anywhere sent the whole rule down a per-value walk of the remainder.
-Nothing in this file could have caught that, because nothing in this file wraps.
+**Whether an operand is *wrapped* is an axis of its own, and for a long time no
+probe in this lane used it.** `Element/view-result` (#924) was the first row to
+put a view on anything. It is the GAC `Element` row with the result wrapped and
+nothing else changed, and before #925 it walked 10^9 values while the bare row
+beside it removed two ranges: the result-union rule answered "can I say a range
+about these?" with a *type* test, so a view anywhere sent the whole rule down a
+per-value walk of the remainder. Nothing in this file could have caught that,
+because nothing in this file wrapped.
 
-The general question is open and is not really about `Element`. Every constraint
-whose proof reasons about intervals has the same question to answer, and #904
-changed the answer for all of them at once; a lane that only ever asks it about
-bare variables cannot tell which ones were updated. One row is a start, not a
-policy.
+`Abs/view-hole` and `Abs/view-hole-preimage` (#931) are the same finding in the
+arithmetic family, and finding them by looking rather than by accident is what
+settles the method: **put a view-wrapped row wherever a rewrite has an operand it
+could wrap.** The lane exercised widths and holes and never *kinds*, so a
+fallback that is itself width-proportional was invisible to two audits of it.
+
+The general question was never about `Element` or `Abs`. Every constraint whose
+proof reasons about intervals has the same question to answer, and #904 changed
+the answer for all of them at once; a lane that only ever asks it about bare
+variables cannot tell which ones were updated. With #931 there is no site left in
+the tree still answering it the old way, but that is a fact about today's tree
+and not a property the lane enforces — the rows are what enforce it.
 
 It has a **third** site, and finding it was a lesson about the axes a row covers
 rather than about the constraint. `with_closed()` installs a propagator of its
@@ -978,7 +1020,7 @@ time, and the row is now flat at 93.
 | **Both** grow | 10x / 10x | `Power`, `PowerTable`, `NValue`, `Regular`, `RegularLegacy`, `RegularBacchus`, `MDD` |
 | **OPB only** | 10x / 1.0x | `Cumulative` (19046 → 190046 rows; one capacity line per time point, so it is H3 on the encoding side) |
 | **Steps only** | 1.0x / 10x | `GlobalCardinality/hall` (34-row OPB fixed, 43988 → 439988 steps) |
-| neither | 1.0x / 1.0x | everything else, 70 of 79 |
+| neither | 1.0x / 1.0x | everything else, 72 of 81 |
 
 The last row means "does not grow with the width", not "identical at both widths",
 and three entries in it are worth naming so nobody reads them as a promise.

--- a/gcs/constraints/abs/abs.cc
+++ b/gcs/constraints/abs/abs.cc
@@ -30,7 +30,6 @@
 using namespace gcs;
 using namespace gcs::innards;
 
-using std::get;
 using std::holds_alternative;
 using std::max;
 using std::min;
@@ -250,12 +249,23 @@ auto Abs::install_propagators(Propagators & propagators) -> void
             LargeDomainIterationCounter image_guard{"the number of values one Abs image pruning has walked"};
             LargeDomainIterationCounter preimage_guard{"the number of values one Abs preimage pruning has walked"};
 
-            // A range removal needs a range literal in its reason, and a view has
-            // none (issue #882), so anything but two plain variables keeps the
-            // per-value path. A constant v2 keeps it too, which is not merely the
-            // same restriction: the range lemmas below resolve against v2's
-            // order-encoding flags, and a constant has none.
-            auto both_simple = holds_alternative<SimpleIntegerVariableID>(v1) && holds_alternative<SimpleIntegerVariableID>(v2);
+            // A view operand needs nothing extra from either range rule. The
+            // lemmas below name no bit vector, only order conditions on v1 and on
+            // v2, so each is emitted over whichever encoded variable its operand
+            // resolves to -- a registered view's own, which since #904 is where
+            // its range literals live and is also the form the model states the
+            // two half-reified halves in, so the operands' coefficients still
+            // cancel. What picks the form is the width of the run, and both arms
+            // already test for that (#931).
+            //
+            // A *constant* operand is the one case that is not like a bare
+            // variable: it pins every bit, so it has no order-encoding atom for a
+            // resolution to name at all. The two directions were checked
+            // separately rather than assumed to mirror -- the image lemmas
+            // resolve an order atom of each operand against each half, and the
+            // preimage ones additionally resolve v1's two sign atoms -- and both
+            // want both operands, so one test serves them.
+            auto neither_constant = ! holds_alternative<ConstantIntegerVariableID>(v1) && ! v2_is_constant;
 
             auto [post_v2_lb, post_v2_ub] = state.bounds(v2);
             for (auto [lo, hi] : v2_set.each_interval_minus(image_set)) {
@@ -268,18 +278,17 @@ auto Abs::install_propagators(Propagators & propagators) -> void
                 // either way -- a v2 value survives iff v1 holds it or its
                 // negation -- so the search does not change, only how many
                 // inferences it takes to get there.
-                if (both_simple && clipped_lo < clipped_hi) {
+                if (neither_constant && clipped_lo < clipped_hi) {
                     inference.infer_not_in_range(logger, v2, clipped_lo, clipped_hi,
-                        JustifyExplicitly{
-                            [logger, v1s = get<SimpleIntegerVariableID>(v1), v2s = get<SimpleIntegerVariableID>(v2), clipped_lo = clipped_lo,
-                                clipped_hi = clipped_hi, abs_nonneg_le, abs_nonneg_ge, abs_neg_le, abs_neg_ge](const ReasonLiterals & r) {
-                                // The four halves stay optional in the capture and are
-                                // dereferenced here: define_proof_model does not run at
-                                // all with proofs off, so a capture-list dereference is
-                                // reading an empty optional on every call.
-                                justify_abs_hole_range(
-                                    *logger, r, v1s, v2s, clipped_lo, clipped_hi, *abs_nonneg_le, *abs_nonneg_ge, *abs_neg_le, *abs_neg_ge);
-                            },
+                        JustifyExplicitly{[logger, v1, v2, clipped_lo = clipped_lo, clipped_hi = clipped_hi, abs_nonneg_le, abs_nonneg_ge, abs_neg_le,
+                                              abs_neg_ge](const ReasonLiterals & r) {
+                                              // The four halves stay optional in the capture and are
+                                              // dereferenced here: define_proof_model does not run at
+                                              // all with proofs off, so a capture-list dereference is
+                                              // reading an empty optional on every call.
+                                              justify_abs_hole_range(*logger, r, v1, v2, clipped_lo, clipped_hi, *abs_nonneg_le, *abs_nonneg_ge,
+                                                  *abs_neg_le, *abs_neg_ge);
+                                          },
                             ThenRUP::Yes, hints::Abs{originator}},
                         ExplicitReason{ReasonLiterals{{not_in_range(v1, clipped_lo, clipped_hi), not_in_range(v1, -clipped_hi, -clipped_lo)}}});
                     continue;
@@ -314,7 +323,7 @@ auto Abs::install_propagators(Propagators & propagators) -> void
                 if (clipped_lo > clipped_hi)
                     continue;
 
-                if (both_simple) {
+                if (neither_constant) {
                     // Split at zero. A run that straddles it does have a single
                     // image to name -- abs([lo, hi]) is [0, max(-lo, hi)] -- but
                     // its own negation then decides nothing about v1's sign, and
@@ -329,12 +338,11 @@ auto Abs::install_propagators(Propagators & propagators) -> void
                             auto image_lo = piece_lo >= 0_i ? piece_lo : -piece_hi;
                             auto image_hi = piece_lo >= 0_i ? piece_hi : -piece_lo;
                             inference.infer_not_in_range(logger, v1, piece_lo, piece_hi,
-                                JustifyExplicitly{
-                                    [logger, v1s = get<SimpleIntegerVariableID>(v1), v2s = get<SimpleIntegerVariableID>(v2), piece_lo = piece_lo,
-                                        piece_hi = piece_hi, abs_nonneg_le, abs_nonneg_ge, abs_neg_le, abs_neg_ge](const ReasonLiterals &) {
-                                        justify_abs_preimage_range(
-                                            *logger, v1s, v2s, piece_lo, piece_hi, *abs_nonneg_le, *abs_nonneg_ge, *abs_neg_le, *abs_neg_ge);
-                                    },
+                                JustifyExplicitly{[logger, v1, v2, piece_lo = piece_lo, piece_hi = piece_hi, abs_nonneg_le, abs_nonneg_ge, abs_neg_le,
+                                                      abs_neg_ge](const ReasonLiterals &) {
+                                                      justify_abs_preimage_range(*logger, v1, v2, piece_lo, piece_hi, *abs_nonneg_le, *abs_nonneg_ge,
+                                                          *abs_neg_le, *abs_neg_ge);
+                                                  },
                                     ThenRUP::Yes, hints::Abs{originator}},
                                 ExplicitReason{ReasonLiterals{not_in_range(v2, image_lo, image_hi)}});
                             continue;

--- a/gcs/constraints/abs/abs_test.cc
+++ b/gcs/constraints/abs/abs_test.cc
@@ -99,12 +99,15 @@ auto run_dup_abs_test(bool proofs, pair<int, int> x_range) -> void
 // do reach that one. The *image* loop wants v1's image under abs to skip a run
 // that v2 contains, which takes a hole in v1 -- and before this existed, no test
 // in the suite reached it at all.
-auto run_abs_hole_test(bool proofs, const string & label, const vector<int> & v1_values, const vector<int> & v2_values) -> void
+auto run_abs_hole_test(
+    bool proofs, const ViewWrapConfig & view_cfg, const string & label, const vector<int> & v1_values, const vector<int> & v2_values) -> void
 {
+    auto wraps = wraps_for_positions(view_cfg, 2);
+
     // Sizes and extremes rather than the lists: preimage_far's v1 is 101 values
     // wide and dumping it buries every other line of the run.
-    print(cerr, "abs holes [{}] v1={} values in [{},{}] v2={} values in [{},{}]{}", label, v1_values.size(), v1_values.front(), v1_values.back(),
-        v2_values.size(), v2_values.front(), v2_values.back(), proofs ? " with proofs:" : ":");
+    print(cerr, "abs holes [{}] [{}] v1={} values in [{},{}] v2={} values in [{},{}]{}", label, view_wrap_config_label(view_cfg), v1_values.size(),
+        v1_values.front(), v1_values.back(), v2_values.size(), v2_values.front(), v2_values.back(), proofs ? " with proofs:" : ":");
     cerr << flush;
 
     set<pair<int, int>> expected, actual;
@@ -114,20 +117,13 @@ auto run_abs_hole_test(bool proofs, const string & label, const vector<int> & v1
                 expected.emplace(a, b);
     println(cerr, " expecting {} solutions", expected.size());
 
-    auto to_integers = [](const vector<int> & values) {
-        vector<Integer> result;
-        for (auto v : values)
-            result.push_back(Integer{v});
-        return result;
-    };
-
     Problem p;
-    auto v1 = p.create_integer_variable(to_integers(v1_values));
-    auto v2 = p.create_integer_variable(to_integers(v2_values));
+    auto v1 = create_integer_variable_or_constant_with_view(p, v1_values, wraps.at(0));
+    auto v2 = create_integer_variable_or_constant_with_view(p, v2_values, wraps.at(1));
     p.post(Abs{v1, v2});
 
-    auto proof_name = proofs ? make_optional("abs_test_holes_" + label) : nullopt;
-    solve_for_tests_checking_gac(p, proof_name, expected, actual, tuple{IntegerVariableID{v1}, IntegerVariableID{v2}});
+    auto proof_name = proofs ? make_optional("abs_test_holes_" + label + "_" + view_wrap_config_label(view_cfg)) : nullopt;
+    solve_for_tests_checking_gac(p, proof_name, expected, actual, tuple{v1, v2});
 
     check_results(proof_name, expected, actual);
 }
@@ -243,10 +239,11 @@ auto main(int argc, char * argv[]) -> int
         run_abs_initialiser_test("wide_asym_ub_dominant", {-5, 50}, {0, 80});
     }
 
-    // Sparse-domain hole rows, keyed to the two interior loops. Bare handles
-    // only: the interval path needs plain variables (a view has no range
-    // literal, #882), so a view-wrapped run takes the per-value path instead and
-    // these rows would say nothing about it.
+    // Sparse-domain hole rows, keyed to the two interior loops. These run under
+    // the view sweep as well as bare: since #931 a wrapped operand takes the
+    // same interval path a plain one does, and these are the only rows in the
+    // suite that reach either interior loop at all, so without them nothing
+    // exercises a range removal over a view's own encoding.
     auto contiguous = [](int lo, int hi) {
         vector<int> result;
         for (int v = lo; v <= hi; ++v)
@@ -280,11 +277,11 @@ auto main(int argc, char * argv[]) -> int
             continue;
         for (auto & [r1, r2] : data)
             run_abs_test(proofs, view_cfg, r1, r2);
+        for (auto & [label, v1_values, v2_values] : hole_data)
+            run_abs_hole_test(proofs, view_cfg, label, v1_values, v2_values);
         if (view_wrap_config_is_effectively_bare(view_cfg, n_positions)) {
             for (auto & x_range : dup_data)
                 run_dup_abs_test(proofs, x_range);
-            for (auto & [label, v1_values, v2_values] : hole_data)
-                run_abs_hole_test(proofs, label, v1_values, v2_values);
         }
     }
 

--- a/gcs/constraints/abs/justify.cc
+++ b/gcs/constraints/abs/justify.cc
@@ -65,8 +65,8 @@ auto gcs::innards::justify_abs_hole(ProofLogger & logger, const ReasonLiterals &
     // rest follows by RUP
 }
 
-auto gcs::innards::justify_abs_hole_range(ProofLogger & logger, const ReasonLiterals & reason, const SimpleIntegerVariableID & v1,
-    const SimpleIntegerVariableID & v2, Integer lo, Integer hi, ProofLine abs_nonneg_le, ProofLine abs_nonneg_ge, ProofLine abs_neg_le,
+auto gcs::innards::justify_abs_hole_range(ProofLogger & logger, const ReasonLiterals & reason, const IntegerVariableID & v1,
+    const IntegerVariableID & v2, Integer lo, Integer hi, ProofLine abs_nonneg_le, ProofLine abs_nonneg_ge, ProofLine abs_neg_le,
     ProofLine abs_neg_ge) -> void
 {
     auto & ids = logger.names_and_ids_tracker();
@@ -98,8 +98,8 @@ auto gcs::innards::justify_abs_hole_range(ProofLogger & logger, const ReasonLite
     // The two signs being a literal and its negation, the rest follows by RUP.
 }
 
-auto gcs::innards::justify_abs_preimage_range(ProofLogger & logger, const SimpleIntegerVariableID & v1, const SimpleIntegerVariableID & v2,
-    Integer lo, Integer hi, ProofLine abs_nonneg_le, ProofLine abs_nonneg_ge, ProofLine abs_neg_le, ProofLine abs_neg_ge) -> void
+auto gcs::innards::justify_abs_preimage_range(ProofLogger & logger, const IntegerVariableID & v1, const IntegerVariableID & v2, Integer lo,
+    Integer hi, ProofLine abs_nonneg_le, ProofLine abs_nonneg_ge, ProofLine abs_neg_le, ProofLine abs_neg_ge) -> void
 {
     auto & ids = logger.names_and_ids_tracker();
 

--- a/gcs/constraints/abs/justify.hh
+++ b/gcs/constraints/abs/justify.hh
@@ -32,13 +32,14 @@ namespace gcs::innards
     // signs being a literal and its negation, the conclusion follows by RUP.
     //
     // Four resolutions and two RUP lines per removed range, independent of its
-    // width, which is the property that matters. Both variables must be plain:
-    // a range literal on a view is not available (issue #882), and a constant
-    // has no order-encoding atoms to resolve against. Width-1 ranges are left
-    // to justify_abs_hole, which is what they canonicalise to anyway.
-    auto justify_abs_hole_range(ProofLogger & logger, const ReasonLiterals & reason, const SimpleIntegerVariableID & v1,
-        const SimpleIntegerVariableID & v2, Integer lo, Integer hi, ProofLine abs_nonneg_le, ProofLine abs_nonneg_ge, ProofLine abs_neg_le,
-        ProofLine abs_neg_ge) -> void;
+    // width, which is the property that matters. Neither variable may be a
+    // constant, which pins every bit and so has no order-encoding atom for
+    // these resolutions to name; a view is fine, because each atom is taken
+    // over whichever encoded variable its operand resolves to, and since #904
+    // a registered view has one of its own (#931). Width-1 ranges are left to
+    // justify_abs_hole, which is what they canonicalise to anyway.
+    auto justify_abs_hole_range(ProofLogger & logger, const ReasonLiterals & reason, const IntegerVariableID & v1, const IntegerVariableID & v2,
+        Integer lo, Integer hi, ProofLine abs_nonneg_le, ProofLine abs_nonneg_ge, ProofLine abs_neg_le, ProofLine abs_neg_ge) -> void;
 
     // The mirrored direction: justifies `~[v1 in lo..hi]` where the caller's
     // reason says v2 holds nothing in abs([lo, hi]). Takes no ReasonLiterals: all
@@ -51,9 +52,11 @@ namespace gcs::innards
     // active branch is needed and there is no case split left to close. Three
     // resolutions: the sign, and the two bounds it licenses.
     //
-    // Same plain-variable requirement as above.
-    auto justify_abs_preimage_range(ProofLogger & logger, const SimpleIntegerVariableID & v1, const SimpleIntegerVariableID & v2, Integer lo,
-        Integer hi, ProofLine abs_nonneg_le, ProofLine abs_nonneg_ge, ProofLine abs_neg_le, ProofLine abs_neg_ge) -> void;
+    // Same non-constant requirement as above, and for the same reason -- plus
+    // v1's two sign atoms, which this direction resolves against and the other
+    // does not.
+    auto justify_abs_preimage_range(ProofLogger & logger, const IntegerVariableID & v1, const IntegerVariableID & v2, Integer lo, Integer hi,
+        ProofLine abs_nonneg_le, ProofLine abs_nonneg_ge, ProofLine abs_neg_le, ProofLine abs_neg_ge) -> void;
 
     // The bound proofs below share their resolution shape between the
     // prepare-time initialiser and the run-time propagator. The initialiser

--- a/gcs/large_domain_audit_test.cc
+++ b/gcs/large_domain_audit_test.cc
@@ -215,6 +215,23 @@ namespace
             auto v1 = p.create_integer_variable(-probe_width, probe_width);
             p.post(Abs{v1, v2});
         });
+        add("Abs/view-hole", Expect::Clean, [](Problem & p) {
+            // The two rows above with one operand wrapped, and nothing else
+            // changed. They trip before #931, which is the same finding as
+            // Element/view-result one family down: the rule asked "can I say a
+            // range about these?" with a *type* test, so a view on either
+            // operand sent both hole loops down a per-value walk. The one
+            // genuine exemption left is a constant, which has no order-encoding
+            // atom for the lemmas to resolve against.
+            auto v1 = p.create_integer_variable(vector<Integer>{-probe_width, 0_i, probe_width});
+            auto v2 = wide_var(p);
+            p.post(Abs{v1, v2 + 1_i});
+        });
+        add("Abs/view-hole-preimage", Expect::Clean, [](Problem & p) {
+            auto v2 = p.create_integer_variable(vector<Integer>{0_i, probe_width});
+            auto v1 = p.create_integer_variable(-probe_width, probe_width);
+            p.post(Abs{v1 + 1_i, v2});
+        });
         add("Plus", Expect::Clean, [](Problem & p) {
             auto v = wide(p, 3);
             p.post(Plus{v[0], v[1], v[2]});


### PR DESCRIPTION
Closes #931.

Both of `Abs`' interior hole rules asked whether they could state a removal as a
range by testing that each operand was a bare `SimpleIntegerVariableID`. A view
on either side sent **both** loops — image and preimage — down a per-value walk
of the run, which is width-proportional: the audit lane's `Abs/hole` and
`Abs/hole-preimage` rows are `Clean` at `0..10^9` because each run goes in as the
one run it is, and the same instances with one operand wrapped walk 100001 values
and trip the guard.

The reason the test gave stopped being true with #904, which gave a registered
view its own range literals over its own encoded variable. This was the last site
in the tree carrying that shape — #904 retired it in `equals`, `all_equal` and
`min_max`, #912 in `In`, #925 in `Element` (#924).

## The crossing is a different argument from #925's

`Element`'s and `In`'s range justifications are two ge-layer RUP bound lemmas,
and #924's argument was that those "name no bit vector, only order conditions".
**`Abs`' justifiers are not that shape.** `justify_abs_hole_range` and
`justify_abs_preimage_range` are `pol` resolutions against the encoding's two
half-reified rows, and they work by the operands' bit coefficients *cancelling* —
exactly the thing a view could have broken. So it was established here rather
than inherited:

* **Every lane verifies.** `abs_test` bare, `--view-position=mixed`,
  `--view-wrap=8 --view-position=all`, `--view-wrap=10 --view-position=all` and
  `--view-wrap=17 --view-position=1`: 60 VeriPB runs per view lane and 74 bare,
  every one `s VERIFIED`, none `UNDER ASSERTIONS`.
* **The range path really fires on views.** Each `mixed` hole proof states its run
  as a range literal on a *view* proof variable —
  `p[0_neg_view_of__2_plus_13][in2_7]`, `p[1_view_of__1_plus_17][in2_7]` — so the
  removals are stated over the view's own encoding, not the underlying variable's.
* **Both directions' resolutions are load-bearing there.** Dropping the two
  nonneg-branch resolutions from `justify_abs_hole_range` is rejected under views
  (`abs_test_mixed.pbp:422`) and bare (`abs_test_w0_pall.pbp:144`); dropping the
  four bound resolutions from `justify_abs_preimage_range` is rejected at
  `abs_test_mixed.pbp:375` and `abs_test_w0_pall.pbp:139`. (#931 only sabotaged
  the image direction; the preimage one is a separate helper and was checked
  separately.)

## What replaces the type test

Both arms already carried the width test inside them (`clipped_lo < clipped_hi`,
`piece_lo < piece_hi`), so what was left to decide is the **constant** exemption,
which is real: a constant pins every bit, so it has no order-encoding atom for a
resolution to name, and `need_pol_item_defining_literal` throws on one.

#931 expected that test to be on `v2` in the image direction, and asked for the
preimage direction to be checked separately rather than assumed to mirror. Doing
that says **both directions want both operands**: the image lemmas resolve an
order atom of *each* operand against each half, and the preimage ones do that and
additionally resolve `v1`'s two sign atoms. So it is one flag, `neither_constant`,
serving both.

Both `LargeDomainIterationCounter`s stay, unlike #925 which dropped `Element`'s.
The constant fallback here is a genuine per-value walk — a constant `v2` against a
wide `v1` reaches it in the preimage direction — rather than a branch reached once
per interval.

## The tests were gated for the same retired reason

`abs_test.cc` skipped its hole rows under the view sweep because "the interval
path needs plain variables (a view has no range literal, #882)", so nothing in the
suite reached either interval path under a view *at all*. `run_abs_hole_test` now
takes the `ViewWrapConfig` and the rows run in every lane; that is where the
evidence above comes from. The generalisation is worth having: when a guard's
stated reason names views, the tests paired with it almost certainly name them
too — grep for the reason, not just the guard.

## Audit lane and survey

`large_domain_audit_test` gains `Abs/view-hole` and `Abs/view-hole-preimage`: the
two existing rows with one operand wrapped and nothing else changed. Both **trip
on `main`** and survive here:

```
Abs/view-hole                            Clean            trips            <-- MISMATCH
  detail: Large domain guard tripped: the number of values one Abs image
          pruning has walked is 100001, over the limit of 100000.
Abs/view-hole-preimage                   Clean            trips            <-- MISMATCH
```

The lane is 202 assertions green: 81 constraint rows at 47 `Clean` / 19
`KnownTrip` / 15 `NoWidePosition`, plus 20 heuristic rows. Proof-scaling survey:
both new rows flat (185 and 248 steps at 10^3 and at 10^4), 81 rows, 72 flat.

## Proof size

`abs_test --prove --seed=1`, same test rows on both sides, toggling only the
propagator test, total `.pbp` lines:

| lane | type test | here | |
|---|--:|--:|---|
| bare | 8794 | **8794** | byte-identical, all 148 artefacts |
| `mixed` | 19581 | **19406** | −0.9% |
| `w8 --view-position=all` | 19655 | **19324** | −1.7% |
| `w10 --view-position=all` | 19662 | **19847** | +0.9% |
| `w17 --view-position=1` | 13060 | **12725** | −2.6% |

The bare lane being byte-identical — all 74 `.opb` and all 74 `.pbp` — is the
check that this touches nothing it should not. Three of the four view lanes shrink
and one grows, so the effect is within ±2% either way and its sign depends on the
wrap; #931's "unlike `Element`, the proof gets smaller" was measured on `mixed`
alone and is too strong. `Element` went uniformly the other way (+1.2%) because
its range form costs two lemmas *per feasible index tuple*, where `Abs` pays a
fixed handful of resolutions *per run*. Neither number is the point: the per-value
form has no upper bound and this one does.

## Gates

* `ctest` **829/829** release, **829/829** again with `-DGCS_TEST_CAP_DEFAULTS=OFF`,
  **829/829** sanitize, and **833/833** under clang (the four extra are the
  clang-only lifetime-annotation lane). No skips: MiniZinc, `cake_pb_cp` and
  `opbdiff` all on `PATH`.
* `-DGCS_WERROR=ON` builds clean.
* Negative control: with the type test put back and the new rows kept, the lane
  fails on exit 42 with both new rows tripping.
* `clang-format --dry-run --Werror` clean.

`dev_docs/large-domains.md` retires the "does this constraint's range
justification stay within one variable" rule — the sentence that told this guard
to exist — and records that the lane's wrapped rows are now a deliberate axis
rather than one row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AsUZjNThjBFs7VsFkCQfux
