### PR TITLE
Ask whether a literal is entailed, not what it is (#895)

### DIFF
--- a/dev_docs/propagator-performance.md
+++ b/dev_docs/propagator-performance.md
@@ -282,6 +282,36 @@ Finally: guard every reason in a file, not just the hot ones. `comparison` was
 found by a family audit rather than by a profile, and "some of them are guarded"
 is exactly what made the file look finished.
 
+### Ask the cheapest question that settles it
+
+`State::test_literal` answers three ways — `DefinitelyTrue`, `DefinitelyFalse`,
+`Undecided` — so a caller that only wants to know whether a literal *holds* pays
+for the part of the answer it then throws away. For `x != v` entailment is settled
+by one `in_domain`, and `test_literal` goes on to call `has_single_value` purely to
+separate the two negative answers; each bounds operator reads both bounds where
+entailment needs one. `State::literal_is_entailed` is the same question with that
+tail not computed, and it is what the refined-watch firing loop, the
+two-watched-literal nogood store, `NegativeTable` and the difference graph were all
+actually asking.
+
+It is worth **5.9% of `nmseq/100`'s instructions and 2.3% of `magic_series
+--size=300`'s**, because the refined-watch scan asks it about 17 times per
+inference there and 98% of those are watches that have not fired (issue #895).
+Nothing else in benchmarking.md moves, because nothing else asks often enough.
+
+About as much again sits at the call site rather than in this function: the firing
+loop reaches `literal_is_entailed` through an out-of-line call and a `Literal`
+variant visit, and a prototype that inlined the whole test into the loop measured
+10.6% on the same instance. Collecting that means the watch carrying an
+`IntegerVariableCondition` rather than a `Literal`, which belongs with a triggers
+refactor. The lesson for the figure above: a narrower entry point recovers the
+work the wide one did, not the cost of reaching it.
+
+The general shape, which is worth looking for elsewhere: when a general-purpose
+query returns more than a hot caller uses, the surplus is not free. The fix is a
+narrower entry point *beside* the wide one, not a cheaper implementation of it —
+the callers who want all three answers still need all three.
+
 ### Don't throw from a propagator that fails in bulk
 
 `inference.contradiction(...)` signals failure by throwing

--- a/dev_docs/refined-triggers.md
+++ b/dev_docs/refined-triggers.md
@@ -103,9 +103,12 @@ with the `Inference` granularity `inf` (`BoundsChanged` / `InteriorValuesChanged
 
 1. If `inf` is **not** in the watch's `trigger_mask`, skip it (see *Trigger
    masks*).
-2. Otherwise test `state.test_literal(watch.literal)`. If `DefinitelyTrue`,
-   **fire**: append the payload to the owner's inbox, wake the owner, trail the
-   removal, and swap-remove the watch (consume).
+2. Otherwise ask `state.literal_is_entailed(watch.literal)`. If it is, **fire**:
+   append the payload to the owner's inbox, wake the owner, trail the removal, and
+   swap-remove the watch (consume). (`literal_is_entailed` rather than
+   `test_literal`, because the loop does not care whether an unfired watch is false
+   or merely undecided, and finding that out is most of the cost — see
+   propagator-performance.md.)
 
 The owner processes its fired set the next time it runs in the propagation queue
 — firing and processing are *decoupled* (the owner is the schedulable unit). This
@@ -149,7 +152,7 @@ forward-looking, and this table is where a future caller would come to find out
 what they do.
 
 `refined_watch_trigger_mask(literal)` derives this from the operator at arm time.
-The firing loop tests `test_literal` only when `inf` is in the mask, so e.g. an
+The firing loop asks `literal_is_entailed` only when `inf` is in the mask, so e.g. an
 `x == v` watch is never tested on a mere bound move — `x == v` cannot have become
 true there. This is **sound by the same granularity contract the coarse triggers
 rely on** (`on_instantiated` fires iff a variable becomes single-valued, etc.),

