### PR TITLE
Find a generic reason's holes by its intervals, not by its values (#935)

### DIFF
--- a/dev_docs/large-domains.md
+++ b/dev_docs/large-domains.md
@@ -665,6 +665,18 @@ Two kinds of check, and the difference matters:
   covers the walk, which is what it was ever counting. The remaining variable
   with no range literal is a bits-less (direct-only, so zero-one) one, which has
   no interior run to state.
+
+  **The restatement and the walk that finds it are two different costs, and #935
+  is the one where only the second was wrong.** `materialise_generic()` in
+  `reason.cc` already stated a holey domain as one `not_in_range` per run — the
+  right output — but found those runs by testing every value between the bounds
+  for membership. A domain is an `IntervalSet`; its runs are the gaps between
+  consecutive intervals, so they can be read off rather than searched for. Three
+  variables of three values each, spread over `0..10^9`, cost 16.8 s of run-finding
+  under `Among` and now cost nothing measurable. **So the question to ask of an
+  interval rewrite is not only "is the output one literal per run" but "is the
+  work one step per run" — a site can pass the first and fail the second, and the
+  proof-scaling survey cannot tell, because the proof was already the right size.**
 * **`GCS_CHECK_LARGE_DOMAIN`** checks a size up front, for the H3 sites that
   commit to a whole array at once.
 
@@ -705,14 +717,14 @@ is the part worth reading carefully:
 
 ### Where we stand
 
-81 constraint probes, plus 20 heuristic ones in the second table. The lane
+82 constraint probes, plus 20 heuristic ones in the second table. The lane
 itself is the authority — run it rather than trusting this table, which is a
 snapshot for orientation.
 
 | | constraints |
 |---|---|
 | **KnownTrip** (19) | `Power`, `PowerTable`, `AllDifferent`, `AllDifferentExcept`, `Count`, `NValue`, `AtMostOne`, `AtMostOneSmartTable`, `GlobalCardinality/hall`, `ArrayMinMax`, `LexSmartTable`, `SmartTable`, `Regular`, `RegularLegacy`, `RegularBacchus`, `MDD`, `Cumulative`, `Disjunctive`, `Knapsack` |
