### PR TITLE
Certified GF(2) reasoning over a conjunction of XORs (#647)

### DIFF
--- a/dev_docs/README.md
+++ b/dev_docs/README.md
@@ -342,6 +342,19 @@ library. For an introduction to *using* the solver, start with the top-level
   punched, because it crossed a bounds-consistent `int_lin_eq`, and fixing that
   took mario from 4/15 optimal to 9/15 — the same bug is in four more
   redefinitions (#803).
+- [`ParitySystem`: GF(2) reasoning over a conjunction of XORs](parity-system.md) —
+  the design and as-built note for issue #647: why a single `ParityOdd` is
+  already GAC and all the remaining inference lives in the conjunction, the
+  Gocht-Nordstrom slack form under which a Gaussian elimination step is one
+  `pol`, and why it has to be *derived in-proof* from cake's accumulator chain
+  rather than written into the `.opb` (a presolver has no `ProofModel`, and a
+  row cake did not emit is not chain-portable). Records the per-step `red` pair
+  and the five-line subproof that bridges the two encodings — linear, where the
+  paper's CNF recovery is exponential, because our chain already *is* its
+  partial-parity split — the §4.3 fold that makes every inference one `pol` plus
+  one RUP whatever the size of the combination, and the two mutations that
+  survive because they only remove slack the wrapping RUP replaces. Read before
+  touching `ParityOdd`'s encoding, whose rows the derivation cites.
 - [`MinDistance`: encoding and proofs](min-distance-proofs.md) — the definitional
   OPB encoding for `min_distance(D, x, z)` (site-selection flags, per-site counts,
   pair clauses, and the min-attained ladder), the justification for each of the

--- a/dev_docs/README.md
+++ b/dev_docs/README.md
@@ -353,8 +353,15 @@ library. For an introduction to *using* the solver, start with the top-level
   paper's CNF recovery is exponential, because our chain already *is* its
   partial-parity split — the §4.3 fold that makes every inference one `pol` plus
   one RUP whatever the size of the combination, and the two mutations that
-  survive because they only remove slack the wrapping RUP replaces. Read before
-  touching `ParityOdd`'s encoding, whose rows the derivation cites.
+  survive because they only remove slack the wrapping RUP replaces. Also covers
+  `ParitySystemGathering`, the presolver that collects posted `ParityOdd` and
+  Boolean `Equals` / `NotEquals` constraints into per-component systems, why a
+  two-literal donor needs two RUP lines where a chain needs a `red` per step, the
+  measured node-for-node tripwire and the strength differentials that say the
+  gathering buys anything at all, and the two API extensions it forced — a
+  published naming *object* for a family of rows, and a `family` on
+  `ProofFlagKey`, without which `v[id][1]` and `x[id][1]` had the same key. Read
+  before touching `ParityOdd`'s encoding, whose rows the derivation cites.
 - [`MinDistance`: encoding and proofs](min-distance-proofs.md) — the definitional
   OPB encoding for `min_distance(D, x, z)` (site-selection flags, per-site counts,
   pair clauses, and the min-attained ladder), the justification for each of the

--- a/dev_docs/parity-system.md
+++ b/dev_docs/parity-system.md
@@ -1,7 +1,7 @@
 # `ParitySystem`: GF(2) reasoning over a conjunction of XORs
 
-Working note for issue #647. **Status: the constraint is built and its proofs
-verify with zero assertions. `ParitySystemGathering` is not written yet.**
+Working note for issue #647. **Status: built. `ParitySystem` and
+`ParitySystemGathering` both verify with zero assertions.**
 
 `ParityOdd` reasons about one XOR at a time (`gcs/constraints/parity/parity.cc`,
 the `if (++how_many_unknown > 1) return` bail-out). That is GAC for a single
@@ -284,13 +284,10 @@ component with at least two rows. A single-row component is left to its own
 
 `ParitySystemGathering`, in `gcs/presolvers/parity_system_gathering/`, built to
 the `DifferenceLogic` pattern: a shared `ComponentStats` block registered
-unconditionally at the top of `run()`, donor discovery through
-`Problem::each_constraint_of_type_with_proof_data` so the rows it cites are
-named by the donor's published role rather than by a label it built itself, and
-one bucket per reason a candidate was passed over — because a presolver that
-silently gathered nothing passes every solution-equivalence, OPB byte-diff and
-VeriPB check there is, and the counts are the only thing that tells "working"
-from "no-op".
+unconditionally at the top of `run()`, and one bucket per reason a candidate was
+passed over — because a presolver that silently gathered nothing passes every
+solution-equivalence check, OPB byte-diff and VeriPB run there is, and the counts
+are the only thing that tells "working" from "no-op".
 
 Donors come from two families.
 
@@ -300,47 +297,100 @@ Donors come from two families.
 essentially all of this presolver's `Top` output goes.
 
 **Boolean `Equals` / `NotEquals`**, when both operands' declared domains are
-within `{0, 1}` — checkable from the `State` the presolver is handed. `x = y`
-is the 2-XOR `[x != 0] XOR [y != 0] = 0`; `x != y` is the same with
-right-hand side 1. This is where a MiniZinc model's `bool_eq` and `bool_not`
-rows come from, and they are worth having because they are the edges that
-connect otherwise separate XOR components.
+within `{0, 1}`. `x != y` is `[x != 0] XOR [y != 0] = 1`; `x = y` is the same
+with one literal negated, since `!p` is `p XOR 1`. Both are `ReifiedEquals`,
+which is what `clone()` returns, so that is what the enumeration asks for, and
+`reification_condition()` is what says which; `enforces_equality()` is the
+accessor that actually distinguishes them, because `MustNotHold` on an `Equals`
+and `MustHold` on a `NotEquals` are two spellings of the same thing and only one
+is constructible.
 
-Both are `ReifiedEquals` — `Equals` is `reif::MustHold`, `NotEquals` is
-`reif::MustNotHold` — and `clone()` returns the base, so the enumeration asks
-for `ReifiedEquals` and dispatches on `reification_condition()`, exactly as
-`DifferenceLogic` does over `ReifiedLinearInequality`. `ReifiedEquals`
-currently publishes neither its operands nor a `ConstraintProofModelData`, so
-both get added, and the published data has to name **two** rows rather than one
-primary (`Cumulative` is the precedent for a specialisation with more than one
-named role).
+They are worth having less for the rows themselves than for the **atoms they
+share**: they are the edges that join what would otherwise be separate
+components. That is the measured effect, not a hope — see the differentials
+below.
 
-These are also *much* cheaper to lift than a `ParityOdd`, which is the part
-worth writing down: with only two literals, `B` needs no fresh variable, so
-neither donor needs a `red` at all.
+They are also much cheaper to derive, and the reason is worth stating. With two
+literals `B` is zero, so the slack form is just `l1 + l2 = 1`, and **both halves
+are plain RUP** against rows the donor already emitted: negating either half
+fixes both operands and walks straight into one of them. Two RUP lines at `Top`,
+no witness, no subproof, no fresh variables, nothing cited by name.
 
-- `Equals` emits `v1 - v2 == 0` as the labelled pair
-  `ge` / `le`. Writing `a` for `[x != 0]` and `b` for `[y != 0]`, those rows
-  *are* (4.4a) and (4.4b) with right-hand side 0 and `B = b`: `a + b >= 0 + 2b`
-  is `a - b >= 0`, and `a + b <= 0 + 2b` is `a - b <= 0`. Nothing to derive —
-  the donor's own two rows are the slack form, cited directly.
-- `NotEquals` emits big-M `gt` / `lt` rows half-reified on a per-constraint
-  selector flag `b[id][ne]` (cake's `nev`), the flag true selecting `gt`. Here
-  `B = 0`, so the slack form is just `a + b >= 1` and `a + b <= 1`, and both
-  are plain **RUP** against those two rows: negating `a + b >= 1` assigns
-  `a = b = 0`, which unit-propagates the selector through the `lt` row and then
-  falsifies `gt`; negating `a + b <= 1` assigns `a = b = 1`
-  and falsifies the other way round. Two RUP lines at `Top`, no witness, no
-  subproof.
+### Components
 
-The one thing to check rather than assume: for a `{0, 1}` variable, the literal
-`[x != 0]` and the variable's own OPB bit have to resolve to the same
-`XLiteral`, or the `pol` cancellation in §3 does not happen. Go through
-`NamesAndIDsTracker::need_pol_item_defining_literal`, never the surface form.
+The posted XORs usually split into connected components, and eliminating over
+the whole model when the rows do not interact is pure waste. The presolver
+canonicalises every candidate together — so that two donors mentioning the same
+fact land in the same column — unions atoms sharing a row, and installs one
+propagator per component of at least two rows. A single-row component is left to
+its own donor, which computes exactly the same thing more cheaply, and its
+propagator is not retired.
 
-Everything else is skipped and counted: a non-`MustHold` reification kind, an
-operand whose domain is not within `{0, 1}`, a donor whose row cannot be cited
-(only ever possible with proofs on), a row that cancels to nothing.
+A row whose atoms all cancel (`ParityOdd({x, x})`, which says `0 = 1`) has no
+atoms, so it shares none and is alone by construction. It is left to its donor
+too, and that is the right answer rather than a gap: its own propagator refutes
+it the moment `x` is decided.
+
+### Donors are retired by default
+
+Unlike `DifferenceLogic`'s equivalent, which ships off. The system propagator
+subsumes a single XOR's unit propagation outright — a donor row with one literal
+left is a unit row of the reduced system — so a gathered donor is pure overhead
+on every wake. `keeping_donor_propagators()` exists so the subsumption claim can
+be checked rather than assumed, and it is a strong check: disabling a propagator
+changes neither degrees nor adjacency, so the search tree must come out **node
+for node identical**. Measured, on every tripwire fixture:
+
+| fixture | kept | retired |
+|---|---|---|
+| `chain` | 2 solutions / 3 recursions / 14 propagations | 2 / 3 / **5** |
+| `camouflage` | 0 / 1 / 4 | 0 / 1 / **1** |
+| `two_components` | 4 / 7 / 24 | 4 / 7 / **14** |
+| `bool_bridge` | 2 / 3 / 14 | 2 / 3 / **5** |
+
+Identical trees, a third to a half of the propagation.
+
+### What it is measured to buy
+
+The equivalence and tripwire tests would both pass for a presolver that gathered
+the rows and then inferred nothing from them, so there is a third test that is
+the point of the whole exercise: on a system that is unsatisfiable while no
+single row of it conflicts, Gauss-Jordan refutes it without searching and unit
+propagation cannot.
+
+| fixture | no presolver | gathered |
+|---|---|---|
+| `camouflage` (three rows over a cycle summing to `0 = 1`) | 3 recursions | **1** |
+| `bool_bridge_unsat` (two rows that conflict only once an equality identifies their variables) | 3 recursions | **1** |
+
+Small numbers, but the right shape, and the second one is what says the Boolean
+family is doing work rather than merely being counted.
+
+### The API this needed
+
+Two extensions, both because the existing shapes were built for what had been
+needed so far.
+
+- **`ConstraintProofModelData<ParityOdd>` publishes a naming *object*,
+  `ParityChainNaming`, rather than loose role functions.** `Cumulative` publishes
+  several loose ones and that is fine for it; here every name in the family is
+  indexed the same way, by the same optional row index, and bundling them means a
+  citer cannot pick up one without the rest or mix an unprefixed role with a
+  prefixed flag. `define_parity_chain` and `find_parity_chain` both build every
+  name through it, so there is exactly one place the names exist.
+- **`ProofFlagKey` gained a `family`, and `find_proof_flag_values` became
+  `find_proof_flag`.** This was a latent defect rather than a missing feature: a
+  key carried numbers and an annotation but not which of cake's flag families it
+  meant, so `v[id][1]` and `x[id][1]` — different flags — had the same key. The
+  lookup hard-coded `v`, which worked only for as long as nothing needed the
+  other one. `ParityOdd`'s accumulators are cake's `x[id][k]` and cannot be
+  anything else, so they needed `Indices`. The creation side already indexed both
+  families; only the lookup was narrow. `Values` is the default, so every existing
+  published key is unchanged.
+
+Everything else the presolver needed was already there: `Presolver::run`'s
+`ProofLogger *` is enough to resolve labels and flags, because the tracker exists
+by then, and `install_initialiser` from a presolver has worked since PR #658.
 
 ## The constraint
 
@@ -367,26 +417,30 @@ reaches.
 
 ## What this touches in existing code
 
-- `ParityOdd` gains an accessor for its literals, and a
-  `ConstraintProofModelData<ParityOdd>` specialisation in `parity.hh`
-  publishing what the derivation cites: the four per-step clause roles, the
-  `0ge` / `0le` / `acc` roles, and the accumulator `ProofFlagKey`s (values
-  `{k}`, no annotation). Publishing is the point — the alternative is the
-  presolver hard-coding another constraint's naming scheme, which is what
-  `ConstraintProofModelData` exists to stop.
-- `ReifiedEquals` gains operand accessors and its own specialisation, naming
-  both rows of each reification kind it supports.
-- `gcs/constraints/parity.hh` (the umbrella) picks up `parity_system.hh`, and
-  `gcs/gcs.hh` picks up nothing new, since it already includes
-  `constraints/parity.hh` — but the new header must reach it in the same commit
-  as the constraint, not as a follow-up.
-- `gcs/constraint_enumeration_test.cc` gets `ParityOdd` and `ReifiedEquals`
-  cases: the enumeration is a `dynamic_cast` on what `clone()` returns, so it
-  finds nothing at all if `clone()` ever starts returning a type outside the
-  family, and that is a silent failure everywhere else.
-- `dev_docs/README.md` gets an entry for this document, and
-  `dev_docs/frontend-support-matrix.md` a row — neither the constraint nor the
-  presolver is reachable from any frontend at first, and the matrix is the
+- `ParityOdd` gained a `literals()` accessor and a
+  `ConstraintProofModelData<ParityOdd>` specialisation publishing
+  `chain_naming()`. `primary_row_role` is honestly nullopt: a chain is a family,
+  four clauses per literal plus three pins, and no one of them is the row a
+  citer could mean.
+- `ReifiedEquals` gained `left_variable()`, `right_variable()`,
+  `reification_condition()` and `enforces_equality()`. No
+  `ConstraintProofModelData` specialisation, deliberately: nothing cites any of
+  its rows by name, because both halves of a two-literal slack form are RUP.
+- `ProofFlagKey` gained `family`, and `NamesAndIDsTracker::find_proof_flag_values`
+  became `find_proof_flag`. See "The API this needed".
+- `gcs/constraints/parity.hh` picks up `parity_system.hh`; `gcs/gcs.hh` needed
+  nothing new, since it already includes the umbrella.
+- `gcs/scp_reader.cc` reads the `parity_system` form back, so a `.scp` this
+  writes round-trips. Cake has no such rule, and `Nogoods` is the precedent for
+  a form that is ours alone.
+- `gcs/constraint_enumeration_test.cc` gained cases for `ParityOdd` and
+  `ReifiedEquals`: the enumeration is a `dynamic_cast` on what `clone()` returns,
+  so it would find nothing at all if either started returning something else, and
+  that is a failure the presolver's own counts would report as "gathered
+  nothing".
+- `dev_docs/README.md` has an entry for this document.
+  `dev_docs/frontend-support-matrix.md` still needs a row: neither the constraint
+  nor the presolver is reachable from any frontend yet, and the matrix is the
   single source of truth for that.
 
 ## Staging
@@ -442,12 +496,11 @@ is not the certificate, the RUP around it is, and a mutation that removes
 slack is a corruption VeriPB is right to accept. What bites is corrupting the
 *claim* — which is what the five rejections all do.
 
-**The presolver comes after all five**, not alongside them. It has its own gate:
-the counts in its stats block, which is the only thing that distinguishes
-"gathered the system" from "silently gathered nothing" — the lesson
-`DifferenceLogicStats` is written around — plus the node-for-node tripwire that
-with donors *not* retired the search tree must be identical, since the system
-propagator subsumes every donor's single-XOR unit propagation.
+**The presolver came after all five**, with its own three gates rather than a
+staged bring-up, because it adds no new proof shape for the `ParityOdd` family
+and only the two-RUP shape for the Boolean one: the exact counts in its stats
+block, the node-for-node tripwire, and the strength differential. All three are
+in "The presolver" above with their measured numbers.
 
 ## What would exercise it
 
@@ -465,20 +518,18 @@ line count are the numbers this design is making claims about.
 
 ## Decisions taken
 
-1. **`ParitySystem` installs child `ParityOdd`s** rather than writing a slack
-   form into its own OPB. Writing the slack form directly would make
-   elimination free and is much less code, but it would leave two proof paths
-   to keep in step and a `ParitySystem` whose proofs are checked against
-   nothing but our own OPB. One derivation, exercised by both entry points, is
-   worth the extra work.
-2. **Rows are all odd**, as above.
+1. **`ParitySystem` shares `ParityOdd`'s encoding emitter** rather than writing a
+   slack form into its own OPB, so the posted constraint and the presolver derive
+   their slack rows the same way, through one piece of code. The means changed
+   from the original plan: installing child `ParityOdd` constraints does not work,
+   because a child takes the parent's `ConstraintID` and *k* identical children
+   would collide on every row label. Extracting `define_parity_chain` keeps the
+   substance and drops the child propagators, which were not wanted anyway.
+2. **Rows are all odd**, matching `ParityOdd`; an even row is written with one
+   literal negated, which is what the canonicalisation does internally.
 3. **Both donor families**: `ParityOdd`, and Boolean `Equals` / `NotEquals`.
-4. **Donors are retired by default.** The issue says "replaces", and the system
-   propagator subsumes every donor's single-XOR unit propagation, so a donor
-   that has been lifted is pure overhead. The hybrid stays available behind an
-   option because it is the stage-5 tripwire: with donors kept, the search tree
-   must come out node-for-node identical, and it differing means the
-   subsumption claim is wrong.
+4. **Donors are retired by default**, with `keeping_donor_propagators()` as the
+   tripwire. See "Donors are retired by default".
 
 ## Residue
 
@@ -498,3 +549,18 @@ line count are the numbers this design is making claims about.
   at `Top` and citing those rows instead is the obvious next move, and it is a
   measurement, not a guess: it trades `Top` footprint (which taxes every later
   unhinted RUP) against per-inference line count.
+- Components inside `ParitySystem` itself. The presolver splits its rows; the
+  posted constraint eliminates over everything it was given as one system. Pure
+  waste when the rows a caller passed do not interact, and the machinery is
+  already there — `install_parity_system_propagator` is per-component by
+  construction — so this is a few lines whenever someone posts a system big
+  enough to care.
+- The MiniZinc side. Nothing exposes the presolver to `fzn-glasgow` yet, so the
+  `parity-learning` and `cryptanalysis` benchmarks above cannot be run without
+  wiring a flag through. That is the next thing to do, and it is also what turns
+  every number here from a fixture measurement into a real one.
+- No benchmark numbers at all. Everything measured above is a handful of
+  three- and four-variable fixtures. The `Top` footprint, the per-inference line
+  count and the wall-clock are all claims this design makes and nothing has yet
+  checked at scale — see [proof-benchmarks.md](proof-benchmarks.md) for what to
+  measure and [benchmarking.md](benchmarking.md) for how.

--- a/dev_docs/parity-system.md
+++ b/dev_docs/parity-system.md
@@ -1,0 +1,409 @@
+# `ParitySystem`: GF(2) reasoning over a conjunction of XORs
+
+Working-design note for issue #647. **Draft: nothing here has been built, and
+the derivation in §2 is the part to disbelieve until VeriPB has accepted it.**
+
+`ParityOdd` reasons about one XOR at a time (`gcs/constraints/parity/parity.cc`,
+the `if (++how_many_unknown > 1) return` bail-out). That is GAC for a single
+XOR — unit propagation on one parity constraint *is* GAC, because any value has
+a support while two literals are still free — so all of the available inference
+lives in the conjunction, and we currently throw it away. Over GF(2) the
+conjunction is one of the rare tractable cases: Gauss-Jordan on the system
+exposes every implied literal, and implied literals are exactly what GAC on the
+system means.
+
+Two things get built:
+
+- **`ParitySystem`**, a global constraint over a set of XOR rows; and
+- **`ParitySystemGathering`**, a presolver that scans a posted `Problem` for
+  XOR-shaped constraints, gathers them into a system, installs the global
+  propagator over them, and retires the donors' own propagators.
+
+The presolver is the one that will actually be used: the XOR structure survives
+MiniZinc flattening intact (`array_bool_xor` → `ParityOdd`, `minizinc/fzn_glasgow.cc`),
+so a model already arrives as a pile of individual `ParityOdd`s and nothing has
+to be re-modelled to get the system propagation. `gcs/presolvers/difference_logic/`
+is the template throughout: same shape, same reasons.
+
+## What is new, and what is not
+
+Nobody in mainline CP does the system (issue #647 has the survey). CP-SAT knows
+it should and says so in a TODO. The two research artifacts are `abstractXOR`
+(Rouquette and Solnon, CP 2020, a Choco prototype that never landed) and
+MiniCPBP's linear modular constraint. The SAT side is far ahead — CryptoMiniSat
+runs Gauss-Jordan during search — so **the claim here is the certificate, not
+the speed**: first CP solver with *certified* system-level parity reasoning.
+"Fastest" is not the claim and should not be made.
+
+The proof technique is Gocht and Nordström, *Certifying Parity Reasoning
+Efficiently Using Pseudo-Boolean Proofs* (AAAI 2022, arXiv:2209.12185); section
+numbers below are theirs. What is new here is not the technique but the bridge:
+their §4.4 recovers the pseudo-Boolean form of an XOR from a *CNF* encoding it
+did not write, by brute force over all assignments. We wrote our encoding, and
+it is already the split-into-3-XORs shape their (4.15) describes, so we get the
+same row in a linear number of steps instead. See "Deriving the slack row".
+
+## The proof shape, bottom up
+
+### 1. The slack form, and why we cannot just write it in the OPB
+
+Gocht and Nordström's (4.3): for fresh, otherwise unconstrained `y`,
+
+```
+    sum_{i in [k]} x_i  =  b + 2 * sum_{j in [floor(k/2)]} y_j
+```
+
+is satisfiable exactly when `x_1 XOR ... XOR x_k = b` is. Their (4.4)
+generalises `2 * sum y_j` to `2B` for *any* integer linear form `B`, and that
+generality is what makes everything below cheap. Under this form **a Gaussian
+elimination step is adding two pseudo-Boolean equalities: one `pol` line.**
+
+We cannot put that form in the `.opb`, for two independent reasons.
+
+- `ParityOdd::define_proof_model` emits cake_pb_cp's accumulator chain, because
+  the `.scp` says `parity` and cake re-derives its own OPB from that (workflow
+  2, [workflow2_testing.md](workflow2_testing.md)). A proof line citing a row
+  that only *our* OPB contains fails against cake's. The slack rows must
+  therefore be **introduced inside the proof**, which is the
+  chain-portable option — see [variable-encodings.md](variable-encodings.md),
+  "Why 'not in OPB' is a first-class option".
+- A presolver runs after the proof model is finalised. `Presolver::run` has no
+  `ProofModel *` at all; that door is shut by the time it is reached.
+
+So the slack rows are derived, once per donor, at `ProofLevel::Top`, from rows
+the donor already emitted. That is the same discipline `DifferenceLogic`
+follows, one step further along: it cites donors' rows directly, we derive one
+row per donor from them first.
+
+### 2. Deriving the slack row from the accumulator chain
+
+`ParityOdd`'s encoding introduces flags `a_0 .. a_n` (`x[id][k]` in cake's
+naming) with
+
+| row | label | as `>= 0` |
+|---|---|---|
+| `a_0 <= 1` | `0ge` | `1 - a_0 >= 0` |
+| `a_0 >= 1` | `0le` | `a_0 - 1 >= 0` |
+| step `k`, `00` | `k_0_0` | `a_{k-1} + l_k - a_k >= 0` |
+| step `k`, `11` | `k_1_1` | `-a_{k-1} - l_k - a_k >= -2` |
+| step `k`, `10` | `k_1_0` | `-a_{k-1} + l_k + a_k >= 0` |
+| step `k`, `01` | `k_0_1` | `a_{k-1} - l_k + a_k >= 0` |
+| `a_n = 0` | `acc` | `-a_n >= 0` |
+
+Each step is a 3-XOR, `a_{k-1} XOR l_k XOR a_k = 0`, which is exactly the
+partial-parity split of Gocht and Nordström's (4.15) — so the long XOR is
+recovered by summing the steps (their §4.2), and only the steps need a
+translation. Writing `a`, `l`, `a'` for `a_{k-1}`, `l_k`, `a_k`, and
+introducing one fresh in-proof flag `y_k` per step:
+
+- **`red` 1, witness `y -> 1`:** `2y - a - l - a' >= 0`. The goal on the new
+  constraint is `2 - a - l - a' >= 0`, which *is* the `k_1_1` row; the goals on
+  the formula are vacuous because `y` is fresh. No subproof.
+- **`red` 2, witness `y -> 0`:** `a + l + a' - 2y >= 0`. The goal on the new
+  constraint is `a + l + a' >= 0`, trivially true. The goal on the formula is
+  the first red's constraint under `y = 0`, namely `-a - l - a' >= 0`, and that
+  needs a five-line `pol` subproof against the negation `2y - a - l - a' >= 1`:
+
+  ```
+  S1 = negation + 2 * (literal axiom ~y)     ->  -a - l - a' >= -1
+  S2 = S1 + k_0_0  ->  -2a' >= -1  -> /2 ->  -a' >= 0
+  S3 = S1 + k_1_0  ->  -2a  >= -1  -> /2 ->  -a  >= 0
+  S4 = S1 + k_0_1  ->  -2l  >= -1  -> /2 ->  -l  >= 0
+  S5 = S2 + S3 + S4                         ->  -a - l - a' >= 0
+  ```
+
+  The three divisions are where the parity argument lives: unit propagation
+  cannot do it, which is why this is not a RUP.
+
+Summing the two directions over `k = 1..n` telescopes the accumulators (every
+`a_j` for `0 < j < n` appears twice, so with coefficient 2, which is even and
+therefore part of `B`):
+
+```
+  sum_k (red2_k) + `0ge` + `acc`                ->  sum_i l_i >= 1 + 2B
+  sum_k (red1_k) + `0le` + (literal axiom a_n)  ->  sum_i l_i <= 1 + 2B
+  where B = sum_k y_k - sum_{0<j<n} a_j - 1
+```
+
+which is (4.4a) and (4.4b) with `b = 1`. **Two `pol` lines per donor.**
+
+Cost: `2n` `red` lines and `5n` subproof lines per donor of length `n`, all at
+`Top`, plus two `pol`s. The `red`s and the per-step rows are scaffolding — only
+the two summed rows are ever cited again, and nothing downstream needs `y`'s
+definition — so they are deleted immediately afterwards. `Top` is never
+forgotten, and every line left there taxes every later unhinted RUP (#666), so
+the deletion is not tidiness. **Steady-state `Top` footprint: two lines per
+donor.**
+
+### 3. Elimination is one `pol`
+
+Adding two donors' (4.4a) rows gives shared literals coefficient 2, which is
+even and so folds into the new `B`; literals appearing with opposite polarity
+in the two rows cancel to a constant, which is exactly `¬p = p XOR 1`. Either
+way the sum is the (4.4a) row of the XOR of the two donors. Same for (4.4b).
+So a row of the reduced system is one `pol` over the donor rows it is a sum of,
+and the propagator tracks that sum as a bitset over donors while it eliminates.
+
+### 4. Reason and conflict clauses: §4.3, and it folds into the same `pol`
+
+Given a derived row and an assignment `ρ` over its support, with
+`F = {i : ρ(l_i) = 0}` and `T = {j : ρ(l_j) = 1}`:
+
+```
+  (4.4a) + { literal axiom l_i : i in F } + { literal axiom ~l_j : j in T }
+      ->  sum_F 2 l_i >= 1 - |T| + 2B
+  /2 then *2                             (gains 1, because |T| is even here)
+      ->  sum_F 2 l_i >= 2 - |T| + 2B
+  + (4.4b)
+      ->  sum_F l_i + sum_T ~l_j >= 1
+```
+
+which is a clause falsified by `ρ`. For a propagation, run it with `ρ` extended
+by the *wrong* value for the one unassigned literal: the clause then has that
+literal as its only non-falsified term, so it propagates.
+
+Everything above — summing donors for both directions, the literal axioms, the
+divide, the multiply — is one RPN expression, so it is **one `pol` line plus
+one RUP per inference**, whatever the size of the combination. `PolBuilder`
+builds it (`add(line)`, `add_for_literal`, `divide_by`, `multiply_by`).
+
+## The propagator
+
+Vocabulary: an **atom** is a canonicalised literal, a **row** is a set of atoms
+plus a right-hand-side bit.
+
+**Canonicalisation.** Each donor literal is reduced to (atom, flip). `v != c` is
+`¬(v == c)`, `v < c` is `¬(v >= c)`; flips move to the row's right-hand side.
+Duplicate atoms within a row cancel (`x XOR x = 0`); this is the same
+cancellation `parity_test.cc`'s duplicate-variable case already exercises.
+Root-fixed literals and `TrueLiteral`/`FalseLiteral` fold into `b`. A row that
+cancels to empty is a root contradiction (`b = 1`) or is dropped (`b = 0`).
+
+Two atoms over the same variable that happen to be equivalent (`v != 0` and
+`v == 3` where the domain is `{0, 3}`) are treated as independent. That only
+loses strength, never soundness: the system is a relaxation in which every atom
+is free, and that is exactly the relaxation the PB rows state, so the proof and
+the propagator agree about what is being claimed. It is also what "GAC" means
+here, and the honest statement of it: **GAC on the PB relaxation of the
+system**. Where each variable contributes one atom — which is every model that
+arrives through a frontend, since `ParityOdd(vars)` builds `v != 0` — that
+coincides with GAC on the conjunction.
+
+**Canonicalisation must go through the tracker**, not the surface syntax: the
+`pol` cancellation in step 3 is a representation-consistency argument, and
+`v != 0` and `v == 0` have to resolve to the same `XLiteral` up to negation for
+it to hold. See [view-proof-logging.md](view-proof-logging.md).
+
+**Propagation.** On each wake: substitute the current assignment into every
+row, Gauss-Jordan the result, and read off
+
+- an empty row with `b = 1` → contradiction;
+- a unit row `{a}` with `b = c` → infer `a` or `¬a`;
+- a two-atom row → an implied equivalence, which is real strength but has
+  nowhere to live (issue #649) and is **out of scope**. Detecting implied
+  literals alone is GAC; equivalences are the layer above it.
+
+Reason for an inference: the assigned literals of the derived row's support
+before substitution, which is precisely the `ρ` of §4.3.
+
+**From scratch, to begin with.** Each call re-eliminates. `abstractXOR` reports
+that sparse sets do not trail cleanly here, because XORing rows *creates*
+non-zero cells, and undoing has to be explicit; maintaining the RREF
+incrementally under backtracking is the interesting engineering and it is not
+where this should start. `DifferenceConstraints` took the same route — one
+from-scratch pass first, an `incrementally()` option added afterwards, with the
+audit mode that requires the two to agree. Bitset rows make from-scratch
+`O(rows * atoms / 64)` per call, which is enough to find out whether any of this
+pays.
+
+**Components.** The posted XORs usually split into connected components, and
+eliminating over the whole model when the rows do not interact is pure waste.
+The presolver partitions by shared atom and installs one propagator per
+component with at least two rows. A single-row component is left to its own
+`ParityOdd`, which computes exactly the same thing more cheaply.
+
+## The presolver
+
+`ParitySystemGathering`, in `gcs/presolvers/parity_system_gathering/`, built to
+the `DifferenceLogic` pattern: a shared `ComponentStats` block registered
+unconditionally at the top of `run()`, donor discovery through
+`Problem::each_constraint_of_type_with_proof_data` so the rows it cites are
+named by the donor's published role rather than by a label it built itself, and
+one bucket per reason a candidate was passed over — because a presolver that
+silently gathered nothing passes every solution-equivalence, OPB byte-diff and
+VeriPB check there is, and the counts are the only thing that tells "working"
+from "no-op".
+
+Donors come from two families.
+
+**`ParityOdd`.** The main one; everything a frontend produces lands here
+(`array_bool_xor` and `bool_xor` via `minizinc/fzn_glasgow.cc`, XCSP3, CPMpy,
+`.scp`). Its slack row is derived as in §2 above, and that derivation is where
+essentially all of this presolver's `Top` output goes.
+
+**Boolean `Equals` / `NotEquals`**, when both operands' declared domains are
+within `{0, 1}` — checkable from the `State` the presolver is handed. `x = y`
+is the 2-XOR `[x != 0] XOR [y != 0] = 0`; `x != y` is the same with
+right-hand side 1. This is where a MiniZinc model's `bool_eq` and `bool_not`
+rows come from, and they are worth having because they are the edges that
+connect otherwise separate XOR components.
+
+Both are `ReifiedEquals` — `Equals` is `reif::MustHold`, `NotEquals` is
+`reif::MustNotHold` — and `clone()` returns the base, so the enumeration asks
+for `ReifiedEquals` and dispatches on `reification_condition()`, exactly as
+`DifferenceLogic` does over `ReifiedLinearInequality`. `ReifiedEquals`
+currently publishes neither its operands nor a `ConstraintProofModelData`, so
+both get added, and the published data has to name **two** rows rather than one
+primary (`Cumulative` is the precedent for a specialisation with more than one
+named role).
+
+These are also *much* cheaper to lift than a `ParityOdd`, which is the part
+worth writing down: with only two literals, `B` needs no fresh variable, so
+neither donor needs a `red` at all.
+
+- `Equals` emits `v1 - v2 == 0` as the labelled pair
+  `ge` / `le`. Writing `a` for `[x != 0]` and `b` for `[y != 0]`, those rows
+  *are* (4.4a) and (4.4b) with right-hand side 0 and `B = b`: `a + b >= 0 + 2b`
+  is `a - b >= 0`, and `a + b <= 0 + 2b` is `a - b <= 0`. Nothing to derive —
+  the donor's own two rows are the slack form, cited directly.
+- `NotEquals` emits big-M `gt` / `lt` rows half-reified on a per-constraint
+  selector flag `b[id][ne]` (cake's `nev`), the flag true selecting `gt`. Here
+  `B = 0`, so the slack form is just `a + b >= 1` and `a + b <= 1`, and both
+  are plain **RUP** against those two rows: negating `a + b >= 1` assigns
+  `a = b = 0`, which unit-propagates the selector through the `lt` row and then
+  falsifies `gt`; negating `a + b <= 1` assigns `a = b = 1`
+  and falsifies the other way round. Two RUP lines at `Top`, no witness, no
+  subproof.
+
+The one thing to check rather than assume: for a `{0, 1}` variable, the literal
+`[x != 0]` and the variable's own OPB bit have to resolve to the same
+`XLiteral`, or the `pol` cancellation in §3 does not happen. Go through
+`NamesAndIDsTracker::need_pol_item_defining_literal`, never the surface form.
+
+Everything else is skipped and counted: a non-`MustHold` reification kind, an
+operand whose domain is not within `{0, 1}`, a donor whose row cannot be cited
+(only ever possible with proofs on), a row that cancels to nothing.
+
+## The constraint
+
+`ParitySystem`, in `gcs/constraints/parity/`, alongside `ParityOdd`. It takes a
+`vector<Literals>` — **every row is odd parity**, matching `ParityOdd`'s
+spelling, so an even row is written with one literal negated. That is what the
+GF(2) canonicalisation does internally anyway, and it keeps one convention
+across the two constraints rather than two.
+
+Its OPB encoding is `ParityOdd`'s, once per row: `prepare()` installs one child
+`ParityOdd` per row (the `path.cc` / `tree.cc` pattern), which gives the rows
+their accumulator chains, and `install_propagators` adds the system propagator
+on top. The point is that **there is then one proof path, not two**: the posted
+constraint and the presolver both derive their slack rows from accumulator
+chains, so `define_proof_model`, the derivation, and the justifications are the
+same code, exercised by both entry points.
+
+`s_expr()` throws: the `.scp` grammar has `parity` for one row and nothing for a
+system, and `write_scp` renders the whole file before opening it, so a throw
+leaves no `.scp` behind. The SCP chain lane does not cover `ParitySystem`. It
+does still cover the presolver's donors, which are ordinary `ParityOdd`s — and
+that is the configuration that matters, because it is the one a real model
+reaches.
+
+## What this touches in existing code
+
+- `ParityOdd` gains an accessor for its literals, and a
+  `ConstraintProofModelData<ParityOdd>` specialisation in `parity.hh`
+  publishing what the derivation cites: the four per-step clause roles, the
+  `0ge` / `0le` / `acc` roles, and the accumulator `ProofFlagKey`s (values
+  `{k}`, no annotation). Publishing is the point — the alternative is the
+  presolver hard-coding another constraint's naming scheme, which is what
+  `ConstraintProofModelData` exists to stop.
+- `ReifiedEquals` gains operand accessors and its own specialisation, naming
+  both rows of each reification kind it supports.
+- `gcs/constraints/parity.hh` (the umbrella) picks up `parity_system.hh`, and
+  `gcs/gcs.hh` picks up nothing new, since it already includes
+  `constraints/parity.hh` — but the new header must reach it in the same commit
+  as the constraint, not as a follow-up.
+- `gcs/constraint_enumeration_test.cc` gets `ParityOdd` and `ReifiedEquals`
+  cases: the enumeration is a `dynamic_cast` on what `clone()` returns, so it
+  finds nothing at all if `clone()` ever starts returning a type outside the
+  family, and that is a silent failure everywhere else.
+- `dev_docs/README.md` gets an entry for this document, and
+  `dev_docs/frontend-support-matrix.md` a row — neither the constraint nor the
+  presolver is reachable from any frontend at first, and the matrix is the
+  single source of truth for that.
+
+## Staging
+
+Following `constraints.md`, "Bringing up a new constraint" — the gates are what
+make each stage's failure diagnosable.
+
+1. **Encoding.** `ParitySystem` with child `ParityOdd`s and a check-only
+   propagator (wait until assigned, check, contradict). Gate: the data-driven
+   tests verify. This says the child-installation and the row plumbing are
+   right, before any system reasoning exists.
+2. **The algorithm, no proofs.** Gauss-Jordan, tested with proofs off against
+   `solve_for_tests_checking_gac`, which is where the GAC claim gets checked
+   rather than asserted. Gate: solution sets match and GAC holds.
+3. **Slack-row derivation.** The `red`s, the subproof, the telescoping `pol`s,
+   at `Top`, with every inference still on `AssertRatherThanJustifying`. Gate:
+   VeriPB accepts the `Top` block. This is the stage the whole design is
+   uncertain about, and it is isolated here on purpose: if the derivation is
+   wrong, nothing else is being blamed for it. **Watch for `s UNDER
+   ASSERTIONS`, not `s VERIFIED`, at this stage.**
+4. **Justifications.** §4.3, one inference kind at a time — conflict first
+   (`|T|` even, no extension), then propagation. Every cheat from stage 3 comes
+   out. Gate: `s VERIFIED`, and every mutation of the derivation is rejected
+   (`constraints.md`, Mutation testing). A `pol` that verifies but is not tight
+   is the failure mode here, and mutation is the only thing that catches it.
+5. **The presolver.** Donor discovery, canonicalisation, components, retirement
+   of donors. Gate: the counts in its stats block, which is the only thing that
+   distinguishes "lifted the system" from "silently lifted nothing" — the
+   lesson `DifferenceLogicStats` is written around. Plus the node-for-node
+   tripwire: with donors *not* retired, the search tree must be identical, since
+   the system propagator subsumes every donor's single-XOR unit propagation.
+
+Stage 3 is where a second opinion is worth buying (`CLAUDE.md`, "When to ask for
+a second opinion"): the derivation is not a shape this tree already uses.
+
+## What would exercise it
+
+- MiniZinc Challenge 2012 `parity-learning`, the family CP-SAT's TODO names.
+  It is the *optimisation* variant, so Gauss-Jordan alone will not crack it —
+  the noise is the hard part — but it is the obvious first benchmark.
+- MiniZinc Challenge 2016 `cryptanalysis` (Gérault, Minier and Solnon's AES
+  related-key step 1). The 2017/2018/2021 `opt-cryptanalysis` model has no XOR
+  system in it, so the honest challenge count is two families, both old.
+- Hashing-based model counting; LDPC decoding as XOR-SAT.
+
+Measure against [proof-benchmarks.md](proof-benchmarks.md) as well as
+[benchmarking.md](benchmarking.md): the `Top` footprint and the per-inference
+line count are the numbers this design is making claims about.
+
+## Decisions taken
+
+1. **`ParitySystem` installs child `ParityOdd`s** rather than writing a slack
+   form into its own OPB. Writing the slack form directly would make
+   elimination free and is much less code, but it would leave two proof paths
+   to keep in step and a `ParitySystem` whose proofs are checked against
+   nothing but our own OPB. One derivation, exercised by both entry points, is
+   worth the extra work.
+2. **Rows are all odd**, as above.
+3. **Both donor families**: `ParityOdd`, and Boolean `Equals` / `NotEquals`.
+4. **Donors are retired by default.** The issue says "replaces", and the system
+   propagator subsumes every donor's single-XOR unit propagation, so a donor
+   that has been lifted is pure overhead. The hybrid stays available behind an
+   option because it is the stage-5 tripwire: with donors kept, the search tree
+   must come out node-for-node identical, and it differing means the
+   subsumption claim is wrong.
+
+## Residue
+
+- Implied equivalences (`x = y`, `x = ~y`) are the real payoff over unit
+  propagation and have nowhere to live; issue #649 scopes an equivalence store.
+  Out of scope here, and detecting implied literals alone is already GAC.
+- Incremental RREF maintenance under backtracking; see "From scratch, to begin
+  with".
+- Caching derived rows. Each inference re-emits its `pol` over donor rows even
+  when the same combination recurs, which it will. Emitting the root RREF once
+  at `Top` and citing those rows instead is the obvious next move, and it is a
+  measurement, not a guess: it trades `Top` footprint (which taxes every later
+  unhinted RUP) against per-inference line count.

--- a/dev_docs/parity-system.md
+++ b/dev_docs/parity-system.md
@@ -1,7 +1,7 @@
 # `ParitySystem`: GF(2) reasoning over a conjunction of XORs
 
-Working-design note for issue #647. **Draft: nothing here has been built, and
-the derivation in §2 is the part to disbelieve until VeriPB has accepted it.**
+Working note for issue #647. **Status: the constraint is built and its proofs
+verify with zero assertions. `ParitySystemGathering` is not written yet.**
 
 `ParityOdd` reasons about one XOR at a time (`gcs/constraints/parity/parity.cc`,
 the `if (++how_many_unknown > 1) return` bail-out). That is GAC for a single
@@ -122,6 +122,14 @@ introducing one fresh in-proof flag `y_k` per step:
   the shape VeriPB rejects, and it costs nothing to avoid, since the negated
   goal is already in scope.
 
+  Two line references inside that block, and both have to be **absolute**.
+  `ProofLogger::get_current_proof_line()` at the top of the subproof body is
+  the negated goal, and the negation of the constraint the `red` is adding sits
+  one before it. Capture both there: a relative `-1` still says `-1` five lines
+  later, by which point it means the line just emitted rather than the one
+  intended — which is what the first attempt at this did, and what VeriPB
+  reported as a `proofgoal` not ending in a contradiction.
+
 Only steps of the *other* order carry goals over the earlier steps' rows: a
 `y_{k'}` from step `k' < k` is not in step `k`'s witness domain, so those rows
 restrict to themselves and generate nothing. That is also a canary — an
@@ -135,9 +143,14 @@ Swapping them moves the work: `red(D2)` first is entirely goal-free, and
 rather than five. Take the cheaper order.
 
 Rows of length 0 have no chain to telescope — `a_0` and `a_n` are the same flag
-— so they are excluded before any of this runs. They need nothing: an empty odd
-row is a root contradiction, which the `0ge`/`0le`/`acc` rows state on their
-own.
+— so `derive_parity_slack_rows` returns nothing for one, and `ParitySystem`
+does not build a system at all when it sees one: it installs an initial
+contradiction instead, justified by plain RUP. That is the honest answer rather
+than a special case. An empty odd row says zero is odd, its own `0ge` / `0le` /
+`acc` rows pin `a_0` to one and to zero at once, and there is nothing for
+elimination to do with a system containing it. Getting this wrong is what a
+half-built row looks like from VeriPB's side: a justification citing a slack
+row that was never derived, reported as a reference to a deleted constraint.
 
 Summing the two directions over `k = 1..n` telescopes the accumulators (every
 `a_j` for `0 < j < n` appears twice, so with coefficient 2, which is even and
@@ -378,36 +391,63 @@ reaches.
 
 ## Staging
 
-Following `constraints.md`, "Bringing up a new constraint" — the gates are what
-make each stage's failure diagnosable.
+`constraints.md`, "Bringing up a new constraint", numbered as it numbers them —
+the gates are what make each stage's failure diagnosable. All five are done for
+the constraint; the presolver has not been started.
 
-1. **Encoding.** `ParitySystem` with child `ParityOdd`s and a check-only
-   propagator (wait until assigned, check, contradict). Gate: the data-driven
-   tests verify. This says the child-installation and the row plumbing are
-   right, before any system reasoning exists.
-2. **The algorithm, no proofs.** Gauss-Jordan, tested with proofs off against
-   `solve_for_tests_checking_gac`, which is where the GAC claim gets checked
-   rather than asserted. Gate: solution sets match and GAC holds.
-3. **Slack-row derivation.** The `red`s, the subproof, the telescoping `pol`s,
-   at `Top`, with every inference still on `AssertRatherThanJustifying`. Gate:
-   VeriPB accepts the `Top` block. This is the stage the whole design is
-   uncertain about, and it is isolated here on purpose: if the derivation is
-   wrong, nothing else is being blamed for it. **Watch for `s UNDER
-   ASSERTIONS`, not `s VERIFIED`, at this stage.**
-4. **Justifications.** §4.3, one inference kind at a time — conflict first
-   (`|T|` even, no extension), then propagation. Every cheat from stage 3 comes
-   out. Gate: `s VERIFIED`, and every mutation of the derivation is rejected
-   (`constraints.md`, Mutation testing). A `pol` that verifies but is not tight
-   is the failure mode here, and mutation is the only thing that catches it.
-5. **The presolver.** Donor discovery, canonicalisation, components, retirement
-   of donors. Gate: the counts in its stats block, which is the only thing that
-   distinguishes "lifted the system" from "silently lifted nothing" — the
-   lesson `DifferenceLogicStats` is written around. Plus the node-for-node
-   tripwire: with donors *not* retired, the search tree must be identical, since
-   the system propagator subsumes every donor's single-XOR unit propagation.
+1. **The encoding, with a check-only propagator.** *Gate: the whole suite
+   verifies* — which says the encoding is definitionally correct and that RUP
+   alone certifies every consequence of a complete assignment. Passed.
+2. **State the consistency level in the tests.** Switched to
+   `solve_for_tests_checking_gac` before any pruning existed, so the tests
+   failed for the reason about to be fixed. They did, with "consistency not
+   achieved", and they still do if `ParitySystemPropagation::CheckOnly` is
+   selected — which is what keeps that mode honest as the encoding's standing
+   regression test.
+3. **Gauss-Jordan, with every inference cheated.** *Gate: the stage 2 tests
+   pass and VeriPB still accepts.* Passed, at 23 runs `s UNDER ASSERTIONS` and
+   2 `s VERIFIED` (the two with no system inference to make).
+4. **Discharge the cheats.** The slack-row derivation at `Top` first, then
+   §4.3's fold. Both landed together rather than one inference kind at a time,
+   which was a small mistake: the two failures that followed — the subproof's
+   line references, and the empty row — each had to be separated out by reading
+   the `.pbp`, and a stricter order would have pointed at them.
+5. **Zero assertions.** 25 of 25 `s VERIFIED`, no assertion warning, and
+   `grep -c '^a '` is zero on a preserved `.pbp`.
 
-Stage 3 is where a second opinion is worth buying (`CLAUDE.md`, "When to ask for
-a second opinion"): the derivation is not a shape this tree already uses.
+GAC here means *GAC on the PB relaxation of the system* — see "The propagator"
+— which coincides with GAC on the conjunction for every model that reaches this
+through a frontend.
+
+### What mutation testing says
+
+Seven mutations, five rejected by VeriPB and two not. The two are worth
+recording, because neither is a defect:
+
+| Mutation | Verdict |
+|---|---|
+| Drop the `/2` then `*2` in the §4.3 fold | rejected |
+| Flip which polarity of each support atom is pushed as an axiom | rejected |
+| Use two of the three step clauses in the `red` subproof | rejected |
+| Close the `<=` telescoping with `~a_n` rather than `a_n` | rejected |
+| Infer the opposite literal from a unit row | rejected (wrong solutions) |
+| Telescope the `>=` direction with `a_0 >= 1` rather than `a_0 <= 1` | **accepted** |
+| Telescope the `>=` direction without the `a_n <= 0` pin | **accepted** |
+
+Both survivors only *weaken* the derived row, by a term the `.opb` pins anyway
+(`a_0 = 1`, `a_n = 0`), so the row stays valid and the wrapping RUP still
+closes by propagating that pin. This is
+[veripb-facts.md](veripb-facts.md)'s "a `pol` only has to get close": the `pol`
+is not the certificate, the RUP around it is, and a mutation that removes
+slack is a corruption VeriPB is right to accept. What bites is corrupting the
+*claim* — which is what the five rejections all do.
+
+**The presolver comes after all five**, not alongside them. It has its own gate:
+the counts in its stats block, which is the only thing that distinguishes
+"gathered the system" from "silently gathered nothing" — the lesson
+`DifferenceLogicStats` is written around — plus the node-for-node tripwire that
+with donors *not* retired the search tree must be identical, since the system
+propagator subsumes every donor's single-XOR unit propagation.
 
 ## What would exercise it
 
@@ -447,6 +487,12 @@ line count are the numbers this design is making claims about.
   Out of scope here, and detecting implied literals alone is already GAC.
 - Incremental RREF maintenance under backtracking; see "From scratch, to begin
   with".
+- Deleting the per-step scaffolding. The `red`s and their subproof lines are
+  only needed until the two telescoping `pol`s have run, and everything above
+  says to delete them afterwards — but that is not implemented yet, so the
+  current `Top` footprint is the full `7n` lines per row rather than two. Do
+  this before pointing it at anything large: every line left at `Top` taxes
+  every later unhinted RUP (#666).
 - Caching derived rows. Each inference re-emits its `pol` over donor rows even
   when the same combination recurs, which it will. Emitting the root RREF once
   at `Top` and citing those rows instead is the obvious next move, and it is a

--- a/dev_docs/parity-system.md
+++ b/dev_docs/parity-system.md
@@ -96,24 +96,48 @@ recovered by summing the steps (their §4.2), and only the steps need a
 translation. Writing `a`, `l`, `a'` for `a_{k-1}`, `l_k`, `a_k`, and
 introducing one fresh in-proof flag `y_k` per step:
 
-- **`red` 1, witness `y -> 1`:** `2y - a - l - a' >= 0`. The goal on the new
-  constraint is `2 - a - l - a' >= 0`, which *is* the `k_1_1` row; the goals on
-  the formula are vacuous because `y` is fresh. No subproof.
+- **`red` 1, witness `y -> 1`:** `2y - a - l - a' >= 0`. The only goal is on
+  the new constraint, `2 - a - l - a' >= 0`, and it discharges by RUP: negating
+  it fixes all three of `a`, `l`, `a'` true, and `k_1_1` then reads `-3 >= -2`.
+  The goals on the formula are vacuous because `y` is fresh, so nothing already
+  in the database mentions it. No subproof.
 - **`red` 2, witness `y -> 0`:** `a + l + a' - 2y >= 0`. The goal on the new
-  constraint is `a + l + a' >= 0`, trivially true. The goal on the formula is
-  the first red's constraint under `y = 0`, namely `-a - l - a' >= 0`, and that
-  needs a five-line `pol` subproof against the negation `2y - a - l - a' >= 1`:
+  constraint is `a + l + a' >= 0`, which normalises to degree 0 and
+  auto-discharges. The one real goal is the *first* red's constraint under
+  `y = 0`, namely `-a - l - a' >= 0`, and it needs a five-line `pol` subproof
+  against the negation `N: 2y - a - l - a' >= 1`:
 
   ```
-  S1 = negation + 2 * (literal axiom ~y)     ->  -a - l - a' >= -1
+  S1 = N + 2 * (literal axiom ~y)  ->  -a - l - a' >= -1
   S2 = S1 + k_0_0  ->  -2a' >= -1  -> /2 ->  -a' >= 0
   S3 = S1 + k_1_0  ->  -2a  >= -1  -> /2 ->  -a  >= 0
   S4 = S1 + k_0_1  ->  -2l  >= -1  -> /2 ->  -l  >= 0
-  S5 = S2 + S3 + S4                         ->  -a - l - a' >= 0
+  S5 = S2 + S3 + S4 + (negated goal, a + l + a' >= 1)  ->  0 >= 1
   ```
 
   The three divisions are where the parity argument lives: unit propagation
-  cannot do it, which is why this is not a RUP.
+  cannot do it, which is why this is not a RUP. **`S5` adds the negated goal**,
+  because a `proofgoal` block has to end in a contradiction rather than in a
+  derivation of the goal — deriving `-a - l - a' >= 0` and stopping there is
+  the shape VeriPB rejects, and it costs nothing to avoid, since the negated
+  goal is already in scope.
+
+Only steps of the *other* order carry goals over the earlier steps' rows: a
+`y_{k'}` from step `k' < k` is not in step `k`'s witness domain, so those rows
+restrict to themselves and generate nothing. That is also a canary — an
+implementation that accidentally reused one `y` across steps would not go
+quietly wrong, it would acquire goals it cannot discharge and fail at check
+time.
+
+The order of the two `red`s is not load-bearing for soundness, only for cost.
+Swapping them moves the work: `red(D2)` first is entirely goal-free, and
+`red(D1)` second then has to prove `a + l + a' >= 2`, which takes seven lines
+rather than five. Take the cheaper order.
+
+Rows of length 0 have no chain to telescope — `a_0` and `a_n` are the same flag
+— so they are excluded before any of this runs. They need nothing: an empty odd
+row is a root contradiction, which the `0ge`/`0le`/`acc` rows state on their
+own.
 
 Summing the two directions over `k = 1..n` telescopes the accumulators (every
 `a_j` for `0 < j < n` appears twice, so with coefficient 2, which is even and
@@ -134,6 +158,21 @@ definition — so they are deleted immediately afterwards. `Top` is never
 forgotten, and every line left there taxes every later unhinted RUP (#666), so
 the deletion is not tidiness. **Steady-state `Top` footprint: two lines per
 donor.**
+
+Deleting them is safe and is *unchecked*: redundance established
+equisatisfiability while the rows still stood, and every model of the chain
+rows extends to one of (A) and (B) by `y_k = (a_{k-1} + l_k + a_k) / 2`, which
+those rows make integral. The deletion goes unchecked because `D1`/`D2` are
+red-derived and so live in the derived set, and whether a deletion is checked
+follows where the target lives rather than which rule wrote it — see
+[veripb-facts.md](veripb-facts.md). Subproof lines need no deleting at all;
+their scope ends with the block.
+
+What does stay has a cost worth naming: (A) and (B) sit at `Top` mentioning
+every `l_i` and every interior `a_j`, so any later `red` whose witness touches
+one of those variables acquires proofgoals over them. Nothing in the tree does
+today — the flag-reifying `red`s all use fresh witnesses — but it is the thing
+that would make this expensive from a distance.
 
 ### 3. Elimination is one `pol`
 
@@ -161,6 +200,12 @@ Given a derived row and an assignment `ρ` over its support, with
 which is a clause falsified by `ρ`. For a propagation, run it with `ρ` extended
 by the *wrong* value for the one unassigned literal: the clause then has that
 literal as its only non-falsified term, so it propagates.
+
+The fold is not optional. (A) and (B) on their own do **not** make the XOR's
+clauses RUP: fixing the literals to the wrong parity leaves the pair feasible
+at a half-integral point — `n = 2` with both literals 0 gives
+`2(y_1 + y_2 - a_1) >= 1` and `<= 1`, slack either way, nothing propagates.
+The rounding in the `/2` is what closes it, exactly as in the subproof above.
 
 Everything above — summing donors for both directions, the literal axioms, the
 divide, the multiply — is one RPN expression, so it is **one `pol` line plus

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -90,6 +90,7 @@ add_library(glasgow_constraint_solver
         constraints/n_value/n_value.cc
         constraints/nogoods/nogoods.cc
         constraints/parity/parity.cc
+        constraints/parity/gf2_system.cc
         constraints/parity/parity_chain.cc
         constraints/parity/parity_system.cc
         constraints/path/path.cc
@@ -666,6 +667,7 @@ if(GCS_BUILD_TESTS)
     add_view_tests(min_max_constraint min_max_test 6)
     add_view_tests(at_most_one_constraint at_most_one_test 5)
     add_view_tests(parity_constraint parity_test 4)
+    add_view_tests(parity_system_constraint parity_system_test 4)
     add_view_tests(n_value_constraint n_value_test 6)
     add_view_tests(min_distance_constraint min_distance_test 6)
     add_view_tests(seq_precede_chain_constraint seq_precede_chain_test 5)

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -90,6 +90,8 @@ add_library(glasgow_constraint_solver
         constraints/n_value/n_value.cc
         constraints/nogoods/nogoods.cc
         constraints/parity/parity.cc
+        constraints/parity/parity_chain.cc
+        constraints/parity/parity_system.cc
         constraints/path/path.cc
         constraints/plus_minus/plus.cc
         constraints/power/power.cc
@@ -347,6 +349,7 @@ if(GCS_BUILD_TESTS)
     add_executable(n_value_test constraints/n_value/n_value_test.cc)
     add_executable(nogoods_test constraints/nogoods/nogoods_test.cc)
     add_executable(parity_test constraints/parity/parity_test.cc)
+    add_executable(parity_system_test constraints/parity/parity_system_test.cc)
     add_executable(plus_minus_test constraints/plus_minus/plus_minus_test.cc)
     add_executable(power_test constraints/power/power_test.cc)
     add_executable(product_bounds_test constraints/innards/product_bounds_test.cc)
@@ -375,7 +378,7 @@ if(GCS_BUILD_TESTS)
     foreach(test_target
             abs_test all_different_test all_different_except_test all_equal_test among_test at_most_one_test bin_packing_test comparison_test
             count_test cumulative_test cumulative_overload_test cumulative_edge_finding_test cumulative_ttef_test cumulative_energetic_test cumulative_nfnl_test cumulative_published_nfnl_test cumulative_kaoc_test cumulative_optional_test derived_cumulative_test difference_test disjunctive_test disjunctive_optional_test disjunctive_overload_test disjunctive_edge_finding_test disjunctive_nfnl_test disjunctive_precedences_test disjunctive_set_precedences_test disjunctive_published_nfnl_test disjunctive_2d_test divide_modulus_test element_test equals_test bounds_global_cardinality_test gac_global_cardinality_test in_test increasing_test inverse_test knapsack_test knapsack_upfront_test lex_test linear_test linear_constant_test
-            logical_test mdd_test min_distance_test min_distance_matching_test min_max_test mini_linear_test multiply_test n_value_test nogoods_test parity_test
+            logical_test mdd_test min_distance_test min_distance_matching_test min_max_test mini_linear_test multiply_test n_value_test nogoods_test parity_test parity_system_test
             plus_minus_test power_test product_bounds_test product_justify_test reachable_test dag_test regular_test regular_bacchus_test regular_legacy_test seq_precede_chain_test smart_table_test subgraph_test tree_test path_test sort_test arg_sort_test symmetric_all_different_test
             negative_table_test table_test tabulation_test value_precede_test)
         target_link_libraries(${test_target} PRIVATE glasgow_constraint_solver)
@@ -730,6 +733,7 @@ if(GCS_BUILD_TESTS)
     add_test(NAME n_value_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:n_value_test>)
     add_test(NAME nogoods_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:nogoods_test>)
     add_test(NAME parity_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:parity_test>)
+    add_test(NAME parity_system_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:parity_system_test>)
     add_test(NAME plus_minus_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:plus_minus_test>)
     add_test(NAME path_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:path_test>)
     add_test(NAME tree_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:tree_test>)

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -144,6 +144,7 @@ add_library(glasgow_constraint_solver
         presolvers/inferred_cumulative/inferred_cumulative.cc
         presolvers/inferred_disjunctive/inferred_disjunctive.cc
         presolvers/innards/makespan_links.cc
+        presolvers/parity_system_gathering/parity_system_gathering.cc
 )
 
 # The repo root contains both gcs/ and util/, so it must be on the include path.
@@ -251,6 +252,11 @@ if(GCS_BUILD_TESTS)
     target_link_libraries(inferred_disjunctive_presolver_test PRIVATE glasgow_constraint_solver)
     add_test(NAME inferred_disjunctive_presolver
         COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:inferred_disjunctive_presolver_test>)
+
+    add_executable(parity_system_gathering_presolver_test presolvers/parity_system_gathering/parity_system_gathering_test.cc)
+    target_link_libraries(parity_system_gathering_presolver_test PRIVATE glasgow_constraint_solver)
+    add_test(NAME parity_system_gathering_presolver
+        COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:parity_system_gathering_presolver_test>)
 
     add_executable(cumulative_strengthening_presolver_test presolvers/cumulative_strengthening/cumulative_strengthening_test.cc)
     target_link_libraries(cumulative_strengthening_presolver_test PRIVATE glasgow_constraint_solver)

--- a/gcs/constraint_enumeration_test.cc
+++ b/gcs/constraint_enumeration_test.cc
@@ -1,6 +1,7 @@
 #include <gcs/constraints/comparison.hh>
 #include <gcs/constraints/equals.hh>
 #include <gcs/constraints/linear.hh>
+#include <gcs/constraints/parity.hh>
 #include <gcs/innards/variable_id_utils.hh>
 #include <gcs/presolver.hh>
 #include <gcs/problem.hh>
@@ -49,7 +50,7 @@ namespace
 
     // A ReificationCondition is variant<MustHold, MustNotHold, If, NotIf, Iff>,
     // and its index is all these tests need to tell the forms apart.
-    constexpr size_t must_hold = 0, if_cond = 2, iff_cond = 4;
+    constexpr size_t must_hold = 0, must_not_hold = 1, if_cond = 2, iff_cond = 4;
 
     // The bits of a linear inequality a difference-logic presolver reads back,
     // flattened so that a test can compare two of them.
@@ -74,6 +75,45 @@ namespace
     };
 
     // Deliberately takes a const Problem &: enumeration must work on one.
+    // ParitySystemGathering's two donor families. ParityOdd has no hierarchy at
+    // all, and Equals / NotEquals are both stored as their ReifiedEquals base ---
+    // which is what makes asking for the base the right thing, and what would
+    // silently stop matching if either clone() ever returned something else.
+    struct SeenParity final
+    {
+        string id;
+        vector<innards::Literal> literals;
+
+        [[nodiscard]] auto operator==(const SeenParity &) const -> bool = default;
+    };
+
+    struct SeenEquals final
+    {
+        string id;
+        IntegerVariableID left, right;
+        bool equality;
+        size_t reification_kind;
+
+        [[nodiscard]] auto operator==(const SeenEquals &) const -> bool = default;
+    };
+
+    [[nodiscard]] auto collect_parities(const Problem & problem) -> vector<SeenParity>
+    {
+        vector<SeenParity> result;
+        for (const auto & c : problem.each_constraint_of_type<ParityOdd>())
+            result.push_back(SeenParity{as_string(c.constraint_id()), vector<innards::Literal>{c.literals().begin(), c.literals().end()}});
+        return result;
+    }
+
+    [[nodiscard]] auto collect_equals(const Problem & problem) -> vector<SeenEquals>
+    {
+        vector<SeenEquals> result;
+        for (const auto & c : problem.each_constraint_of_type<ReifiedEquals>())
+            result.push_back(SeenEquals{
+                as_string(c.constraint_id()), c.left_variable(), c.right_variable(), c.enforces_equality(), c.reification_condition().index()});
+        return result;
+    }
+
     [[nodiscard]] auto collect_linears(const Problem & problem) -> vector<SeenLinear>
     {
         vector<SeenLinear> result;
@@ -243,6 +283,34 @@ namespace Catch
     };
 }
 
+TEST_CASE("Typed enumeration recovers ParityOdd and the Equals family")
+{
+    // ParitySystemGathering reads both of these back to build its GF(2) rows, so
+    // if either enumeration stops matching, that presolver silently gathers
+    // nothing rather than failing. Its own stats assertions are the other half of
+    // holding this down; this is the half that says which API it relies on.
+    Problem p;
+    auto x = p.create_integer_variable(0_i, 1_i, "x"s);
+    auto y = p.create_integer_variable(0_i, 1_i, "y"s);
+    auto z = p.create_integer_variable(0_i, 1_i, "z"s);
+
+    p.post(ParityOdd{vector<IntegerVariableID>{x, y}});
+    p.post(ParityOdd{innards::Literals{x != 0_i, z == 1_i}});
+    p.post(Equals{x, y});
+    p.post(NotEquals{y, z});
+    // Not a member of either family, and must not be enumerated by either.
+    p.post(LessThan{x, z});
+
+    CHECK(collect_parities(p) == vector<SeenParity>{{"_1", {x != 0_i, y != 0_i}}, {"_2", {x != 0_i, z == 1_i}}});
+
+    // Equals is MustHold and NotEquals is MustNotHold, so the reification kinds
+    // differ while enforces_equality() is what actually says which is which.
+    auto equals = collect_equals(p);
+    REQUIRE(equals.size() == 2);
+    CHECK(equals[0] == SeenEquals{"_3", x, y, true, must_hold});
+    CHECK(equals[1] == SeenEquals{"_4", y, z, false, must_not_hold});
+}
+
 TEST_CASE("Typed enumeration finds nothing in an empty problem")
 {
     Problem p;
@@ -250,6 +318,8 @@ TEST_CASE("Typed enumeration finds nothing in an empty problem")
 
     CHECK(collect_linears(p).empty());
     CHECK(collect_comparisons(p).empty());
+    CHECK(collect_parities(p).empty());
+    CHECK(collect_equals(p).empty());
 }
 
 TEST_CASE("Typed enumeration finds a single constraint")

--- a/gcs/constraints/cumulative/cumulative.hh
+++ b/gcs/constraints/cumulative/cumulative.hh
@@ -453,7 +453,7 @@ namespace gcs
          *
          * `before` is `start[i] <= t`, `after` is `start[i] + length[i] > t`,
          * and `active` is their conjunction. Ask
-         * NamesAndIDsTracker::find_proof_flag_values for the flag: a key
+         * NamesAndIDsTracker::find_proof_flag for the flag: a key
          * outside the task's possible-active window has none, which is how a
          * citer discovers it is asking about a window the constraint did not
          * encode.
@@ -471,7 +471,7 @@ namespace gcs
          *
          * How many bits there are is a fact about the height's initial upper
          * bound, and is not published separately: ask
-         * NamesAndIDsTracker::find_proof_flag_values for bit zero, one, two and
+         * NamesAndIDsTracker::find_proof_flag for bit zero, one, two and
          * so on until it has none, which is the same "is it there?" question a
          * citer asks about every other key here. A constant-height task has
          * none at all.

--- a/gcs/constraints/cumulative/derived_cumulative.cc
+++ b/gcs/constraints/cumulative/derived_cumulative.cc
@@ -160,9 +160,9 @@ auto gcs::innards::install_derived_cumulative(
             }
 
             for (Integer t = inputs->per_task_t_lo[i]; t <= per_task_t_hi[i]; ++t) {
-                auto before = tracker.find_proof_flag_values(task.donor, ConstraintProofModelData<Cumulative>::before_flag_key(position, t));
-                auto after = tracker.find_proof_flag_values(task.donor, ConstraintProofModelData<Cumulative>::after_flag_key(position, t));
-                auto active = tracker.find_proof_flag_values(task.donor, ConstraintProofModelData<Cumulative>::active_flag_key(position, t));
+                auto before = tracker.find_proof_flag(task.donor, ConstraintProofModelData<Cumulative>::before_flag_key(position, t));
+                auto after = tracker.find_proof_flag(task.donor, ConstraintProofModelData<Cumulative>::after_flag_key(position, t));
+                auto active = tracker.find_proof_flag(task.donor, ConstraintProofModelData<Cumulative>::active_flag_key(position, t));
                 // Missing means that donor never encoded this (task, time): it
                 // was not installed, or it windowed the task differently. Either
                 // way there is nothing to pin, so decline rather than guess.

--- a/gcs/constraints/cumulative/derived_cumulative_test.cc
+++ b/gcs/constraints/cumulative/derived_cumulative_test.cc
@@ -207,8 +207,8 @@ namespace
                         for (size_t i = 0; i < starts.size(); ++i) {
                             if (length_ubs[i] <= 0_i || heights[i] <= 0_i)
                                 continue;
-                            auto active = logger.names_and_ids_tracker().find_proof_flag_values(
-                                donor_id, ConstraintProofModelData<Cumulative>::active_flag_key(i, t));
+                            auto active =
+                                logger.names_and_ids_tracker().find_proof_flag(donor_id, ConstraintProofModelData<Cumulative>::active_flag_key(i, t));
                             if (active)
                                 items.push_back(SubsetSumItem{heights[i], *active});
                         }

--- a/gcs/constraints/cumulative/donor_view.cc
+++ b/gcs/constraints/cumulative/donor_view.cc
@@ -104,7 +104,7 @@ auto gcs::innards::cumulative_donor_view(const Cumulative & donor, const State &
             // posted zero height is not a donor being used in part, and the
             // counters that say so would stop meaning anything.
             if (logger &&
-                logger->names_and_ids_tracker().find_proof_flag_values(
+                logger->names_and_ids_tracker().find_proof_flag(
                     donor.constraint_id(), ConstraintProofModelData<Cumulative>::active_flag_key(i, state.lower_bound(donor.starts()[i]))))
                 view.set_aside.push_back(i);
             continue;
@@ -180,7 +180,7 @@ auto gcs::innards::recover_constant_argument_row(ProofLogger & logger, const Cum
     // whether there is anything here to weaken.
     vector<ProofFlag> weaken_out;
     for (auto i : view.set_aside) {
-        if (auto active = tracker.find_proof_flag_values(donor, ConstraintProofModelData<Cumulative>::active_flag_key(i, t))) {
+        if (auto active = tracker.find_proof_flag(donor, ConstraintProofModelData<Cumulative>::active_flag_key(i, t))) {
             // A constant height puts `height x active` in the row, so the one
             // flag is the whole term. A variable one puts the bits of a
             // linearised contribution there instead, and every one of them has
@@ -188,7 +188,7 @@ auto gcs::innards::recover_constant_argument_row(ProofLogger & logger, const Cum
             // zero, one, two and so on until it has no more.
             auto bits = 0;
             for (;; ++bits) {
-                auto cc = tracker.find_proof_flag_values(donor, ConstraintProofModelData<Cumulative>::contribution_flag_key(i, t, Integer{bits}));
+                auto cc = tracker.find_proof_flag(donor, ConstraintProofModelData<Cumulative>::contribution_flag_key(i, t, Integer{bits}));
                 if (! cc)
                     break;
                 weaken_out.push_back(*cc);
@@ -217,7 +217,7 @@ auto gcs::innards::recover_constant_argument_row(ProofLogger & logger, const Cum
             continue;
         vector<ProofFlag> cc;
         for (auto bit = 0;; ++bit) {
-            auto flag = tracker.find_proof_flag_values(donor, ConstraintProofModelData<Cumulative>::contribution_flag_key(i, t, Integer{bit}));
+            auto flag = tracker.find_proof_flag(donor, ConstraintProofModelData<Cumulative>::contribution_flag_key(i, t, Integer{bit}));
             if (! flag)
                 break;
             cc.push_back(*flag);
@@ -258,7 +258,7 @@ auto gcs::innards::recover_constant_argument_row(ProofLogger & logger, const Cum
     // file, and so is written down rather than tested.
     for (const auto & [i, cc] : convert) {
         auto height = std::get<SimpleIntegerVariableID>(*view.height_bounded_by[i]);
-        auto active = tracker.find_proof_flag_values(donor, ConstraintProofModelData<Cumulative>::active_flag_key(i, t));
+        auto active = tracker.find_proof_flag(donor, ConstraintProofModelData<Cumulative>::active_flag_key(i, t));
         auto contribution_row = tracker.constraint_row_label(donor, ConstraintProofModelData<Cumulative>::contribution_ge_row_role(i, t));
         // The flags exist, so the donor gave this task a window here and both
         // of these went out with them. Missing means the donor is not the

--- a/gcs/constraints/equals/equals.hh
+++ b/gcs/constraints/equals/equals.hh
@@ -7,6 +7,7 @@
 #include <gcs/innards/proofs/proof_logger-fwd.hh>
 #include <gcs/innards/proofs/reification.hh>
 #include <gcs/innards/reason.hh>
+#include <gcs/lifetime.hh>
 #include <gcs/reification.hh>
 #include <gcs/variable_condition.hh>
 #include <gcs/variable_id.hh>
@@ -48,6 +49,43 @@ namespace gcs
         auto with_proof_mutation(innards::EqualsProofMutation mutation) -> ReifiedEquals &;
 
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
+
+        /**
+         * \name The constraint as posted.
+         *
+         * Public so that a presolver can read a posted Equals or NotEquals back
+         * and decide whether to lift it. Over `{0, 1}` operands either is a
+         * 2-XOR, which is what ParitySystemGathering wants them for; nothing in
+         * these says anything about the proof output, which
+         * ConstraintProofModelData is for.
+         *
+         * `enforces_equality()` is false for a NotEquals: the reification
+         * condition alone does not say which, because MustNotHold on an Equals
+         * and MustHold on a NotEquals are different spellings of the same thing
+         * and only one of them is constructible.
+         * @{
+         */
+        [[nodiscard]] auto left_variable() const -> IntegerVariableID
+        {
+            return _v1;
+        }
+
+        [[nodiscard]] auto right_variable() const -> IntegerVariableID
+        {
+            return _v2;
+        }
+
+        [[nodiscard]] auto reification_condition() const GCS_LIFETIME_BOUND -> const ReificationCondition &
+        {
+            return _cond;
+        }
+
+        [[nodiscard]] auto enforces_equality() const -> bool
+        {
+            return ! _neq;
+        }
+        ///@}
+
         [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
         [[nodiscard]] virtual auto constraint_type() const -> std::string override;
     };

--- a/gcs/constraints/parity.hh
+++ b/gcs/constraints/parity.hh
@@ -2,5 +2,6 @@
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_PARITY_HH
 
 #include <gcs/constraints/parity/parity.hh>
+#include <gcs/constraints/parity/parity_system.hh>
 
 #endif

--- a/gcs/constraints/parity/gf2_system.cc
+++ b/gcs/constraints/parity/gf2_system.cc
@@ -1,5 +1,14 @@
+#include <gcs/constraints/innards/triggers.hh>
 #include <gcs/constraints/parity/gf2_system.hh>
+#include <gcs/constraints/parity/hints.hh>
 #include <gcs/exception.hh>
+#include <gcs/innards/inference_tracker.hh>
+#include <gcs/innards/proofs/names_and_ids_tracker.hh>
+#include <gcs/innards/proofs/pol_builder.hh>
+#include <gcs/innards/proofs/proof_logger.hh>
+#include <gcs/innards/proofs/simplify_literal.hh>
+#include <gcs/innards/propagators.hh>
+#include <gcs/innards/state.hh>
 
 #include <util/enumerate.hh>
 #include <util/overloaded.hh>
@@ -7,6 +16,8 @@
 #include <algorithm>
 #include <bit>
 #include <map>
+#include <memory>
+#include <string>
 #include <utility>
 #include <variant>
 
@@ -16,6 +27,8 @@ using namespace gcs::innards;
 using std::countr_zero;
 using std::get;
 using std::holds_alternative;
+using std::make_optional;
+using std::make_shared;
 using std::map;
 using std::move;
 using std::nullopt;
@@ -23,9 +36,11 @@ using std::optional;
 using std::pair;
 using std::popcount;
 using std::size_t;
+using std::string;
 using std::swap;
 using std::vector;
 using std::ranges::all_of;
+using std::ranges::any_of;
 
 auto GF2Bits::none() const -> bool
 {
@@ -134,4 +149,188 @@ auto gcs::innards::gauss_jordan(vector<GF2Row> & rows, size_t n_atoms) -> size_t
         ++rank;
     }
     return rank;
+}
+
+namespace
+{
+    // The trivially-true axiom `lit >= 0`, spelled the way the row that mentions
+    // the literal spells it: through simplify_literal, so that a view or a
+    // lazily-named atom resolves to the same XLiteral the OPB row carries and
+    // the pol arithmetic actually cancels. See dev_docs/view-proof-logging.md.
+    auto push_literal_axiom(PolBuilder & pol, NamesAndIDsTracker & tracker, const Literal & lit) -> void
+    {
+        overloaded{//
+            [&](const TrueLiteral &) {}, [&](const FalseLiteral &) {},
+            [&]<typename T_>(const VariableConditionFrom<T_> & cond) { pol.add(tracker.xliteral_for_ensuring(cond), tracker); }}
+            .visit(simplify_literal(tracker, lit));
+    }
+
+    auto literals_of(const vector<ParitySystemRow> & rows) -> vector<Literals>
+    {
+        vector<Literals> result;
+        result.reserve(rows.size());
+        for (const auto & row : rows)
+            result.push_back(row.literals);
+        return result;
+    }
+
+    auto triggers_for(const vector<ParitySystemRow> & rows) -> Triggers
+    {
+        Triggers triggers;
+        for (const auto & row : rows)
+            for (const auto & l : row.literals)
+                add_trigger_for(triggers, l);
+        return triggers;
+    }
+}
+
+auto gcs::innards::install_parity_system_propagator(
+    Propagators & propagators, const ConstraintID & id, const string & constraint_type, vector<ParitySystemRow> rows) -> void
+{
+    // A row over no literals says that zero is odd. It has no step to
+    // telescope and so no slack row, and there is nothing for elimination to do
+    // with it either --- but its own three chain rows pin a_0 both to one and
+    // to zero, so refuting it here is a plain RUP and leaves the rest of the
+    // system with a system it can actually reason about.
+    if (any_of(rows, [](const auto & row) { return row.literals.empty(); })) {
+        propagators.install_initial_contradiction(
+            id, constraint_type, "a parity row has no literals in it, so nothing can make it odd", JustifyUsingRUP{hints::Parity{id}});
+        return;
+    }
+
+    // The two slack rows per posted row, derived once at Top by the initialiser
+    // below and cited by every justification afterwards. Shared rather than
+    // copied because the propagator's closure is built here, before the
+    // initialiser has run. Empty for a row over no literals, which needs none.
+    auto slack_rows = make_shared<vector<optional<pair<ProofLine, ProofLine>>>>();
+
+    propagators.install_initialiser(
+        [rows, slack_rows](State &, auto &, ProofLogger * const logger) -> void {
+            if (! logger)
+                return;
+
+            for (const auto & row : rows)
+                slack_rows->push_back(derive_parity_slack_rows(*logger, *row.slack_source, row.literals, row.flag_stem));
+        },
+        InitialiserPriority::SimpleDefinition);
+
+    propagators.install(
+        id,
+        [system = build_gf2_system(literals_of(rows)), slack_rows, owner = id](
+            const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+            auto n_atoms = system.atoms.size();
+
+            // Read the trail once. An atom fixed at the root is no different
+            // from one a guess decided: either way it leaves the columns and
+            // flips the right-hand sides it appeared in.
+            vector<LiteralIs> assignment;
+            assignment.reserve(n_atoms);
+            auto any_undecided = false;
+            for (const auto & atom : system.atoms) {
+                assignment.push_back(state.test_literal(atom));
+                if (LiteralIs::Undecided == assignment.back())
+                    any_undecided = true;
+            }
+
+            // Substitute, then eliminate. From scratch every time: maintaining
+            // the reduced row echelon form incrementally is the interesting
+            // engineering and it does not belong in the first version, because
+            // XORing rows *creates* non-zero cells and so does not trail
+            // cleanly. See dev_docs/parity-system.md.
+            auto working = system.rows;
+            for (auto & row : working)
+                for (const auto & a : row.atoms.set_indices())
+                    switch (assignment[a]) {
+                        using enum LiteralIs;
+                    case DefinitelyTrue:
+                        row.atoms.reset(a);
+                        row.rhs = ! row.rhs;
+                        break;
+                    case DefinitelyFalse: row.atoms.reset(a); break;
+                    case Undecided: break;
+                    }
+
+            gauss_jordan(working, n_atoms);
+
+            // A row's support is the atoms of the rows it is the sum of, before
+            // substitution, and the assignment to those is the rho of Gocht and
+            // Nordstrom's section 4.3 --- so it is both the reason and what the
+            // justification has to walk.
+            auto support_of = [&](const GF2Row & row) {
+                GF2Bits support{n_atoms};
+                for (const auto & o : row.origin.set_indices())
+                    support ^= system.rows[o].atoms;
+                return support;
+            };
+
+            auto reason_for = [&](const GF2Bits & support) {
+                ReasonLiterals reason;
+                for (const auto & a : support.set_indices())
+                    switch (assignment[a]) {
+                        using enum LiteralIs;
+                    case DefinitelyTrue: reason.push_back(system.atoms[a]); break;
+                    case DefinitelyFalse: reason.push_back(! system.atoms[a]); break;
+                    case Undecided: break;
+                    }
+                return reason;
+            };
+
+            // Gocht and Nordstrom's section 4.3, as one pol: sum the slack rows
+            // of everything that went into this row, add a literal axiom for
+            // each atom of its support --- the atom itself where rho makes it
+            // false, its negation where rho makes it true --- then divide by two
+            // and multiply back, which is the step that gains one because the
+            // right-hand side is odd exactly when rho falsifies the row's
+            // parity. Adding the other direction turns what is left into a
+            // clause falsified by rho, and the framework's wrapping RUP closes
+            // on it. Atoms outside the support have even coefficients already
+            // and need nothing.
+            // `pretend` is how a propagation is justified rather than a
+            // conflict: the one unassigned atom is given the value that would
+            // violate the row, and the clause that comes out then has that
+            // atom's literal as its only term rho does not falsify, so it
+            // propagates. A conflict passes nullopt, rho being complete already.
+            auto justify_from = [&](const GF2Bits & origin, const GF2Bits & support, const optional<pair<size_t, bool>> & pretend) {
+                return [&, origin, support, pretend](const ReasonLiterals &) {
+                    PolBuilder pol;
+                    for (const auto & o : origin.set_indices())
+                        pol.add((*slack_rows)[o]->first);
+
+                    for (const auto & a : support.set_indices()) {
+                        auto rho_says_true = pretend && pretend->first == a ? pretend->second : LiteralIs::DefinitelyTrue == assignment[a];
+                        push_literal_axiom(
+                            pol, logger->names_and_ids_tracker(), rho_says_true ? Literal{! system.atoms[a]} : Literal{system.atoms[a]});
+                    }
+
+                    pol.divide_by(2_i).multiply_by(2_i);
+                    for (const auto & o : origin.set_indices())
+                        pol.add((*slack_rows)[o]->second);
+                    pol.emit(*logger, ProofLevel::Temporary);
+                };
+            };
+
+            for (const auto & row : working) {
+                auto how_many = row.atoms.count();
+                if (0 != how_many && 1 != how_many)
+                    continue;
+                if (0 == how_many && ! row.rhs)
+                    continue;
+
+                auto support = support_of(row);
+                auto reason = reason_for(support);
+
+                if (0 == how_many)
+                    inference.contradiction(logger, JustifyExplicitly{justify_from(row.origin, support, nullopt), ThenRUP::Yes, hints::Parity{owner}},
+                        ExplicitReason{reason});
+                else {
+                    auto a = *row.atoms.first_set();
+                    inference.infer(logger, row.rhs ? Literal{system.atoms[a]} : Literal{! system.atoms[a]},
+                        JustifyExplicitly{justify_from(row.origin, support, make_optional(pair{a, ! row.rhs})), ThenRUP::Yes, hints::Parity{owner}},
+                        ExplicitReason{reason});
+                }
+            }
+
+            return any_undecided ? PropagatorState::Enable : PropagatorState::DisableUntilBacktrack;
+        },
+        triggers_for(rows));
 }

--- a/gcs/constraints/parity/gf2_system.cc
+++ b/gcs/constraints/parity/gf2_system.cc
@@ -1,0 +1,137 @@
+#include <gcs/constraints/parity/gf2_system.hh>
+#include <gcs/exception.hh>
+
+#include <util/enumerate.hh>
+#include <util/overloaded.hh>
+
+#include <algorithm>
+#include <bit>
+#include <map>
+#include <utility>
+#include <variant>
+
+using namespace gcs;
+using namespace gcs::innards;
+
+using std::countr_zero;
+using std::get;
+using std::holds_alternative;
+using std::map;
+using std::move;
+using std::nullopt;
+using std::optional;
+using std::pair;
+using std::popcount;
+using std::size_t;
+using std::swap;
+using std::vector;
+using std::ranges::all_of;
+
+auto GF2Bits::none() const -> bool
+{
+    return all_of(_words, [](const auto & w) { return 0 == w; });
+}
+
+auto GF2Bits::count() const -> size_t
+{
+    size_t result = 0;
+    for (const auto & w : _words)
+        result += static_cast<size_t>(popcount(w));
+    return result;
+}
+
+auto GF2Bits::first_set() const -> optional<size_t>
+{
+    for (size_t w = 0; w != _words.size(); ++w)
+        if (0 != _words[w])
+            return w * 64 + static_cast<size_t>(countr_zero(_words[w]));
+    return nullopt;
+}
+
+auto GF2Bits::set_indices() const -> vector<size_t>
+{
+    vector<size_t> result;
+    for (size_t w = 0; w != _words.size(); ++w) {
+        auto bits = _words[w];
+        while (0 != bits) {
+            result.push_back(w * 64 + static_cast<size_t>(countr_zero(bits)));
+            bits &= bits - 1;
+        }
+    }
+    return result;
+}
+
+auto gcs::innards::canonical_atom(const IntegerVariableCondition & lit) -> pair<IntegerVariableCondition, bool>
+{
+    switch (lit.op) {
+        using enum VariableConditionOperator;
+    case Equal:
+    case GreaterEqual:
+    case InRange: return {lit, false};
+    case NotEqual: return {IntegerVariableCondition{lit.var, Equal, lit.value, lit.upper_value}, true};
+    case Less: return {IntegerVariableCondition{lit.var, GreaterEqual, lit.value, lit.upper_value}, true};
+    case NotInRange: return {IntegerVariableCondition{lit.var, InRange, lit.value, lit.upper_value}, true};
+    }
+    throw NonExhaustiveSwitch{};
+}
+
+auto gcs::innards::build_gf2_system(const vector<Literals> & posted_rows) -> GF2System
+{
+    // Two passes: the first finds the columns, because a row cannot be built
+    // until the width is known.
+    map<IntegerVariableCondition, size_t> column_of;
+    GF2System result;
+    for (const auto & row : posted_rows)
+        for (const auto & lit : row)
+            if (holds_alternative<IntegerVariableCondition>(lit)) {
+                auto atom = canonical_atom(get<IntegerVariableCondition>(lit)).first;
+                if (column_of.emplace(atom, result.atoms.size()).second)
+                    result.atoms.push_back(atom);
+            }
+
+    for (const auto & [r, posted] : enumerate(posted_rows)) {
+        GF2Row row{GF2Bits{result.atoms.size()}, GF2Bits{posted_rows.size()}, true};
+        row.origin.set(r);
+        for (const auto & lit : posted)
+            overloaded{//
+                [&](const IntegerVariableCondition & cond) {
+                    auto [atom, negated] = canonical_atom(cond);
+                    // XOR rather than set: a repeated atom cancels, which is
+                    // exactly what `x XOR x = 0` says, and a negated literal is
+                    // its atom plus a flip of the right-hand side.
+                    row.atoms.flip(column_of.at(atom));
+                    if (negated)
+                        row.rhs = ! row.rhs;
+                },
+                [&](const TrueLiteral &) { row.rhs = ! row.rhs; }, [&](const FalseLiteral &) {}}
+                .visit(lit);
+        result.rows.push_back(move(row));
+    }
+
+    return result;
+}
+
+auto gcs::innards::gauss_jordan(vector<GF2Row> & rows, size_t n_atoms) -> size_t
+{
+    size_t rank = 0;
+    for (size_t col = 0; col != n_atoms && rank != rows.size(); ++col) {
+        auto pivot = rows.size();
+        for (size_t r = rank; r != rows.size(); ++r)
+            if (rows[r].atoms.test(col)) {
+                pivot = r;
+                break;
+            }
+        if (pivot == rows.size())
+            continue;
+
+        swap(rows[rank], rows[pivot]);
+        for (size_t r = 0; r != rows.size(); ++r)
+            if (r != rank && rows[r].atoms.test(col)) {
+                rows[r].atoms ^= rows[rank].atoms;
+                rows[r].origin ^= rows[rank].origin;
+                rows[r].rhs = rows[r].rhs != rows[rank].rhs;
+            }
+        ++rank;
+    }
+    return rank;
+}

--- a/gcs/constraints/parity/gf2_system.hh
+++ b/gcs/constraints/parity/gf2_system.hh
@@ -1,0 +1,154 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_PARITY_GF2_SYSTEM_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_PARITY_GF2_SYSTEM_HH 1
+
+#include <gcs/innards/literal.hh>
+#include <gcs/variable_condition.hh>
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <utility>
+#include <vector>
+
+namespace gcs::innards
+{
+    /**
+     * \brief A set of GF(2) row indices, or of atom indices: a fixed-width bit
+     * vector with XOR, which is the only operation either use needs.
+     *
+     * Rows are XORed together during elimination and so are the origin sets
+     * that record which posted rows a working row is the sum of, and those are
+     * the same operation over different index spaces.
+     *
+     * \ingroup Innards
+     */
+    class GF2Bits
+    {
+    private:
+        std::vector<std::uint64_t> _words;
+
+    public:
+        explicit GF2Bits(std::size_t size = 0) : _words((size + 63) / 64, 0)
+        {
+        }
+
+        auto set(std::size_t i) -> void
+        {
+            _words[i / 64] |= std::uint64_t{1} << (i % 64);
+        }
+
+        auto flip(std::size_t i) -> void
+        {
+            _words[i / 64] ^= std::uint64_t{1} << (i % 64);
+        }
+
+        auto reset(std::size_t i) -> void
+        {
+            _words[i / 64] &= ~(std::uint64_t{1} << (i % 64));
+        }
+
+        [[nodiscard]] auto test(std::size_t i) const -> bool
+        {
+            return 0 != (_words[i / 64] & (std::uint64_t{1} << (i % 64)));
+        }
+
+        auto operator^=(const GF2Bits & other) -> GF2Bits &
+        {
+            for (std::size_t w = 0; w != _words.size(); ++w)
+                _words[w] ^= other._words[w];
+            return *this;
+        }
+
+        [[nodiscard]] auto none() const -> bool;
+
+        /// How many bits are set. Only ever compared against 0, 1 and 2, but
+        /// counting is no more expensive than stopping early over words.
+        [[nodiscard]] auto count() const -> std::size_t;
+
+        /// The index of the lowest set bit, or nullopt if there is none.
+        [[nodiscard]] auto first_set() const -> std::optional<std::size_t>;
+
+        /// Every index that is set, lowest first.
+        [[nodiscard]] auto set_indices() const -> std::vector<std::size_t>;
+    };
+
+    /**
+     * \brief One row of a GF(2) system: the XOR of the atoms whose bits are
+     * set equals \c rhs.
+     *
+     * \ingroup Innards
+     */
+    struct GF2Row
+    {
+        GF2Bits atoms;
+
+        /// Which posted rows this is the XOR of. For a posted row, just itself;
+        /// for a row elimination produced, everything that went into it. This
+        /// is what a justification cites, so it is maintained even when proofs
+        /// are off --- the cost is one word of XOR per elimination step.
+        GF2Bits origin;
+
+        bool rhs = false;
+    };
+
+    /**
+     * \brief A system of odd-parity rows over literals, canonicalised so that
+     * every column is a distinct positive atom.
+     *
+     * gcs literals come in negated pairs (`v != c` is `!(v == c)`, `v < c` is
+     * `!(v >= c)`), and GF(2) has no notion of a negated variable: `!p` is
+     * `p XOR 1`, so a negation is a column entry plus a flip of the row's
+     * right-hand side. Canonicalising to the positive form of each pair is
+     * what makes two rows that mention the same underlying fact share a column,
+     * and so is what makes them cancel --- both here and, later, in the `pol`
+     * that adds their pseudo-Boolean rows.
+     *
+     * Two atoms that are semantically equivalent without being a negation pair
+     * (`v != 0` and `v == 3` where the domain is `{0, 3}`) stay separate
+     * columns. That loses strength and never soundness: the system is a
+     * relaxation in which every atom is free, which is exactly what the
+     * pseudo-Boolean rows state, so the propagator and the proof agree about
+     * what is being claimed.
+     *
+     * \ingroup Innards
+     */
+    struct GF2System
+    {
+        std::vector<IntegerVariableCondition> atoms;
+        std::vector<GF2Row> rows;
+    };
+
+    /**
+     * \brief Turn posted rows of literals, each asserting odd parity, into a
+     * canonicalised GF2System.
+     *
+     * Duplicate atoms within a row cancel, and `TrueLiteral` / `FalseLiteral`
+     * fold into the right-hand side. Rows are kept even when they come out
+     * empty: an empty row with an odd right-hand side is a contradiction the
+     * propagator still has to report.
+     *
+     * \ingroup Innards
+     */
+    [[nodiscard]] auto build_gf2_system(const std::vector<Literals> & posted_rows) -> GF2System;
+
+    /**
+     * \brief Split the positive atom out of a literal, and say whether the
+     * literal was its negation.
+     *
+     * \ingroup Innards
+     */
+    [[nodiscard]] auto canonical_atom(const IntegerVariableCondition & lit) -> std::pair<IntegerVariableCondition, bool>;
+
+    /**
+     * \brief Reduce every row to reduced row echelon form in place, and report
+     * how many rows are non-zero.
+     *
+     * The rows left below the rank are all-zero in their atoms; those with an
+     * odd right-hand side are the contradictions.
+     *
+     * \ingroup Innards
+     */
+    auto gauss_jordan(std::vector<GF2Row> & rows, std::size_t n_atoms) -> std::size_t;
+}
+
+#endif

--- a/gcs/constraints/parity/gf2_system.hh
+++ b/gcs/constraints/parity/gf2_system.hh
@@ -1,12 +1,16 @@
 #ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_PARITY_GF2_SYSTEM_HH
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_PARITY_GF2_SYSTEM_HH 1
 
+#include <gcs/constraint_id.hh>
+#include <gcs/constraints/parity/parity_chain.hh>
 #include <gcs/innards/literal.hh>
+#include <gcs/innards/propagators-fwd.hh>
 #include <gcs/variable_condition.hh>
 
 #include <cstddef>
 #include <cstdint>
 #include <optional>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -149,6 +153,62 @@ namespace gcs::innards
      * \ingroup Innards
      */
     auto gauss_jordan(std::vector<GF2Row> & rows, std::size_t n_atoms) -> std::size_t;
+
+    /**
+     * \brief One row a ParitySystem propagator is to reason over, with
+     * everything its proofs will need to cite about that row.
+     *
+     * The three fields travel together because they have to: the chain is the
+     * chain *of these literals*, and getting them out of step would produce a
+     * justification citing rows about something else. Passing them as three
+     * parallel vectors is what this exists instead of.
+     *
+     * \ingroup Innards
+     */
+    struct ParitySystemRow
+    {
+        /// An odd number of these is true.
+        Literals literals;
+
+        /// How this row's slack form is to be derived: the accumulator chain in
+        /// the `.opb` for exactly these literals, or the claim that two RUP lines
+        /// will do. Nullopt when proofs are off, which is also when nothing reads
+        /// it.
+        std::optional<ParitySlackSource> slack_source;
+
+        /// Names the fresh per-step variables the slack-form derivation
+        /// introduces. Only ever cosmetic --- a flag's identity is its index,
+        /// not its name --- but a readable `.pbp` is worth the parameter.
+        std::string flag_stem;
+    };
+
+    /**
+     * \brief Install a propagator doing Gauss-Jordan over a system of
+     * odd-parity rows, and the initialiser that derives the proofs it needs.
+     *
+     * Two things are installed rather than one. The slack-form rows the
+     * justifications cite have to be derived inside the proof, at
+     * ProofLevel::Top, and an initialiser is where that can happen: it runs once
+     * before search, with a logger, which is later than a ProofModel is
+     * available and earlier than any inference needs the rows. See
+     * dev_docs/parity-system.md.
+     *
+     * Called from ParitySystem, which emitted its own chains, and from
+     * ParitySystemGathering, which found other constraints'. Neither owns the
+     * algorithm, which is why it lives here.
+     *
+     * A row over no literals says that zero is odd. It cannot be eliminated over
+     * and has no slack row, so rather than leave a caller to remember that, this
+     * installs an initial contradiction for the whole constraint instead of a
+     * propagator --- which is what such a row means anyway. `constraint_type`
+     * names the component in the note that gets reported when it does. A caller
+     * that would rather leave an empty row to whoever else is enforcing it
+     * should not pass it in.
+     *
+     * \ingroup Innards
+     */
+    auto install_parity_system_propagator(
+        Propagators & propagators, const ConstraintID & id, const std::string & constraint_type, std::vector<ParitySystemRow> rows) -> void;
 }
 
 #endif

--- a/gcs/constraints/parity/parity.cc
+++ b/gcs/constraints/parity/parity.cc
@@ -67,7 +67,17 @@ auto ParityOdd::clone() const -> unique_ptr<Constraint>
 
 auto ParityOdd::define_proof_model(ProofModel & model, const State &) -> void
 {
-    define_parity_chain(model, _constraint_id, nullopt, _lits);
+    static_cast<void>(define_parity_chain(model, _constraint_id, ConstraintProofModelData<ParityOdd>::chain_naming(), _lits));
+}
+
+auto ConstraintProofModelData<ParityOdd>::primary_row_role(const ParityOdd &) -> optional<string>
+{
+    return nullopt;
+}
+
+auto ConstraintProofModelData<ParityOdd>::chain_naming() -> ParityChainNaming
+{
+    return ParityChainNaming{nullopt};
 }
 
 auto ParityOdd::install_propagators(Propagators & propagators) -> void

--- a/gcs/constraints/parity/parity.cc
+++ b/gcs/constraints/parity/parity.cc
@@ -2,6 +2,7 @@
 #include <gcs/constraints/innards/triggers.hh>
 #include <gcs/constraints/parity/hints.hh>
 #include <gcs/constraints/parity/parity.hh>
+#include <gcs/constraints/parity/parity_chain.hh>
 #include <gcs/exception.hh>
 #include <gcs/innards/inference_tracker.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
@@ -10,7 +11,6 @@
 #include <gcs/innards/propagators.hh>
 #include <gcs/innards/s_expr.hh>
 #include <gcs/innards/state.hh>
-#include <util/enumerate.hh>
 
 #include <optional>
 #include <sstream>
@@ -31,7 +31,6 @@ using std::nullopt;
 using std::optional;
 using std::string;
 using std::stringstream;
-using std::to_string;
 using std::unique_ptr;
 using std::vector;
 
@@ -68,30 +67,7 @@ auto ParityOdd::clone() const -> unique_ptr<Constraint>
 
 auto ParityOdd::define_proof_model(ProofModel & model, const State &) -> void
 {
-    // cake_pb_cp's accumulator scheme, over the literals as cake reads them
-    // (each operand tuple maps to the same ge / eq atom our proof uses):
-    // x[id][0] channels the parity bit (always the constant 1 here, which cake
-    // carries as its pinned-true n[1][ge1] atom; our rows fold it), x[id][k] =
-    // x[id][k-1] XOR the k'th literal via four labelled clauses, and the acc
-    // row pins the final accumulator to 0, i.e. 1 XOR (parity of the literals)
-    // = 0.
-    PseudoBooleanTerm acc = FalseLiteral{}, not_acc = TrueLiteral{};
-    auto x0 = model.create_proof_flag(_constraint_id, vector<long long>{0}, nullopt);
-    model.add_labelled_constraint(_constraint_id, "0ge", WPBSum{} + 1_i * TrueLiteral{} + -1_i * x0 >= 0_i);
-    model.add_labelled_constraint(_constraint_id, "0le", WPBSum{} + 1_i * x0 + -1_i * TrueLiteral{} >= 0_i);
-    acc = x0;
-    not_acc = ! x0;
-    for (const auto & [k, l] : enumerate(_lits)) {
-        auto new_acc = model.create_proof_flag(_constraint_id, vector<long long>{static_cast<long long>(k) + 1}, nullopt);
-        auto stem = to_string(k + 1);
-        model.add_labelled_constraint(_constraint_id, stem + "_0_0", WPBSum{} + 1_i * acc + 1_i * l + 1_i * ! new_acc >= 1_i);
-        model.add_labelled_constraint(_constraint_id, stem + "_1_1", WPBSum{} + 1_i * not_acc + 1_i * ! l + 1_i * ! new_acc >= 1_i);
-        model.add_labelled_constraint(_constraint_id, stem + "_1_0", WPBSum{} + 1_i * not_acc + 1_i * l + 1_i * new_acc >= 1_i);
-        model.add_labelled_constraint(_constraint_id, stem + "_0_1", WPBSum{} + 1_i * acc + 1_i * ! l + 1_i * new_acc >= 1_i);
-        acc = new_acc;
-        not_acc = ! new_acc;
-    }
-    model.add_labelled_constraint(_constraint_id, "acc", WPBSum{} + -1_i * acc >= 0_i);
+    define_parity_chain(model, _constraint_id, nullopt, _lits);
 }
 
 auto ParityOdd::install_propagators(Propagators & propagators) -> void

--- a/gcs/constraints/parity/parity.hh
+++ b/gcs/constraints/parity/parity.hh
@@ -2,10 +2,14 @@
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_PARITY_PARITY_HH 1
 
 #include <gcs/constraint.hh>
+#include <gcs/constraints/parity/parity_chain.hh>
 #include <gcs/innards/literal.hh>
+#include <gcs/lifetime.hh>
 #include <gcs/variable_condition.hh>
 #include <gcs/variable_id.hh>
 
+#include <optional>
+#include <string>
 #include <vector>
 
 namespace gcs
@@ -30,8 +34,49 @@ namespace gcs
         explicit ParityOdd(innards::Literals);
 
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
+
+        /**
+         * \brief The literals, as posted.
+         *
+         * Public so that a presolver gathering several of these into one GF(2)
+         * system can read the rows back. \sa ParitySystemGathering
+         */
+        [[nodiscard]] auto literals() const GCS_LIFETIME_BOUND -> const innards::Literals &
+        {
+            return _lits;
+        }
+
         [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
         [[nodiscard]] virtual auto constraint_type() const -> std::string override;
+    };
+
+    /**
+     * \brief ParityOdd's published proof output: its accumulator chain.
+     *
+     * There is no single primary row --- the chain is a family, four clauses per
+     * literal plus three pins --- so primary_row_role is honestly nullopt and
+     * \ref chain_naming is what a citer wants. Pass what it returns to
+     * innards::find_parity_chain along with this constraint's id and its
+     * literals().size(), and the whole chain comes back or nothing does.
+     *
+     * Public API, and doubly so: these are cake_pb_cp's own names, re-derived at
+     * the other end from the `.scp`, so changing one is a cross-tool break
+     * rather than merely an internal one.
+     *
+     * \ingroup Innards
+     */
+    template <>
+    struct innards::ConstraintProofModelData<ParityOdd>
+    {
+        /**
+         * \brief Always nullopt: a chain has no one row a citer could mean.
+         */
+        [[nodiscard]] static auto primary_row_role(const ParityOdd &) -> std::optional<std::string>;
+
+        /**
+         * \brief How this constraint's single chain names its rows and flags.
+         */
+        [[nodiscard]] static auto chain_naming() -> innards::ParityChainNaming;
     };
 }
 

--- a/gcs/constraints/parity/parity_chain.cc
+++ b/gcs/constraints/parity/parity_chain.cc
@@ -1,21 +1,31 @@
 #include <gcs/constraints/parity/parity_chain.hh>
+#include <gcs/innards/proofs/names_and_ids_tracker.hh>
+#include <gcs/innards/proofs/pol_builder.hh>
 #include <gcs/innards/proofs/proof_line.hh>
+#include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/proofs/proof_model.hh>
+
 #include <util/enumerate.hh>
 
+#include <map>
 #include <string>
+#include <utility>
 #include <vector>
 
 using namespace gcs;
 using namespace gcs::innards;
 
+using std::make_optional;
+using std::map;
 using std::nullopt;
 using std::optional;
+using std::pair;
 using std::string;
 using std::to_string;
 using std::vector;
 
-auto gcs::innards::define_parity_chain(ProofModel & model, const ConstraintID & id, const optional<long long> & row, const Literals & lits) -> void
+auto gcs::innards::define_parity_chain(ProofModel & model, const ConstraintID & id, const optional<long long> & row, const Literals & lits)
+    -> ParityChainRows
 {
     // cake_pb_cp's accumulator scheme, over the literals as cake reads them
     // (each operand tuple maps to the same ge / eq atom our proof uses):
@@ -33,19 +43,112 @@ auto gcs::innards::define_parity_chain(ProofModel & model, const ConstraintID & 
         return values;
     };
 
+    ParityChainRows result;
     auto x0 = model.create_proof_flag(id, flag_values(0), nullopt);
-    model.add_labelled_constraint(id, role_prefix + "0ge", WPBSum{} + 1_i * TrueLiteral{} + -1_i * x0 >= 0_i);
-    model.add_labelled_constraint(id, role_prefix + "0le", WPBSum{} + 1_i * x0 + -1_i * TrueLiteral{} >= 0_i);
+    result.accumulators.push_back(x0);
+    result.a0_le_1 = model.add_labelled_constraint(id, role_prefix + "0ge", WPBSum{} + 1_i * TrueLiteral{} + -1_i * x0 >= 0_i);
+    result.a0_ge_1 = model.add_labelled_constraint(id, role_prefix + "0le", WPBSum{} + 1_i * x0 + -1_i * TrueLiteral{} >= 0_i);
     PseudoBooleanTerm acc = x0, not_acc = ! x0;
     for (const auto & [k, l] : enumerate(lits)) {
         auto new_acc = model.create_proof_flag(id, flag_values(static_cast<long long>(k) + 1), nullopt);
         auto stem = role_prefix + to_string(k + 1);
-        model.add_labelled_constraint(id, stem + "_0_0", WPBSum{} + 1_i * acc + 1_i * l + 1_i * ! new_acc >= 1_i);
-        model.add_labelled_constraint(id, stem + "_1_1", WPBSum{} + 1_i * not_acc + 1_i * ! l + 1_i * ! new_acc >= 1_i);
-        model.add_labelled_constraint(id, stem + "_1_0", WPBSum{} + 1_i * not_acc + 1_i * l + 1_i * new_acc >= 1_i);
-        model.add_labelled_constraint(id, stem + "_0_1", WPBSum{} + 1_i * acc + 1_i * ! l + 1_i * new_acc >= 1_i);
+        result.steps.push_back(
+            ParityChainRows::Step{model.add_labelled_constraint(id, stem + "_0_0", WPBSum{} + 1_i * acc + 1_i * l + 1_i * ! new_acc >= 1_i),
+                model.add_labelled_constraint(id, stem + "_1_1", WPBSum{} + 1_i * not_acc + 1_i * ! l + 1_i * ! new_acc >= 1_i),
+                model.add_labelled_constraint(id, stem + "_1_0", WPBSum{} + 1_i * not_acc + 1_i * l + 1_i * new_acc >= 1_i),
+                model.add_labelled_constraint(id, stem + "_0_1", WPBSum{} + 1_i * acc + 1_i * ! l + 1_i * new_acc >= 1_i)});
+        result.accumulators.push_back(new_acc);
         acc = new_acc;
         not_acc = ! new_acc;
     }
-    model.add_labelled_constraint(id, role_prefix + "acc", WPBSum{} + -1_i * acc >= 0_i);
+    result.an_le_0 = model.add_labelled_constraint(id, role_prefix + "acc", WPBSum{} + -1_i * acc >= 0_i);
+
+    return result;
+}
+
+auto gcs::innards::derive_parity_slack_rows(ProofLogger & logger, const ParityChainRows & chain, const Literals & lits, const string & flag_stem)
+    -> optional<pair<ProofLine, ProofLine>>
+{
+    if (lits.empty())
+        return nullopt;
+
+    auto & tracker = logger.names_and_ids_tracker();
+
+    // Per step, a fresh y_k with a_{k-1} + l_k + a_k = 2 y_k, in two halves.
+    // Neither half is RUP --- unit propagation cannot do parity --- so both are
+    // redundance steps, and the order matters for cost: this way round the
+    // first is goal-free and the second needs a five-line subproof, whereas
+    // swapping them makes the first free and the second seven.
+    vector<ProofLine> d1_lines, d2_lines;
+    for (const auto & [k, l] : enumerate(lits)) {
+        const auto & a = chain.accumulators[k];
+        const auto & a_next = chain.accumulators[k + 1];
+        auto y = logger.create_proof_flag(flag_stem + "y" + to_string(k + 1));
+
+        // 2y >= a + l + a'. The only goal is on the constraint itself, and
+        // reads a + l + a' <= 2, which is the step's own 1_1 clause; the goals
+        // on the formula are vacuous because y is fresh, so nothing already in
+        // the database mentions it.
+        auto d1 = logger.emit_red_proof_line(WPBSum{} + 2_i * y + -1_i * a + -1_i * l + -1_i * a_next >= 0_i, {{y, TrueLiteral{}}}, ProofLevel::Top);
+
+        // a + l + a' >= 2y. The goal on the constraint itself is trivial; the
+        // one that is not is d1 under y = 0, namely a + l + a' <= 0, and that
+        // is where the parity argument lives. Inside the subproof the negation
+        // of the constraint being added sits one line below the negated goal,
+        // and the three divisions below are what unit propagation cannot do.
+        map<ProofGoal, Subproof> subproofs;
+        subproofs.emplace(d1, Subproof{[&](ProofLogger & sub_logger) {
+            // The negated goal is the last line added as the subproof opens,
+            // and the negation of the constraint the `red` is adding sits one
+            // before it. Both have to be captured here and used as absolute
+            // references: a relative one would still say -1 several lines
+            // later, by which point it means something else entirely.
+            auto negated_goal = sub_logger.get_current_proof_line();
+            auto negated_constraint = ProofLineNumber{negated_goal.number - 1};
+
+            PolBuilder s1;
+            s1.add(negated_constraint).add(! tracker.xliteral_for(y), 2_i, tracker);
+            auto s1_line = s1.emit(sub_logger, ProofLevel::Temporary);
+
+            vector<ProofLine> units;
+            for (const auto & clause : {chain.steps[k].c00, chain.steps[k].c10, chain.steps[k].c01}) {
+                PolBuilder unit;
+                unit.add(s1_line).add(clause).divide_by(2_i);
+                units.push_back(unit.emit(sub_logger, ProofLevel::Temporary));
+            }
+
+            // The three units sum to the goal; adding the negated goal turns
+            // that into the contradiction a proofgoal block has to end on.
+            PolBuilder contradiction;
+            for (const auto & unit : units)
+                contradiction.add(unit);
+            contradiction.add(negated_goal);
+            contradiction.emit(sub_logger, ProofLevel::Temporary);
+        }});
+
+        auto d2 = logger.emit_red_proof_line(
+            WPBSum{} + 1_i * a + 1_i * l + 1_i * a_next + -2_i * y >= 0_i, {{y, FalseLiteral{}}}, ProofLevel::Top, subproofs);
+
+        d1_lines.push_back(d1);
+        d2_lines.push_back(d2);
+    }
+
+    // Telescoping: every interior accumulator appears in two consecutive steps,
+    // so with coefficient 2, which is even and therefore part of B. The two
+    // boundary rows each go with exactly one direction --- the d2 sum carries
+    // +a_n and only `acc` supplies -a_n, the d1 sum carries -a_n and only the
+    // literal axiom supplies +a_n --- so this placement is forced, not chosen.
+    PolBuilder ge;
+    for (const auto & d2 : d2_lines)
+        ge.add(d2);
+    ge.add(chain.a0_le_1).add(chain.an_le_0);
+    auto ge_line = ge.emit(logger, ProofLevel::Top);
+
+    PolBuilder le;
+    for (const auto & d1 : d1_lines)
+        le.add(d1);
+    le.add(chain.a0_ge_1).add(tracker.xliteral_for(chain.accumulators.back()), tracker);
+    auto le_line = le.emit(logger, ProofLevel::Top);
+
+    return make_optional(pair{ge_line, le_line});
 }

--- a/gcs/constraints/parity/parity_chain.cc
+++ b/gcs/constraints/parity/parity_chain.cc
@@ -1,0 +1,51 @@
+#include <gcs/constraints/parity/parity_chain.hh>
+#include <gcs/innards/proofs/proof_line.hh>
+#include <gcs/innards/proofs/proof_model.hh>
+#include <util/enumerate.hh>
+
+#include <string>
+#include <vector>
+
+using namespace gcs;
+using namespace gcs::innards;
+
+using std::nullopt;
+using std::optional;
+using std::string;
+using std::to_string;
+using std::vector;
+
+auto gcs::innards::define_parity_chain(ProofModel & model, const ConstraintID & id, const optional<long long> & row, const Literals & lits) -> void
+{
+    // cake_pb_cp's accumulator scheme, over the literals as cake reads them
+    // (each operand tuple maps to the same ge / eq atom our proof uses):
+    // x[id][0] channels the parity bit (always the constant 1 here, which cake
+    // carries as its pinned-true n[1][ge1] atom; our rows fold it), x[id][k] =
+    // x[id][k-1] XOR the k'th literal via four labelled clauses, and the acc
+    // row pins the final accumulator to 0, i.e. 1 XOR (parity of the literals)
+    // = 0.
+    auto role_prefix = row ? "r" + to_string(*row) + "_" : string{};
+    auto flag_values = [&](long long k) {
+        vector<long long> values;
+        if (row)
+            values.push_back(*row);
+        values.push_back(k);
+        return values;
+    };
+
+    auto x0 = model.create_proof_flag(id, flag_values(0), nullopt);
+    model.add_labelled_constraint(id, role_prefix + "0ge", WPBSum{} + 1_i * TrueLiteral{} + -1_i * x0 >= 0_i);
+    model.add_labelled_constraint(id, role_prefix + "0le", WPBSum{} + 1_i * x0 + -1_i * TrueLiteral{} >= 0_i);
+    PseudoBooleanTerm acc = x0, not_acc = ! x0;
+    for (const auto & [k, l] : enumerate(lits)) {
+        auto new_acc = model.create_proof_flag(id, flag_values(static_cast<long long>(k) + 1), nullopt);
+        auto stem = role_prefix + to_string(k + 1);
+        model.add_labelled_constraint(id, stem + "_0_0", WPBSum{} + 1_i * acc + 1_i * l + 1_i * ! new_acc >= 1_i);
+        model.add_labelled_constraint(id, stem + "_1_1", WPBSum{} + 1_i * not_acc + 1_i * ! l + 1_i * ! new_acc >= 1_i);
+        model.add_labelled_constraint(id, stem + "_1_0", WPBSum{} + 1_i * not_acc + 1_i * l + 1_i * new_acc >= 1_i);
+        model.add_labelled_constraint(id, stem + "_0_1", WPBSum{} + 1_i * acc + 1_i * ! l + 1_i * new_acc >= 1_i);
+        acc = new_acc;
+        not_acc = ! new_acc;
+    }
+    model.add_labelled_constraint(id, role_prefix + "acc", WPBSum{} + -1_i * acc >= 0_i);
+}

--- a/gcs/constraints/parity/parity_chain.cc
+++ b/gcs/constraints/parity/parity_chain.cc
@@ -1,4 +1,5 @@
 #include <gcs/constraints/parity/parity_chain.hh>
+#include <gcs/exception.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
 #include <gcs/innards/proofs/pol_builder.hh>
 #include <gcs/innards/proofs/proof_line.hh>
@@ -6,6 +7,7 @@
 #include <gcs/innards/proofs/proof_model.hh>
 
 #include <util/enumerate.hh>
+#include <util/overloaded.hh>
 
 #include <map>
 #include <string>
@@ -17,14 +19,55 @@ using namespace gcs::innards;
 
 using std::make_optional;
 using std::map;
+using std::move;
 using std::nullopt;
 using std::optional;
 using std::pair;
+using std::size_t;
 using std::string;
 using std::to_string;
 using std::vector;
 
-auto gcs::innards::define_parity_chain(ProofModel & model, const ConstraintID & id, const optional<long long> & row, const Literals & lits)
+namespace
+{
+    auto role_prefix_for(const optional<long long> & row) -> string
+    {
+        return row ? "r" + to_string(*row) + "_" : string{};
+    }
+}
+
+auto ParityChainNaming::role_0ge() const -> string
+{
+    return role_prefix_for(row) + "0ge";
+}
+
+auto ParityChainNaming::role_0le() const -> string
+{
+    return role_prefix_for(row) + "0le";
+}
+
+auto ParityChainNaming::role_acc() const -> string
+{
+    return role_prefix_for(row) + "acc";
+}
+
+auto ParityChainNaming::role_step(size_t k, bool accumulator_in, bool literal) const -> string
+{
+    return role_prefix_for(row) + to_string(k) + (accumulator_in ? "_1" : "_0") + (literal ? "_1" : "_0");
+}
+
+auto ParityChainNaming::accumulator_flag_key(size_t k) const -> ProofFlagKey
+{
+    vector<long long> values;
+    if (row)
+        values.push_back(*row);
+    values.push_back(static_cast<long long>(k));
+    // Indices, not Values: these are cake's x[id][k] accumulators, whose numbers
+    // are chain positions rather than domain values.
+    return ProofFlagKey{move(values), nullopt, ProofFlagFamily::Indices};
+}
+
+auto gcs::innards::define_parity_chain(ProofModel & model, const ConstraintID & id, const ParityChainNaming & naming, const Literals & lits)
     -> ParityChainRows
 {
     // cake_pb_cp's accumulator scheme, over the literals as cake reads them
@@ -34,121 +77,179 @@ auto gcs::innards::define_parity_chain(ProofModel & model, const ConstraintID & 
     // x[id][k-1] XOR the k'th literal via four labelled clauses, and the acc
     // row pins the final accumulator to 0, i.e. 1 XOR (parity of the literals)
     // = 0.
-    auto role_prefix = row ? "r" + to_string(*row) + "_" : string{};
-    auto flag_values = [&](long long k) {
-        vector<long long> values;
-        if (row)
-            values.push_back(*row);
-        values.push_back(k);
-        return values;
-    };
-
     ParityChainRows result;
-    auto x0 = model.create_proof_flag(id, flag_values(0), nullopt);
+    auto x0 = model.create_proof_flag(id, naming.accumulator_flag_key(0).values, nullopt);
     result.accumulators.push_back(x0);
-    result.a0_le_1 = model.add_labelled_constraint(id, role_prefix + "0ge", WPBSum{} + 1_i * TrueLiteral{} + -1_i * x0 >= 0_i);
-    result.a0_ge_1 = model.add_labelled_constraint(id, role_prefix + "0le", WPBSum{} + 1_i * x0 + -1_i * TrueLiteral{} >= 0_i);
+    result.a0_le_1 = model.add_labelled_constraint(id, naming.role_0ge(), WPBSum{} + 1_i * TrueLiteral{} + -1_i * x0 >= 0_i);
+    result.a0_ge_1 = model.add_labelled_constraint(id, naming.role_0le(), WPBSum{} + 1_i * x0 + -1_i * TrueLiteral{} >= 0_i);
     PseudoBooleanTerm acc = x0, not_acc = ! x0;
     for (const auto & [k, l] : enumerate(lits)) {
-        auto new_acc = model.create_proof_flag(id, flag_values(static_cast<long long>(k) + 1), nullopt);
-        auto stem = role_prefix + to_string(k + 1);
-        result.steps.push_back(
-            ParityChainRows::Step{model.add_labelled_constraint(id, stem + "_0_0", WPBSum{} + 1_i * acc + 1_i * l + 1_i * ! new_acc >= 1_i),
-                model.add_labelled_constraint(id, stem + "_1_1", WPBSum{} + 1_i * not_acc + 1_i * ! l + 1_i * ! new_acc >= 1_i),
-                model.add_labelled_constraint(id, stem + "_1_0", WPBSum{} + 1_i * not_acc + 1_i * l + 1_i * new_acc >= 1_i),
-                model.add_labelled_constraint(id, stem + "_0_1", WPBSum{} + 1_i * acc + 1_i * ! l + 1_i * new_acc >= 1_i)});
+        auto new_acc = model.create_proof_flag(id, naming.accumulator_flag_key(k + 1).values, nullopt);
+        result.steps.push_back(ParityChainRows::Step{
+            model.add_labelled_constraint(id, naming.role_step(k + 1, false, false), WPBSum{} + 1_i * acc + 1_i * l + 1_i * ! new_acc >= 1_i),
+            model.add_labelled_constraint(id, naming.role_step(k + 1, true, true), WPBSum{} + 1_i * not_acc + 1_i * ! l + 1_i * ! new_acc >= 1_i),
+            model.add_labelled_constraint(id, naming.role_step(k + 1, true, false), WPBSum{} + 1_i * not_acc + 1_i * l + 1_i * new_acc >= 1_i),
+            model.add_labelled_constraint(id, naming.role_step(k + 1, false, true), WPBSum{} + 1_i * acc + 1_i * ! l + 1_i * new_acc >= 1_i)});
         result.accumulators.push_back(new_acc);
         acc = new_acc;
         not_acc = ! new_acc;
     }
-    result.an_le_0 = model.add_labelled_constraint(id, role_prefix + "acc", WPBSum{} + -1_i * acc >= 0_i);
+    result.an_le_0 = model.add_labelled_constraint(id, naming.role_acc(), WPBSum{} + -1_i * acc >= 0_i);
 
     return result;
 }
 
-auto gcs::innards::derive_parity_slack_rows(ProofLogger & logger, const ParityChainRows & chain, const Literals & lits, const string & flag_stem)
-    -> optional<pair<ProofLine, ProofLine>>
+auto gcs::innards::find_parity_chain(const ProofLogger & logger, const ConstraintID & id, const ParityChainNaming & naming, size_t how_many_literals)
+    -> optional<ParityChainRows>
 {
-    if (lits.empty())
+    const auto & tracker = logger.names_and_ids_tracker();
+
+    // All or nothing: a chain missing one of its four per-step clauses cannot be
+    // telescoped, so a partial answer would only move the failure into the pol.
+    auto row_of = [&](const string & role) { return tracker.constraint_row_label(id, role); };
+
+    auto a0_le_1 = row_of(naming.role_0ge());
+    auto a0_ge_1 = row_of(naming.role_0le());
+    auto an_le_0 = row_of(naming.role_acc());
+    if (! a0_le_1 || ! a0_ge_1 || ! an_le_0)
         return nullopt;
 
-    auto & tracker = logger.names_and_ids_tracker();
+    ParityChainRows result;
+    result.a0_le_1 = *a0_le_1;
+    result.a0_ge_1 = *a0_ge_1;
+    result.an_le_0 = *an_le_0;
 
-    // Per step, a fresh y_k with a_{k-1} + l_k + a_k = 2 y_k, in two halves.
-    // Neither half is RUP --- unit propagation cannot do parity --- so both are
-    // redundance steps, and the order matters for cost: this way round the
-    // first is goal-free and the second needs a five-line subproof, whereas
-    // swapping them makes the first free and the second seven.
-    vector<ProofLine> d1_lines, d2_lines;
-    for (const auto & [k, l] : enumerate(lits)) {
-        const auto & a = chain.accumulators[k];
-        const auto & a_next = chain.accumulators[k + 1];
-        auto y = logger.create_proof_flag(flag_stem + "y" + to_string(k + 1));
-
-        // 2y >= a + l + a'. The only goal is on the constraint itself, and
-        // reads a + l + a' <= 2, which is the step's own 1_1 clause; the goals
-        // on the formula are vacuous because y is fresh, so nothing already in
-        // the database mentions it.
-        auto d1 = logger.emit_red_proof_line(WPBSum{} + 2_i * y + -1_i * a + -1_i * l + -1_i * a_next >= 0_i, {{y, TrueLiteral{}}}, ProofLevel::Top);
-
-        // a + l + a' >= 2y. The goal on the constraint itself is trivial; the
-        // one that is not is d1 under y = 0, namely a + l + a' <= 0, and that
-        // is where the parity argument lives. Inside the subproof the negation
-        // of the constraint being added sits one line below the negated goal,
-        // and the three divisions below are what unit propagation cannot do.
-        map<ProofGoal, Subproof> subproofs;
-        subproofs.emplace(d1, Subproof{[&](ProofLogger & sub_logger) {
-            // The negated goal is the last line added as the subproof opens,
-            // and the negation of the constraint the `red` is adding sits one
-            // before it. Both have to be captured here and used as absolute
-            // references: a relative one would still say -1 several lines
-            // later, by which point it means something else entirely.
-            auto negated_goal = sub_logger.get_current_proof_line();
-            auto negated_constraint = ProofLineNumber{negated_goal.number - 1};
-
-            PolBuilder s1;
-            s1.add(negated_constraint).add(! tracker.xliteral_for(y), 2_i, tracker);
-            auto s1_line = s1.emit(sub_logger, ProofLevel::Temporary);
-
-            vector<ProofLine> units;
-            for (const auto & clause : {chain.steps[k].c00, chain.steps[k].c10, chain.steps[k].c01}) {
-                PolBuilder unit;
-                unit.add(s1_line).add(clause).divide_by(2_i);
-                units.push_back(unit.emit(sub_logger, ProofLevel::Temporary));
-            }
-
-            // The three units sum to the goal; adding the negated goal turns
-            // that into the contradiction a proofgoal block has to end on.
-            PolBuilder contradiction;
-            for (const auto & unit : units)
-                contradiction.add(unit);
-            contradiction.add(negated_goal);
-            contradiction.emit(sub_logger, ProofLevel::Temporary);
-        }});
-
-        auto d2 = logger.emit_red_proof_line(
-            WPBSum{} + 1_i * a + 1_i * l + 1_i * a_next + -2_i * y >= 0_i, {{y, FalseLiteral{}}}, ProofLevel::Top, subproofs);
-
-        d1_lines.push_back(d1);
-        d2_lines.push_back(d2);
+    for (size_t k = 0; k != how_many_literals + 1; ++k) {
+        auto flag = tracker.find_proof_flag(id, naming.accumulator_flag_key(k));
+        if (! flag)
+            return nullopt;
+        result.accumulators.push_back(*flag);
     }
 
-    // Telescoping: every interior accumulator appears in two consecutive steps,
-    // so with coefficient 2, which is even and therefore part of B. The two
-    // boundary rows each go with exactly one direction --- the d2 sum carries
-    // +a_n and only `acc` supplies -a_n, the d1 sum carries -a_n and only the
-    // literal axiom supplies +a_n --- so this placement is forced, not chosen.
-    PolBuilder ge;
-    for (const auto & d2 : d2_lines)
-        ge.add(d2);
-    ge.add(chain.a0_le_1).add(chain.an_le_0);
-    auto ge_line = ge.emit(logger, ProofLevel::Top);
+    for (size_t k = 1; k != how_many_literals + 1; ++k) {
+        auto c00 = row_of(naming.role_step(k, false, false));
+        auto c11 = row_of(naming.role_step(k, true, true));
+        auto c10 = row_of(naming.role_step(k, true, false));
+        auto c01 = row_of(naming.role_step(k, false, true));
+        if (! c00 || ! c11 || ! c10 || ! c01)
+            return nullopt;
+        result.steps.push_back(ParityChainRows::Step{*c00, *c11, *c10, *c01});
+    }
 
-    PolBuilder le;
-    for (const auto & d1 : d1_lines)
-        le.add(d1);
-    le.add(chain.a0_ge_1).add(tracker.xliteral_for(chain.accumulators.back()), tracker);
-    auto le_line = le.emit(logger, ProofLevel::Top);
+    return result;
+}
 
-    return make_optional(pair{ge_line, le_line});
+namespace
+{
+    auto derive_from_chain(ProofLogger & logger, const ParityChainRows & chain, const Literals & lits, const string & flag_stem)
+        -> optional<pair<ProofLine, ProofLine>>
+    {
+        if (lits.empty())
+            return nullopt;
+
+        auto & tracker = logger.names_and_ids_tracker();
+
+        // Per step, a fresh y_k with a_{k-1} + l_k + a_k = 2 y_k, in two halves.
+        // Neither half is RUP --- unit propagation cannot do parity --- so both are
+        // redundance steps, and the order matters for cost: this way round the
+        // first is goal-free and the second needs a five-line subproof, whereas
+        // swapping them makes the first free and the second seven.
+        vector<ProofLine> d1_lines, d2_lines;
+        for (const auto & [k, l] : enumerate(lits)) {
+            const auto & a = chain.accumulators[k];
+            const auto & a_next = chain.accumulators[k + 1];
+            auto y = logger.create_proof_flag(flag_stem + "y" + to_string(k + 1));
+
+            // 2y >= a + l + a'. The only goal is on the constraint itself, and
+            // reads a + l + a' <= 2, which is the step's own 1_1 clause; the goals
+            // on the formula are vacuous because y is fresh, so nothing already in
+            // the database mentions it.
+            auto d1 =
+                logger.emit_red_proof_line(WPBSum{} + 2_i * y + -1_i * a + -1_i * l + -1_i * a_next >= 0_i, {{y, TrueLiteral{}}}, ProofLevel::Top);
+
+            // a + l + a' >= 2y. The goal on the constraint itself is trivial; the
+            // one that is not is d1 under y = 0, namely a + l + a' <= 0, and that
+            // is where the parity argument lives. Inside the subproof the negation
+            // of the constraint being added sits one line below the negated goal,
+            // and the three divisions below are what unit propagation cannot do.
+            map<ProofGoal, Subproof> subproofs;
+            subproofs.emplace(d1, Subproof{[&](ProofLogger & sub_logger) {
+                // The negated goal is the last line added as the subproof opens,
+                // and the negation of the constraint the `red` is adding sits one
+                // before it. Both have to be captured here and used as absolute
+                // references: a relative one would still say -1 several lines
+                // later, by which point it means something else entirely.
+                auto negated_goal = sub_logger.get_current_proof_line();
+                auto negated_constraint = ProofLineNumber{negated_goal.number - 1};
+
+                PolBuilder s1;
+                s1.add(negated_constraint).add(! tracker.xliteral_for(y), 2_i, tracker);
+                auto s1_line = s1.emit(sub_logger, ProofLevel::Temporary);
+
+                vector<ProofLine> units;
+                for (const auto & clause : {chain.steps[k].c00, chain.steps[k].c10, chain.steps[k].c01}) {
+                    PolBuilder unit;
+                    unit.add(s1_line).add(clause).divide_by(2_i);
+                    units.push_back(unit.emit(sub_logger, ProofLevel::Temporary));
+                }
+
+                // The three units sum to the goal; adding the negated goal turns
+                // that into the contradiction a proofgoal block has to end on.
+                PolBuilder contradiction;
+                for (const auto & unit : units)
+                    contradiction.add(unit);
+                contradiction.add(negated_goal);
+                contradiction.emit(sub_logger, ProofLevel::Temporary);
+            }});
+
+            auto d2 = logger.emit_red_proof_line(
+                WPBSum{} + 1_i * a + 1_i * l + 1_i * a_next + -2_i * y >= 0_i, {{y, FalseLiteral{}}}, ProofLevel::Top, subproofs);
+
+            d1_lines.push_back(d1);
+            d2_lines.push_back(d2);
+        }
+
+        // Telescoping: every interior accumulator appears in two consecutive steps,
+        // so with coefficient 2, which is even and therefore part of B. The two
+        // boundary rows each go with exactly one direction --- the d2 sum carries
+        // +a_n and only `acc` supplies -a_n, the d1 sum carries -a_n and only the
+        // literal axiom supplies +a_n --- so this placement is forced, not chosen.
+        PolBuilder ge;
+        for (const auto & d2 : d2_lines)
+            ge.add(d2);
+        ge.add(chain.a0_le_1).add(chain.an_le_0);
+        auto ge_line = ge.emit(logger, ProofLevel::Top);
+
+        PolBuilder le;
+        for (const auto & d1 : d1_lines)
+            le.add(d1);
+        le.add(chain.a0_ge_1).add(tracker.xliteral_for(chain.accumulators.back()), tracker);
+        auto le_line = le.emit(logger, ProofLevel::Top);
+
+        return make_optional(pair{ge_line, le_line});
+    }
+
+    // `l1 + l2 = 1`: odd parity over two literals means exactly one holds, so B
+    // is zero and there is nothing to introduce. Both halves are RUP against the
+    // donor's own encoding --- negating either fixes both operands and walks
+    // into one of the rows it emitted --- which is the whole reason this shape
+    // exists rather than being made to look like a chain.
+    auto derive_by_rup(ProofLogger & logger, const Literals & lits) -> optional<pair<ProofLine, ProofLine>>
+    {
+        if (2 != lits.size())
+            throw UnexpectedException{"a parity row claiming its slack form is RUP has " + to_string(lits.size()) + " literals, not two"};
+
+        auto ge = logger.emit_rup_proof_line(WPBSum{} + 1_i * lits[0] + 1_i * lits[1] >= 1_i, ProofLevel::Top);
+        auto le = logger.emit_rup_proof_line(WPBSum{} + -1_i * lits[0] + -1_i * lits[1] >= -1_i, ProofLevel::Top);
+        return make_optional(pair{ge, le});
+    }
+}
+
+auto gcs::innards::derive_parity_slack_rows(ProofLogger & logger, const ParitySlackSource & source, const Literals & lits, const string & flag_stem)
+    -> optional<pair<ProofLine, ProofLine>>
+{
+    return overloaded{//
+        [&](const ParityChainRows & chain) { return derive_from_chain(logger, chain, lits, flag_stem); },
+        [&](const ParitySlackFormIsRUP &) { return derive_by_rup(logger, lits); }}
+        .visit(source);
 }

--- a/gcs/constraints/parity/parity_chain.hh
+++ b/gcs/constraints/parity/parity_chain.hh
@@ -3,13 +3,46 @@
 
 #include <gcs/constraint_id.hh>
 #include <gcs/innards/literal.hh>
+#include <gcs/innards/proofs/proof_line.hh>
+#include <gcs/innards/proofs/proof_logger-fwd.hh>
 #include <gcs/innards/proofs/proof_model-fwd.hh>
+#include <gcs/innards/proofs/proof_only_variables.hh>
 
 #include <optional>
 #include <string>
+#include <utility>
+#include <vector>
 
 namespace gcs::innards
 {
+    /**
+     * \brief The rows and flags one accumulator chain put in the `.opb`, as the
+     * slack-form derivation needs to cite them.
+     *
+     * Handed back by define_parity_chain, and reconstructible from a
+     * ParityOdd's published ConstraintProofModelData, so that the derivation is
+     * one piece of code whether the chain was emitted by ParitySystem or by a
+     * separately posted constraint a presolver went looking for.
+     *
+     * \ingroup Innards
+     */
+    struct ParityChainRows
+    {
+        /// The four clauses of one step, `a_{k-1} XOR l_k XOR a_k = 0`, named
+        /// for the (accumulator-in, literal) case each one rules out.
+        struct Step
+        {
+            ProofLine c00, c11, c10, c01;
+        };
+
+        /// `a_0 .. a_n`: n + 1 of them for a chain over n literals.
+        std::vector<ProofFlag> accumulators;
+        std::vector<Step> steps;
+
+        /// `a_0 <= 1`, `a_0 >= 1`, and `a_n <= 0`.
+        ProofLine a0_le_1, a0_ge_1, an_le_0;
+    };
+
     /**
      * \brief Emit cake_pb_cp's accumulator-chain OPB encoding of "an odd number
      * of these literals is true", under the given constraint's identity.
@@ -30,7 +63,30 @@ namespace gcs::innards
      *
      * \ingroup Innards
      */
-    auto define_parity_chain(ProofModel & model, const ConstraintID & id, const std::optional<long long> & row, const Literals & lits) -> void;
+    auto define_parity_chain(ProofModel & model, const ConstraintID & id, const std::optional<long long> & row, const Literals & lits)
+        -> ParityChainRows;
+
+    /**
+     * \brief Derive the two pseudo-Boolean inequalities saying the chain's
+     * literals sum to `1 + 2B`, and return them.
+     *
+     * Gocht and Nordstrom's (4.4a) and (4.4b) --- the form under which adding
+     * two parity constraints together is one `pol` line. The accumulator chain
+     * cannot state it directly, and a presolver could not add it to the `.opb`
+     * even if it wanted to, so it is derived inside the proof at
+     * ProofLevel::Top. See dev_docs/parity-system.md, "Deriving the slack row
+     * from the accumulator chain", for the argument and for why each step needs
+     * a `red` rather than a RUP.
+     *
+     * `flag_stem` names the fresh per-step variables and must be unique across
+     * chains. Returns nullopt for a chain over no literals: there is no step to
+     * telescope, `a_0` and `a_n` are the same flag, and nothing is needed ---
+     * an empty odd row is a contradiction the chain's own three rows state.
+     *
+     * \ingroup Innards
+     */
+    [[nodiscard]] auto derive_parity_slack_rows(ProofLogger & logger, const ParityChainRows & chain, const Literals & lits,
+        const std::string & flag_stem) -> std::optional<std::pair<ProofLine, ProofLine>>;
 }
 
 #endif

--- a/gcs/constraints/parity/parity_chain.hh
+++ b/gcs/constraints/parity/parity_chain.hh
@@ -1,0 +1,36 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_PARITY_PARITY_CHAIN_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_PARITY_PARITY_CHAIN_HH 1
+
+#include <gcs/constraint_id.hh>
+#include <gcs/innards/literal.hh>
+#include <gcs/innards/proofs/proof_model-fwd.hh>
+
+#include <optional>
+#include <string>
+
+namespace gcs::innards
+{
+    /**
+     * \brief Emit cake_pb_cp's accumulator-chain OPB encoding of "an odd number
+     * of these literals is true", under the given constraint's identity.
+     *
+     * Shared by ParityOdd, which has one chain, and ParitySystem, which has one
+     * per row: the point is that both entry points put the *same* rows in the
+     * `.opb`, so the slack-form derivation that reads them back
+     * (dev_docs/parity-system.md) is one piece of code rather than two.
+     *
+     * `row` disambiguates when there is more than one chain under one identity.
+     * Left unset --- ParityOdd's case, and the only one cake ever sees --- the
+     * flags are `x[id][k]` and the roles are `0ge`, `0le`, `<k>_0_0` and so on,
+     * which is cake's naming exactly and must stay that way. Set, every flag
+     * gains a leading index and every role a leading `r<row>_`, which keeps the
+     * chains apart; nothing in cake's vocabulary corresponds to that, and
+     * nothing needs to, because a constraint with several chains has no `.scp`
+     * spelling to be checked against.
+     *
+     * \ingroup Innards
+     */
+    auto define_parity_chain(ProofModel & model, const ConstraintID & id, const std::optional<long long> & row, const Literals & lits) -> void;
+}
+
+#endif

--- a/gcs/constraints/parity/parity_chain.hh
+++ b/gcs/constraints/parity/parity_chain.hh
@@ -3,26 +3,85 @@
 
 #include <gcs/constraint_id.hh>
 #include <gcs/innards/literal.hh>
+#include <gcs/innards/proofs/constraint_proof_model_data.hh>
 #include <gcs/innards/proofs/proof_line.hh>
 #include <gcs/innards/proofs/proof_logger-fwd.hh>
 #include <gcs/innards/proofs/proof_model-fwd.hh>
 #include <gcs/innards/proofs/proof_only_variables.hh>
 
+#include <cstddef>
 #include <optional>
 #include <string>
 #include <utility>
+#include <variant>
 #include <vector>
 
 namespace gcs::innards
 {
     /**
+     * \brief What one accumulator chain calls the rows and flags it emits.
+     *
+     * These are cake_pb_cp's own names, which is what makes them a contract
+     * rather than an implementation detail: cake re-derives the same ones from
+     * the `.scp`, so renaming any of them is a cross-tool break. A constraint
+     * that emits a chain publishes this object through its
+     * ConstraintProofModelData, and both the emitter (define_parity_chain) and
+     * anything looking a chain up afterwards (find_parity_chain) build every
+     * name through it --- so there is exactly one place the names exist, and
+     * nobody is guessing at another constraint's scheme.
+     *
+     * Publishing a small naming *object* rather than a handful of loose
+     * role-producing functions is deliberate. ConstraintProofModelData is happy
+     * with either --- \c Cumulative publishes several loose functions --- but
+     * this family's names are all indexed the same way, by the same optional row
+     * index, and bundling them means a citer cannot pick up one of them without
+     * the rest or accidentally mix an unprefixed role with a prefixed flag.
+     *
+     * \ingroup Innards
+     */
+    struct ParityChainNaming
+    {
+        /**
+         * \brief Which chain, when one constraint emits several.
+         *
+         * Left unset --- ParityOdd's case, and the only one cake ever sees ---
+         * the flags are `x[id][k]` and the roles are `0ge`, `0le`, `<k>_0_0`,
+         * which is cake's naming exactly. Set, every flag gains a leading index
+         * and every role a leading `r<row>_`, which is what keeps several chains
+         * under one identity apart; cake has no counterpart for that, and needs
+         * none, because a constraint with several chains has no `.scp` spelling
+         * to be checked against.
+         */
+        std::optional<long long> row;
+
+        /// `1 - a_0 >= 0`. Cake's name, which reads the other way round from
+        /// what the row says; kept because it is cake's.
+        [[nodiscard]] auto role_0ge() const -> std::string;
+
+        /// `a_0 - 1 >= 0`.
+        [[nodiscard]] auto role_0le() const -> std::string;
+
+        /// `-a_n >= 0`.
+        [[nodiscard]] auto role_acc() const -> std::string;
+
+        /**
+         * \brief One of the four clauses of step `k` (one-based, as cake counts
+         * them), naming the `(a_{k-1}, l_k)` case it rules out.
+         */
+        [[nodiscard]] auto role_step(std::size_t k, bool accumulator_in, bool literal) const -> std::string;
+
+        /// The key of `a_k`, for k in 0..n.
+        [[nodiscard]] auto accumulator_flag_key(std::size_t k) const -> ProofFlagKey;
+    };
+
+    /**
      * \brief The rows and flags one accumulator chain put in the `.opb`, as the
      * slack-form derivation needs to cite them.
      *
-     * Handed back by define_parity_chain, and reconstructible from a
-     * ParityOdd's published ConstraintProofModelData, so that the derivation is
-     * one piece of code whether the chain was emitted by ParitySystem or by a
-     * separately posted constraint a presolver went looking for.
+     * Handed back by define_parity_chain, and recoverable afterwards by
+     * find_parity_chain, so that the derivation is one piece of code whether the
+     * chain was emitted by ParitySystem or by a separately posted ParityOdd that
+     * a presolver went looking for.
      *
      * \ingroup Innards
      */
@@ -52,40 +111,89 @@ namespace gcs::innards
      * `.opb`, so the slack-form derivation that reads them back
      * (dev_docs/parity-system.md) is one piece of code rather than two.
      *
-     * `row` disambiguates when there is more than one chain under one identity.
-     * Left unset --- ParityOdd's case, and the only one cake ever sees --- the
-     * flags are `x[id][k]` and the roles are `0ge`, `0le`, `<k>_0_0` and so on,
-     * which is cake's naming exactly and must stay that way. Set, every flag
-     * gains a leading index and every role a leading `r<row>_`, which keeps the
-     * chains apart; nothing in cake's vocabulary corresponds to that, and
-     * nothing needs to, because a constraint with several chains has no `.scp`
-     * spelling to be checked against.
+     * \sa ParityChainNaming, which is where `naming` comes from and what every
+     * name emitted here is built through.
      *
      * \ingroup Innards
      */
-    auto define_parity_chain(ProofModel & model, const ConstraintID & id, const std::optional<long long> & row, const Literals & lits)
-        -> ParityChainRows;
+    auto define_parity_chain(ProofModel & model, const ConstraintID & id, const ParityChainNaming & naming, const Literals & lits) -> ParityChainRows;
 
     /**
-     * \brief Derive the two pseudo-Boolean inequalities saying the chain's
-     * literals sum to `1 + 2B`, and return them.
+     * \brief Recover a chain that was emitted earlier, by asking the tracker for
+     * every row and flag `naming` names.
      *
-     * Gocht and Nordstrom's (4.4a) and (4.4b) --- the form under which adding
-     * two parity constraints together is one `pol` line. The accumulator chain
-     * cannot state it directly, and a presolver could not add it to the `.opb`
-     * even if it wanted to, so it is derived inside the proof at
-     * ProofLevel::Top. See dev_docs/parity-system.md, "Deriving the slack row
-     * from the accumulator chain", for the argument and for why each step needs
-     * a `red` rather than a RUP.
+     * The counterpart of define_parity_chain, for a presolver: a constraint that
+     * emitted its own chain still has the struct, but one that means to build
+     * proofs on *another* constraint's chain has only that constraint's
+     * published naming and the number of literals it was posted with.
      *
-     * `flag_stem` names the fresh per-step variables and must be unique across
-     * chains. Returns nullopt for a chain over no literals: there is no step to
-     * telescope, `a_0` and `a_n` are the same flag, and nothing is needed ---
-     * an empty odd row is a contradiction the chain's own three rows state.
+     * Returns nullopt when any part of the chain is missing --- proofs are off,
+     * the constraint was never installed, or it published a naming whose rows
+     * were not emitted. All of those mean the same thing to a caller: there is
+     * nothing to cite, so do not do the thing that would need citing. It is
+     * deliberately all-or-nothing, because a chain missing one of its four
+     * per-step clauses cannot be telescoped, and a partial answer would only
+     * move the failure to the `pol`.
      *
      * \ingroup Innards
      */
-    [[nodiscard]] auto derive_parity_slack_rows(ProofLogger & logger, const ParityChainRows & chain, const Literals & lits,
+    [[nodiscard]] auto find_parity_chain(const ProofLogger & logger, const ConstraintID & id, const ParityChainNaming & naming,
+        std::size_t how_many_literals) -> std::optional<ParityChainRows>;
+
+    /**
+     * \brief A row of exactly two literals whose slack form is `l1 + l2 = 1`,
+     * with both halves plain RUP against rows the donor already emitted.
+     *
+     * `B` is zero for such a row --- odd parity over two literals means exactly
+     * one of them holds --- so there is nothing to introduce and nothing to
+     * telescope. What makes the two halves RUP rather than merely true is the
+     * donor's own encoding: a Boolean `Equals` or `NotEquals` states its
+     * operands' relationship over their bits, and negating either half fixes
+     * both bits and walks straight into one of those rows. A donor claiming this
+     * shape is claiming that; it is not a property of being short.
+     *
+     * \ingroup Innards
+     */
+    struct ParitySlackFormIsRUP
+    {
+        [[nodiscard]] auto operator<=>(const ParitySlackFormIsRUP &) const = default;
+    };
+
+    /**
+     * \brief How one row's slack form is to be derived, which depends on what
+     * kind of donor the row came from.
+     *
+     * Two shapes so far, and the variant rather than a callback because both are
+     * short, closed, and worth being able to read: a ParityChainRows row is
+     * telescoped out of cake's accumulator chain, and a ParitySlackFormIsRUP row
+     * is two RUP lines. A third donor family would add an alternative here and a
+     * case to derive_parity_slack_rows, and nothing else.
+     *
+     * \ingroup Innards
+     */
+    using ParitySlackSource = std::variant<ParityChainRows, ParitySlackFormIsRUP>;
+
+    /**
+     * \brief Derive the two pseudo-Boolean inequalities saying a row's literals
+     * sum to `1 + 2B`, and return them.
+     *
+     * Gocht and Nordstrom's (4.4a) and (4.4b) --- the form under which adding
+     * two parity constraints together is one `pol` line. Neither shape of donor
+     * states it directly, and a presolver could not add it to the `.opb` even if
+     * it wanted to, so it is derived inside the proof at ProofLevel::Top. See
+     * dev_docs/parity-system.md, "Deriving the slack row", for the argument, and
+     * for why an accumulator chain needs a `red` per step where a two-literal
+     * row needs only a RUP.
+     *
+     * `flag_stem` names the fresh per-step variables a chain introduces, and
+     * must be unique across chains; a RUP-shaped row introduces none and ignores
+     * it. Returns nullopt for a chain over no literals: there is no step to
+     * telescope, `a_0` and `a_n` are the same flag, and nothing is needed --- an
+     * empty odd row is a contradiction the chain's own three rows state.
+     *
+     * \ingroup Innards
+     */
+    [[nodiscard]] auto derive_parity_slack_rows(ProofLogger & logger, const ParitySlackSource & source, const Literals & lits,
         const std::string & flag_stem) -> std::optional<std::pair<ProofLine, ProofLine>>;
 }
 

--- a/gcs/constraints/parity/parity_system.cc
+++ b/gcs/constraints/parity/parity_system.cc
@@ -1,0 +1,129 @@
+#include <gcs/constraints/innards/cake_truthiness.hh>
+#include <gcs/constraints/innards/triggers.hh>
+#include <gcs/constraints/parity/hints.hh>
+#include <gcs/constraints/parity/parity_chain.hh>
+#include <gcs/constraints/parity/parity_system.hh>
+#include <gcs/innards/inference_tracker.hh>
+#include <gcs/innards/proofs/names_and_ids_tracker.hh>
+#include <gcs/innards/proofs/proof_logger.hh>
+#include <gcs/innards/proofs/proof_model.hh>
+#include <gcs/innards/propagators.hh>
+#include <gcs/innards/s_expr.hh>
+#include <gcs/innards/state.hh>
+#include <util/enumerate.hh>
+
+#include <optional>
+#include <vector>
+
+using namespace gcs;
+using namespace gcs::innards;
+
+using std::make_unique;
+using std::move;
+using std::nullopt;
+using std::unique_ptr;
+using std::vector;
+
+namespace
+{
+    auto to_lit_rows(const vector<vector<IntegerVariableID>> & rows) -> vector<Literals>
+    {
+        vector<Literals> result;
+        result.reserve(rows.size());
+        for (const auto & row : rows) {
+            Literals lits;
+            lits.reserve(row.size());
+            for (const auto & v : row)
+                lits.emplace_back(v != 0_i);
+            result.push_back(move(lits));
+        }
+        return result;
+    }
+}
+
+ParitySystem::ParitySystem(const vector<vector<IntegerVariableID>> & rows) : ParitySystem(to_lit_rows(rows))
+{
+}
+
+ParitySystem::ParitySystem(vector<Literals> rows) : _rows(move(rows))
+{
+}
+
+auto ParitySystem::clone() const -> unique_ptr<Constraint>
+{
+    return make_unique<ParitySystem>(_rows);
+}
+
+auto ParitySystem::define_proof_model(ProofModel & model, const State &) -> void
+{
+    // One accumulator chain per row, exactly what a row posted as its own
+    // ParityOdd would have emitted, only with the row index threaded through
+    // the flag values and the role names so that the chains stay apart. Sharing
+    // the emitter with ParityOdd is the whole point: the slack-form derivation
+    // reads these rows back the same way whether they were posted here or
+    // gathered from individual constraints.
+    for (const auto & [r, row] : enumerate(_rows))
+        define_parity_chain(model, _constraint_id, static_cast<long long>(r), row);
+}
+
+auto ParitySystem::install_propagators(Propagators & propagators) -> void
+{
+    Triggers triggers;
+    for (const auto & row : _rows)
+        for (const auto & l : row)
+            add_trigger_for(triggers, l);
+
+    propagators.install(
+        constraint_id(),
+        [rows = _rows, owner = constraint_id()](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+            // Stage 1 of dev_docs/parity-system.md: check only, no pruning at
+            // all, so that the encoding can be settled before any system
+            // reasoning exists to be blamed for a failure. Every inference here
+            // is over a fully assigned row, which is exactly the case unit
+            // propagation closes on its own.
+            auto everything_decided = true;
+            for (const auto & row : rows) {
+                long how_many_true = 0;
+                auto row_decided = true;
+                ReasonLiterals reason;
+                for (const auto & l : row) {
+                    switch (state.test_literal(l)) {
+                        using enum LiteralIs;
+                    case DefinitelyTrue:
+                        reason.push_back(l);
+                        ++how_many_true;
+                        break;
+                    case DefinitelyFalse: reason.push_back(! l); break;
+                    case Undecided: row_decided = false; break;
+                    }
+                }
+
+                if (! row_decided)
+                    everything_decided = false;
+                else if (how_many_true % 2 == 0)
+                    inference.contradiction(logger, JustifyUsingRUP{hints::Parity{owner}}, ExplicitReason{reason});
+            }
+
+            return everything_decided ? PropagatorState::DisableUntilBacktrack : PropagatorState::Enable;
+        },
+        triggers);
+}
+
+auto ParitySystem::constraint_type() const -> std::string
+{
+    return "parity_system";
+}
+
+auto ParitySystem::s_expr(const innards::ProofModel * const model) const -> SExpr
+{
+    auto & tracker = model->names_and_ids_tracker();
+
+    vector<SExpr> row_terms;
+    for (const auto & row : _rows) {
+        vector<SExpr> lits;
+        for (const auto & lit : row)
+            lits.push_back(reify_tuple_term(lit, tracker));
+        row_terms.push_back(SExpr::list(move(lits)));
+    }
+    return SExpr::list({SExpr::atom(as_string(_constraint_id)), SExpr::atom(constraint_type()), SExpr::list(move(row_terms))});
+}

--- a/gcs/constraints/parity/parity_system.cc
+++ b/gcs/constraints/parity/parity_system.cc
@@ -1,28 +1,44 @@
 #include <gcs/constraints/innards/cake_truthiness.hh>
 #include <gcs/constraints/innards/triggers.hh>
+#include <gcs/constraints/parity/gf2_system.hh>
 #include <gcs/constraints/parity/hints.hh>
 #include <gcs/constraints/parity/parity_chain.hh>
 #include <gcs/constraints/parity/parity_system.hh>
 #include <gcs/innards/inference_tracker.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
+#include <gcs/innards/proofs/pol_builder.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/proofs/proof_model.hh>
+#include <gcs/innards/proofs/simplify_literal.hh>
 #include <gcs/innards/propagators.hh>
 #include <gcs/innards/s_expr.hh>
 #include <gcs/innards/state.hh>
 #include <util/enumerate.hh>
+#include <util/overloaded.hh>
 
+#include <algorithm>
+#include <memory>
 #include <optional>
+#include <string>
+#include <utility>
 #include <vector>
 
 using namespace gcs;
 using namespace gcs::innards;
 
+using std::make_optional;
+using std::make_shared;
 using std::make_unique;
 using std::move;
 using std::nullopt;
+using std::optional;
+using std::pair;
+using std::shared_ptr;
+using std::size_t;
+using std::to_string;
 using std::unique_ptr;
 using std::vector;
+using std::ranges::any_of;
 
 namespace
 {
@@ -41,17 +57,18 @@ namespace
     }
 }
 
-ParitySystem::ParitySystem(const vector<vector<IntegerVariableID>> & rows) : ParitySystem(to_lit_rows(rows))
+ParitySystem::ParitySystem(const vector<vector<IntegerVariableID>> & rows, ParitySystemPropagation propagation) :
+    ParitySystem(to_lit_rows(rows), propagation)
 {
 }
 
-ParitySystem::ParitySystem(vector<Literals> rows) : _rows(move(rows))
+ParitySystem::ParitySystem(vector<Literals> rows, ParitySystemPropagation propagation) : _rows(move(rows)), _propagation(propagation)
 {
 }
 
 auto ParitySystem::clone() const -> unique_ptr<Constraint>
 {
-    return make_unique<ParitySystem>(_rows);
+    return make_unique<ParitySystem>(_rows, _propagation);
 }
 
 auto ParitySystem::define_proof_model(ProofModel & model, const State &) -> void
@@ -63,24 +80,53 @@ auto ParitySystem::define_proof_model(ProofModel & model, const State &) -> void
     // reads these rows back the same way whether they were posted here or
     // gathered from individual constraints.
     for (const auto & [r, row] : enumerate(_rows))
-        define_parity_chain(model, _constraint_id, static_cast<long long>(r), row);
+        _chains.push_back(define_parity_chain(model, _constraint_id, static_cast<long long>(r), row));
+}
+
+namespace
+{
+    // The trivially-true axiom `lit >= 0`, spelled the way the row that
+    // mentions the literal spells it: through simplify_literal, so that a view
+    // or a lazily-named atom resolves to the same XLiteral the OPB row carries
+    // and the pol arithmetic actually cancels. See
+    // dev_docs/view-proof-logging.md.
+    auto push_literal_axiom(PolBuilder & pol, NamesAndIDsTracker & tracker, const Literal & lit) -> void
+    {
+        overloaded{//
+            [&](const TrueLiteral &) {}, [&](const FalseLiteral &) {},
+            [&]<typename T_>(const VariableConditionFrom<T_> & cond) { pol.add(tracker.xliteral_for_ensuring(cond), tracker); }}
+            .visit(simplify_literal(tracker, lit));
+    }
+
+    auto triggers_for(const vector<Literals> & rows) -> Triggers
+    {
+        Triggers triggers;
+        for (const auto & row : rows)
+            for (const auto & l : row)
+                add_trigger_for(triggers, l);
+        return triggers;
+    }
 }
 
 auto ParitySystem::install_propagators(Propagators & propagators) -> void
 {
-    Triggers triggers;
-    for (const auto & row : _rows)
-        for (const auto & l : row)
-            add_trigger_for(triggers, l);
+    switch (_propagation) {
+        using enum ParitySystemPropagation;
+    case CheckOnly: install_check_only_propagator(propagators); return;
+    case GaussJordan: install_gauss_jordan_propagator(propagators); return;
+    }
+    throw NonExhaustiveSwitch{};
+}
 
+auto ParitySystem::install_check_only_propagator(Propagators & propagators) -> void
+{
     propagators.install(
         constraint_id(),
         [rows = _rows, owner = constraint_id()](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
-            // Stage 1 of dev_docs/parity-system.md: check only, no pruning at
-            // all, so that the encoding can be settled before any system
-            // reasoning exists to be blamed for a failure. Every inference here
-            // is over a fully assigned row, which is exactly the case unit
-            // propagation closes on its own.
+            // No pruning at all: wait for a row to be fully assigned, check it,
+            // and contradict if the parity is wrong. Every inference is over a
+            // complete assignment, which is exactly the case unit propagation
+            // closes on its own.
             auto everything_decided = true;
             for (const auto & row : rows) {
                 long how_many_true = 0;
@@ -106,7 +152,157 @@ auto ParitySystem::install_propagators(Propagators & propagators) -> void
 
             return everything_decided ? PropagatorState::DisableUntilBacktrack : PropagatorState::Enable;
         },
-        triggers);
+        triggers_for(_rows));
+}
+
+auto ParitySystem::install_gauss_jordan_propagator(Propagators & propagators) -> void
+{
+    // A row over no literals says that zero is odd. It has no step to
+    // telescope and so no slack row, and there is nothing for elimination to do
+    // with it either --- but its own three chain rows pin a_0 both to one and
+    // to zero, so refuting it here is a plain RUP and leaves the rest of the
+    // system with a system it can actually reason about.
+    if (any_of(_rows, [](const auto & row) { return row.empty(); })) {
+        propagators.install_initial_contradiction(constraint_id(), constraint_type(),
+            "a parity row has no literals in it, so nothing can make it odd", JustifyUsingRUP{hints::Parity{constraint_id()}});
+        return;
+    }
+
+    // The two slack rows per posted row, derived once at Top by the initialiser
+    // below and cited by every justification afterwards. Shared rather than
+    // copied because the propagator's closure is built here, before the
+    // initialiser has run. Empty for a row over no literals, which needs none.
+    auto slack_rows = make_shared<vector<optional<pair<ProofLine, ProofLine>>>>();
+
+    propagators.install_initialiser(
+        [rows = _rows, chains = _chains, slack_rows, owner = constraint_id()](State &, auto &, ProofLogger * const logger) -> void {
+            if (! logger)
+                return;
+
+            for (const auto & [r, row] : enumerate(rows))
+                slack_rows->push_back(derive_parity_slack_rows(*logger, chains[r], row, "psys" + as_string(owner) + "r" + to_string(r) + "_"));
+        },
+        InitialiserPriority::SimpleDefinition);
+
+    propagators.install(
+        constraint_id(),
+        [system = build_gf2_system(_rows), slack_rows, owner = constraint_id()](
+            const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+            auto n_atoms = system.atoms.size();
+
+            // Read the trail once. An atom fixed at the root is no different
+            // from one a guess decided: either way it leaves the columns and
+            // flips the right-hand sides it appeared in.
+            vector<LiteralIs> assignment;
+            assignment.reserve(n_atoms);
+            auto any_undecided = false;
+            for (const auto & atom : system.atoms) {
+                assignment.push_back(state.test_literal(atom));
+                if (LiteralIs::Undecided == assignment.back())
+                    any_undecided = true;
+            }
+
+            // Substitute, then eliminate. From scratch every time: maintaining
+            // the reduced row echelon form incrementally is the interesting
+            // engineering and it does not belong in the first version, because
+            // XORing rows *creates* non-zero cells and so does not trail
+            // cleanly. See dev_docs/parity-system.md.
+            auto working = system.rows;
+            for (auto & row : working)
+                for (const auto & a : row.atoms.set_indices())
+                    switch (assignment[a]) {
+                        using enum LiteralIs;
+                    case DefinitelyTrue:
+                        row.atoms.reset(a);
+                        row.rhs = ! row.rhs;
+                        break;
+                    case DefinitelyFalse: row.atoms.reset(a); break;
+                    case Undecided: break;
+                    }
+
+            gauss_jordan(working, n_atoms);
+
+            // A row's support is the atoms of the rows it is the sum of, before
+            // substitution, and the assignment to those is the rho of Gocht and
+            // Nordstrom's section 4.3 --- so it is both the reason and what the
+            // justification has to walk.
+            auto support_of = [&](const GF2Row & row) {
+                GF2Bits support{n_atoms};
+                for (const auto & o : row.origin.set_indices())
+                    support ^= system.rows[o].atoms;
+                return support;
+            };
+
+            auto reason_for = [&](const GF2Bits & support) {
+                ReasonLiterals reason;
+                for (const auto & a : support.set_indices())
+                    switch (assignment[a]) {
+                        using enum LiteralIs;
+                    case DefinitelyTrue: reason.push_back(system.atoms[a]); break;
+                    case DefinitelyFalse: reason.push_back(! system.atoms[a]); break;
+                    case Undecided: break;
+                    }
+                return reason;
+            };
+
+            // Gocht and Nordstrom's section 4.3, as one pol: sum the slack rows
+            // of everything that went into this row, add a literal axiom for
+            // each atom of its support --- the atom itself where rho makes it
+            // false, its negation where rho makes it true --- then divide by two
+            // and multiply back, which is the step that gains one because the
+            // right-hand side is odd exactly when rho falsifies the row's
+            // parity. Adding the other direction turns what is left into a
+            // clause falsified by rho, and the framework's wrapping RUP closes
+            // on it. Atoms outside the support have even coefficients already
+            // and need nothing.
+            // `pretend` is how a propagation is justified rather than a
+            // conflict: the one unassigned atom is given the value that would
+            // violate the row, and the clause that comes out then has that
+            // atom's literal as its only term rho does not falsify, so it
+            // propagates. A conflict passes nullopt, rho being complete already.
+            auto justify_from = [&](const GF2Bits & origin, const GF2Bits & support, const optional<pair<size_t, bool>> & pretend) {
+                return [&, origin, support, pretend](const ReasonLiterals &) {
+                    PolBuilder pol;
+                    for (const auto & o : origin.set_indices())
+                        pol.add((*slack_rows)[o]->first);
+
+                    for (const auto & a : support.set_indices()) {
+                        auto rho_says_true = pretend && pretend->first == a ? pretend->second : LiteralIs::DefinitelyTrue == assignment[a];
+                        push_literal_axiom(
+                            pol, logger->names_and_ids_tracker(), rho_says_true ? Literal{! system.atoms[a]} : Literal{system.atoms[a]});
+                    }
+
+                    pol.divide_by(2_i).multiply_by(2_i);
+                    for (const auto & o : origin.set_indices())
+                        pol.add((*slack_rows)[o]->second);
+                    pol.emit(*logger, ProofLevel::Temporary);
+                };
+            };
+
+            for (const auto & row : working) {
+                auto how_many = row.atoms.count();
+                if (0 != how_many && 1 != how_many)
+                    continue;
+                if (0 == how_many && ! row.rhs)
+                    continue;
+
+                auto support = support_of(row);
+                auto reason = reason_for(support);
+
+                if (0 == how_many)
+                    inference.contradiction(logger, JustifyExplicitly{justify_from(row.origin, support, nullopt), ThenRUP::Yes, hints::Parity{owner}},
+                        ExplicitReason{reason});
+                else {
+                    auto a = *row.atoms.first_set();
+                    inference.infer(logger, row.rhs ? Literal{system.atoms[a]} : Literal{! system.atoms[a]},
+                        JustifyExplicitly{justify_from(row.origin, support, make_optional(pair{a, ! row.rhs})), ThenRUP::Yes, hints::Parity{owner}},
+                        ExplicitReason{reason});
+                }
+            }
+
+            return any_undecided ? PropagatorState::Enable : PropagatorState::DisableUntilBacktrack;
+        },
+        triggers_for(_rows));
 }
 
 auto ParitySystem::constraint_type() const -> std::string

--- a/gcs/constraints/parity/parity_system.cc
+++ b/gcs/constraints/parity/parity_system.cc
@@ -6,39 +6,27 @@
 #include <gcs/constraints/parity/parity_system.hh>
 #include <gcs/innards/inference_tracker.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
-#include <gcs/innards/proofs/pol_builder.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/proofs/proof_model.hh>
-#include <gcs/innards/proofs/simplify_literal.hh>
 #include <gcs/innards/propagators.hh>
 #include <gcs/innards/s_expr.hh>
 #include <gcs/innards/state.hh>
 #include <util/enumerate.hh>
-#include <util/overloaded.hh>
 
-#include <algorithm>
-#include <memory>
 #include <optional>
 #include <string>
-#include <utility>
 #include <vector>
 
 using namespace gcs;
 using namespace gcs::innards;
 
 using std::make_optional;
-using std::make_shared;
 using std::make_unique;
 using std::move;
 using std::nullopt;
-using std::optional;
-using std::pair;
-using std::shared_ptr;
-using std::size_t;
 using std::to_string;
 using std::unique_ptr;
 using std::vector;
-using std::ranges::any_of;
 
 namespace
 {
@@ -80,24 +68,11 @@ auto ParitySystem::define_proof_model(ProofModel & model, const State &) -> void
     // reads these rows back the same way whether they were posted here or
     // gathered from individual constraints.
     for (const auto & [r, row] : enumerate(_rows))
-        _chains.push_back(define_parity_chain(model, _constraint_id, static_cast<long long>(r), row));
+        _chains.push_back(define_parity_chain(model, _constraint_id, ParityChainNaming{static_cast<long long>(r)}, row));
 }
 
 namespace
 {
-    // The trivially-true axiom `lit >= 0`, spelled the way the row that
-    // mentions the literal spells it: through simplify_literal, so that a view
-    // or a lazily-named atom resolves to the same XLiteral the OPB row carries
-    // and the pol arithmetic actually cancels. See
-    // dev_docs/view-proof-logging.md.
-    auto push_literal_axiom(PolBuilder & pol, NamesAndIDsTracker & tracker, const Literal & lit) -> void
-    {
-        overloaded{//
-            [&](const TrueLiteral &) {}, [&](const FalseLiteral &) {},
-            [&]<typename T_>(const VariableConditionFrom<T_> & cond) { pol.add(tracker.xliteral_for_ensuring(cond), tracker); }}
-            .visit(simplify_literal(tracker, lit));
-    }
-
     auto triggers_for(const vector<Literals> & rows) -> Triggers
     {
         Triggers triggers;
@@ -157,152 +132,14 @@ auto ParitySystem::install_check_only_propagator(Propagators & propagators) -> v
 
 auto ParitySystem::install_gauss_jordan_propagator(Propagators & propagators) -> void
 {
-    // A row over no literals says that zero is odd. It has no step to
-    // telescope and so no slack row, and there is nothing for elimination to do
-    // with it either --- but its own three chain rows pin a_0 both to one and
-    // to zero, so refuting it here is a plain RUP and leaves the rest of the
-    // system with a system it can actually reason about.
-    if (any_of(_rows, [](const auto & row) { return row.empty(); })) {
-        propagators.install_initial_contradiction(constraint_id(), constraint_type(),
-            "a parity row has no literals in it, so nothing can make it odd", JustifyUsingRUP{hints::Parity{constraint_id()}});
-        return;
-    }
+    // The chains are empty when proofs are off, which is also when nothing reads
+    // them; a row's ParitySystemRow then carries nullopt, as it is meant to.
+    vector<ParitySystemRow> rows;
+    for (const auto & [r, literals] : enumerate(_rows))
+        rows.push_back(ParitySystemRow{literals, _chains.empty() ? nullopt : make_optional(ParitySlackSource{_chains[r]}),
+            "psys" + as_string(constraint_id()) + "r" + to_string(r) + "_"});
 
-    // The two slack rows per posted row, derived once at Top by the initialiser
-    // below and cited by every justification afterwards. Shared rather than
-    // copied because the propagator's closure is built here, before the
-    // initialiser has run. Empty for a row over no literals, which needs none.
-    auto slack_rows = make_shared<vector<optional<pair<ProofLine, ProofLine>>>>();
-
-    propagators.install_initialiser(
-        [rows = _rows, chains = _chains, slack_rows, owner = constraint_id()](State &, auto &, ProofLogger * const logger) -> void {
-            if (! logger)
-                return;
-
-            for (const auto & [r, row] : enumerate(rows))
-                slack_rows->push_back(derive_parity_slack_rows(*logger, chains[r], row, "psys" + as_string(owner) + "r" + to_string(r) + "_"));
-        },
-        InitialiserPriority::SimpleDefinition);
-
-    propagators.install(
-        constraint_id(),
-        [system = build_gf2_system(_rows), slack_rows, owner = constraint_id()](
-            const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
-            auto n_atoms = system.atoms.size();
-
-            // Read the trail once. An atom fixed at the root is no different
-            // from one a guess decided: either way it leaves the columns and
-            // flips the right-hand sides it appeared in.
-            vector<LiteralIs> assignment;
-            assignment.reserve(n_atoms);
-            auto any_undecided = false;
-            for (const auto & atom : system.atoms) {
-                assignment.push_back(state.test_literal(atom));
-                if (LiteralIs::Undecided == assignment.back())
-                    any_undecided = true;
-            }
-
-            // Substitute, then eliminate. From scratch every time: maintaining
-            // the reduced row echelon form incrementally is the interesting
-            // engineering and it does not belong in the first version, because
-            // XORing rows *creates* non-zero cells and so does not trail
-            // cleanly. See dev_docs/parity-system.md.
-            auto working = system.rows;
-            for (auto & row : working)
-                for (const auto & a : row.atoms.set_indices())
-                    switch (assignment[a]) {
-                        using enum LiteralIs;
-                    case DefinitelyTrue:
-                        row.atoms.reset(a);
-                        row.rhs = ! row.rhs;
-                        break;
-                    case DefinitelyFalse: row.atoms.reset(a); break;
-                    case Undecided: break;
-                    }
-
-            gauss_jordan(working, n_atoms);
-
-            // A row's support is the atoms of the rows it is the sum of, before
-            // substitution, and the assignment to those is the rho of Gocht and
-            // Nordstrom's section 4.3 --- so it is both the reason and what the
-            // justification has to walk.
-            auto support_of = [&](const GF2Row & row) {
-                GF2Bits support{n_atoms};
-                for (const auto & o : row.origin.set_indices())
-                    support ^= system.rows[o].atoms;
-                return support;
-            };
-
-            auto reason_for = [&](const GF2Bits & support) {
-                ReasonLiterals reason;
-                for (const auto & a : support.set_indices())
-                    switch (assignment[a]) {
-                        using enum LiteralIs;
-                    case DefinitelyTrue: reason.push_back(system.atoms[a]); break;
-                    case DefinitelyFalse: reason.push_back(! system.atoms[a]); break;
-                    case Undecided: break;
-                    }
-                return reason;
-            };
-
-            // Gocht and Nordstrom's section 4.3, as one pol: sum the slack rows
-            // of everything that went into this row, add a literal axiom for
-            // each atom of its support --- the atom itself where rho makes it
-            // false, its negation where rho makes it true --- then divide by two
-            // and multiply back, which is the step that gains one because the
-            // right-hand side is odd exactly when rho falsifies the row's
-            // parity. Adding the other direction turns what is left into a
-            // clause falsified by rho, and the framework's wrapping RUP closes
-            // on it. Atoms outside the support have even coefficients already
-            // and need nothing.
-            // `pretend` is how a propagation is justified rather than a
-            // conflict: the one unassigned atom is given the value that would
-            // violate the row, and the clause that comes out then has that
-            // atom's literal as its only term rho does not falsify, so it
-            // propagates. A conflict passes nullopt, rho being complete already.
-            auto justify_from = [&](const GF2Bits & origin, const GF2Bits & support, const optional<pair<size_t, bool>> & pretend) {
-                return [&, origin, support, pretend](const ReasonLiterals &) {
-                    PolBuilder pol;
-                    for (const auto & o : origin.set_indices())
-                        pol.add((*slack_rows)[o]->first);
-
-                    for (const auto & a : support.set_indices()) {
-                        auto rho_says_true = pretend && pretend->first == a ? pretend->second : LiteralIs::DefinitelyTrue == assignment[a];
-                        push_literal_axiom(
-                            pol, logger->names_and_ids_tracker(), rho_says_true ? Literal{! system.atoms[a]} : Literal{system.atoms[a]});
-                    }
-
-                    pol.divide_by(2_i).multiply_by(2_i);
-                    for (const auto & o : origin.set_indices())
-                        pol.add((*slack_rows)[o]->second);
-                    pol.emit(*logger, ProofLevel::Temporary);
-                };
-            };
-
-            for (const auto & row : working) {
-                auto how_many = row.atoms.count();
-                if (0 != how_many && 1 != how_many)
-                    continue;
-                if (0 == how_many && ! row.rhs)
-                    continue;
-
-                auto support = support_of(row);
-                auto reason = reason_for(support);
-
-                if (0 == how_many)
-                    inference.contradiction(logger, JustifyExplicitly{justify_from(row.origin, support, nullopt), ThenRUP::Yes, hints::Parity{owner}},
-                        ExplicitReason{reason});
-                else {
-                    auto a = *row.atoms.first_set();
-                    inference.infer(logger, row.rhs ? Literal{system.atoms[a]} : Literal{! system.atoms[a]},
-                        JustifyExplicitly{justify_from(row.origin, support, make_optional(pair{a, ! row.rhs})), ThenRUP::Yes, hints::Parity{owner}},
-                        ExplicitReason{reason});
-                }
-            }
-
-            return any_undecided ? PropagatorState::Enable : PropagatorState::DisableUntilBacktrack;
-        },
-        triggers_for(_rows));
+    install_parity_system_propagator(propagators, constraint_id(), constraint_type(), move(rows));
 }
 
 auto ParitySystem::constraint_type() const -> std::string

--- a/gcs/constraints/parity/parity_system.hh
+++ b/gcs/constraints/parity/parity_system.hh
@@ -2,6 +2,7 @@
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_PARITY_PARITY_SYSTEM_HH 1
 
 #include <gcs/constraint.hh>
+#include <gcs/constraints/parity/parity_chain.hh>
 #include <gcs/innards/literal.hh>
 #include <gcs/variable_condition.hh>
 #include <gcs/variable_id.hh>
@@ -10,6 +11,29 @@
 
 namespace gcs
 {
+    /**
+     * \brief Propagation strength for the ParitySystem constraint.
+     *
+     * Neither setting changes the OPB encoding: define_proof_model is identical
+     * for both.
+     *
+     * - \c CheckOnly acts only once every literal of a row is assigned, and
+     *   then only to refute a wrong parity. That is no stronger than posting
+     *   each row as its own ParityOdd and rather slower, so it is not a
+     *   strength anyone wants --- it is the encoding's standing regression
+     *   test, kept because the encoding is what everything else here is built
+     *   on. \c MinDistance keeps its check-only mode for the same reason.
+     * - \c GaussJordan is the real thing: eliminate over the whole system at
+     *   every wake and read off every literal it implies.
+     *
+     * \ingroup Constraints
+     */
+    enum class ParitySystemPropagation
+    {
+        CheckOnly,
+        GaussJordan
+    };
+
     /**
      * \brief Constrain that an odd number of literals is true in each of
      * several rows, reasoning about the rows together rather than one at a
@@ -38,15 +62,25 @@ namespace gcs
     {
     private:
         const std::vector<innards::Literals> _rows;
+        ParitySystemPropagation _propagation;
+
+        // Filled in by define_proof_model, read by install_propagators, which
+        // runs next on the same object. Empty when proofs are off, which is
+        // also when nothing reads it.
+        std::vector<innards::ParityChainRows> _chains;
 
         virtual auto define_proof_model(innards::ProofModel &, const innards::State &) -> void override;
         virtual auto install_propagators(innards::Propagators &) -> void override;
 
+        auto install_check_only_propagator(innards::Propagators &) -> void;
+        auto install_gauss_jordan_propagator(innards::Propagators &) -> void;
+
     public:
         // Equivalent to ParitySystem([[var != 0 : var in row] : row in rows])
-        explicit ParitySystem(const std::vector<std::vector<IntegerVariableID>> & rows);
+        explicit ParitySystem(
+            const std::vector<std::vector<IntegerVariableID>> & rows, ParitySystemPropagation = ParitySystemPropagation::GaussJordan);
 
-        explicit ParitySystem(std::vector<innards::Literals>);
+        explicit ParitySystem(std::vector<innards::Literals>, ParitySystemPropagation = ParitySystemPropagation::GaussJordan);
 
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
 

--- a/gcs/constraints/parity/parity_system.hh
+++ b/gcs/constraints/parity/parity_system.hh
@@ -1,0 +1,77 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_PARITY_PARITY_SYSTEM_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_PARITY_PARITY_SYSTEM_HH 1
+
+#include <gcs/constraint.hh>
+#include <gcs/innards/literal.hh>
+#include <gcs/variable_condition.hh>
+#include <gcs/variable_id.hh>
+
+#include <vector>
+
+namespace gcs
+{
+    /**
+     * \brief Constrain that an odd number of literals is true in each of
+     * several rows, reasoning about the rows together rather than one at a
+     * time.
+     *
+     * A single ParityOdd is already GAC --- unit propagation on one parity
+     * constraint *is* GAC, because any value has a support while two of its
+     * literals are still free --- so all of the inference a system of them
+     * offers lives in the conjunction. Over GF(2) that conjunction is one of
+     * the rare tractable cases: Gauss-Jordan exposes every literal the system
+     * implies, and implied literals are exactly what GAC on the system means.
+     *
+     * Every row is *odd* parity, as ParityOdd's name says; an even row is
+     * written with one of its literals negated, which is what this constraint
+     * does with it internally anyway.
+     *
+     * See dev_docs/parity-system.md, and ParitySystemGathering, which builds
+     * one of these out of the ParityOdd constraints a model has already posted
+     * --- which is how a model reaching us through a frontend will get here,
+     * since XOR structure survives MiniZinc flattening as individual
+     * `array_bool_xor` constraints.
+     *
+     * \ingroup Constraints
+     */
+    class ParitySystem : public Constraint
+    {
+    private:
+        const std::vector<innards::Literals> _rows;
+
+        virtual auto define_proof_model(innards::ProofModel &, const innards::State &) -> void override;
+        virtual auto install_propagators(innards::Propagators &) -> void override;
+
+    public:
+        // Equivalent to ParitySystem([[var != 0 : var in row] : row in rows])
+        explicit ParitySystem(const std::vector<std::vector<IntegerVariableID>> & rows);
+
+        explicit ParitySystem(std::vector<innards::Literals>);
+
+        virtual auto clone() const -> std::unique_ptr<Constraint> override;
+
+        /**
+         * \brief The rows, as posted.
+         *
+         * \sa ParitySystemGathering
+         */
+        [[nodiscard]] auto rows() const GCS_LIFETIME_BOUND -> const std::vector<innards::Literals> &
+        {
+            return _rows;
+        }
+
+        /**
+         * \brief `(id parity_system ((lits...) ...))`.
+         *
+         * Not part of the CakePB workflow --- cake has `parity` for one row and
+         * nothing for a system of them --- but a `.scp` is written on every
+         * proof-logged run that asks for one, so this has to produce valid
+         * output rather than throw. Nogoods is the precedent, and as there, our
+         * own `.scp` reader round-trips it.
+         */
+        [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
+        [[nodiscard]] virtual auto constraint_type() const -> std::string override;
+    };
+}
+
+#endif

--- a/gcs/constraints/parity/parity_system_test.cc
+++ b/gcs/constraints/parity/parity_system_test.cc
@@ -1,0 +1,173 @@
+#include <gcs/constraints/innards/constraints_test_utils.hh>
+#include <gcs/constraints/parity.hh>
+#include <gcs/problem.hh>
+#include <gcs/solve.hh>
+
+#include <cstdlib>
+#include <iostream>
+#include <optional>
+#include <random>
+#include <set>
+#include <tuple>
+#include <utility>
+#include <variant>
+#include <vector>
+#include <version>
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+#include <print>
+#else
+#include <fmt/core.h>
+#include <fmt/ostream.h>
+#include <fmt/ranges.h>
+#endif
+
+using std::cerr;
+using std::flush;
+using std::make_optional;
+using std::move;
+using std::mt19937;
+using std::nullopt;
+using std::pair;
+using std::set;
+using std::tuple;
+using std::uniform_int_distribution;
+using std::variant;
+using std::vector;
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+using std::print;
+using std::println;
+#else
+using fmt::print;
+using fmt::println;
+#endif
+
+using namespace gcs;
+using namespace gcs::test_innards;
+
+// Each row is a list of positions in the variable array, and asserts that an
+// odd number of the variables at those positions are non-zero.
+using Rows = vector<vector<int>>;
+
+auto run_parity_system_test(bool proofs, const ViewWrapConfig & view_cfg, const vector<variant<int, pair<int, int>>> & array_range, const Rows & rows)
+    -> void
+{
+    auto wraps = wraps_for_positions(view_cfg, static_cast<int>(array_range.size()));
+    print(cerr, "parity system [{}] {} rows {} {}", view_wrap_config_label(view_cfg), array_range, rows, proofs ? " with proofs:" : ":");
+    cerr << flush;
+
+    auto is_satisfying = [&](const vector<int> & a) {
+        for (const auto & row : rows) {
+            int trues = 0;
+            for (auto pos : row)
+                if (a.at(pos) != 0)
+                    ++trues;
+            if (trues % 2 != 1)
+                return false;
+        }
+        return true;
+    };
+
+    set<tuple<vector<int>>> expected, actual;
+    build_expected(expected, is_satisfying, array_range);
+    println(cerr, " expecting {} solutions", expected.size());
+
+    Problem p;
+    vector<IntegerVariableID> array;
+    for (std::size_t i = 0; i < array_range.size(); ++i)
+        array.push_back(visit([&](const auto & e) { return create_integer_variable_or_constant_with_view(p, e, wraps.at(i)); }, array_range[i]));
+
+    vector<vector<IntegerVariableID>> posted_rows;
+    for (const auto & row : rows) {
+        vector<IntegerVariableID> vars;
+        for (auto pos : row)
+            vars.push_back(array.at(pos));
+        posted_rows.push_back(move(vars));
+    }
+    p.post(ParitySystem{posted_rows});
+
+    auto proof_name = proofs ? make_optional("parity_system_test_" + view_wrap_config_label(view_cfg)) : nullopt;
+    // Stage 1 of dev_docs/parity-system.md: the propagator only checks, so
+    // there is no consistency level to state yet. Stage 2 replaces this with
+    // solve_for_tests_checking_gac, which is where the GAC claim gets checked
+    // rather than asserted.
+    solve_for_tests(p, proof_name, actual, tuple{array});
+
+    check_results(proof_name, expected, actual);
+}
+
+auto main(int argc, char * argv[]) -> int
+{
+    establish_and_announce_seed(argc, argv);
+
+    auto view_cfg = parse_view_wrap_config_from_argv(argc, argv);
+
+    constexpr int n_positions = 4;
+    if (view_cfg.single_position && (*view_cfg.single_position < 0 || *view_cfg.single_position >= n_positions)) {
+        println(cerr, "parity system view sweep: position {} out of range for n_positions = {}; skipping", *view_cfg.single_position, n_positions);
+        return EXIT_SUCCESS;
+    }
+
+    using Entry = variant<int, pair<int, int>>;
+    vector<pair<vector<Entry>, Rows>> data = {// No rows at all: everything is a solution.
+        {{pair{0, 1}, pair{0, 1}}, {}},
+        // One row is just ParityOdd, and must stay so.
+        {{pair{0, 1}, pair{0, 1}, pair{0, 1}}, {{0, 1, 2}}},
+        // Two rows over disjoint variables: the components do not interact.
+        {{pair{0, 1}, pair{0, 1}, pair{0, 1}, pair{0, 1}}, {{0, 1}, {2, 3}}},
+        // Two rows sharing one variable. Adding them gives x0 XOR x3 = 0, which
+        // is the first thing the system can say that no single row can.
+        {{pair{0, 1}, pair{0, 1}, pair{0, 1}, pair{0, 1}}, {{0, 1, 2}, {1, 2, 3}}},
+        // Three rows summing to the empty row with an odd right-hand side:
+        // unsatisfiable, but no two of them conflict.
+        {{pair{0, 1}, pair{0, 1}, pair{0, 1}}, {{0, 1}, {1, 2}, {0, 2}}},
+        // The same shape, satisfiable: an even number of odd rows over a cycle.
+        {{pair{0, 1}, pair{0, 1}, pair{0, 1}}, {{0, 1}, {1, 2}, {0, 1, 2}}},
+        // A row repeated: redundant, and must not become a contradiction.
+        {{pair{0, 1}, pair{0, 1}}, {{0, 1}, {0, 1}}},
+        // Wider domains: only zero / non-zero matters.
+        {{pair{0, 4}, pair{-3, 3}, pair{0, 2}}, {{0, 1}, {1, 2}}},
+        // Domains not containing zero, so every literal is fixed true.
+        {{pair{1, 5}, pair{1, 5}, pair{0, 1}}, {{0, 1, 2}, {0, 2}}},
+        // Constants mixed in, one of each parity contribution.
+        {{1, pair{0, 3}, pair{0, 3}}, {{0, 1}, {1, 2}}}, {{0, pair{0, 3}, pair{0, 3}}, {{0, 1}, {0, 1, 2}}},
+        // An empty row, which is the even-parity assertion and so unsatisfiable
+        // on its own.
+        {{pair{0, 1}, pair{0, 1}}, {{0, 1}, {}}},
+        // A duplicated position within a row: duplicates XOR-cancel.
+        {{pair{0, 1}, pair{0, 1}}, {{0, 0, 1}}},
+        // All-constant rows, one satisfiable and one not.
+        {{1, 0, 0}, {{0, 1, 2}}}, {{1, 1, 0}, {{0, 1, 2}}}};
+
+    mt19937 rand(*get_seed());
+    for (int x = 0; x < 10; ++x) {
+        uniform_int_distribution n_values_dist(2, 4);
+        uniform_int_distribution n_rows_dist(2, 3);
+        uniform_int_distribution include(0, 1);
+        auto n_values = n_values_dist(rand);
+
+        vector<Entry> entries;
+        for (int i = 0; i < n_values; ++i)
+            entries.push_back(pair{0, 1});
+
+        Rows rows;
+        for (int r = 0; r < n_rows_dist(rand); ++r) {
+            vector<int> row;
+            for (int i = 0; i < n_values; ++i)
+                if (include(rand))
+                    row.push_back(i);
+            rows.push_back(move(row));
+        }
+        data.emplace_back(move(entries), move(rows));
+    }
+
+    for (bool proofs : {false, true}) {
+        if (proofs && ! can_run_veripb())
+            continue;
+        for (auto & [entries, rows] : data)
+            run_parity_system_test(proofs, view_cfg, entries, rows);
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/gcs/constraints/parity/parity_system_test.cc
+++ b/gcs/constraints/parity/parity_system_test.cc
@@ -88,11 +88,7 @@ auto run_parity_system_test(bool proofs, const ViewWrapConfig & view_cfg, const 
     p.post(ParitySystem{posted_rows});
 
     auto proof_name = proofs ? make_optional("parity_system_test_" + view_wrap_config_label(view_cfg)) : nullopt;
-    // Stage 1 of dev_docs/parity-system.md: the propagator only checks, so
-    // there is no consistency level to state yet. Stage 2 replaces this with
-    // solve_for_tests_checking_gac, which is where the GAC claim gets checked
-    // rather than asserted.
-    solve_for_tests(p, proof_name, actual, tuple{array});
+    solve_for_tests_checking_gac(p, proof_name, expected, actual, tuple{array});
 
     check_results(proof_name, expected, actual);
 }

--- a/gcs/innards/proofs/constraint_proof_model_data.hh
+++ b/gcs/innards/proofs/constraint_proof_model_data.hh
@@ -42,7 +42,7 @@ namespace gcs::innards
      * Three kinds of thing get published this way, and they differ only in
      * which half of the tracker answers. A **row** is named by a role and found
      * by NamesAndIDsTracker::constraint_row_label. A **flag** is named by a
-     * ProofFlagKey and found by NamesAndIDsTracker::find_proof_flag_values. And
+     * ProofFlagKey and found by NamesAndIDsTracker::find_proof_flag. And
      * a **line the constraint derived inside the proof** --- an install
      * initialiser's work, which has no OPB row to label and no reification to
      * key --- is named by a role and found by
@@ -52,7 +52,7 @@ namespace gcs::innards
      *
      * \ingroup Innards
      * \sa NamesAndIDsTracker::constraint_row_label
-     * \sa NamesAndIDsTracker::find_proof_flag_values
+     * \sa NamesAndIDsTracker::find_proof_flag
      * \sa NamesAndIDsTracker::find_derived_line
      * \sa Problem::each_constraint_of_type_with_proof_data
      */
@@ -60,9 +60,27 @@ namespace gcs::innards
     struct ConstraintProofModelData;
 
     /**
+     * \brief Which of cake_pb_cp's flag-naming families a ProofFlagKey names.
+     *
+     * The numbers in a key mean different things in the two, and the two render
+     * differently, so a key that did not say which family it meant would not
+     * determine a name: `v[id][1]` and `x[id][1]` are different flags with the
+     * same numbers. That ambiguity was latent for as long as only one family
+     * was ever looked up.
+     *
+     * \ingroup Innards
+     */
+    enum class ProofFlagFamily
+    {
+        Values, ///< `v[id][...]`, from NamesAndIDsTracker::create_proof_flag_values: the numbers are domain values.
+        Indices ///< `x[id][...]`, from NamesAndIDsTracker::create_proof_flag: the numbers are array positions.
+    };
+
+    /**
      * \brief The key a constraint created one of its proof flags under: the
-     * value list and optional annotation it passed to
-     * NamesAndIDsTracker::create_proof_flag_values.
+     * number list, optional annotation, and family it passed to
+     * NamesAndIDsTracker::create_proof_flag_values or
+     * NamesAndIDsTracker::create_proof_flag.
      *
      * The flag-side counterpart of a published row role, and published the same
      * way and for the same reason. A flag's name is a pure function of
@@ -77,12 +95,16 @@ namespace gcs::innards
      * constraint_row_label deliberately does not cover them.
      *
      * \ingroup Innards
-     * \sa NamesAndIDsTracker::find_proof_flag_values
+     * \sa NamesAndIDsTracker::find_proof_flag
      */
     struct ProofFlagKey
     {
         std::vector<long long> values;
         std::optional<std::string> annotation;
+
+        /// Defaulted, because most published keys are Values keys and a key
+        /// naming a cake-indexed flag is the one that has to say so.
+        ProofFlagFamily family = ProofFlagFamily::Values;
     };
 
     /**

--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -148,7 +148,7 @@ namespace
     // positions, 'v' where they are domain values. See #354.
     //
     // Shared rather than written out at each caller because
-    // find_proof_flag_values has to rebuild *exactly* the string
+    // find_proof_flag has to rebuild *exactly* the string
     // create_proof_flag_values built: that is what makes the lookup a pure
     // function of (id, values, annotation) rather than a read of per-solve
     // state. One builder is what keeps "the same string" a fact rather than an
@@ -206,7 +206,7 @@ struct NamesAndIDsTracker::Imp
     set<string> emitted_constraint_row_labels;
 
     // Every flag created under a ConstraintID-keyed name, so that a caller
-    // holding the key can find it (find_proof_flag_values). Filled by
+    // holding the key can find it (find_proof_flag). Filled by
     // make_proof_flag_named, which is the funnel for exactly those namespaces:
     // an f[index][stem] flag is anonymous and has no key. Same write-only
     // during model definition, read-only afterwards story as
@@ -1885,12 +1885,16 @@ auto NamesAndIDsTracker::constraint_row_label(const ConstraintID & id, const str
     return ProofLineLabel{label};
 }
 
-auto NamesAndIDsTracker::find_proof_flag_values(const ConstraintID & id, const ProofFlagKey & key) const -> optional<ProofFlag>
+auto NamesAndIDsTracker::find_proof_flag(const ConstraintID & id, const ProofFlagKey & key) const -> optional<ProofFlag>
 {
-    // Built by the same helper create_proof_flag_values builds with, because it
-    // has to be the same string: that is what makes this a pure function of
-    // (id, values, annotation) rather than a lookup into per-solve state.
-    auto found = _imp->constraint_keyed_flags.find(bracketed_flag_name('v', id, key.values, key.annotation));
+    // Built by the same helper the matching create_proof_flag overload builds
+    // with, because it has to be the same string: that is what makes this a pure
+    // function of (id, numbers, annotation, family) rather than a lookup into
+    // per-solve state. The family is what says which of the two that overload
+    // was --- the numbers alone do not, since v[id][1] and x[id][1] are
+    // different flags.
+    auto found =
+        _imp->constraint_keyed_flags.find(bracketed_flag_name(ProofFlagFamily::Indices == key.family ? 'x' : 'v', id, key.values, key.annotation));
     if (found == _imp->constraint_keyed_flags.end())
         return nullopt;
     return found->second;
@@ -1979,7 +1983,7 @@ auto NamesAndIDsTracker::make_proof_flag_named(const string & full_name) -> Proo
     auto flagvar = allocate_flag_xliteral(result, full_name);
     _imp->flags.emplace(result, flagvar);
     _imp->flags.emplace(! result, ! flagvar);
-    // Indexed so that find_proof_flag_values can answer for it. A repeat is a
+    // Indexed so that find_proof_flag can answer for it. A repeat is a
     // name collision in the PB file --- two flags rendering as one variable ---
     // so it is a bug in whichever namer produced it rather than something to
     // resolve here, but this is not the place to be strict about it: the

--- a/gcs/innards/proofs/names_and_ids_tracker.hh
+++ b/gcs/innards/proofs/names_and_ids_tracker.hh
@@ -591,10 +591,17 @@ namespace gcs::innards
          *
          * The flag-side counterpart of \ref constraint_row_label, and the same
          * shape of answer: "may I cite this?", not "what does it say". A flag's
-         * name is a pure function of `(id, values, annotation)` --- the same
-         * function \ref create_proof_flag_values applies --- so this finds the
-         * flag whichever clone of the constraint created it, and stores nothing
-         * a solve depends on beyond the name index the flags already need.
+         * name is a pure function of `(id, numbers, annotation, family)` --- the
+         * same function the matching \ref create_proof_flag overload applies ---
+         * so this finds the flag whichever clone of the constraint created it,
+         * and stores nothing a solve depends on beyond the name index the flags
+         * already need.
+         *
+         * The family is part of the key because it has to be: the numbers alone
+         * do not determine a name, since `v[id][1]` and `x[id][1]` are different
+         * flags. A key that does not say defaults to Values, which is what most
+         * published keys mean; cake-indexed flags such as ParityOdd's accumulator
+         * chain have to say Indices.
          *
          * nullopt means no flag went out under that key: the constraint was
          * never installed, or proofs are off, or the key names a
@@ -611,14 +618,14 @@ namespace gcs::innards
          * `f[index][stem]` flag is anonymous by construction and has no key to
          * look up.
          */
-        [[nodiscard]] auto find_proof_flag_values(const ConstraintID & id, const ProofFlagKey & key) const -> std::optional<ProofFlag>;
+        [[nodiscard]] auto find_proof_flag(const ConstraintID & id, const ProofFlagKey & key) const -> std::optional<ProofFlag>;
 
         /**
          * \brief Record a line this constraint established *inside the proof*,
          * under a role, so that another constraint may build on it.
          *
          * The third kind of citable thing, beside a labelled OPB row
-         * (\ref constraint_row_label) and a flag (\ref find_proof_flag_values),
+         * (\ref constraint_row_label) and a flag (\ref find_proof_flag),
          * and the one neither of those can express: a line an install
          * initialiser derived, which has no OPB row to label and no reification
          * to key. Cumulative's proof-only `end >= start + length` is the
@@ -646,7 +653,7 @@ namespace gcs::innards
          * published one.
          *
          * The same "may I cite this?" answer \ref constraint_row_label and
-         * \ref find_proof_flag_values give, and nullopt means the same thing it
+         * \ref find_proof_flag give, and nullopt means the same thing it
          * means there: the constraint was never installed, or proofs are off,
          * or it had nothing to publish under that role --- and in each case
          * there is nothing to cite, so do not do the thing that would need

--- a/gcs/presolvers/cumulative_strengthening/cumulative_strengthening.cc
+++ b/gcs/presolvers/cumulative_strengthening/cumulative_strengthening.cc
@@ -515,7 +515,7 @@ auto CumulativeStrengthening::run(Problem & problem, Propagators & propagators, 
 
                 auto & tracker = recipe_logger.names_and_ids_tracker();
                 auto flag_for = [&](size_t i) -> ProofFlag {
-                    auto active = tracker.find_proof_flag_values(donor_id, ConstraintProofModelData<Cumulative>::active_flag_key(i, t));
+                    auto active = tracker.find_proof_flag(donor_id, ConstraintProofModelData<Cumulative>::active_flag_key(i, t));
                     if (! active)
                         throw ProofError{"cumulative strengthening: the donor has no active flag for task " + to_string(i) + " at time " +
                             to_string(t.raw_value) + ", which install_derived_cumulative should already have declined over"};

--- a/gcs/presolvers/inferred_cumulative/inferred_cumulative.cc
+++ b/gcs/presolvers/inferred_cumulative/inferred_cumulative.cc
@@ -127,7 +127,7 @@ namespace
     [[nodiscard]] auto active_flag_for(const NamesAndIDsTracker & tracker, const ConstraintID & donor, size_t position, Integer t)
         -> optional<ProofFlag>
     {
-        return tracker.find_proof_flag_values(donor, ConstraintProofModelData<Cumulative>::active_flag_key(position, t));
+        return tracker.find_proof_flag(donor, ConstraintProofModelData<Cumulative>::active_flag_key(position, t));
     }
 
     /// The `before` and `after` flags an `active` flag is the conjunction of,
@@ -135,8 +135,8 @@ namespace
     [[nodiscard]] auto active_conjuncts_for(const NamesAndIDsTracker & tracker, const ConstraintID & donor, size_t position, Integer t)
         -> optional<vector<ProofFlag>>
     {
-        auto before = tracker.find_proof_flag_values(donor, ConstraintProofModelData<Cumulative>::before_flag_key(position, t));
-        auto after = tracker.find_proof_flag_values(donor, ConstraintProofModelData<Cumulative>::after_flag_key(position, t));
+        auto before = tracker.find_proof_flag(donor, ConstraintProofModelData<Cumulative>::before_flag_key(position, t));
+        auto after = tracker.find_proof_flag(donor, ConstraintProofModelData<Cumulative>::after_flag_key(position, t));
         if (! before || ! after)
             return std::nullopt;
         return vector<ProofFlag>{*before, *after};

--- a/gcs/presolvers/inferred_disjunctive/inferred_disjunctive.cc
+++ b/gcs/presolvers/inferred_disjunctive/inferred_disjunctive.cc
@@ -112,9 +112,9 @@ namespace
     [[nodiscard]] auto flags_for(const NamesAndIDsTracker & tracker, const ConstraintID & donor, size_t position, Integer t)
         -> optional<std::tuple<ProofFlag, ProofFlag, ProofFlag>>
     {
-        auto before = tracker.find_proof_flag_values(donor, ConstraintProofModelData<Cumulative>::before_flag_key(position, t));
-        auto after = tracker.find_proof_flag_values(donor, ConstraintProofModelData<Cumulative>::after_flag_key(position, t));
-        auto active = tracker.find_proof_flag_values(donor, ConstraintProofModelData<Cumulative>::active_flag_key(position, t));
+        auto before = tracker.find_proof_flag(donor, ConstraintProofModelData<Cumulative>::before_flag_key(position, t));
+        auto after = tracker.find_proof_flag(donor, ConstraintProofModelData<Cumulative>::after_flag_key(position, t));
+        auto active = tracker.find_proof_flag(donor, ConstraintProofModelData<Cumulative>::active_flag_key(position, t));
         if (! before || ! after || ! active)
             return std::nullopt;
         return std::tuple{*before, *after, *active};

--- a/gcs/presolvers/parity_system_gathering.hh
+++ b/gcs/presolvers/parity_system_gathering.hh
@@ -1,0 +1,6 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_PRESOLVERS_PARITY_SYSTEM_GATHERING_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_PRESOLVERS_PARITY_SYSTEM_GATHERING_HH
+
+#include <gcs/presolvers/parity_system_gathering/parity_system_gathering.hh>
+
+#endif

--- a/gcs/presolvers/parity_system_gathering/parity_system_gathering.cc
+++ b/gcs/presolvers/parity_system_gathering/parity_system_gathering.cc
@@ -1,0 +1,285 @@
+#include <gcs/constraints/equals/equals.hh>
+#include <gcs/constraints/parity/gf2_system.hh>
+#include <gcs/constraints/parity/parity.hh>
+#include <gcs/innards/propagators.hh>
+#include <gcs/presolvers/parity_system_gathering/parity_system_gathering.hh>
+#include <gcs/problem.hh>
+
+#include <util/enumerate.hh>
+#include <util/overloaded.hh>
+
+#include <concepts>
+#include <map>
+#include <memory>
+#include <numeric>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+using namespace gcs;
+using namespace gcs::innards;
+
+using std::make_optional;
+using std::make_shared;
+using std::make_unique;
+using std::move;
+using std::nullopt;
+using std::shared_ptr;
+using std::size_t;
+using std::string;
+using std::to_string;
+using std::unique_ptr;
+using std::vector;
+
+ParitySystemGathering::ParitySystemGathering(shared_ptr<ParitySystemGatheringStats> stats) :
+    // Always a block, whether or not anyone asked for one, as
+    // CumulativeStrengthening and DifferenceLogic both do it: what reaches a
+    // report is what was registered, and a presolver that registers nothing is a
+    // presolver that cannot be told apart from one that did nothing.
+    _stats(stats ? move(stats) : make_shared<ParitySystemGatheringStats>()), _keep_donor_propagators(false)
+{
+}
+
+auto ParitySystemGathering::keeping_donor_propagators(bool keep) -> ParitySystemGathering &
+{
+    _keep_donor_propagators = keep;
+    return *this;
+}
+
+auto ParitySystemGathering::clone() const -> unique_ptr<Presolver>
+{
+    auto result = make_unique<ParitySystemGathering>(_stats);
+    result->keeping_donor_propagators(_keep_donor_propagators);
+    return result;
+}
+
+namespace
+{
+    // A donor that survived every check, with what the propagator will need.
+    struct Candidate
+    {
+        ParitySystemRow row;
+        ConstraintID donor;
+    };
+
+    // Union-find over atom indices, for splitting the gathered rows into the
+    // components that can actually inform each other.
+    class Components
+    {
+    private:
+        vector<size_t> _parent;
+
+    public:
+        explicit Components(size_t n) : _parent(n)
+        {
+            std::iota(_parent.begin(), _parent.end(), size_t{0});
+        }
+
+        auto find(size_t x) -> size_t
+        {
+            while (_parent[x] != x) {
+                _parent[x] = _parent[_parent[x]];
+                x = _parent[x];
+            }
+            return x;
+        }
+
+        auto merge(size_t a, size_t b) -> void
+        {
+            _parent[find(a)] = find(b);
+        }
+    };
+}
+
+auto ParitySystemGathering::run(Problem & problem, Propagators & propagators, State & initial_state, ProofLogger * const logger) -> bool
+{
+    // Registered before anything is decided, so that a run which gathers nothing
+    // still reports having looked. The counters are filled in at the end, into
+    // this same object.
+    propagators.add_component_stats(_stats);
+
+    ParitySystemGatheringStats stats;
+
+    // ParityOdd is what Problem stores --- its clone() returns its own type, and
+    // it has no hierarchy to flatten within --- so that is what to ask for. The
+    // residual that this cannot pin is that clone() might one day return
+    // something else entirely, at which point the enumeration would silently find
+    // nothing; gcs/constraint_enumeration_test.cc is what holds that down, and
+    // the counts below are what would notice.
+    vector<Candidate> candidates;
+    for (const auto & c : problem.each_constraint_of_type<ParityOdd>()) {
+        if (c.literals().empty()) {
+            ++stats.skipped_empty_row;
+            continue;
+        }
+
+        // With no logger there is nothing to cite and nothing to check, so a
+        // chain is neither looked for nor needed.
+        std::optional<ParitySlackSource> slack_source;
+        if (logger) {
+            auto chain = find_parity_chain(*logger, c.constraint_id(), ConstraintProofModelData<ParityOdd>::chain_naming(), c.literals().size());
+            if (! chain) {
+                ++stats.skipped_uncitable_chain;
+                continue;
+            }
+            slack_source = ParitySlackSource{*chain};
+        }
+
+        candidates.push_back(
+            Candidate{ParitySystemRow{c.literals(), move(slack_source), "pgather" + as_string(c.constraint_id()) + "_"}, c.constraint_id()});
+    }
+
+    // Boolean Equals / NotEquals are 2-XORs when both operands are within
+    // {0, 1}: `x = y` is `[x != 0] XOR [y != 0] = 0`, which as an odd row is the
+    // same with one literal negated, and `x != y` is the odd row directly. This
+    // is where a MiniZinc model's bool_eq and bool_not rows come from, and they
+    // are worth having because they are the edges that join what would otherwise
+    // be separate XOR components.
+    //
+    // Both are ReifiedEquals, which is what clone() returns, so that is what to
+    // ask for; the reification condition is what says which. Neither needs a row
+    // cited: with two literals B is zero, and both halves of the slack form are
+    // plain RUP against the rows the donor itself emitted.
+    static_assert(std::derived_from<Equals, ReifiedEquals>);
+    static_assert(std::derived_from<NotEquals, ReifiedEquals>);
+
+    for (const auto & c : problem.each_constraint_of_type<ReifiedEquals>()) {
+        auto unconditional = false;
+        overloaded{//
+            [&](const reif::MustHold &) { unconditional = true; }, [&](const reif::MustNotHold &) { unconditional = true; }, [&](const auto &) {}}
+            .visit(c.reification_condition());
+        if (! unconditional) {
+            // A conditional equality is not a parity row at all until the
+            // condition is decided, and the system has no vocabulary for that.
+            ++stats.skipped_reified;
+            continue;
+        }
+
+        auto within_a_bit = [&](const IntegerVariableID & v) {
+            auto [lower, upper] = initial_state.bounds(v);
+            return lower >= 0_i && upper <= 1_i;
+        };
+        if (! within_a_bit(c.left_variable()) || ! within_a_bit(c.right_variable())) {
+            // Over wider operands equality is not a parity constraint: `x = y`
+            // says far more than "the same number of them are non-zero".
+            ++stats.skipped_wide_operands;
+            continue;
+        }
+
+        // Odd parity either way: for an equality one literal is negated, which
+        // is exactly `!p = p XOR 1`.
+        Literals literals{c.left_variable() != 0_i, c.enforces_equality() ? c.right_variable() == 0_i : c.right_variable() != 0_i};
+        candidates.push_back(Candidate{ParitySystemRow{move(literals), logger ? make_optional(ParitySlackSource{ParitySlackFormIsRUP{}}) : nullopt,
+                                           "pgather" + as_string(c.constraint_id()) + "_"},
+            c.constraint_id()});
+        ++stats.boolean_rows_offered;
+    }
+
+    // Canonicalise once, over every candidate together, so that two donors
+    // mentioning the same fact land in the same column and so in the same
+    // component. A row whose atoms all cancelled --- `ParityOdd({x, x})` --- has
+    // none, shares none, and so is alone by construction.
+    vector<Literals> all_literals;
+    for (const auto & candidate : candidates)
+        all_literals.push_back(candidate.row.literals);
+    auto system = build_gf2_system(all_literals);
+
+    Components components{system.atoms.size()};
+    for (const auto & row : system.rows) {
+        auto atoms = row.atoms.set_indices();
+        for (size_t i = 1; i < atoms.size(); ++i)
+            components.merge(atoms[0], atoms[i]);
+    }
+
+    // Group the candidates by the component of their first atom. An atom-less
+    // row gets a group of its own, which is then skipped by the size gate below.
+    std::map<std::optional<size_t>, vector<size_t>> grouped;
+    for (const auto & [r, row] : enumerate(system.rows)) {
+        auto first = row.atoms.first_set();
+        grouped[first ? make_optional(components.find(*first)) : nullopt].push_back(r);
+    }
+
+    vector<ConstraintID> gathered_donors;
+    for (const auto & [component, members] : grouped) {
+        // Fewer than two rows is not a threshold, it is a degeneracy: over a
+        // single row the system propagator computes exactly what that row's own
+        // ParityOdd computes, so installing one buys nothing and costs a wake.
+        // The atom-less rows all land in one nullopt group, which is why this
+        // counts members rather than trusting the group to be a real component.
+        if (! component || members.size() < 2) {
+            stats.skipped_alone_in_component += members.size();
+            continue;
+        }
+
+        vector<ParitySystemRow> rows;
+        for (const auto & r : members) {
+            rows.push_back(candidates[r].row);
+            gathered_donors.push_back(candidates[r].donor);
+        }
+
+        // A presolver-derived propagator has no posted-constraint identity of
+        // its own, exactly as for AutoTable and DifferenceLogic. No row it
+        // installs can be empty --- those were skipped above --- so the
+        // contradiction path inside is unreachable from here.
+        install_parity_system_propagator(propagators, CurrentlyUnnamedConstraint{}, "parity_system", move(rows));
+        ++stats.components_installed;
+        stats.rows_gathered += members.size();
+
+        // Atoms of the components that got a propagator, not of every candidate:
+        // a reader comparing this against rows_gathered is asking how big the
+        // systems being eliminated over are, and rows that were skipped are not
+        // in one.
+        for (size_t a = 0; a != system.atoms.size(); ++a)
+            if (components.find(a) == *component)
+                ++stats.atoms;
+    }
+
+    if (0 != stats.components_installed && ! _keep_donor_propagators)
+        stats.donor_propagators_disabled = propagators.disable_propagators_for_constraints(gathered_donors);
+
+    // Assigning rather than replacing is what keeps a caller's handle, and the
+    // block registered at the top of this function, the same object.
+    *_stats = stats;
+
+    return true;
+}
+
+auto ParitySystemGatheringStats::component_name() const -> string
+{
+    return "parity_system_gathering";
+}
+
+auto ParitySystemGatheringStats::summary() const -> string
+{
+    if (0 == rows_gathered)
+        return "gathered nothing";
+
+    auto result = to_string(rows_gathered) + " rows gathered over " + to_string(atoms) + " atoms into " + to_string(components_installed) +
+        (1 == components_installed ? " system" : " systems");
+
+    // "offered" and not "of them": such a row still has to land in a component
+    // with something else to be gathered at all. Worth saying even when it is
+    // zero, because a model whose XORs all arrived as ParityOdd looks identical
+    // to one where the Boolean detection has stopped working, and this is the
+    // line that separates them.
+    result += ", with " + to_string(boolean_rows_offered) + " rows offered by a Boolean equality";
+
+    if (0 != donor_propagators_disabled)
+        result += ", retiring " + to_string(donor_propagators_disabled) + " donor propagators";
+
+    return result;
+}
+
+auto ParitySystemGatheringStats::entries() const -> vector<StatsEntry>
+{
+    return {StatsEntry{"rows_gathered", static_cast<long long>(rows_gathered)}, StatsEntry{"atoms", static_cast<long long>(atoms)},
+        StatsEntry{"components_installed", static_cast<long long>(components_installed)},
+        StatsEntry{"donor_propagators_disabled", static_cast<long long>(donor_propagators_disabled)},
+        StatsEntry{"skipped_empty_row", static_cast<long long>(skipped_empty_row)},
+        StatsEntry{"skipped_uncitable_chain", static_cast<long long>(skipped_uncitable_chain)},
+        StatsEntry{"skipped_alone_in_component", static_cast<long long>(skipped_alone_in_component)},
+        StatsEntry{"boolean_rows_offered", static_cast<long long>(boolean_rows_offered)},
+        StatsEntry{"skipped_reified", static_cast<long long>(skipped_reified)},
+        StatsEntry{"skipped_wide_operands", static_cast<long long>(skipped_wide_operands)}};
+}

--- a/gcs/presolvers/parity_system_gathering/parity_system_gathering.hh
+++ b/gcs/presolvers/parity_system_gathering/parity_system_gathering.hh
@@ -1,0 +1,203 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_PRESOLVERS_PARITY_SYSTEM_GATHERING_PARITY_SYSTEM_GATHERING_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_PRESOLVERS_PARITY_SYSTEM_GATHERING_PARITY_SYSTEM_GATHERING_HH
+
+#include <gcs/presolver.hh>
+#include <gcs/stats.hh>
+
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace gcs
+{
+    /**
+     * \brief What the parity-system gathering presolver did, filled in when it
+     * runs.
+     *
+     * As for DifferenceLogicStats, these counts are not decoration: they are the
+     * only thing that tells "gathered the system" from "silently gathered
+     * nothing". A presolver that lifted no rows --- because, say, ParityOdd
+     * stopped publishing its chain naming, so find_parity_chain started
+     * returning nullopt for every donor --- adds no OPB content, changes no
+     * solution, and leaves every proof verifying. It would pass every
+     * solution-equivalence check, OPB byte-diff and VeriPB run there is, and
+     * look exactly like a model with no XOR structure in it.
+     *
+     * Being a ComponentStats is what puts these into a report without anything
+     * having to list them: `fzn-glasgow` renders every registered block through
+     * entries().
+     *
+     * \sa ParitySystemGathering
+     * \ingroup Presolvers
+     */
+    struct ParitySystemGatheringStats final : ComponentStats
+    {
+        /// Donor rows lifted into a system that got a propagator: the number
+        /// that matters.
+        std::size_t rows_gathered = 0;
+
+        /// Distinct atoms those rows span, after canonicalisation --- so after
+        /// `v != c` and `v == c` have been recognised as one column, and after
+        /// duplicates within a row have cancelled.
+        std::size_t atoms = 0;
+
+        /// Propagators installed: one per connected component of the rows that
+        /// were gathered, since rows sharing no atom cannot inform each other
+        /// and eliminating over them together is pure waste.
+        std::size_t components_installed = 0;
+
+        /// Donor propagators retired, because the system subsumes them.
+        std::size_t donor_propagators_disabled = 0;
+
+        /**
+         * \brief How many rows were offered by a Boolean `Equals` / `NotEquals`
+         * donor rather than by a ParityOdd.
+         *
+         * Offered, not gathered: such a row still has to land in a component
+         * with something else, and rows_gathered is what counts those. Broken
+         * out because it is a separate detection path over a separate class
+         * hierarchy, and the one that can regress silently on its own --- a
+         * model whose XORs were all posted as ParityOdd would still look busy.
+         */
+        std::size_t boolean_rows_offered = 0;
+
+        /**
+         * \name Why a candidate was not gathered.
+         *
+         * Every ParityOdd and every ReifiedEquals in the model falls into
+         * exactly one of rows_gathered, skipped_alone_in_component, or one of
+         * these, so the counts together account for all of them.
+         * @{
+         */
+
+        /// A ParityOdd over no literals. It asserts that zero is odd, and its
+        /// own propagator refutes it at the root; lifting it would be this
+        /// presolver claiming a refutation that was never its business, and
+        /// there is nothing for elimination to do with a row that has no atoms.
+        std::size_t skipped_empty_row = 0;
+
+        /// A donor whose accumulator chain could not be recovered in full: it
+        /// published no naming, or published one and some row under it was never
+        /// emitted. The justifications are `pol`s over rows derived from that
+        /// chain, so a chain that is not all there is not a weaker proof but an
+        /// invalid one. Only ever non-zero when proofs are being logged: with no
+        /// logger there is nothing to cite and nothing to check.
+        std::size_t skipped_uncitable_chain = 0;
+
+        /// A Boolean donor whose reification condition is neither
+        /// reif::MustHold nor reif::MustNotHold. A conditional equality is not a
+        /// parity row at all until its condition is decided, and the system has
+        /// no vocabulary for a row that might not be there. A deliberate gap
+        /// rather than an impossibility --- #649's equivalence store is where it
+        /// would be picked up --- and counted rather than guessed at.
+        std::size_t skipped_reified = 0;
+
+        /// A Boolean donor with an operand whose declared domain reaches outside
+        /// `{0, 1}`. Over wider operands equality is not a parity constraint at
+        /// all: `x = y` says far more than "the same number of them are
+        /// non-zero", so lifting it would be unsound rather than merely weak.
+        std::size_t skipped_wide_operands = 0;
+
+        /// A row that ended up alone in its component, once atoms had been
+        /// shared out. Over a single row the system propagator computes exactly
+        /// what that row's own ParityOdd computes, more slowly, so it is left to
+        /// it --- and its propagator is not retired. This is also where a row
+        /// whose atoms all cancelled goes (`ParityOdd({x, x})`), since a row
+        /// with no atoms can share none.
+        std::size_t skipped_alone_in_component = 0;
+
+        ///@}
+
+        [[nodiscard]] auto component_name() const -> std::string override;
+        [[nodiscard]] auto summary() const -> std::string override;
+        [[nodiscard]] auto entries() const -> std::vector<StatsEntry> override;
+    };
+
+    /**
+     * \brief Scan a posted Problem for XOR-shaped constraints, gather them into
+     * GF(2) systems, and install a Gauss-Jordan propagator over each.
+     *
+     * A model does not have to be rewritten against ParitySystem to get
+     * system-level parity reasoning: post the XORs as ordinary ParityOdd
+     * constraints, add this presolver, and each connected component of them is
+     * eliminated over as one system. That is how a model arriving through a
+     * frontend gets here, since XOR structure survives MiniZinc flattening as
+     * individual `array_bool_xor` constraints and there is nothing to re-model.
+     *
+     * A single ParityOdd is already GAC on its own row --- unit propagation on
+     * one parity constraint *is* GAC --- so everything this buys lives in the
+     * conjunction. See dev_docs/parity-system.md.
+     *
+     * \par What is gathered
+     *
+     * Two donor families. A ParityOdd is a row directly. A Boolean `Equals` or
+     * `NotEquals` --- both operands' declared domains within `{0, 1}` --- is a
+     * 2-XOR: `x != y` is `[x != 0] XOR [y != 0] = 1`, and `x = y` is the same
+     * with one literal negated, since `!p` is `p XOR 1`. The second family is
+     * where a MiniZinc model's `bool_eq` and `bool_not` rows come from, and it is
+     * worth having less for the rows themselves than for the atoms they share:
+     * they are the edges that join what would otherwise be separate components.
+     * Everything else is skipped and counted --- see
+     * ParitySystemGatheringStats.
+     *
+     * Off by default, as every presolver is: opted into with
+     * Problem::add_presolver.
+     *
+     * \par Why this can be a presolver at all
+     *
+     * Presolvers run after create_propagators and after the proof model has been
+     * finalised, so no new OPB content can be added --- Presolver::run has no
+     * ProofModel * precisely because that door has closed. The slack-form rows
+     * the justifications need are therefore derived *inside* the proof, at
+     * ProofLevel::Top, from rows each donor already emitted. That is not a
+     * limitation worked around; it is the chain-portable option anyway, since a
+     * row only our own `.opb` contained would fail against the one cake_pb_cp
+     * re-derives from the `.scp`.
+     *
+     * \ingroup Presolvers
+     */
+    class ParitySystemGathering : public Presolver
+    {
+    private:
+        std::shared_ptr<ParitySystemGatheringStats> _stats;
+        bool _keep_donor_propagators;
+
+    public:
+        /**
+         * \brief Construct the presolver, optionally sharing a stats block that
+         * will be filled in when it runs.
+         *
+         * The block is shared, not copied, so it survives
+         * Problem::add_presolver cloning the presolver and can be read after
+         * solving.
+         */
+        explicit ParitySystemGathering(std::shared_ptr<ParitySystemGatheringStats> stats = nullptr);
+
+        /**
+         * \brief Leave the gathered donors' own propagators running, instead of
+         * retiring them.
+         *
+         * Ships **off**, unlike DifferenceLogic's equivalent: the system
+         * propagator subsumes a single XOR's unit propagation outright (a donor
+         * row with one literal left becomes a unit row of the reduced system, so
+         * the system infers exactly what the donor would have), and a donor
+         * whose rows have been gathered is then pure overhead on every wake.
+         *
+         * This exists so that the subsumption claim can be checked rather than
+         * assumed, and it is a strong check: disabling a propagator changes
+         * neither degrees nor adjacency, so the search tree must come out
+         * **node for node identical** either way. It differing means the
+         * subsumption claim is wrong.
+         *
+         * Donors in a component that got no propagator are never retired,
+         * however this is set.
+         */
+        auto keeping_donor_propagators(bool = true) -> ParitySystemGathering &;
+
+        [[nodiscard]] virtual auto run(Problem &, innards::Propagators &, innards::State &, innards::ProofLogger * const) -> bool override;
+        [[nodiscard]] virtual auto clone() const -> std::unique_ptr<Presolver> override;
+    };
+}
+
+#endif

--- a/gcs/presolvers/parity_system_gathering/parity_system_gathering_test.cc
+++ b/gcs/presolvers/parity_system_gathering/parity_system_gathering_test.cc
@@ -1,0 +1,412 @@
+// Tests for the parity-system gathering presolver.
+//
+// READ THIS BEFORE "FIXING" A FAILURE HERE.
+//
+// This presolver adds no OPB content and changes no solution set. A version of
+// it that silently gathered *nothing* -- because, say, ParityOdd stopped
+// publishing its chain naming, so find_parity_chain returned nullopt for every
+// donor, or because clone() started returning some other type so the
+// enumeration matched nothing -- would pass:
+//
+//   * every solution-set equivalence check (a no-op presolver preserves them);
+//   * every VeriPB run (there would be nothing new to verify).
+//
+// So the assertions on ParitySystemGatheringStats below, and the `strength`
+// differentials, are the only things standing between a silent regression and
+// shipping. If one of those fails, DETECTION IS BROKEN. Do not update the
+// expected numbers to match what the code now does; fix
+// gcs/presolvers/parity_system_gathering/parity_system_gathering.cc.
+//
+// There are two detection paths over two unrelated class hierarchies -- ParityOdd
+// and ReifiedEquals -- and either can regress while the other keeps the presolver
+// looking busy. That is what boolean_rows_offered is asserted for on every
+// fixture, including where it is zero, and what the bool_bridge_unsat strength
+// fixture exists for: it is unsatisfiable only once an equality has been used to
+// identify two XOR rows' variables, so it separates "the Boolean family is
+// counted" from "the Boolean family is doing work".
+
+#include <gcs/constraints/equals.hh>
+#include <gcs/constraints/innards/constraints_test_utils.hh>
+#include <gcs/constraints/parity.hh>
+#include <gcs/exception.hh>
+#include <gcs/presolvers/parity_system_gathering.hh>
+#include <gcs/problem.hh>
+#include <gcs/solve.hh>
+
+#include <cstdlib>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <set>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+#include <version>
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+#include <print>
+#else
+#include <fmt/core.h>
+#include <fmt/ostream.h>
+#include <fmt/ranges.h>
+#endif
+
+using std::cerr;
+using std::flush;
+using std::make_optional;
+using std::make_shared;
+using std::nullopt;
+using std::pair;
+using std::set;
+using std::shared_ptr;
+using std::size_t;
+using std::string;
+using std::to_string;
+using std::tuple;
+using std::vector;
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+using std::print;
+using std::println;
+#else
+using fmt::print;
+using fmt::println;
+#endif
+
+using namespace gcs;
+using namespace gcs::test_innards;
+
+namespace
+{
+    const string detection_is_broken = " DETECTION IS BROKEN: this presolver is invisible except through its stats block, so"
+                                       " do not update the expected number. Fix the presolver.";
+
+    // Each row is a list of positions in the variable array; an odd number of
+    // the variables at those positions must be non-zero.
+    using Rows = vector<vector<int>>;
+
+    // A Boolean Equals / NotEquals donor, which over {0, 1} operands is a 2-XOR.
+    // `condition` set posts the `If` form instead, which is not liftable and is
+    // here to check that it is refused and counted rather than lifted wrongly.
+    struct BoolDonor
+    {
+        bool equality;
+        int a, b;
+        std::optional<int> condition = nullopt;
+    };
+    using BoolDonors = vector<BoolDonor>;
+
+    enum class Config
+    {
+        NoPresolver,
+        DonorsKept,
+        DonorsRetired
+    };
+
+    auto config_name(Config c) -> string
+    {
+        switch (c) {
+            using enum Config;
+        case NoPresolver: return "none";
+        case DonorsKept: return "kept";
+        case DonorsRetired: return "retired";
+        }
+        throw NonExhaustiveSwitch{};
+    }
+
+    // What the presolver should report on a fixture. Every ParityOdd posted
+    // falls into exactly one of rows_gathered and the two skip buckets a test
+    // fixture can provoke, so these account for all of them.
+    struct Expected
+    {
+        size_t rows_gathered;
+        size_t atoms;
+        size_t components_installed;
+        size_t skipped_empty_row = 0;
+        size_t skipped_alone_in_component = 0;
+        size_t boolean_rows_offered = 0;
+        size_t skipped_reified = 0;
+        size_t skipped_wide_operands = 0;
+    };
+
+    auto check_count(const string & what, size_t expected, size_t actual, const string & fixture) -> void
+    {
+        if (expected != actual)
+            throw UnexpectedException{"parity gathering fixture '" + fixture + "' reported " + to_string(actual) + " " + what + ", expected " +
+                to_string(expected) + "." + detection_is_broken};
+    }
+
+    auto build(Problem & p, const vector<pair<int, int>> & domains, const Rows & rows, const BoolDonors & bools, Config config,
+        const shared_ptr<ParitySystemGatheringStats> & stats) -> vector<IntegerVariableID>
+    {
+        vector<IntegerVariableID> vars;
+        for (const auto & [lo, hi] : domains)
+            vars.push_back(p.create_integer_variable(Integer(lo), Integer(hi)));
+
+        for (const auto & row : rows) {
+            vector<IntegerVariableID> operands;
+            for (const auto & pos : row)
+                operands.push_back(vars.at(pos));
+            p.post(ParityOdd{operands});
+        }
+
+        for (const auto & b : bools) {
+            if (b.condition) {
+                if (b.equality)
+                    p.post(EqualsIf{vars.at(b.a), vars.at(b.b), vars.at(*b.condition) != 0_i});
+                else
+                    p.post(NotEqualsIf{vars.at(b.a), vars.at(b.b), vars.at(*b.condition) != 0_i});
+            }
+            else if (b.equality)
+                p.post(Equals{vars.at(b.a), vars.at(b.b)});
+            else
+                p.post(NotEquals{vars.at(b.a), vars.at(b.b)});
+        }
+
+        switch (config) {
+            using enum Config;
+        case NoPresolver: break;
+        case DonorsKept: p.add_presolver(ParitySystemGathering{stats}.keeping_donor_propagators()); break;
+        case DonorsRetired: p.add_presolver(ParitySystemGathering{stats}); break;
+        }
+
+        return vars;
+    }
+
+    auto satisfied(const vector<int> & vals, const Rows & rows, const BoolDonors & bools) -> bool
+    {
+        for (const auto & row : rows) {
+            int trues = 0;
+            for (const auto & pos : row)
+                if (vals.at(pos) != 0)
+                    ++trues;
+            if (trues % 2 != 1)
+                return false;
+        }
+
+        for (const auto & b : bools) {
+            if (b.condition && 0 == vals.at(*b.condition))
+                continue;
+            if (b.equality != (vals.at(b.a) == vals.at(b.b)))
+                return false;
+        }
+
+        return true;
+    }
+
+    // Solution-set equivalence across all three configurations, against an
+    // independent oracle. Sound and complete in both directions: a presolver
+    // that over-prunes loses a solution and one that is unsound gains one, and
+    // no proof would catch either, since a proof only certifies what was
+    // derived.
+    auto run_equivalence_test(bool proofs, const string & name, const vector<pair<int, int>> & domains, const Rows & rows, const BoolDonors & bools,
+        const Expected & expected_stats) -> void
+    {
+        print(
+            cerr, "parity gathering equivalence {} domains={} rows={} bools={}{}", name, domains, rows, bools.size(), proofs ? " with proofs:" : ":");
+        cerr << flush;
+
+        set<tuple<vector<int>>> expected;
+        build_expected(expected, [&](const vector<int> & vals) { return satisfied(vals, rows, bools); }, domains);
+        println(cerr, " expecting {} solutions", expected.size());
+
+        for (auto config : {Config::NoPresolver, Config::DonorsKept, Config::DonorsRetired}) {
+            auto stats = make_shared<ParitySystemGatheringStats>();
+            Problem p;
+            auto vars = build(p, domains, rows, bools, config, stats);
+
+            set<tuple<vector<int>>> actual;
+            auto proof_name = proofs ? make_optional("parity_gathering_" + name + "_" + config_name(config)) : nullopt;
+            solve_for_tests(p, proof_name, actual, tuple{vars});
+            check_results(proof_name, expected, actual);
+
+            if (config == Config::NoPresolver)
+                continue;
+
+            check_count("rows gathered", expected_stats.rows_gathered, stats->rows_gathered, name);
+            check_count("atoms", expected_stats.atoms, stats->atoms, name);
+            check_count("components installed", expected_stats.components_installed, stats->components_installed, name);
+            check_count("empty rows skipped", expected_stats.skipped_empty_row, stats->skipped_empty_row, name);
+            check_count("rows skipped as alone", expected_stats.skipped_alone_in_component, stats->skipped_alone_in_component, name);
+            check_count("Boolean rows offered", expected_stats.boolean_rows_offered, stats->boolean_rows_offered, name);
+            check_count("Boolean donors skipped as reified", expected_stats.skipped_reified, stats->skipped_reified, name);
+            check_count("Boolean donors skipped for wide operands", expected_stats.skipped_wide_operands, stats->skipped_wide_operands, name);
+
+            // Only ever non-zero with proofs off, and then it would mean the
+            // chain lookup had stopped working -- which is the failure mode this
+            // whole file exists to catch, so say so specifically.
+            check_count("donors skipped for an uncitable chain", 0, stats->skipped_uncitable_chain, name);
+
+            if (config == Config::DonorsRetired && expected_stats.components_installed != 0 && 0 == stats->donor_propagators_disabled)
+                throw UnexpectedException{"parity gathering fixture '" + name + "' gathered " + to_string(stats->rows_gathered) +
+                    " rows but retired no donor propagators." + detection_is_broken};
+            if (config == Config::DonorsKept && 0 != stats->donor_propagators_disabled)
+                throw UnexpectedException{"parity gathering fixture '" + name + "' retired donor propagators with keeping_donor_propagators() set"};
+        }
+    }
+
+    // The tripwire. Retiring the donors' own propagators must not change the
+    // search at all: the system propagator subsumes a single XOR's unit
+    // propagation outright (a donor row with one literal left is a unit row of
+    // the reduced system), and disabling a propagator changes neither degrees
+    // nor adjacency, so the branching heuristic sees an unchanged problem.
+    // Solutions *and* recursions must match exactly. Propagation counts of
+    // course do not, and are the point of the option.
+    auto run_tripwire_test(const string & name, const vector<pair<int, int>> & domains, const Rows & rows, const BoolDonors & bools) -> void
+    {
+        print(cerr, "parity gathering tripwire {}:", name);
+        cerr << flush;
+
+        Stats results[2];
+        for (auto [index, config] : {pair{0, Config::DonorsKept}, pair{1, Config::DonorsRetired}}) {
+            auto stats = make_shared<ParitySystemGatheringStats>();
+            Problem p;
+            static_cast<void>(build(p, domains, rows, bools, config, stats));
+            results[index] = solve_with(p, SolveCallbacks{.solution = [&](const CurrentState &) -> bool { return true; }});
+            if (config == Config::DonorsRetired && 0 == stats->donor_propagators_disabled)
+                throw UnexpectedException{"parity gathering fixture '" + name +
+                    "' retired no donor propagators, so the tripwire compared two identical configurations." + detection_is_broken};
+        }
+
+        println(cerr, " kept {} solutions / {} recursions / {} propagations, retired {} / {} / {}", results[0].solutions, results[0].recursions,
+            results[0].propagations, results[1].solutions, results[1].recursions, results[1].propagations);
+
+        if (results[0].solutions != results[1].solutions)
+            throw UnexpectedException{"parity gathering fixture '" + name + "' found " + to_string(results[0].solutions) +
+                " solutions with the donors kept but " + to_string(results[1].solutions) +
+                " with them retired: the system propagator does not subsume them and retiring is unsound"};
+
+        if (results[0].recursions != results[1].recursions)
+            throw UnexpectedException{"parity gathering fixture '" + name + "' searched " + to_string(results[0].recursions) +
+                " recursions with the donors kept but " + to_string(results[1].recursions) +
+                " with them retired. Retiring changes neither degrees nor adjacency, so the tree must be identical node for node; it differing "
+                "means the system propagator does not subsume a single XOR's unit propagation after all."};
+    }
+
+    // The strength differential. The other two tests would both pass for a
+    // presolver that gathered the rows and then inferred nothing from them, so
+    // this is where the point of the whole exercise gets checked: on a system
+    // that is unsatisfiable while no single row of it conflicts, Gauss-Jordan
+    // refutes it without searching and unit propagation cannot.
+    auto run_strength_test(const string & name, const vector<pair<int, int>> & domains, const Rows & rows, const BoolDonors & bools) -> void
+    {
+        print(cerr, "parity gathering strength {}:", name);
+        cerr << flush;
+
+        Stats results[2];
+        for (auto [index, config] : {pair{0, Config::NoPresolver}, pair{1, Config::DonorsRetired}}) {
+            auto stats = make_shared<ParitySystemGatheringStats>();
+            Problem p;
+            static_cast<void>(build(p, domains, rows, bools, config, stats));
+            results[index] = solve_with(p, SolveCallbacks{.solution = [&](const CurrentState &) -> bool { return true; }});
+        }
+
+        println(cerr, " no presolver {} solutions / {} recursions, gathered {} / {}", results[0].solutions, results[0].recursions,
+            results[1].solutions, results[1].recursions);
+
+        if (0 != results[0].solutions || 0 != results[1].solutions)
+            throw UnexpectedException{"parity gathering strength fixture '" + name +
+                "' is meant to be unsatisfiable, and is not: it cannot separate the two configurations."};
+
+        if (results[1].recursions >= results[0].recursions)
+            throw UnexpectedException{"parity gathering fixture '" + name + "' took " + to_string(results[1].recursions) +
+                " recursions with the system gathered and " + to_string(results[0].recursions) +
+                " without, so gathering bought no strength at all. The whole point is that the conjunction refutes what no single row does." +
+                detection_is_broken};
+    }
+}
+
+auto main(int, char *[]) -> int
+{
+    const vector<pair<int, int>> four_bits{{0, 1}, {0, 1}, {0, 1}, {0, 1}};
+    const vector<pair<int, int>> three_bits{{0, 1}, {0, 1}, {0, 1}};
+    const vector<pair<int, int>> six_bits{{0, 1}, {0, 1}, {0, 1}, {0, 1}, {0, 1}, {0, 1}};
+
+    // Three rows over a cycle summing to the empty row with an odd right-hand
+    // side: unsatisfiable, and no two of the three conflict, so nothing short of
+    // the system sees it. This is the camouflage fixture, and the one the
+    // strength differential runs on.
+    const Rows camouflage{{0, 1}, {1, 2}, {0, 2}};
+
+    for (bool proofs : {false, true}) {
+        if (proofs && ! can_run_veripb())
+            continue;
+
+        // One component, every row sharing with the next.
+        run_equivalence_test(
+            proofs, "chain", four_bits, {{0, 1}, {1, 2}, {2, 3}}, {}, Expected{.rows_gathered = 3, .atoms = 4, .components_installed = 1});
+
+        run_equivalence_test(proofs, "camouflage", three_bits, camouflage, {}, Expected{.rows_gathered = 3, .atoms = 3, .components_installed = 1});
+
+        // Two components that share nothing: two propagators, not one over the
+        // lot. Eliminating over rows that cannot inform each other is waste, and
+        // a version that merged them would report one component here.
+        run_equivalence_test(proofs, "two_components", six_bits, {{0, 1}, {1, 2}, {3, 4}, {4, 5}}, {},
+            Expected{.rows_gathered = 4, .atoms = 6, .components_installed = 2});
+
+        // A single row is left to its own ParityOdd: over one row the system
+        // propagator computes exactly what it does, more slowly.
+        run_equivalence_test(proofs, "singleton", three_bits, {{0, 1, 2}}, {},
+            Expected{.rows_gathered = 0, .atoms = 0, .components_installed = 0, .skipped_alone_in_component = 1});
+
+        // A row whose atoms all cancel is `x XOR x = 1`, which is false. It has
+        // no atoms, so it shares none and is alone by construction -- and its
+        // own propagator is what refutes it.
+        run_equivalence_test(proofs, "all_cancel", three_bits, {{0, 0}, {1, 2}, {0, 1}}, {},
+            Expected{.rows_gathered = 2, .atoms = 3, .components_installed = 1, .skipped_alone_in_component = 1});
+
+        // An empty row asserts that zero is odd. Left to its own propagator, and
+        // counted; the other two rows still form a system.
+        run_equivalence_test(proofs, "empty_row", three_bits, {{}, {0, 1}, {1, 2}}, {},
+            Expected{.rows_gathered = 2, .atoms = 3, .components_installed = 1, .skipped_empty_row = 1});
+
+        // Wider domains: the atoms are `v != 0`, so only zero versus non-zero
+        // matters, and a variable contributes one column however wide it is.
+        run_equivalence_test(proofs, "wide_domains", {{0, 3}, {-2, 2}, {0, 1}}, {{0, 1}, {1, 2}}, {},
+            Expected{.rows_gathered = 2, .atoms = 3, .components_installed = 1});
+
+        // The Boolean family's whole point: without the NotEquals in the middle
+        // these are two components of one row each, both left to their own
+        // propagators. With it they are one system of three rows. A version that
+        // gathered only ParityOdd would report zero rows gathered here.
+        run_equivalence_test(proofs, "bool_bridge", four_bits, {{0, 1}, {2, 3}}, {BoolDonor{false, 1, 2}},
+            Expected{.rows_gathered = 3, .atoms = 4, .components_installed = 1, .boolean_rows_offered = 1});
+
+        // An equality, which is the *even* 2-XOR and so is lifted with one
+        // literal negated. Getting that negation backwards would show up as a
+        // solution-set mismatch, not merely a weaker system.
+        run_equivalence_test(proofs, "bool_equals", three_bits, {{0, 1}}, {BoolDonor{true, 1, 2}},
+            Expected{.rows_gathered = 2, .atoms = 3, .components_installed = 1, .boolean_rows_offered = 1});
+
+        // Both together, and an equality between two variables the XOR rows
+        // already mention -- so the row is redundant as a constraint while still
+        // joining the components.
+        run_equivalence_test(proofs, "bool_both", four_bits, {{0, 1}, {2, 3}}, {BoolDonor{true, 0, 2}, BoolDonor{false, 1, 3}},
+            Expected{.rows_gathered = 4, .atoms = 4, .components_installed = 1, .boolean_rows_offered = 2});
+
+        // An operand reaching outside {0, 1}: equality there says far more than
+        // parity does, so lifting it would be unsound rather than weak.
+        run_equivalence_test(proofs, "bool_wide_operand", {{0, 1}, {0, 1}, {0, 3}}, {{0, 1}}, {BoolDonor{true, 1, 2}},
+            Expected{.rows_gathered = 0, .atoms = 0, .components_installed = 0, .skipped_alone_in_component = 1, .skipped_wide_operands = 1});
+
+        // A half-reified equality is not a parity row until its condition is
+        // decided. Refused and counted.
+        run_equivalence_test(proofs, "bool_reified", four_bits, {{0, 1}}, {BoolDonor{true, 1, 2, make_optional(3)}},
+            Expected{.rows_gathered = 0, .atoms = 0, .components_installed = 0, .skipped_alone_in_component = 1, .skipped_reified = 1});
+    }
+
+    run_tripwire_test("chain", four_bits, {{0, 1}, {1, 2}, {2, 3}}, {});
+    run_tripwire_test("camouflage", three_bits, camouflage, {});
+    run_tripwire_test("two_components", six_bits, {{0, 1}, {1, 2}, {3, 4}, {4, 5}}, {});
+    run_tripwire_test("bool_bridge", four_bits, {{0, 1}, {2, 3}}, {BoolDonor{false, 1, 2}});
+
+    run_strength_test("camouflage", three_bits, camouflage, {});
+
+    // The Boolean family's own strength differential: two rows that conflict only
+    // once the equality has been used to identify their variables. Neither row
+    // nor the equality conflicts with either other alone.
+    run_strength_test("bool_bridge_unsat", four_bits, {{0, 1}, {2, 3}}, {BoolDonor{true, 0, 2}, BoolDonor{false, 1, 3}});
+
+    return EXIT_SUCCESS;
+}

--- a/gcs/scp_reader.cc
+++ b/gcs/scp_reader.cc
@@ -1305,6 +1305,19 @@ auto gcs::read_scp(Problem & problem, string_view text) -> ScpModel
                 throw ScpReadError{"parity output must be statically true (only bare odd parity is supported)"};
             post_constraint(problem, ParityOdd{move(lits)}, label);
         }
+        else if (op == "parity_system") {
+            // (label parity_system (((Z op v) ...) ...)): each inner list is one
+            // odd-parity row. Not a cake rule -- cake has `parity` for a single
+            // row and nothing for a system of them -- but a .scp is written on
+            // every proof-logged run that asks for one, so the form has to be
+            // readable as well as writable. Nogoods is the same case.
+            if (terms.size() != 3)
+                throw ScpReadError{"parity_system is (label parity_system ((literals...) ...))"};
+            vector<innards::Literals> rows;
+            for (const auto & row : children_of(terms[2], "the parity_system row list"))
+                rows.push_back(resolve_literal_list(variables, row, "a parity_system row"));
+            post_constraint(problem, ParitySystem{move(rows)}, label);
+        }
         else if (op == "plus") {
             // (label plus a b result): a + b = result.
             if (terms.size() != 5)


### PR DESCRIPTION
Closes #647.

`ParityOdd` reasons about one XOR at a time, and that is the right answer for one
XOR — unit propagation on a single parity constraint *is* GAC, because any value
has a support while two literals are still free. So every bit of inference a
system of them offers lives in the conjunction, and we were throwing all of it
away. Over GF(2) that conjunction is one of the rare tractable cases.

Two things here. **`ParitySystem`** eliminates over a set of rows and reads off
every literal the system implies, which is GAC. **`ParitySystemGathering`** is a
presolver that collects posted `ParityOdd` and Boolean `Equals`/`NotEquals`
constraints into per-component systems, so a model arriving through a frontend
gets this without being re-modelled — XOR structure survives MiniZinc flattening
as individual `array_bool_xor` constraints.

Nobody in mainline CP does the system; CP-SAT has a TODO saying it should. The
claim here is **the certificate, not the speed** — CryptoMiniSat is very good at
this and is not being competed with.

## The proof

Gocht and Nordström (arXiv:2209.12185). Their slack form `Σx = b + 2B` makes a
Gaussian elimination step one `pol` line, but it cannot go in the `.opb`: cake
re-derives its own OPB from the `.scp`, and a presolver has no `ProofModel` at
all. So it is derived in-proof at `Top` from rows each donor already emitted —
which is the chain-portable option anyway.

That derivation is cheaper than the paper's. Their §4.4 recovers the form from a
CNF encoding they did not write, by brute force over all assignments; our
accumulator chain already *is* the partial-parity split of their (4.15), so each
step is a 3-XOR needing two `red`s — one discharged by RUP against the step's own
`1_1` clause, one carrying a five-line `pol` subproof whose three divide-by-2s are
where the parity argument lives — and the steps then telescope. Linear, not
exponential.

§4.3's clause extraction folds into the same RPN expression as the elimination, so
**an inference is one `pol` plus one RUP** whatever the size of the row
combination.

A two-literal donor is cheaper still: `B` is zero, so the slack form is just
`l1 + l2 = 1` and both halves are plain RUP against rows the donor emitted —
negating either fixes both operands and walks into one of them.

## What is verified

- **Zero assertions.** 61 veripb 3.0.2 runs across the two test binaries, all
  `s VERIFIED`, and `grep -c '^a '` zero on a preserved `.pbp`. With and without
  the view wrapper.
- **GAC is checked, not asserted** — `solve_for_tests_checking_gac`, and
  selecting `ParitySystemPropagation::CheckOnly` makes it fail, which is what
  says the check has teeth.
- **Mutation testing: 5 of 7 rejected.** The two survivors only *weaken* the
  derived row, by a term the `.opb` pins anyway, so the wrapping RUP replaces it
  — `veripb-facts.md`'s "a `pol` only has to get close", not a defect. The five
  that corrupt the *claim* are all caught. Written up as a table so nobody reads
  5/7 as a gap.
- **The presolver's tripwire holds node-for-node.** Retiring the gathered donors'
  propagators leaves solutions *and* recursions identical on every fixture while
  propagations drop by a third to a half, which is what says the system subsumes
  a single XOR's unit propagation.
- **It buys something.** On a system unsatisfiable while no single row conflicts,
  gathering takes the refutation from 3 recursions to 1. Two such fixtures, one
  unsatisfiable only once an equality has identified two XOR rows' variables — so
  it separates "the Boolean family is counted" from "the Boolean family is doing
  work".

## Two API extensions

The presolver API is very much "what has been needed so far", and this needed two
things it did not have.

- `ConstraintProofModelData<ParityOdd>` publishes a naming **object**,
  `ParityChainNaming`, rather than loose role functions. `Cumulative` publishes
  loose ones and that is right for it; here every name in the family is indexed
  the same way, by the same optional row index, and bundling them stops a citer
  picking up one without the rest or mixing an unprefixed role with a prefixed
  flag. `define_parity_chain` and `find_parity_chain` both build every name
  through it.
- **`ProofFlagKey` gained a `family`, and `find_proof_flag_values` became
  `find_proof_flag`.** This is a latent defect fixed rather than a feature added:
  a key carried numbers and an annotation but not which of cake's flag families
  it meant, so `v[id][1]` and `x[id][1]` — genuinely different flags — had the
  same key. The lookup hard-coded `v`, which worked only while nothing needed the
  other one. `ParityOdd`'s accumulators are cake's `x[id][k]` and cannot be
  anything else. The creation side already indexed both families, so only the
  lookup was narrow; `Values` is the default, so every existing published key is
  unchanged.

## What is NOT done, and should be read before merging

- **No sanitize build, and not the full test suite.** 372 related `release` tests
  pass (parity, scp chain, constraint enumeration, equals, cumulative,
  disjunctive, difference, presolvers, propagators, abs — everything the rename
  touched), and the whole tree builds. But `CONTRIBUTING.md` asks for `release`
  *and* `sanitize`, both full, and for `-DGCS_TEST_CAP_DEFAULTS=OFF` when a
  propagator has changed. None of those three has been run.
- **No benchmark numbers at all.** Everything measured is three- and
  four-variable fixtures. The `Top` footprint, the per-inference line count and
  the wall clock are all claims this design makes and nothing has checked at
  scale.
- **The `Top` footprint is still `7n` lines per row, not 2.** The per-step `red`s
  and their subproof lines are only needed until the telescoping `pol`s have run
  and are meant to be deleted afterwards; that is not implemented. Worth doing
  before pointing this at anything large, since every line left at `Top` taxes
  every later unhinted RUP (#666).
- **No frontend exposure**, so `parity-learning` and `cryptanalysis` cannot be
  run yet. That is the next thing, and it is also what would turn the numbers
  above into real ones.
- Implied equivalences (`x = y`, `x = ¬y`) are the real payoff over unit
  propagation and have nowhere to live — #649 scopes an equivalence store.
  Deliberately out of scope; detecting implied literals alone is already GAC.

`dev_docs/parity-system.md` has all of the above with the reasoning, including
the two things that bit during bring-up (line references inside a `red` subproof
must be absolute, and a row over no literals has no chain to telescope).

## AI use

Written with **Claude Code**, model **Claude Opus 5 (1M context)**
(`claude-opus-5[1m]`); every commit carries a matching `Co-Authored-By:` trailer.
The slack-row derivation was additionally put in front of a critical-review
subagent on the Fable model before being implemented, per `CLAUDE.md`'s "When to
ask for a second opinion"; it found the `proofgoal`-must-end-in-contradiction
defect and the empty-row exclusion, both of which are recorded in the design
note. **This has not yet been checked by a human**, which given
`CONTRIBUTING.md`'s bar — being able to explain why each change is correct — is
the main thing outstanding alongside the sanitize run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ayd9oqNB3Qwif1MpYy1ySh