--- a/gcs/constraints/difference/difference_graph.cc
+++ b/gcs/constraints/difference/difference_graph.cc
@@ -430,7 +430,7 @@ namespace
         const vector<SimpleIntegerVariableID> & nodes, const vector<DifferenceStaticBound> & static_bounds) -> void
     {
         for (const auto & sb : static_bounds) {
-            if (sb.cond && LiteralIs::DefinitelyTrue != state.test_literal(*sb.cond))
+            if (sb.cond && ! state.literal_is_entailed(*sb.cond))
                 continue;
             Reason why = sb.cond ? Reason{ExplicitReason{ReasonLiterals{{*sb.cond}}}} : Reason{NoReason{}};
             if (sb.is_lower) {
@@ -1350,7 +1350,7 @@ auto gcs::innards::install_difference_propagator(Propagators & propagators, Stat
                 memory.active_edges.reserve(m);
                 memory.active_flags.resize(m);
                 for (size_t e = 0; e < m; ++e) {
-                    char active = (! arc_conditions[e] || LiteralIs::DefinitelyTrue == state.test_literal(*arc_conditions[e])) ? 1 : 0;
+                    char active = (! arc_conditions[e] || state.literal_is_entailed(*arc_conditions[e])) ? 1 : 0;
                     memory.active_flags[e] = active;
                     if (active)
                         memory.active_edges.push_back(e);

--- a/gcs/constraints/nogoods/nogoods.cc
+++ b/gcs/constraints/nogoods/nogoods.cc
@@ -109,7 +109,7 @@ namespace
             for (size_t p = 0; p < nogood.size(); ++p) {
                 if (p == skip)
                     continue;
-                if (state.test_literal(nogood[p]) != LiteralIs::DefinitelyTrue)
+                if (! state.literal_is_entailed(nogood[p]))
                     return p;
             }
             return nullopt;
@@ -158,13 +158,13 @@ namespace
                 for (size_t ni = watches->size(); ni < nogoods->size(); ++ni)
                     init_watches_for(ni, *nogoods, *nogood_vars, *watches, state, inference, logger);
 
-                auto is_broken = [&](const Nogood & nogood, size_t p) -> bool { return state.test_literal(nogood[p]) == LiteralIs::DefinitelyTrue; };
+                auto is_broken = [&](const Nogood & nogood, size_t p) -> bool { return state.literal_is_entailed(nogood[p]); };
 
                 auto find_unbroken = [&](const Nogood & nogood, size_t skip1, size_t skip2) -> optional<size_t> {
                     for (size_t p = 0; p < nogood.size(); ++p) {
                         if (p == skip1 || p == skip2)
                             continue;
-                        if (state.test_literal(nogood[p]) != LiteralIs::DefinitelyTrue)
+                        if (! state.literal_is_entailed(nogood[p]))
                             return p;
                     }
                     return nullopt;
@@ -261,7 +261,7 @@ namespace
                     for (size_t p = 0; p < nogood.size(); ++p) {
                         if (p == skip1 || p == skip2)
                             continue;
-                        if (state.test_literal(nogood[p]) != LiteralIs::DefinitelyTrue)
+                        if (! state.literal_is_entailed(nogood[p]))
                             return p;
                     }
                     return nullopt;
@@ -307,7 +307,7 @@ namespace
                 sort(fired);
                 fired.erase(unique(fired.begin(), fired.end()), fired.end());
 
-                auto is_broken = [&](const Nogood & nogood, size_t p) { return state.test_literal(nogood[p]) == LiteralIs::DefinitelyTrue; };
+                auto is_broken = [&](const Nogood & nogood, size_t p) { return state.literal_is_entailed(nogood[p]); };
 
                 for (size_t ni : fired) {
                     const auto & nogood = (*nogoods)[ni];

--- a/gcs/constraints/table/negative_table.cc
+++ b/gcs/constraints/table/negative_table.cc
@@ -177,7 +177,7 @@ namespace
                 for (size_t p = 0; p < vars.size(); ++p) {
                     if (p == skip)
                         continue;
-                    if (state.test_literal(vars[p] == t[p]) != LiteralIs::DefinitelyTrue)
+                    if (! state.literal_is_entailed(vars[p] == t[p]))
                         return p;
                 }
                 return nullopt;
@@ -219,7 +219,7 @@ namespace
             for (size_t p = 0; p < vars.size(); ++p) {
                 if (p == skip1 || p == skip2)
                     continue;
-                if (state.test_literal(vars[p] == t[p]) != LiteralIs::DefinitelyTrue)
+                if (! state.literal_is_entailed(vars[p] == t[p]))
                     return p;
             }
             return nullopt;
@@ -259,7 +259,7 @@ namespace
         sort(fired);
         fired.erase(unique(fired.begin(), fired.end()), fired.end());
 
-        auto is_broken = [&](const auto & t, size_t p) { return state.test_literal(vars[p] == t[p]) == LiteralIs::DefinitelyTrue; };
+        auto is_broken = [&](const auto & t, size_t p) { return state.literal_is_entailed(vars[p] == t[p]); };
 
         for (size_t ti : fired) {
             const auto & t = tuple_data[ti];

--- a/gcs/innards/inference_tracker.hh
+++ b/gcs/innards/inference_tracker.hh
@@ -694,7 +694,7 @@ namespace gcs::innards
                 if (logger && logger->get_assertion_level() == AssertionLevel::Off) {
                     auto any_will_fire = false;
                     for (const auto & lit : lits)
-                        if (_state.test_literal(lit) != LiteralIs::DefinitelyTrue) {
+                        if (! _state.literal_is_entailed(lit)) {
                             any_will_fire = true;
                             break;
                         }

--- a/gcs/innards/propagators.cc
+++ b/gcs/innards/propagators.cc
@@ -212,7 +212,7 @@ namespace
     // identity used to find and undo the watch on backtrack. `trigger_mask` is the
     // set of Inference granularities that could make `literal` newly entailed (see
     // refined_watch_trigger_mask); a change outside it cannot fire this watch, so
-    // the firing loop skips the test_literal for it.
+    // the firing loop skips the entailment test for it.
     struct RefinedWatch
     {
         Literal literal;
@@ -263,7 +263,7 @@ namespace
     // over Inference -- mirroring the coarse iv_triggers masks. `x == v` can only
     // become true when x is instantiated; `x >= k` / `x < k` only when a bound
     // moves (an interior removal never changes a bound); `x != v` on any value
-    // removal. So the firing loop can skip the (expensive) test_literal for a watch
+    // removal. So the firing loop can skip the entailment test for a watch
     // whose literal cannot have flipped under the current inference. The mask is
     // derived from the literal alone -- the engine knows each operator's entailment
     // semantics -- so every client benefits without passing anything extra.
@@ -821,8 +821,8 @@ auto Propagators::propagate(const Literals & guesses, State & state, ProofLogger
     //
     // A watch is only tested when the current inference granularity is in its
     // trigger_mask -- e.g. an `x==v` watch is skipped on a mere bound move, since
-    // x==v can only become true when x is instantiated. This gates the expensive
-    // test_literal; the firing of a watch outside its mask would be a no-op
+    // x==v can only become true when x is instantiated. This gates the entailment
+    // test; the firing of a watch outside its mask would be a no-op
     // anyway (the literal cannot have changed status), so this is
     // semantics-preserving.
     auto requeue_honouring = [&]<bool HonourClaims_>(const SimpleIntegerVariableID & v, const Inference inf) {
@@ -837,7 +837,7 @@ auto Propagators::propagate(const Literals & guesses, State & state, ProofLogger
             const auto inf_bit = 1u << to_underlying(inf);
             auto & watches = _imp->refined_watches_by_var[v.index];
             for (std::size_t i = 0; i < watches.size();) {
-                if ((watches[i].trigger_mask & inf_bit) && state.test_literal(watches[i].literal) == LiteralIs::DefinitelyTrue) {
+                if ((watches[i].trigger_mask & inf_bit) && state.literal_is_entailed(watches[i].literal)) {
                     const auto fired = watches[i];
                     if (_imp->inbox_by_propagator[fired.owner].empty())
                         _imp->pending_inbox_owners.push_back(fired.owner);

--- a/gcs/innards/state.cc
+++ b/gcs/innards/state.cc
@@ -853,6 +853,44 @@ auto State::test_literal(const IntegerVariableCondition & cond) const -> Literal
     throw NonExhaustiveSwitch{};
 }
 
+auto State::literal_is_entailed(const Literal & lit) const -> bool
+{
+    return overloaded{
+        [&](const IntegerVariableCondition & cond) -> bool { return literal_is_entailed(cond); }, //
+        [](const TrueLiteral &) { return true; },                                                 //
+        [](const FalseLiteral &) { return false; }                                                //
+    }
+        .visit(lit);
+}
+
+// Each arm is the DefinitelyTrue arm of test_literal above, and nothing else: the
+// reads that only separate DefinitelyFalse from Undecided are not made. For
+// NotEqual that is a whole has_single_value call saved on the common answer, and
+// for the bounds operators one of the two bounds. See the header for why a caller
+// would want this rather than test_literal.
+auto State::literal_is_entailed(const IntegerVariableCondition & cond) const -> bool
+{
+    switch (cond.op) {
+        using enum VariableConditionOperator;
+    case Equal:
+        // Entailed exactly when the domain is the single value: that implies the
+        // in_domain test_literal makes, and is one read rather than two.
+        return optional_single_value(cond.var) == cond.value;
+
+    case NotEqual: return ! in_domain(cond.var, cond.value);
+
+    case Less: return upper_bound(cond.var) < cond.value;
+
+    case GreaterEqual: return lower_bound(cond.var) >= cond.value;
+
+    case InRange: return lower_bound(cond.var) >= cond.value && upper_bound(cond.var) <= cond.upper_value;
+
+    case NotInRange: return ! domain_intersects_with(cond.var, IntervalSet<Integer>{cond.value, cond.upper_value});
+    }
+
+    throw NonExhaustiveSwitch{};
+}
+
 auto State::on_backtrack(std::function<auto()->void> f) -> void
 {
     _imp->on_backtracks.back().push_back(move(f));

--- a/gcs/innards/state.hh
+++ b/gcs/innards/state.hh
@@ -574,6 +574,46 @@ namespace gcs::innards
         }
 
         /**
+         * Is the specified Literal definitely true? Exactly
+         * `test_literal(lit) == LiteralIs::DefinitelyTrue`, but without
+         * establishing which of the other two answers applies when it is not.
+         *
+         * That distinction is not free. `x != v` is settled as entailed by a
+         * single in_domain, and test_literal then calls has_single_value purely
+         * to tell DefinitelyFalse from Undecided; each bounds operator likewise
+         * reads both bounds where entailment needs one. A caller that only asks
+         * whether a literal holds should ask this instead: it is the same
+         * question, with the part of the answer it was going to discard not
+         * computed.
+         *
+         * \sa State::test_literal()
+         */
+        [[nodiscard]] auto literal_is_entailed(const Literal &) const -> bool;
+
+        /**
+         * Is the specified IntegerVariableCondition definitely true?
+         *
+         * \sa State::literal_is_entailed(const Literal &)
+         */
+        [[nodiscard]] auto literal_is_entailed(const IntegerVariableCondition &) const -> bool;
+
+        /**
+         * A TrueLiteral is entailed. Performance overload.
+         */
+        [[nodiscard]] inline auto literal_is_entailed(const TrueLiteral &) const -> bool
+        {
+            return true;
+        }
+
+        /**
+         * A FalseLiteral is not entailed. Performance overload.
+         */
+        [[nodiscard]] inline auto literal_is_entailed(const FalseLiteral &) const -> bool
+        {
+            return false;
+        }
+
+        /**
          * Return the single value held by this IntegerVariableID, or throw
          * VariableDoesNotHaveUniqueValue.
          *

--- a/gcs/innards/state_test.cc
+++ b/gcs/innards/state_test.cc
@@ -1,3 +1,4 @@
+#include <gcs/innards/inference_tracker.hh>
 #include <gcs/innards/state.hh>
 
 #include <catch2/catch_test_macros.hpp>
@@ -337,6 +338,82 @@ TEST_CASE("copy_of_values / domains_intersect on multi-interval negated views")
         CHECK(state.domains_intersect(-a, d));
         CHECK(state.domains_intersect(d, -a)); // symmetry
     }
+}
+
+// literal_is_entailed is defined as exactly the DefinitelyTrue answer of
+// test_literal, arrived at without working out which of the other two applies. So
+// the property to test is the identity, over every operator and over domains that
+// have been pushed into every shape that matters: full, holed, bound-narrowed and
+// instantiated, on plain variables, on views and on constants. Testing the arms
+// against hand-written expectations instead would let both functions be wrong in
+// the same way; testing them against each other cannot.
+
+namespace
+{
+    auto check_entailment_matches_test_literal(State & state, const std::vector<IntegerVariableID> & vars) -> void
+    {
+        for (const auto & var : vars)
+            for (auto value = -8_i; value <= 12_i; ++value)
+                for (const auto & lit : std::vector<Literal>{var == value, var != value, var < value, var >= value, in_range(var, value, value + 3_i),
+                         not_in_range(var, value, value + 3_i)})
+                    CHECK(state.literal_is_entailed(lit) == (state.test_literal(lit) == LiteralIs::DefinitelyTrue));
+    }
+}
+
+TEST_CASE("literal_is_entailed agrees with test_literal on every operator and domain shape")
+{
+    State state;
+    auto x = state.allocate_integer_variable_with_state(1_i, 8_i);
+    auto y = state.allocate_integer_variable_with_state(0_i, 4_i);
+
+    std::vector<IntegerVariableID> vars{x, y, -x, x + 3_i, -x + 6_i, constant_variable(5_i)};
+
+    SECTION("untouched domains")
+    {
+        check_entailment_matches_test_literal(state, vars);
+    }
+
+    SECTION("a hole punched in the middle")
+    {
+        SimpleInferenceTracker inference{state};
+        inference.infer(nullptr, x != 4_i, NoJustificationNeeded{}, NoReason{});
+        inference.infer(nullptr, x != 5_i, NoJustificationNeeded{}, NoReason{});
+        check_entailment_matches_test_literal(state, vars);
+    }
+
+    SECTION("bounds narrowed to a range")
+    {
+        SimpleInferenceTracker inference{state};
+        inference.infer(nullptr, x >= 3_i, NoJustificationNeeded{}, NoReason{});
+        inference.infer(nullptr, x < 7_i, NoJustificationNeeded{}, NoReason{});
+        check_entailment_matches_test_literal(state, vars);
+    }
+
+    SECTION("narrowed to a single value")
+    {
+        SimpleInferenceTracker inference{state};
+        inference.infer(nullptr, x == 6_i, NoJustificationNeeded{}, NoReason{});
+        inference.infer(nullptr, y == 0_i, NoJustificationNeeded{}, NoReason{});
+        check_entailment_matches_test_literal(state, vars);
+    }
+
+    SECTION("holed and then narrowed, so the domain is neither contiguous nor single")
+    {
+        SimpleInferenceTracker inference{state};
+        inference.infer(nullptr, x != 3_i, NoJustificationNeeded{}, NoReason{});
+        inference.infer(nullptr, x != 6_i, NoJustificationNeeded{}, NoReason{});
+        inference.infer(nullptr, x >= 2_i, NoJustificationNeeded{}, NoReason{});
+        check_entailment_matches_test_literal(state, vars);
+    }
+}
+
+TEST_CASE("literal_is_entailed on constant literals")
+{
+    State state;
+    CHECK(state.literal_is_entailed(Literal{TrueLiteral{}}));
+    CHECK_FALSE(state.literal_is_entailed(Literal{FalseLiteral{}}));
+    CHECK(state.literal_is_entailed(TrueLiteral{}));
+    CHECK_FALSE(state.literal_is_entailed(FalseLiteral{}));
 }
 
 TEST_CASE("Every way of iterating a domain hands values out in ascending order")


### PR DESCRIPTION
`State::test_literal` answers three ways, so a caller that only wants to know
whether a literal *holds* pays for the part of the answer it discards. For
`x != v` entailment is settled by the `in_domain` call, and `test_literal` then
calls `has_single_value` purely to separate `DefinitelyFalse` from `Undecided`;
each bounds operator reads both bounds where entailment needs one.

`State::literal_is_entailed` is the same question with that tail not computed.
**Eleven call sites were already asking it** and throwing the rest away: the
refined-watch firing loop, the two-watched-literal nogood store (5), `NegativeTable`
(3), the difference graph (2), and the `infer_all` short-circuit.

## Where it pays

The refined-watch firing loop. On `nmseq/100` — FlatZinc's `int_eq_reif` against a
constant, the model #889 and #895 are about — the loop asks the question **99.0 M
times over 5.81 M inferences, 17 per inference, and 97.8 % of those are watches
that have not fired**.

Instructions, `perf stat`, medians of two, pinned, boost off. `recursions` and
`propagations` identical in every row:

| | |
|---|---|
| `nmseq/100` | **−5.87 %** |
| `magic_series --size=300` | **−2.27 %** |
| `tsp` | +0.015 % |
| `magic_square --size=5` | +0.009 % |
| `ortho_latin --size=6 --all` | +0.023 % |
| `qap --size=12` | 0.000 % |
| `langford --size=11` | −0.008 % |
| `n_queens --size=14 --all` | +0.051 % |

The rest of the set does not move — nothing else asks often enough — and those six
rows sit well inside the ±0.15 % band `propagate()` moves by for a change that
executes nothing at all (the null-change control documented in #932).

**About as much again is still on the table**, at the firing site rather than in
this function: a prototype that inlined the check into the loop, instead of calling
out of line and visiting the `Literal` variant on the way, measured **−10.6 %** on
the same instance. Getting that means the watch carrying an
`IntegerVariableCondition` rather than a `Literal`, which belongs with a triggers
refactor, not here.

For context on what is left after both: one full scan of the watch list costs 27 %
of `nmseq/100`'s instructions (measured by running the scan twice and taking the
delta, which leaves the search untouched), and 97.8 % of it is wasted. Indexing
equality watches by value — part 2 of #895 — is what removes the rest.

## Testing

The property is the *identity* with `test_literal`, not hand-written expectations
per arm, which would let both functions be wrong in the same way. `state_test`
gains a differential over every operator, on plain variables, views, negated views
and constants, against domains that are full, holed, bound-narrowed, instantiated,
and holed-then-narrowed — **5,179 assertions**.

**Mutation tested one arm at a time** (`Equal` → `in_domain`, `NotEqual` → wrong
value, `Less`/`GreaterEqual` → the other bound, `InRange` → half the test,
`NotInRange` → `in_domain`): each is caught by between 81 and 251 assertions.

- 829/829 on `release` and `sanitize`, with `minizinc` and `cake_pb_cp` on `PATH`.
- `langford --size=11 --restarts=100` explores the same 258,670 recursions and
  learns the same 2,746 nogoods on the refined and the scan path, before and after
  — the check that matters for the nogood store's five sites.

Based on `main`, not on #932, so the two are independent; they touch neighbouring
lines in `propagator-performance.md` and `refined-triggers.md` and may want a
trivial merge in whichever lands second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LwP4aznqMKhCH8PLBmCdNi