-| **Clean** (47) | the arithmetic family (with four rows of its own for `Abs`' interior holes, two of them view-wrapped), comparison, equality, linear, `AllDifferent` under `VC`, `Element` in both arms, on the index side, with a holey entry and with a *view* on the result, `AllEqual` with holes and without, `Among`, `In` in three rows (a constant candidate list, and a variable one in each of its two rules), `GlobalCardinality` open and closed, `Table` (both shapes), `ValuePrecede`, `SeqPrecedeChain`, `IncreasingChain`, `Lex`, `Sort`, `ArgSort`, `NegativeTable`, `Disjunctive2D`, `BinPacking`, `MinDistance`, `DifferenceConstraints`, `Nogoods` |
+| **Clean** (48) | the arithmetic family (with four rows of its own for `Abs`' interior holes, two of them view-wrapped), comparison, equality, linear, `AllDifferent` under `VC`, `Element` in both arms, on the index side, with a holey entry and with a *view* on the result, `AllEqual` with holes and without, `Among` contiguous and holey, `In` in three rows (a constant candidate list, and a variable one in each of its two rules), `GlobalCardinality` open and closed, `Table` (both shapes), `ValuePrecede`, `SeqPrecedeChain`, `IncreasingChain`, `Lex`, `Sort`, `ArgSort`, `NegativeTable`, `Disjunctive2D`, `BinPacking`, `MinDistance`, `DifferenceConstraints`, `Nogoods` |
 | **NoWidePosition** (15) | the graph and permutation family, and the Boolean constraints |
 
 `Among`, `In`, `AllEqual/holes`, `GlobalCardinality` (open and closed), `Table`
@@ -749,6 +761,15 @@ the answer for all of them at once; a lane that only ever asks it about bare
 variables cannot tell which ones were updated. With #931 there is no site left in
 the tree still answering it the old way, but that is a fact about today's tree
 and not a property the lane enforces — the rows are what enforce it.
+
+**`Among/holey` is the same lesson on a second axis: wide, holey, and reaching a
+*reason*.** The lane had ten wide-and-holey rows before it and not one of them
+reached a reason — `Among`, `Table`, `Nogoods`, `MinDistance` and `In/vars` all
+post contiguous wide variables — so `materialise_generic()`'s per-value
+run-finding, which sits behind the 31 constraints that call `generic_reason()`,
+was invisible here (#935). The axes a row can vary are the width, the holes, the
+variable's *kind*, and whether the probe gets as far as materialising a reason;
+most rows vary only the first.
 
 It has a **third** site, and finding it was a lesson about the axes a row covers
 rather than about the constraint. `with_closed()` installs a propagator of its
@@ -1020,7 +1041,7 @@ time, and the row is now flat at 93.
 | **Both** grow | 10x / 10x | `Power`, `PowerTable`, `NValue`, `Regular`, `RegularLegacy`, `RegularBacchus`, `MDD` |
 | **OPB only** | 10x / 1.0x | `Cumulative` (19046 → 190046 rows; one capacity line per time point, so it is H3 on the encoding side) |
 | **Steps only** | 1.0x / 10x | `GlobalCardinality/hall` (34-row OPB fixed, 43988 → 439988 steps) |
-| neither | 1.0x / 1.0x | everything else, 72 of 81 |
+| neither | 1.0x / 1.0x | everything else, 73 of 82 |
 
 The last row means "does not grow with the width", not "identical at both widths",
 and three entries in it are worth naming so nobody reads them as a promise.

--- a/gcs/innards/reason.cc
+++ b/gcs/innards/reason.cc
@@ -1,3 +1,4 @@
+#include <gcs/innards/large_domain_guard.hh>
 #include <gcs/innards/reason.hh>
 #include <gcs/innards/state.hh>
 
@@ -9,13 +10,13 @@ using namespace gcs;
 using namespace gcs::innards;
 
 using std::optional;
-using std::pair;
 
 namespace
 {
-    // Walk every value in each variable's domain (lower bound, upper bound, and
-    // any holes), appending the facts to `reason`. This is the materialisation
-    // of GenericReasonOver.
+    // State each variable's domain exactly -- its lower bound, its upper bound,
+    // and one range condition per interior run of missing values -- appending the
+    // facts to `reason`. This is the materialisation of GenericReasonOver. The
+    // cost is one step per run, not per value; see the note on the runs below.
     auto materialise_generic(const State & state, const std::vector<IntegerVariableID> & vars, ReasonLiterals & reason) -> void
     {
         for (const auto & var : vars) {
@@ -39,22 +40,31 @@ namespace
                     // variable is a zero-one one, whose domain has no interior value
                     // and so no run to state. Anything that made a wider variable
                     // direct-only would have to revisit this.
-                    optional<pair<Integer, Integer>> run;
-                    auto flush = [&]() {
-                        if (run) {
-                            reason.push_back(not_in_range(var, run->first, run->second));
-                            run.reset();
+                    //
+                    // The runs are read off the domain's intervals rather than found
+                    // by walking its values: the gap between two consecutive intervals
+                    // IS a maximal run of missing values, so this costs one step per
+                    // run where the walk cost one per value of the whole bounds range
+                    // (issue #935). copy_of_values() hands the intervals over in the
+                    // variable's own value order, negated views included, so the runs
+                    // come out ascending and identical to what the walk produced.
+                    // Inline rather than IntervalSet::each_gap_interval(), which is a
+                    // coroutine, because this is on the propagation path.
+                    //
+                    // One step per run is a much better cost but still not a bound --
+                    // a domain can have as many runs as it has values, and a reason
+                    // has to name every one -- so the counter stays, now measuring the
+                    // quantity that is actually unbounded.
+                    LargeDomainIterationCounter guard{"the number of runs one generic reason materialisation has stated"};
+                    auto values = state.copy_of_values(var);
+                    optional<Integer> prev_hi;
+                    values.for_each_interval([&](Integer lo, Integer hi) {
+                        if (prev_hi) {
+                            guard.step();
+                            reason.push_back(not_in_range(var, *prev_hi + 1_i, lo - 1_i));
                         }
-                    };
-                    for (auto v = bounds.first + 1_i; v < bounds.second; ++v) {
-                        if (state.in_domain(var, v))
-                            flush();
-                        else if (run)
-                            run->second = v;
-                        else
-                            run = pair{v, v};
-                    }
-                    flush();
+                        prev_hi = hi;
+                    });
                 }
             }
         }

--- a/gcs/large_domain_audit_test.cc
+++ b/gcs/large_domain_audit_test.cc
@@ -373,6 +373,25 @@ namespace
             auto v = wide(p, 3);
             p.post(Among{v, {1_i, 2_i}, p.create_integer_variable(3_i, 3_i)});
         });
+        add("Among/holey", Expect::Clean, [](Problem & p) {
+            // The row above, with each domain given two interior gaps. A different
+            // axis, not a sharper version of it: `Among` materialises a
+            // generic_reason over its whole scope on every propagation, and before
+            // #935 that reason found its runs by walking every value between a
+            // variable's bounds rather than reading them off its intervals.
+            //
+            // Wide *and* holey *and* reaching a reason is what it takes. This file
+            // had ten wide-and-holey rows already and not one of them reached a
+            // reason -- `Among`, `Table`, `Nogoods`, `MinDistance` and `In/vars` all
+            // post contiguous wide variables -- so a per-value walk sitting behind
+            // 31 constraints was invisible to it. The counter is on the run-finding,
+            // which is unbounded in its own right: a domain can have as many runs as
+            // it has values, and a reason has to name every one.
+            vector<IntegerVariableID> v;
+            for (int i = 0; i < 3; ++i)
+                v.push_back(p.create_integer_variable(vector<Integer>{wide_lo, probe_width / 2_i, probe_width}));
+            p.post(Among{v, {1_i, 2_i}, p.create_integer_variable(3_i, 3_i)});
+        });
         add("Count", Expect::KnownTrip, [](Problem & p) {
             // H1c: a genuine per-value support scan over the value variable.
             auto v = wide(p, 3);


### PR DESCRIPTION
Closes #935.

`materialise_generic()` states a variable's domain as its two bounds plus one
`not_in_range` per interior run of missing values. That *output* is right, and has
been since #904 made a view's range conditions available. What was wrong is how it
found the runs — it tested **every value between the bounds** for membership:

```cpp
for (auto v = bounds.first + 1_i; v < bounds.second; ++v)
    if (state.in_domain(var, v)) ...
```

A domain is an `IntervalSet`, and the gap between two consecutive intervals *is* a
maximal run of missing values, so the runs can be read off in one step each.
`copy_of_values()` hands them over in the variable's own value order, negated views
included, so the runs come out ascending and the emitted literals are unchanged.

## Why it was worth finding

`generic_reason()` has **31 callers**, so this sat behind a large part of the tree.
It is also not proof-only: the inference tracker defers materialisation when there is
no logger, but `among.cc:167` calls `eager_reason()` unconditionally, so every `Among`
propagation paid it whether or not anything would read the result.

Three variables of three values each, spread over `0..w`, under `Among`, proofs off:

| span | before | here |
|---:|---:|---:|
| 10^6 | 15 ms | **0 ms** |
| 10^7 | 153 ms | **0 ms** |
| 10^8 | 1685 ms | **0 ms** |
| 10^9 | **16847 ms** | **0 ms** |

Nine values in the whole problem, and seventeen seconds of it. What was walked is
`ub - lb`, so the cost was set by how far apart a domain's values are, not by how many
there are.

## The counter stays, and it is not the vacuous kind

#925 removed `element.cc`'s counter because the branch above it took every run of two
or more values, so it would have been counting intervals. This one is different: one
step per run is a much better cost but still **not a bound**, because a domain can have
as many runs as it has values and a reason has to name every one.

## A new lane axis, not a sharper probe

`large_domain_audit_test` gains `Among/holey` — the existing `Among` row with two
interior gaps in each domain. The lane had **ten wide-and-holey rows already and not one
of them reached a reason**: `Among`, `Table`, `Nogoods`, `MinDistance` and `In/vars` all
post contiguous wide variables. That is why a per-value walk behind 31 constraints was
invisible to two audits of this file.

The axes a row can vary are the width, the holes, the variable's *kind*, and whether the
probe gets as far as materialising a reason. Most rows vary only the first.

## Gates

* **The emitted reasons are unchanged, which is the real test here.** 22 constraint test
  binaries at `--seed=1` under `GCS_PRESERVE_PROOF_FILES=all`: **2198 proof artefacts,
  byte-identical, none differing.**
  *(Unseeded, the suite reseeds every run and the comparison measures the seed instead —
  14142 of 25513 artefacts "differ" that way, on a change that alters nothing. Worth
  knowing before anyone repeats this check.)*
* `ctest` **829/829** release, **829/829** with `-DGCS_TEST_CAP_DEFAULTS=OFF`,
  **829/829** sanitize, **833/833** clang. `-DGCS_WERROR=ON` clean. No skips: MiniZinc,
  `cake_pb_cp` and `opbdiff` all on `PATH`.
* Audit lane 204 assertions green: 82 constraint rows at 48 `Clean` / 19 `KnownTrip` /
  15 `NoWidePosition`, plus 20 heuristic rows.
* Proof-scaling survey: 82 rows, 73 flat; `Among/holey` flat at 96 OPB rows and 169
  steps across a 10x width.
* Rebased onto `main` after #933 merged; lane and survey tallies above are re-derived
  from a run on the rebased tree, and `ctest` is 829/829 again there.
* Negative control: put the per-value walk back, keep the counter on it, and the lane
  fails on exit 42 with `Among/holey` tripping at 100001.

## Left alone deliberately

`lex.cc`, `smart_table.cc`, `circuit_scc.cc`, `regular_legacy.cc`, `regular.cc` and
`mdd.cc` call `eager_reason()` with the same lack of a guard as `Among`. Now that the
walk is proportional to the runs, those are an ordinary `want_reasons()` question rather
than a #833 hazard, so they are not touched here.

#936 is the other half of the same sweep: bounds `GlobalCardinality`'s `capacity_reason`
emits one literal **per absent value** in a confined variable's span, so there the
reason itself is width-proportional and not just the walk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AsUZjNThjBFs7VsFkCQfux