### PR TITLE
GlobalCardinality: state a confined variable's confinement over runs (#936)

### DIFF
--- a/gcs/constraints/global_cardinality/bounds_global_cardinality.cc
+++ b/gcs/constraints/global_cardinality/bounds_global_cardinality.cc
@@ -1,5 +1,6 @@
 #include <gcs/constraints/global_cardinality/bounds_global_cardinality.hh>
 #include <gcs/constraints/global_cardinality/hints.hh>
+#include <gcs/constraints/global_cardinality/justify.hh>
 #include <gcs/constraints/in.hh>
 #include <gcs/constraints/innards/recover_am1.hh>
 #include <gcs/innards/inference_tracker.hh>
@@ -240,14 +241,11 @@ auto gcs::innards::propagate_bounds_global_cardinality(const vector<IntegerVaria
 
             auto capacity_reason = [&, a = a, b = b](optional<std::size_t> exclude) -> ReasonLiterals {
                 ReasonLiterals r;
-                for (const auto & var : confined) {
-                    auto [v_lo, v_hi] = state.bounds(var);
-                    for (Integer s = v_lo; s <= v_hi; ++s)
-                        if (! hall_contains(s) && ! state.in_domain(var, s))
-                            r.emplace_back(var != s);
-                    r.emplace_back(var >= v_lo);
-                    r.emplace_back(var <= v_hi);
-                }
+                // The hall set is the slice values[a..b] of the sorted cover, so
+                // it is already in ascending order for the helper.
+                for (const auto & var : confined)
+                    append_confined_to_hall_reason(
+                        state, var, values.begin() + static_cast<std::ptrdiff_t>(a), values.begin() + static_cast<std::ptrdiff_t>(b) + 1, r);
                 for (std::size_t v = a; v <= b; ++v)
                     if (exclude != optional<std::size_t>{v} && ! holds_alternative<ConstantIntegerVariableID>(counts[v]))
                         r.emplace_back(counts[v] <= state.bounds(counts[v]).second);

--- a/gcs/constraints/global_cardinality/bounds_global_cardinality_test.cc
+++ b/gcs/constraints/global_cardinality/bounds_global_cardinality_test.cc
@@ -106,6 +106,14 @@ auto main(int argc, char * argv[]) -> int
         // fires. First three confined to {1,2} with fixed capacity 2+1 force the
         // fourth off value 1.
         {{pair{1, 2}, pair{1, 2}, pair{1, 2}, pair{1, 4}}, {1, 2}, {2, 1}, false},
+        // The same shape with the cover values spread apart, which is what makes
+        // the capacity reason's "confined to the hall set" a real *range* rather
+        // than a run of one (#936). The three confined variables take 1 or 5 and
+        // nothing between, so the reason states that as ~[v in 2..4]; with the
+        // cover at {1, 2} every run is a single value and `not_in_range`
+        // canonicalises back to the disequality the per-value spelling emitted,
+        // so no row above this one exercises the interval form at all.
+        {{vector<int>{1, 5}, vector<int>{1, 5}, vector<int>{1, 5}, pair{1, 7}}, {1, 5}, {2, 1}, false},
         // Upper-capacity Hall: first three confined to {1,2} with capacity 2+1,
         // so the fourth variable is forced off value 1.
         {{pair{1, 2}, pair{1, 2}, pair{1, 2}, pair{1, 3}}, {1, 2, 3}, {pair{0, 2}, pair{0, 1}, pair{0, 3}}, false},

--- a/gcs/constraints/global_cardinality/justify.cc
+++ b/gcs/constraints/global_cardinality/justify.cc
@@ -48,14 +48,8 @@ auto gcs::innards::gcc_capacity_reason(const State & state, const vector<Integer
 {
     auto hall = hall_set(values, cut_values);
     ReasonLiterals r;
-    for (const auto & var : confined) {
-        auto [v_lo, v_hi] = state.bounds(var);
-        for (Integer s = v_lo; s <= v_hi; ++s)
-            if (! hall.contains(s) && ! state.in_domain(var, s))
-                r.emplace_back(var != s);
-        r.emplace_back(var >= v_lo);
-        r.emplace_back(var <= v_hi);
-    }
+    for (const auto & var : confined)
+        append_confined_to_hall_reason(state, var, hall.begin(), hall.end(), r);
     for (auto v : cut_values)
         if (! holds_alternative<ConstantIntegerVariableID>(counts[v]))
             r.emplace_back(counts[v] <= state.bounds(counts[v]).second);

--- a/gcs/constraints/global_cardinality/justify.hh
+++ b/gcs/constraints/global_cardinality/justify.hh
@@ -7,6 +7,8 @@
 #include <gcs/integer.hh>
 #include <gcs/variable_id.hh>
 
+#include <algorithm>
+#include <iterator>
 #include <optional>
 #include <utility>
 #include <vector>
@@ -36,6 +38,63 @@ namespace gcs::innards
 
     auto gcc_capacity_reason(const State &, const std::vector<Integer> & values, const std::vector<IntegerVariableID> & counts,
         const std::vector<std::size_t> & cut_values, const std::vector<IntegerVariableID> & confined) -> ReasonLiterals;
+
+    /**
+     * \brief Append "this variable is confined to the hall set" to a reason, as
+     * its two bounds plus one range condition per run of values it cannot take.
+     *
+     * \p hall_begin / \p hall_end are the hall set's values in ascending order;
+     * both arms hold theirs that way already (a slice of the sorted cover in the
+     * bounds propagator, a std::set in the GAC one).
+     *
+     * The facts stated are the same ones the per-value spelling stated, and they
+     * are what turns each confined variable's at-least-one into an at-least-one
+     * *over the hall set* in the capacity pol: every term outside the set has to
+     * be falsified for that aggregate to come out. What changes is the count. A
+     * confined variable's domain lies inside the hall set, so both of its bounds
+     * are hall values and every value it cannot take between them is a gap
+     * between two consecutive hall values -- so there are at most |H| - 1 runs,
+     * where walking the values cost ub - lb, and that is the *span* of the cover
+     * the model chose rather than anything about the variable (issue #936).
+     *
+     * **Why a range literal is as strong here as the disequalities it replaces,
+     * and what would break that.** The closure RUP has to falsify each individual
+     * `x[j=s]` term the AL1 contributes for s in a gap. It can, because the AL1 is
+     * built over the definition range and so has already shattered every gap into
+     * singleton eq atoms, and `link_immediate_containment` emits `~[j=s] \/ [j in
+     * g]` for each eq atom a range literal contains -- so unit propagation
+     * descends the containment tree and zeroes them one by one. It is *not* the
+     * threshold crossing dev_docs/large-domains.md warns about under "Getting a
+     * range removal past the checker"; that is a different step.
+     *
+     * The consequence is a coupling worth stating: **if the AL1 stops naming every
+     * value of the definition range (which is what issue #939 is about), these
+     * range literals stop propagating and the closure fails.** The shattering and
+     * the range spelling have to move together. #939's own suggested fix -- a
+     * per-firing at-least-one over the hall set, stated under exactly these
+     * literals -- does move them together, and makes this list the literal list of
+     * that line rather than a separate patch.
+     */
+    template <typename Iter_>
+    auto append_confined_to_hall_reason(const State & state, const IntegerVariableID & var, Iter_ hall_begin, Iter_ hall_end, ReasonLiterals & r)
+        -> void
+    {
+        auto [v_lo, v_hi] = state.bounds(var);
+        for (auto it = hall_begin; it != hall_end; ++it) {
+            auto next = std::next(it);
+            if (next == hall_end)
+                break;
+            // Clipped to the variable's bounds, exactly as the per-value loop
+            // was. Both bounds are themselves hall values, so this only drops
+            // gaps that lie wholly outside them.
+            auto lo = std::max(*it + 1_i, v_lo);
+            auto hi = std::min(*next - 1_i, v_hi);
+            if (lo <= hi)
+                r.emplace_back(not_in_range(var, lo, hi));
+        }
+        r.emplace_back(var >= v_lo);
+        r.emplace_back(var <= v_hi);
+    }
 
     /**
      * \brief Emit the demand-cut aggregate (dual of the capacity one) for a set


### PR DESCRIPTION
Closes #936.

The capacity rule's reason says, per confined variable, which values between its
bounds it cannot take — and said it one value at a time:

```cpp
for (Integer s = v_lo; s <= v_hi; ++s)
    if (! hall_contains(s) && ! state.in_domain(var, s))
        r.emplace_back(var != s);
```

A *confined* variable's domain lies inside the hall set, so its **cardinality** is
small; its **span** is whatever spread the model gave the cover. Two cover values
far apart and this walks between them, appending one literal per value, on the
propagation path. Instrumented at a cover of `{1, 10000}`: span 9999, three
confined variables.

Since the domain lies inside the hall set, both bounds are themselves hall values,
and every value the variable cannot take between them is a gap between two
consecutive hall values. So the same facts go in as at most `|H| - 1` range
conditions, clipped to the bounds exactly as the walk was. Both arms had the
identical loop, so this is one helper used by each.

## The issue was wrong about what this costs, and I have corrected it

#936 attributed an 11.6x-per-10x proof growth to this loop. **It is not this
loop** — the restatement moves those proofs by about 2.5%.

The growth is `emit_capacity_pol` adding
`need_constraint_saying_variable_takes_at_least_one_value` per confined variable.
That primitive builds its at-least-one over the variable's whole *definition
range*, one term and one `eq` atom per value, and those atoms then make every
later range literal's covering span-proportional too (997 covering cells per
variable, for a variable with **two** values in its domain). Filed as **#939**.

What this PR fixes is the **work**: an O(span) walk and O(span) reason literals
per firing become O(|H|).

## The literals are load-bearing — but it took an adversarial fixture to show it

Deleting them entirely — on `main` as well as here — still verifies across ten
seeds, both arms, and even with confinement derived by propagation rather than
declared. That is a property of the fixtures, not of the encoding: an explicit
value list posts `In`, whose root removal is a `NoReason` unit, so the checker
gets the holes for free. Under a *decision* the hole is only an implication clause
that the closure RUP never asserts, and there the proof **is** rejected without
these literals.

I had this reviewed by a second model before shipping, which is what produced that
fixture and the analysis below. Without it I would have had a change whose
justification I could not test.

## Why the range spelling is as strong as the disequalities

Not for the reason in dev_docs' "Getting a range removal past the checker" — that
warns about carrying `~[x in a..b]` across a link row via its thresholds, which is
a different step. The step needed here is *down the containment tree*:
`link_immediate_containment` emits `~[j=s] \/ [j in g]` for each `eq` atom a range
literal contains, so unit propagation zeroes the gap terms one at a time.

**Which is a coupling worth stating, and it is now in the header.** Those
containment edges exist only because the AL1 has already shattered the gap into
singleton `eq` atoms. So **#939 cannot narrow the AL1 without moving this at the
same time** — narrow it alone and these range literals propagate nothing and the
closure fails. #939 carries the shape that moves both: a per-firing at-least-one
over the hall set stated under exactly these literals, whose literal list is
precisely this helper's output.

## A test that actually exercises it

`bounds_global_cardinality_test` gains a row whose cover is `{1, 5}` rather than
`{1, 2}`. Every existing row's gaps are a single value, where `not_in_range`
canonicalises back to the disequality the old spelling emitted — so nothing in the
suite built an interval here at all. Instrumented: the bounds arm produced none
before this row, and produces `[2,4]` three times with it. (The GAC arm already
reached a five-wide one.)

## Gates

* `ctest` **829/829** release, **829/829** with `-DGCS_TEST_CAP_DEFAULTS=OFF`,
  **829/829** sanitize, **833/833** clang. `-DGCS_WERROR=ON` clean. No skips.
* Both GCC test binaries at `--seed=1`: 47 and 43 VeriPB runs, every one
  `s VERIFIED`, none `UNDER ASSERTIONS`.

## Follow-up

#939 is the one that moves the table, and the survey needs a `GlobalCardinality`
row with a *spread* cover to make it visible — every row it has uses `{1_i}` or
`{1_i, 2_i}`, so the definition range the AL1 spans is small and the growth never
shows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AsUZjNThjBFs7VsFkCQfux
