### PR TITLE
State an at-least-one over an interval cover, not per value (#939)

### DIFF
--- a/dev_docs/large-domains.md
+++ b/dev_docs/large-domains.md
@@ -966,6 +966,81 @@ ns/node before and 3 912 after, i.e. no difference outside noise, because a
 branching decision is a per-cent of what a node costs. The trade is a constant
 against an asymptote, which is the right way round.
 
+## The proof-size lane
+
+The audit lane above solves **without** `ProofOptions`, so nothing that happens
+only while a proof is being written is reachable from it: no justification is
+emitted and no reason is materialised. The `[.proofscaling]` survey below can see
+that work, but a survey is run by hand and pins nothing. Between them sat a class
+with no instrument at all, and #935, #936 and #939 all came out of it.
+
+`TEST_CASE("Large domain proof sizes")` in the same file is the gate for it. Each
+row is one shape — a variable **declared** over a wide range, a domain confined by
+`In` to a couple of values inside it, and an inference whose justification names
+those values — solved with proofs, and its proof both counted and checked with
+VeriPB. The bound is loose on purpose: it separates "a few hundred lines" from
+"one line per value", which is orders of magnitude, not a byte count to retune
+whenever the encoding shifts. Checking as well as counting matters, because a
+small proof that does not verify is a worse outcome than a big one that does.
+
+**This shape is why the class was invisible.** Every other probe in the file gets
+its wide definition range *by* wanting a wide domain, so a variable whose domain
+is narrow while its definition range is wide never arose — and that is exactly the
+gap between a domain (what a propagator sees) and a definition range (what the
+proof encoding names). Before #939 each of these rows wrote about 66 × width proof
+lines; the lane fails in about 39 seconds if that comes back, against 0.2 seconds
+when it has not.
+
+### At-least-one constraints span the definition range (#939)
+
+`need_constraint_saying_variable_takes_at_least_one_value` spells its at-least-one
+out one term per value over the variable's whole **definition** range, and asking
+for those eq atoms also splits the variable's interval partition into singletons,
+so every later covering is span-proportional too. Neither cost has anything to do
+with how many values the variable can still take.
+
+`..._over_cover(var, singled_out)` states the same fact over an interval cover
+instead: the caller's values of interest as their own eq atoms, the maximal runs
+between and around them as one range literal each. A pol that adds it gets the
+same `+[x = v]` for each named value, so cancellation against per-value
+at-most-ones and count lines is unchanged; what differs is the residue, one term
+per run rather than one per unnamed value. The caller's reason has to rule those
+runs out, which it does exactly when it pins the variable's bounds and excludes
+its holes — a run outside the bounds dies on the order chain, and a run inside one
+sits inside an excluded hole, so containment falsifies it. `generic_reason` and
+the Hall-set reasons all qualify.
+
+Measured on a `GlobalCardinality` whose variables are confined to two values:
+
+| width | before | after |
+|---|---|---|
+| 10^3 | 66 057 lines, 0.14 s | 255 lines, 0.001 s |
+| 10^4 | 660 057 lines, 10.9 s | 255 lines, 0.001 s |
+| 10^5 | 2 528 821+ lines, >600 s | 255 lines, 0.001 s |
+| 10^9 | — | 255 lines, 0.001 s |
+
+`AllDifferent` and `Among` in the same shape go 659 937 → 133 and 659 940 → 135 at
+10^4.
+
+**It is a threshold, not an unconditional rewrite, and that is the interesting
+part.** The per-value line is emitted once per variable and then serves every
+cover anyone asks for, because it names every value; a cover is specialised, so a
+caller whose cover changes from firing to firing — a Hall set — pays a line per
+distinct one. Over a *narrow* definition range each of those lines is about as big
+as the single per-value line it replaces, and there are many of them: going to
+covers unconditionally cost `sudoku` 16 % more proof lines and `ortho_latin` 3 %,
+for variables declared over nine values, where naming every value was never the
+problem. Caching the cover lines recovered only a fifth of that, because the Hall
+sets genuinely differ. With the width test the examples are byte-identical again
+(`ortho_latin`, `sudoku`, `crystal_maze`, `colour`, `n_fractions` all unchanged to
+the line) and the wide case is flat. **A rewrite that is asymptotically better can
+still be worse everywhere anyone actually is**, and the only way to find that out
+is to measure the narrow case as well as the wide one.
+
+`subcircuit` deliberately keeps the per-value form: its pigeonhole needs every
+value named, and a successor's definition range *is* the node set, so there is no
+width there to spend on values the counting does not use.
+
 ## Proofs
 
 **Out of scope for fixing.** Several of these have no viable fix today, and a

--- a/dev_docs/large-domains.md
+++ b/dev_docs/large-domains.md
@@ -1041,6 +1041,47 @@ is to measure the narrow case as well as the wide one.
 value named, and a successor's definition range *is* the node set, so there is no
 width there to spend on values the counting does not use.
 
+Each caller names only the values **its variable can still take**, not its whole
+value set. The two are different whenever the value set is a Hall set, a cover or
+a union of domains and one variable's domain is a small part of it, and the
+correspondence it buys is worth more than the terms: the residue is then exactly
+the complement of the domain, which is exactly what the reason states, so the
+leftovers discharge by construction instead of by an argument about which runs
+happen to sit inside which holes. Measured, it is a **0.5–0.8 % proof-size**
+saving on a Hall violator whose hall set is four to sixty-four times any one
+domain — real, but small, because the at-least-ones are not where the volume is
+(the pairwise at-most-ones are, and they are cached at Top). It does **not**
+remove the need for the width threshold: it makes each line smaller, and the
+narrow-domain regression is about how *many* lines there are, so `sudoku` only
+improves from +16.3 % to +10.4 % with the threshold off.
+
+### AllDifferent's compressed value set was quadratic
+
+Separately from anything proof-shaped, `AllDifferent::prepare` built its
+compressed value set --- the union of the initial domains, which is the right-hand
+side of GAC's bipartite graph --- by walking every value of every domain and
+doing a **linear scan of what it had collected so far** for each one. That is
+O(values x distinct values), so it was asymptotically worse than the algorithm it
+feeds:
+
+| initial domain | before | after |
+|---|---|---|
+| `0..10^4` | 67 ms | 2 ms |
+| `0..10^5` | 6 637 ms | 38 ms |
+| `0..10^6` | did not finish in 200 s | 528 ms |
+
+Membership now goes through a set, leaving the order --- first-seen, and so the
+value indices the propagator's graph uses --- exactly as it was: 340 proof
+artefacts across the two `AllDifferent` test binaries are byte-identical at a
+pinned seed. `AllDifferentExcept` had the same loop and gets the same treatment.
+
+**This does not change the audit lane's verdict, and should not.** GAC still wants
+a graph vertex per value, so a genuinely wide domain is still the `KnownTrip` the
+lane records, and what it needs is stage 5's weaker arm rather than a faster
+setup. What the fix removes is only the part that was gratuitous: `consistency::VC`
+on the same probe was 0 ms at every width throughout, which is what made the
+attribution unambiguous.
+
 ## Proofs
 
 **Out of scope for fixing.** Several of these have no viable fix today, and a

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -201,6 +201,13 @@ if(GCS_BUILD_TESTS)
         add_test(NAME large_domain_audit_test COMMAND $<TARGET_FILE:large_domain_audit_test>)
     endif()
 
+    # The proof-size case in the same binary is registered unconditionally,
+    # because it needs no guard: it asserts how big a proof is, which is as
+    # meaningful with the guard off as on, and it is the only lane that can see
+    # per-value work done while writing a proof (the audit above solves without
+    # ProofOptions, so it never emits a justification at all).
+    add_test(NAME large_domain_proof_size_test COMMAND $<TARGET_FILE:large_domain_audit_test> "Large domain proof sizes")
+
     # Checks that the GCS_VERBOSE_LOGGING proof annotation resolves gcs source
     # frames, which depends on the debug info the Release build keeps (-g1 on
     # GCC/Clang, /Z7 + /DEBUG on MSVC; see the top-level CMakeLists.txt). It

--- a/gcs/constraints/all_different/all_different.cc
+++ b/gcs/constraints/all_different/all_different.cc
@@ -15,6 +15,7 @@
 #include <algorithm>
 #include <map>
 #include <memory>
+#include <set>
 #include <utility>
 #include <variant>
 #include <vector>
@@ -27,6 +28,7 @@ using std::make_shared;
 using std::make_unique;
 using std::map;
 using std::move;
+using std::set;
 using std::unique_ptr;
 using std::vector;
 using std::ranges::adjacent_find;
@@ -108,10 +110,21 @@ auto AllDifferent::prepare(Propagators &, State & initial_state, ProofModel * co
 
     // GAC wants the compressed value set. It has to be built before the
     // staging decision below, which depends on its size.
+    //
+    // Membership goes through a set rather than a linear scan of what has been
+    // collected so far. The order is unchanged --- first-seen, which is what the
+    // value indices in the propagator's graph are --- so this is the same vector,
+    // built without the quadratic. It used to be O(values * distinct values): three
+    // variables over 0..10^5 spent 6.6 s here, and 0..10^6 did not finish, for a
+    // constraint whose domains were two values each by the time anything propagated.
+    // That is still O(values) and GAC still wants a graph vertex per value, so a
+    // genuinely wide domain remains the `KnownTrip` the audit lane records --- this
+    // only stops the setup being asymptotically worse than the algorithm it feeds.
     if (holds_alternative<consistency::GAC>(_level)) {
+        set<Integer> seen;
         for (auto & var : _sanitised_vars)
             for (const auto & val : initial_state.each_value_immutable(var))
-                if (_compressed_vals.end() == find(_compressed_vals, val))
+                if (seen.insert(val).second)
                     _compressed_vals.push_back(val);
         _gac_staged = _sanitised_vars.size() * _compressed_vals.size() >= min_var_val_pairs_for_staged_gac;
     }

--- a/gcs/constraints/all_different/all_different_except.cc
+++ b/gcs/constraints/all_different/all_different_except.cc
@@ -22,6 +22,7 @@
 #include <algorithm>
 #include <iterator>
 #include <map>
+#include <set>
 #include <sstream>
 #include <string>
 
@@ -103,10 +104,17 @@ auto AllDifferentExcept::prepare(Propagators &, State & initial_state, ProofMode
     // Compressed value list for the propagator: real (non-excluded) values
     // from the union of variable domains. Excluded values are not part of
     // the bipartite right side; phantoms cover them.
+    //
+    // Membership goes through a set rather than a linear scan of what has been
+    // collected so far, which leaves the order --- first-seen, and so the value
+    // indices the propagator's graph uses --- exactly as it was, without the
+    // quadratic. See AllDifferent::prepare for the measurement. The excluded list
+    // stays a linear scan: it is the model's, and is not domain-sized.
+    std::set<Integer> seen;
     for (auto & var : _sanitised_vars)
         for (const auto & val : initial_state.each_value_immutable(var))
             if (find(_sanitised_excluded.begin(), _sanitised_excluded.end(), val) == _sanitised_excluded.end())
-                if (find(_compressed_vals.begin(), _compressed_vals.end(), val) == _compressed_vals.end())
+                if (seen.insert(val).second)
                     _compressed_vals.push_back(val);
 
     return true;

--- a/gcs/constraints/all_different/gac_all_different.cc
+++ b/gcs/constraints/all_different/gac_all_different.cc
@@ -71,9 +71,9 @@ using fmt::print;
 
 namespace gcs::innards::hints
 {
-    auto emit_justification(ProofLogger & logger, const AllDifferentHall & hall, const ReasonLiterals &) -> void
+    auto emit_justification(ProofLogger & logger, const State & state, const AllDifferentHall & hall, const ReasonLiterals &) -> void
     {
-        justify_all_different_hall_set_or_violator(logger, *hall.all_vars, hall.hall_vars, hall.hall_vals, *hall.value_am1_constraint_numbers);
+        justify_all_different_hall_set_or_violator(logger, state, *hall.all_vars, hall.hall_vars, hall.hall_vals, *hall.value_am1_constraint_numbers);
     }
 }
 
@@ -795,7 +795,8 @@ auto gcs::innards::propagate_gac_all_different(const ConstraintID & constraint_i
         auto [hall, reason] =
             prove_matching_is_too_small(constraint_id, vars, vals, excluded, n_right, value_am1_constraint_numbers, state, logger, scratch);
         return tracker.infer(logger, FalseLiteral{},
-            JustifyExplicitly{[&logger, w = hall](const ReasonLiterals & r) { emit_justification(*logger, w, r); }, ThenRUP::Yes, move(hall)},
+            JustifyExplicitly{
+                [&logger, &state, w = hall](const ReasonLiterals & r) { emit_justification(*logger, state, w, r); }, ThenRUP::Yes, move(hall)},
             reason);
     }
 
@@ -924,15 +925,15 @@ auto gcs::innards::propagate_gac_all_different(const ConstraintID & constraint_i
 
         auto [justification, reason] = prove_deletion_using_sccs(
             constraint_id, vars, vals, excluded, n_right, value_am1_constraint_numbers, state, logger, *representatives_for_scc[scc], scratch);
-        visit(
-            overloaded{
-                [&](hints::AllDifferent & w) { tracker.infer_all(logger, deletions_by_scc[scc], JustifyUsingRUP{w}, reason); }, //
-                [&](hints::AllDifferentHall & w) {
-                    tracker.infer_all(logger, deletions_by_scc[scc],
-                        JustifyExplicitly{[&logger, wc = w](const ReasonLiterals & r) { emit_justification(*logger, wc, r); }, ThenRUP::Yes, move(w)},
-                        reason);
-                } //
-            },
+        visit(overloaded{
+                  [&](hints::AllDifferent & w) { tracker.infer_all(logger, deletions_by_scc[scc], JustifyUsingRUP{w}, reason); }, //
+                  [&](hints::AllDifferentHall & w) {
+                      tracker.infer_all(logger, deletions_by_scc[scc],
+                          JustifyExplicitly{[&logger, &state, wc = w](const ReasonLiterals & r) { emit_justification(*logger, state, wc, r); },
+                              ThenRUP::Yes, move(w)},
+                          reason);
+                  } //
+              },
             justification);
     }
 }

--- a/gcs/constraints/all_different/justify.cc
+++ b/gcs/constraints/all_different/justify.cc
@@ -36,10 +36,14 @@ auto gcs::innards::justify_all_different_hall_set_or_violator(ProofLogger & logg
         value_am1_constraint_numbers.emplace(val, recover_am1_from_pairs(logger, members, at_most_ones, ProofLevel::Top));
     }
 
-    // we are going to need the at least one value variables
+    // We are going to need the at least one value variables. Only the hall values
+    // need naming: they are what the at-most-ones below cancel against, and the
+    // reason (the hall variables' domains, which lie inside the hall values) rules
+    // out the runs the rest of each definition range goes in as.
     vector<ProofLine> at_least_one_constraints;
     for (const auto & var : hall_variables)
-        at_least_one_constraints.push_back(logger.names_and_ids_tracker().need_constraint_saying_variable_takes_at_least_one_value(var));
+        at_least_one_constraints.push_back(
+            logger.names_and_ids_tracker().need_constraint_saying_variable_takes_at_least_one_value_over_cover(var, hall_values));
 
     // each variable in the violator has to take at least one value that is
     // left in its domain, and each value in the component can only be used

--- a/gcs/constraints/all_different/justify.cc
+++ b/gcs/constraints/all_different/justify.cc
@@ -11,9 +11,9 @@ using namespace gcs::innards;
 using std::map;
 using std::vector;
 
-auto gcs::innards::justify_all_different_hall_set_or_violator(ProofLogger & logger, const vector<IntegerVariableID> & all_variables,
-    const vector<IntegerVariableID> & hall_variables, const vector<Integer> & hall_values, map<Integer, ProofLine> & value_am1_constraint_numbers)
-    -> void
+auto gcs::innards::justify_all_different_hall_set_or_violator(ProofLogger & logger, const State & state,
+    const vector<IntegerVariableID> & all_variables, const vector<IntegerVariableID> & hall_variables, const vector<Integer> & hall_values,
+    map<Integer, ProofLine> & value_am1_constraint_numbers) -> void
 {
     // we are going to need the am1s over values, if they don't exist yet
     for (const auto & val : hall_values) {
@@ -36,14 +36,24 @@ auto gcs::innards::justify_all_different_hall_set_or_violator(ProofLogger & logg
         value_am1_constraint_numbers.emplace(val, recover_am1_from_pairs(logger, members, at_most_ones, ProofLevel::Top));
     }
 
-    // We are going to need the at least one value variables. Only the hall values
-    // need naming: they are what the at-most-ones below cancel against, and the
-    // reason (the hall variables' domains, which lie inside the hall values) rules
-    // out the runs the rest of each definition range goes in as.
+    // We are going to need the at least one value variables, and each only has to
+    // name the values its own domain still holds. Those are a subset of the hall
+    // values (that is what makes these variables a Hall set), so the at-most-ones
+    // below still cancel every term this contributes; the hall values a particular
+    // variable *cannot* take would contribute a term with nothing to cancel it, and
+    // the reason would then have to discharge it separately. Everything else in the
+    // definition range goes in as runs, which are exactly the holes the reason
+    // states.
     vector<ProofLine> at_least_one_constraints;
-    for (const auto & var : hall_variables)
+    vector<Integer> still_possible;
+    for (const auto & var : hall_variables) {
+        still_possible.clear();
+        for (const auto & val : hall_values)
+            if (state.in_domain(var, val))
+                still_possible.push_back(val);
         at_least_one_constraints.push_back(
-            logger.names_and_ids_tracker().need_constraint_saying_variable_takes_at_least_one_value_over_cover(var, hall_values));
+            logger.names_and_ids_tracker().need_constraint_saying_variable_takes_at_least_one_value_over_cover(var, still_possible));
+    }
 
     // each variable in the violator has to take at least one value that is
     // left in its domain, and each value in the component can only be used

--- a/gcs/constraints/all_different/justify.hh
+++ b/gcs/constraints/all_different/justify.hh
@@ -2,6 +2,7 @@
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_ALL_DIFFERENT_JUSTIFY_HH
 
 #include <gcs/innards/proofs/proof_logger.hh>
+#include <gcs/innards/state.hh>
 #include <gcs/integer.hh>
 #include <gcs/variable_id.hh>
 
@@ -10,7 +11,7 @@
 
 namespace gcs::innards
 {
-    auto justify_all_different_hall_set_or_violator(ProofLogger &, const std::vector<IntegerVariableID> & all_variables,
+    auto justify_all_different_hall_set_or_violator(ProofLogger &, const State &, const std::vector<IntegerVariableID> & all_variables,
         const std::vector<IntegerVariableID> & hall_variables, const std::vector<Integer> & hall_values,
         std::map<Integer, ProofLine> & constraint_numbers) -> void;
 }

--- a/gcs/constraints/among/among.cc
+++ b/gcs/constraints/among/among.cc
@@ -182,7 +182,12 @@ auto Among::install_propagators(Propagators & propagators) -> void
                         // emission, so they don't need (and don't have) an at-least-one line.
                         if (holds_alternative<ConstantIntegerVariableID>(m))
                             continue;
-                        b.add(logger->names_and_ids_tracker().need_constraint_saying_variable_takes_at_least_one_value(m));
+                        // Only the values of interest need naming: they are what
+                        // sum_line's terms cancel against, and a must_match variable's
+                        // domain lies inside them, so vars_reason rules out the runs
+                        // the rest of its definition range goes in as.
+                        b.add(logger->names_and_ids_tracker().need_constraint_saying_variable_takes_at_least_one_value_over_cover(
+                            m, values_of_interest));
                     }
                     b.emit(*logger, ProofLevel::Temporary);
                 }
@@ -247,7 +252,8 @@ auto Among::install_propagators(Propagators & propagators) -> void
                             for (const auto & m : must_match_vars) {
                                 if (holds_alternative<ConstantIntegerVariableID>(m))
                                     continue;
-                                b.add(logger->names_and_ids_tracker().need_constraint_saying_variable_takes_at_least_one_value(m));
+                                b.add(logger->names_and_ids_tracker().need_constraint_saying_variable_takes_at_least_one_value_over_cover(
+                                    m, values_of_interest));
                             }
                             b.emit(*logger, ProofLevel::Temporary);
                         }

--- a/gcs/constraints/among/among.cc
+++ b/gcs/constraints/among/among.cc
@@ -176,18 +176,23 @@ auto Among::install_propagators(Propagators & propagators) -> void
                 // must_match var, which is not reliable when domains have width > 1.
                 if (sum_line.first && must_match_count > 0_i) {
                     PolBuilder b;
+                    vector<Integer> still_possible;
                     b.add(*sum_line.first);
                     for (const auto & m : must_match_vars) {
                         // Constants in must_match are folded into sum_line.first's RHS at OPB
                         // emission, so they don't need (and don't have) an at-least-one line.
                         if (holds_alternative<ConstantIntegerVariableID>(m))
                             continue;
-                        // Only the values of interest need naming: they are what
-                        // sum_line's terms cancel against, and a must_match variable's
-                        // domain lies inside them, so vars_reason rules out the runs
-                        // the rest of its definition range goes in as.
-                        b.add(logger->names_and_ids_tracker().need_constraint_saying_variable_takes_at_least_one_value_over_cover(
-                            m, values_of_interest));
+                        // Only the values of interest this variable can still take
+                        // need naming: they are what sum_line's terms cancel against,
+                        // and a must_match variable's domain lies inside them, so
+                        // vars_reason rules out the runs the rest of its definition
+                        // range goes in as.
+                        still_possible.clear();
+                        for (const auto & voi : values_of_interest)
+                            if (state.in_domain(m, voi))
+                                still_possible.push_back(voi);
+                        b.add(logger->names_and_ids_tracker().need_constraint_saying_variable_takes_at_least_one_value_over_cover(m, still_possible));
                     }
                     b.emit(*logger, ProofLevel::Temporary);
                 }
@@ -248,12 +253,17 @@ auto Among::install_propagators(Propagators & propagators) -> void
                         // how_many = must_match_count value.
                         if (sum_line.first && ! empty(must_match_vars)) {
                             PolBuilder b;
+                            vector<Integer> still_possible;
                             b.add(*sum_line.first);
                             for (const auto & m : must_match_vars) {
                                 if (holds_alternative<ConstantIntegerVariableID>(m))
                                     continue;
+                                still_possible.clear();
+                                for (const auto & voi : values_of_interest)
+                                    if (state.in_domain(m, voi))
+                                        still_possible.push_back(voi);
                                 b.add(logger->names_and_ids_tracker().need_constraint_saying_variable_takes_at_least_one_value_over_cover(
-                                    m, values_of_interest));
+                                    m, still_possible));
                             }
                             b.emit(*logger, ProofLevel::Temporary);
                         }

--- a/gcs/constraints/circuit/subcircuit.cc
+++ b/gcs/constraints/circuit/subcircuit.cc
@@ -543,6 +543,9 @@ namespace
 
         PolBuilder pigeonhole;
         for (const auto & i : consts.variable_nodes)
+            // Per value, not over a cover: the counting above needs every value
+            // named, and a successor's definition range is the node set, so there
+            // is no width here to be spent on values the pigeonhole does not use.
             pigeonhole.add(logger.names_and_ids_tracker().need_constraint_saying_variable_takes_at_least_one_value(succ[i]));
         for (size_t w = 0; w < succ.size(); ++w) {
             if (cmp_equal(w, v))

--- a/gcs/constraints/global_cardinality/bounds_global_cardinality.cc
+++ b/gcs/constraints/global_cardinality/bounds_global_cardinality.cc
@@ -234,13 +234,18 @@ auto gcs::innards::propagate_bounds_global_cardinality(const vector<IntegerVaria
                     if (keep != optional<std::size_t>{v} && ! holds_alternative<ConstantIntegerVariableID>(counts[v]))
                         pb.add_for_literal(tracker, counts[v] <= state.bounds(counts[v]).second);
                 }
-                // The at-least-one only has to name the hall values: everything
-                // else in the definition range goes in as runs, and those are the
-                // very runs capacity_reason rules out (clipped to the variable's
-                // bounds, which the reason pins too).
-                vector<Integer> hall_values{values.begin() + static_cast<std::ptrdiff_t>(a), values.begin() + static_cast<std::ptrdiff_t>(b) + 1};
-                for (const auto & var : confined)
-                    pb.add(tracker.need_constraint_saying_variable_takes_at_least_one_value_over_cover(var, hall_values));
+                // The at-least-one only has to name the hall values this variable can
+                // still take: everything else in the definition range goes in as
+                // runs, and those are the very runs capacity_reason rules out
+                // (clipped to the variable's bounds, which the reason pins too).
+                vector<Integer> still_possible;
+                for (const auto & var : confined) {
+                    still_possible.clear();
+                    for (auto v = a; v <= b; ++v)
+                        if (state.in_domain(var, values[v]))
+                            still_possible.push_back(values[v]);
+                    pb.add(tracker.need_constraint_saying_variable_takes_at_least_one_value_over_cover(var, still_possible));
+                }
                 pb.emit(*logger, ProofLevel::Temporary);
             };
 
@@ -302,10 +307,14 @@ auto gcs::innards::propagate_bounds_global_cardinality(const vector<IntegerVaria
                                         if (! holds_alternative<ConstantIntegerVariableID>(counts[v]))
                                             pb.add_for_literal(tracker, counts[v] <= state.bounds(counts[v]).second);
                                     }
-                                vector<Integer> hall_values{
-                                    values.begin() + static_cast<std::ptrdiff_t>(a), values.begin() + static_cast<std::ptrdiff_t>(b) + 1};
-                                for (const auto & var : confined)
-                                    pb.add(tracker.need_constraint_saying_variable_takes_at_least_one_value_over_cover(var, hall_values));
+                                vector<Integer> still_possible;
+                                for (const auto & var : confined) {
+                                    still_possible.clear();
+                                    for (auto v = a; v <= b; ++v)
+                                        if (state.in_domain(var, values[v]))
+                                            still_possible.push_back(values[v]);
+                                    pb.add(tracker.need_constraint_saying_variable_takes_at_least_one_value_over_cover(var, still_possible));
+                                }
                                 pb.add(*count_lines[j].first);
                                 pb.emit(*logger, ProofLevel::Temporary);
                             },

--- a/gcs/constraints/global_cardinality/bounds_global_cardinality.cc
+++ b/gcs/constraints/global_cardinality/bounds_global_cardinality.cc
@@ -234,8 +234,13 @@ auto gcs::innards::propagate_bounds_global_cardinality(const vector<IntegerVaria
                     if (keep != optional<std::size_t>{v} && ! holds_alternative<ConstantIntegerVariableID>(counts[v]))
                         pb.add_for_literal(tracker, counts[v] <= state.bounds(counts[v]).second);
                 }
+                // The at-least-one only has to name the hall values: everything
+                // else in the definition range goes in as runs, and those are the
+                // very runs capacity_reason rules out (clipped to the variable's
+                // bounds, which the reason pins too).
+                vector<Integer> hall_values{values.begin() + static_cast<std::ptrdiff_t>(a), values.begin() + static_cast<std::ptrdiff_t>(b) + 1};
                 for (const auto & var : confined)
-                    pb.add(tracker.need_constraint_saying_variable_takes_at_least_one_value(var));
+                    pb.add(tracker.need_constraint_saying_variable_takes_at_least_one_value_over_cover(var, hall_values));
                 pb.emit(*logger, ProofLevel::Temporary);
             };
 
@@ -297,8 +302,10 @@ auto gcs::innards::propagate_bounds_global_cardinality(const vector<IntegerVaria
                                         if (! holds_alternative<ConstantIntegerVariableID>(counts[v]))
                                             pb.add_for_literal(tracker, counts[v] <= state.bounds(counts[v]).second);
                                     }
+                                vector<Integer> hall_values{
+                                    values.begin() + static_cast<std::ptrdiff_t>(a), values.begin() + static_cast<std::ptrdiff_t>(b) + 1};
                                 for (const auto & var : confined)
-                                    pb.add(tracker.need_constraint_saying_variable_takes_at_least_one_value(var));
+                                    pb.add(tracker.need_constraint_saying_variable_takes_at_least_one_value_over_cover(var, hall_values));
                                 pb.add(*count_lines[j].first);
                                 pb.emit(*logger, ProofLevel::Temporary);
                             },

--- a/gcs/constraints/global_cardinality/justify.cc
+++ b/gcs/constraints/global_cardinality/justify.cc
@@ -38,8 +38,13 @@ auto gcs::innards::emit_gcc_capacity_pol(ProofLogger & logger, const State & sta
             pb.add_for_literal(tracker, counts[v] <= state.bounds(counts[v]).second);
     }
     (void)vars;
+    // A confined variable's at-least-one only has to name the hall values --- the
+    // rest of its definition range can go in as runs, which the reason rules out
+    // (see gcc_capacity_reason, whose gaps are these very runs clipped to the
+    // variable's bounds).
+    vector<Integer> hall_values{hall.begin(), hall.end()};
     for (const auto & var : confined)
-        pb.add(tracker.need_constraint_saying_variable_takes_at_least_one_value(var));
+        pb.add(tracker.need_constraint_saying_variable_takes_at_least_one_value_over_cover(var, hall_values));
     pb.emit(logger, ProofLevel::Temporary);
 }
 

--- a/gcs/constraints/global_cardinality/justify.cc
+++ b/gcs/constraints/global_cardinality/justify.cc
@@ -38,13 +38,22 @@ auto gcs::innards::emit_gcc_capacity_pol(ProofLogger & logger, const State & sta
             pb.add_for_literal(tracker, counts[v] <= state.bounds(counts[v]).second);
     }
     (void)vars;
-    // A confined variable's at-least-one only has to name the hall values --- the
-    // rest of its definition range can go in as runs, which the reason rules out
-    // (see gcc_capacity_reason, whose gaps are these very runs clipped to the
-    // variable's bounds).
-    vector<Integer> hall_values{hall.begin(), hall.end()};
-    for (const auto & var : confined)
-        pb.add(tracker.need_constraint_saying_variable_takes_at_least_one_value_over_cover(var, hall_values));
+    // A confined variable's at-least-one only has to name the hall values it can
+    // still take --- a subset of the hall set, since confinement is exactly the
+    // domain lying inside it. The rest of its definition range goes in as runs,
+    // which the reason rules out (see gcc_capacity_reason, whose gaps are these
+    // very runs clipped to the variable's bounds). Naming a hall value the variable
+    // cannot take would cost a term the count lines do cancel, but the cover can be
+    // this much smaller for free, and a cover with many values makes that the
+    // difference between a line per cover value and a line per domain value.
+    vector<Integer> still_possible;
+    for (const auto & var : confined) {
+        still_possible.clear();
+        for (const auto & val : hall)
+            if (state.in_domain(var, val))
+                still_possible.push_back(val);
+        pb.add(tracker.need_constraint_saying_variable_takes_at_least_one_value_over_cover(var, still_possible));
+    }
     pb.emit(logger, ProofLevel::Temporary);
 }
 

--- a/gcs/constraints/min_distance/min_distance.cc
+++ b/gcs/constraints/min_distance/min_distance.cc
@@ -750,7 +750,14 @@ auto MinDistance::install_matching_propagator(Propagators & propagators) -> void
                         // [x_i = c] literal folds to the constant 1 in the pol
                         // arithmetic (and to 0 in the ~[x_i = c] at-most-one terms),
                         // so it needs no at-least-one line: it cancels exactly.
-                        final_pol.add(tracker.need_constraint_saying_variable_takes_at_least_one_value(x[i]));
+                        //
+                        // The active site set is exactly what has to be named: the
+                        // at-most-ones above are over [x_pos = site] for sites in A,
+                        // and A is the union of the positions' domains, so the runs
+                        // the rest of each definition range goes in as are ruled out
+                        // by generic_reason(x). sum_c counts at-most-one members, not
+                        // at-least-one terms, so the division is unaffected.
+                        final_pol.add(tracker.need_constraint_saying_variable_takes_at_least_one_value_over_cover(x[i], A));
                 final_pol.divide_by(sum_c);
                 final_pol.emit(*logger, ProofLevel::Temporary);
             };

--- a/gcs/constraints/min_distance/min_distance.cc
+++ b/gcs/constraints/min_distance/min_distance.cc
@@ -744,20 +744,28 @@ auto MinDistance::install_matching_propagator(Propagators & propagators) -> void
                     if (auto line = emit_am1(lits))
                         final_pol.add(*line);
                 }
+                vector<Integer> still_possible;
                 for (std::size_t i = 0; i < p; ++i)
-                    if (! is_constant_variable(x[i]))
+                    if (! is_constant_variable(x[i])) {
                         // A constant position contributes a fixed selection whose
                         // [x_i = c] literal folds to the constant 1 in the pol
                         // arithmetic (and to 0 in the ~[x_i = c] at-most-one terms),
                         // so it needs no at-least-one line: it cancels exactly.
                         //
-                        // The active site set is exactly what has to be named: the
-                        // at-most-ones above are over [x_pos = site] for sites in A,
-                        // and A is the union of the positions' domains, so the runs
-                        // the rest of each definition range goes in as are ruled out
-                        // by generic_reason(x). sum_c counts at-most-one members, not
+                        // Of the active site set, only the sites this position can
+                        // still take have to be named: the at-most-ones above are
+                        // over [x_pos = site] for sites in A, and A is the *union* of
+                        // the positions' domains, so naming all of it would name
+                        // sites this position has already lost. The runs the rest of
+                        // the definition range goes in as are ruled out by
+                        // generic_reason(x). sum_c counts at-most-one members, not
                         // at-least-one terms, so the division is unaffected.
-                        final_pol.add(tracker.need_constraint_saying_variable_takes_at_least_one_value_over_cover(x[i], A));
+                        still_possible.clear();
+                        for (const auto & site : A)
+                            if (state.in_domain(x[i], site))
+                                still_possible.push_back(site);
+                        final_pol.add(tracker.need_constraint_saying_variable_takes_at_least_one_value_over_cover(x[i], still_possible));
+                    }
                 final_pol.divide_by(sum_c);
                 final_pol.emit(*logger, ProofLevel::Temporary);
             };

--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -78,6 +78,18 @@ using fmt::print;
 
 namespace
 {
+    /**
+     * How wide a variable's definition range has to be before an at-least-one
+     * over it is stated as an interval cover rather than one term per value.
+     *
+     * See need_constraint_saying_variable_takes_at_least_one_value_over_cover for
+     * why this is a threshold rather than an unconditional rewrite. The value only
+     * has to separate "a domain someone wrote out by hand" from "a domain nobody
+     * could name" --- every case the cover exists for is orders of magnitude above
+     * it --- so it is not tuned, and no measurement here is sensitive to it.
+     */
+    const auto at_least_one_cover_threshold = 100_i;
+
     // These three tables are read on every literal rendered into every proof
     // line, so they are hashed rather than tree-ordered. Nothing iterates
     // them. The hashes just have to spread structured small integers; the
@@ -221,6 +233,8 @@ struct NamesAndIDsTracker::Imp
     map<string, ProofLine> published_derived_lines;
 
     unordered_map<SimpleOrProofOnlyIntegerVariableID, ProofLine, HashSimpleOrProofOnlyVariable> variable_at_least_one_constraints;
+    unordered_map<SimpleOrProofOnlyIntegerVariableID, map<vector<Integer>, ProofLine>, HashSimpleOrProofOnlyVariable>
+        variable_at_least_one_over_cover_constraints;
     // Indexed by variable index (variables are allocated with sequential
     // indices, so these stay dense), one per id kind.
     vector<VariableAtoms> simple_variable_atoms;
@@ -526,6 +540,106 @@ auto NamesAndIDsTracker::need_constraint_saying_variable_takes_at_least_one_valu
                 return result->second;
             }
             return need_constraint_saying_variable_takes_at_least_one_value(var.actual_variable);
+        } //
+    }
+        .visit(var);
+}
+
+auto NamesAndIDsTracker::need_constraint_saying_variable_takes_at_least_one_value_over_cover(
+    IntegerVariableID var, const vector<Integer> & singled_out) -> ProofLine
+{
+    // The cover is the singled-out values inside the definition range, each as its
+    // own cell, plus the maximal runs between and around them. need_invar returns
+    // the eq atom for a width-1 request, so both kinds of piece are asked for the
+    // same way and every piece is a literal the partition knows about --- which is
+    // what makes the line RUP: falsifying all of them falsifies the root covering.
+    auto over_cover = [&](const SimpleOrProofOnlyIntegerVariableID & id) -> ProofLine {
+        auto [lower, upper] = _imp->integer_variable_definition_bounds.at(id);
+
+        // Normalised before it is used as a cache key, so that callers asking for
+        // the same cover spelled differently --- unsorted, with repeats, or naming
+        // values outside the definition range, none of which change the line ---
+        // share one line rather than emitting a duplicate each.
+        vector<Integer> cuts;
+        for (const auto & v : singled_out)
+            if (v >= lower && v <= upper)
+                cuts.push_back(v);
+        sort(cuts);
+        auto [dups_from, dups_to] = std::ranges::unique(cuts);
+        cuts.erase(dups_from, dups_to);
+
+        // Cached and emitted at Top like the per-value form, and for the same
+        // reason: the line is a tautology of the encoding, so re-emitting it per
+        // firing would be pure proof growth. The per-value form needs only the
+        // variable as its key, since it names every value; this one is keyed by
+        // the cover too, and a caller whose cover changes from firing to firing
+        // (a Hall set, say) pays a line per distinct cover it asks for.
+        auto & for_this_var = _imp->variable_at_least_one_over_cover_constraints[id];
+        if (auto found = for_this_var.find(cuts); found != for_this_var.end())
+            return found->second;
+
+        WPBSum al1s;
+        auto run_from = lower;
+        auto add_piece = [&](Integer lo, Integer hi) {
+            if (lo <= hi)
+                al1s += 1_i * need_invar(id, lo, hi);
+        };
+
+        for (const auto & v : cuts) {
+            add_piece(run_from, v - 1_i);
+            add_piece(v, v);
+            run_from = v + 1_i;
+        }
+        add_piece(run_from, upper);
+
+        auto line = _imp->logger->emit_rup_proof_line(al1s >= 1_i, ProofLevel::Top);
+        for_this_var.emplace(move(cuts), line);
+        return line;
+    };
+
+    // Is a cover worth stating for this variable at all? The per-value form is
+    // emitted once and then serves every cover anyone asks for, because it names
+    // every value; a cover is specialised, so a caller whose cover changes --- a
+    // Hall set --- pays a line per distinct one. Over a narrow definition range
+    // those lines are each about as big as the single per-value line they replace,
+    // and there are many of them: measured on the examples, going to covers
+    // unconditionally cost sudoku 16% more proof lines and ortho_latin 3%, for
+    // variables declared over nine values, where naming every value was never the
+    // problem #833 is about.
+    //
+    // So the cover is for the case it was written for: a definition range too wide
+    // to name. Below the threshold nothing changes, which is why those examples are
+    // byte-identical; above it the per-value line grows without bound and the cover
+    // does not. This is a policy quantity, not a guard --- it wants to sit where
+    // naming every value stops being free, well below where it becomes ruinous ---
+    // so it is deliberately not large_domain_guard_limit().
+    auto worth_a_cover = [&](const SimpleOrProofOnlyIntegerVariableID & id) {
+        auto [lower, upper] = _imp->integer_variable_definition_bounds.at(id);
+        return upper - lower + 1_i > at_least_one_cover_threshold;
+    };
+
+    return overloaded{
+        [&](const ConstantIntegerVariableID &) -> ProofLine { throw UnimplementedException{}; }, //
+        [&](const SimpleIntegerVariableID & var) -> ProofLine {
+            // No bits means no range literals, so there is no cover to state. A
+            // zero-one variable is the case that reaches this, and its definition
+            // range is two values, so the per-value form is already the cover.
+            if (! has_bit_representation(var) || ! worth_a_cover(var))
+                return need_constraint_saying_variable_takes_at_least_one_value(var);
+            return over_cover(var);
+        }, //
+        [&](const ViewOfIntegerVariableID & var) -> ProofLine {
+            // As in the per-value form, a registered view states its at-least-one in
+            // V-form over its own encoded variable, so that it cancels against
+            // at-most-ones naming V-form atoms. The singled-out values are in the
+            // view's value space, which is that variable's space too.
+            //
+            // An unregistered view would need them mapped back through the view to
+            // be named at all, so it keeps the per-value form over the actual
+            // variable, where naming every value sidesteps the mapping.
+            if (auto v_id = find_view(var); v_id && has_bit_representation(*v_id) && worth_a_cover(*v_id))
+                return over_cover(*v_id);
+            return need_constraint_saying_variable_takes_at_least_one_value(var);
         } //
     }
         .visit(var);

--- a/gcs/innards/proofs/names_and_ids_tracker.hh
+++ b/gcs/innards/proofs/names_and_ids_tracker.hh
@@ -345,18 +345,32 @@ namespace gcs::innards
          * values the variable can still take.
          *
          * WHAT A CALLER OWES. A pol that adds this line gets `+[x = v]` for each
-         * `v` in `singled_out`, exactly as the per-value form does, so cancellation
-         * against per-value at-most-ones and count lines is unchanged --- provided
-         * `singled_out` covers every value that pol names for this variable. What
-         * differs is the residue: instead of one `+[x = w]` per unnamed value, there
-         * is one `+[x in run]` per run. The caller's reason must therefore rule the
-         * runs out, which it does exactly when it pins the variable's bounds and
-         * excludes its holes (as `generic_reason` and the Hall-set reasons do): a run
-         * outside the bounds dies on the order chain, and a run inside one sits inside
-         * an excluded hole, so containment falsifies it. A reason that named holes
-         * only value by value would still work --- the run's own covering reaches the
-         * eq atoms --- but only if every value in the run is named, which is the cost
+         * `v` in `singled_out`, exactly as the per-value form does. What differs is
+         * the residue: instead of one `+[x = w]` per unnamed value, there is one
+         * `+[x in run]` per run. The caller's reason must therefore rule the runs
+         * out, which it does exactly when it pins the variable's bounds and excludes
+         * its holes (as `generic_reason` and the Hall-set reasons do): a run outside
+         * the bounds dies on the order chain, and a run inside one sits inside an
+         * excluded hole, so containment falsifies it. A reason that named holes only
+         * value by value would still work --- the run's own covering reaches the eq
+         * atoms --- but only if every value in the run is named, which is the cost
          * this call exists to avoid.
+         *
+         * So **pass the values the pol names for this variable that it can still
+         * take**, and no more. Two bounds meet here. A value the pol names but this
+         * call omits leaves that pol term with nothing to cancel against; that is
+         * safe when the variable cannot take the value (its term is zero under the
+         * reason anyway) and broken otherwise, which is why the filter must be the
+         * domain and not a guess. A value in `singled_out` that the variable cannot
+         * take is merely wasted --- it costs a term here and a cell in the partition
+         * --- and callers whose value set is much bigger than one variable's domain
+         * (a Hall set, a global cover, a union of domains) should filter it out with
+         * `state.in_domain`. Every current caller does.
+         *
+         * The residue is then exactly the complement of the domain, which is exactly
+         * what the reason states; that correspondence is what makes the line's
+         * leftovers discharge by construction rather than by an argument about which
+         * runs happen to lie inside which holes.
          *
          * FALLS BACK, SILENTLY AND OFTEN, to the per-value form, which is why a
          * caller must stay correct under either: for a variable with no bits encoding

--- a/gcs/innards/proofs/names_and_ids_tracker.hh
+++ b/gcs/innards/proofs/names_and_ids_tracker.hh
@@ -317,8 +317,66 @@ namespace gcs::innards
         /**
          * Say that we are going to need an at-least-one constraint for a
          * variable.
+         *
+         * This spells the at-least-one out one value at a time, over the whole
+         * definition range, so it costs a term (and an eq atom, which becomes a
+         * singleton cell in the variable's interval partition, making every later
+         * covering span-proportional too) per value the variable was declared over.
+         * Prefer the ..._over_cover form below wherever the caller only needs
+         * particular values named.
          */
         [[nodiscard]] auto need_constraint_saying_variable_takes_at_least_one_value(IntegerVariableID) -> ProofLine;
+
+        /**
+         * The same at-least-one, but over an interval cover of the definition range
+         * rather than over its values: the values in `singled_out` are named by their
+         * own eq atoms, and the maximal runs between and around them are named by one
+         * range literal each. So for a variable declared over 0..10^9 and a
+         * `singled_out` of {3, 7} the line is
+         *
+         *     [x in 0..2] + [x = 3] + [x in 4..6] + [x = 7] + [x in 8..10^9] >= 1
+         *
+         * which is five terms rather than a billion, and leaves the variable's
+         * interval partition with five cells rather than a billion.
+         *
+         * It is RUP for the same reason the root covering is (the cells cover the
+         * definition range, and the bound axioms close it), and it is
+         * state-independent: `singled_out` selects which values get named, not which
+         * values the variable can still take.
+         *
+         * WHAT A CALLER OWES. A pol that adds this line gets `+[x = v]` for each
+         * `v` in `singled_out`, exactly as the per-value form does, so cancellation
+         * against per-value at-most-ones and count lines is unchanged --- provided
+         * `singled_out` covers every value that pol names for this variable. What
+         * differs is the residue: instead of one `+[x = w]` per unnamed value, there
+         * is one `+[x in run]` per run. The caller's reason must therefore rule the
+         * runs out, which it does exactly when it pins the variable's bounds and
+         * excludes its holes (as `generic_reason` and the Hall-set reasons do): a run
+         * outside the bounds dies on the order chain, and a run inside one sits inside
+         * an excluded hole, so containment falsifies it. A reason that named holes
+         * only value by value would still work --- the run's own covering reaches the
+         * eq atoms --- but only if every value in the run is named, which is the cost
+         * this call exists to avoid.
+         *
+         * FALLS BACK, SILENTLY AND OFTEN, to the per-value form, which is why a
+         * caller must stay correct under either: for a variable with no bits encoding
+         * (a zero-one variable, where the two spellings agree anyway), for an
+         * unregistered view, whose values would have to be mapped through the view to
+         * be named here, and --- the common one --- for any variable whose definition
+         * range is narrow enough that naming every value is not what #833 is about.
+         *
+         * That last one is a deliberate policy, not an optimisation gap. The
+         * per-value line is emitted once per variable and then serves every cover
+         * anyone asks for, because it names every value; a cover is specialised, so a
+         * caller whose cover changes from firing to firing --- a Hall set --- pays a
+         * line per distinct one. Over a narrow definition range those lines are each
+         * about as big as the one they replace and there are many of them, which
+         * measured as a 16 % proof-size regression on `sudoku`. So a cover is stated
+         * only where it is asymptotically better, and the narrow case is left
+         * byte-identical. See dev_docs/large-domains.md.
+         */
+        [[nodiscard]] auto need_constraint_saying_variable_takes_at_least_one_value_over_cover(
+            IntegerVariableID, const std::vector<Integer> & singled_out) -> ProofLine;
 
         /**
          * Give the proof line specifying the definition of this literal in terms of its bit

--- a/gcs/large_domain_audit_test.cc
+++ b/gcs/large_domain_audit_test.cc
@@ -41,9 +41,12 @@
 #include <gcs/gcs.hh>
 
 #include <gcs/constraints/all_different.hh>
+#include <gcs/constraints/among.hh>
 #include <gcs/constraints/at_most_one.hh>
 #include <gcs/constraints/lex_smart_table.hh>
 #include <gcs/constraints/table.hh>
+
+#include <gcs/constraints/innards/constraints_test_utils.hh>
 
 #include <gcs/constraints/all_different/all_different_except.hh>
 #include <gcs/constraints/all_different/symmetric_all_different.hh>
@@ -1021,4 +1024,98 @@ TEST_CASE("Large domain proof scaling", "[.proofscaling]")
     // that a constraint which cannot be proof-logged at all still shows up as a
     // row rather than ending the run.
     SUCCEED("proof scaling survey complete");
+}
+
+TEST_CASE("Large domain proof sizes")
+{
+    /* A gate for the per-value work that happens only while a proof is being
+     * written, which the audit above structurally cannot see: it solves without
+     * ProofOptions, so a justification is never emitted and a reason is never
+     * materialised. The survey can see this class, but a survey is run by hand
+     * and pins nothing.
+     *
+     * Every row here is the same shape: a variable declared over a wide range,
+     * a domain confined to a couple of values inside it, and an inference whose
+     * justification names those values. That is what makes at-least-one
+     * constraints expensive --- the primitive spells one out over the whole
+     * *definition* range, not the domain --- and it is a shape no other lane
+     * produces, because a probe that wants a wide domain gets a wide definition
+     * range with it.
+     *
+     * The bound is deliberately loose: the point is the difference between "a
+     * few hundred lines" and "one line per value", not a byte count that has to
+     * be retuned whenever the encoding shifts. Before #939 each of these wrote
+     * about 66 * width lines, so any width here separates them by orders of
+     * magnitude. The proofs are checked as well as counted, because a small
+     * proof that does not verify is a worse outcome than a big one that does.
+     */
+    struct SizeProbe
+    {
+        string name;
+        function<auto(Problem &)->void> build;
+    };
+
+    // Wide enough that a per-value at-least-one is unmistakable (about 660,000
+    // proof lines, against the couple of hundred these actually write), and
+    // small enough that the whole case stays well under a second.
+    const auto width = 10000_i;
+    const long long max_proof_lines = 2000;
+
+    auto confined_vars = [](Problem & p, int n) {
+        vector<IntegerVariableID> v;
+        for (int i = 0; i < n; ++i) {
+            auto x = p.create_integer_variable(wide_lo, probe_width);
+            // The domain is two values; the definition range stays wide, which
+            // is the whole point of the shape.
+            p.post(In{x, vector<Integer>{1_i, 2_i}});
+            v.push_back(x);
+        }
+        return v;
+    };
+
+    const auto probes = vector<SizeProbe>{
+        {"GlobalCardinality/confined",
+            [&](Problem & p) {
+                // Every variable is confined to the hall set, which is what puts
+                // an at-least-one per variable into the capacity pol.
+                auto v = confined_vars(p, 3);
+                p.post(GlobalCardinality{v, {1_i, 2_i}, {p.create_integer_variable(0_i, 1_i), p.create_integer_variable(0_i, 1_i)}});
+            }},
+        {"AllDifferent/confined",
+            [&](Problem & p) {
+                // Three variables, two values: a Hall violator, whose
+                // justification wants an at-least-one for each of them.
+                auto v = confined_vars(p, 3);
+                p.post(AllDifferent{v});
+            }},
+        {"Among/confined",
+            [&](Problem & p) {
+                // All three must match, so the count is at least three, which
+                // the how_many variable cannot reach.
+                auto v = confined_vars(p, 3);
+                p.post(Among{v, {1_i, 2_i}, p.create_integer_variable(0_i, 1_i)});
+            }},
+    };
+
+    auto restore = probe_width;
+    probe_width = width;
+
+    for (const auto & probe_case : probes) {
+        INFO("probe: " << probe_case.name);
+        auto basename = "large_domain_proof_size_" + probe_case.name.substr(0, probe_case.name.find('/'));
+        auto names = ProofFileNames{basename};
+
+        Problem problem;
+        probe_case.build(problem);
+        solve_with(problem, SolveCallbacks{.stats_report = silent_stats_report()}, ProofOptions{names});
+
+        // Counted before verifying, which disposes of the files on success.
+        auto lines = count_lines(names.proof_file);
+        println("{:<40} {:>10} proof lines", probe_case.name, lines);
+        CHECK(lines > 0);
+        CHECK(lines <= max_proof_lines);
+        CHECK(gcs::test_innards::verify_proof_and_dispose(basename));
+    }
+
+    probe_width = restore;
 }


### PR DESCRIPTION
Fixes #939. **Stacked on #941** (`issue936-gcc-capacity-reason-runs`) — review that first; this PR's diff against it is the 11 files below.

## The problem

`need_constraint_saying_variable_takes_at_least_one_value` spells its at-least-one out one term per value over the variable's whole **definition** range. Asking for those eq atoms also splits the variable's interval partition into singletons, so every later covering is span-proportional too. Neither cost has anything to do with how many values the variable can still take.

A `GlobalCardinality` whose three variables are declared over `0..width` and confined by `In` to `{1, 2}`:

| width | before | after |
|---|---|---|
| 10^3 | 66 057 lines, 0.14 s | 255 lines, 0.001 s |
| 10^4 | 660 057 lines, 10.9 s | 255 lines, 0.001 s |
| 10^5 | 2 528 821+ lines, >600 s | 255 lines, 0.001 s |
| 10^9 | — | 255 lines, 0.001 s |

`AllDifferent` and `Among` in the same shape go 659 937 → 133 and 659 940 → 135 at 10^4. All verified by VeriPB, with real conclusions (`COMPLETE ENUMERATION OF 6 SOLUTIONS` and `UNSATISFIABLE`), not `NO CONCLUSION`.

## The fix

`..._over_cover(var, singled_out)` states the same fact over an interval cover: the caller's values of interest as their own eq atoms, the maximal runs between and around them as one range literal each.

```
[x in 0..2] + [x = 3] + [x in 4..6] + [x = 7] + [x in 8..10^9] >= 1
```

A pol that adds it still gets `+[x = v]` for each named value, so cancellation against per-value at-most-ones and count lines is unchanged. What differs is the residue: one `+[x in run]` per run instead of one `+[x = w]` per unnamed value. The caller's reason rules those out exactly when it pins the variable's bounds and excludes its holes — a run outside the bounds dies on the order chain, a run inside one sits inside an excluded hole and containment falsifies it. `generic_reason` and the Hall-set reasons all qualify.

**Converted**: both `GlobalCardinality` arms, `gac_all_different`'s Hall set, both `Among` sites, `min_distance`. **`subcircuit` deliberately keeps the per-value form** — its pigeonhole needs every value named, and a successor's definition range *is* the node set, so there is no width there to save. (That call site was not in my first survey of consumers: I had grepped the shared main checkout, whose working tree is weeks stale. Grep the worktree.)

## Why it is a threshold, not an unconditional rewrite

This is the part I would not have predicted. The per-value line is emitted **once per variable** and then serves every cover anyone asks for, because it names every value. A cover is specialised, so a caller whose cover changes from firing to firing — a Hall set — pays a line per distinct one. Over a *narrow* definition range each of those lines is about as big as the single line it replaces, and there are many of them:

| example | base | cover always | cover + cache | with width test |
|---|---|---|---|---|
| `sudoku` | 21 050 | 25 211 (+16.3%) | 24 474 | **21 050** |
| `ortho_latin 5 --all-different gac` | 123 288 | 127 423 (+3.4%) | 127 423 | **123 288** |
| `crystal_maze` | 12 395 | 13 414 | 13 305 | **12 395** |
| `colour` | 1 187 | 1 187 | 1 187 | **1 187** |
| `n_fractions` | 3 677 826 | 3 678 077 | 3 678 018 | **3 677 826** |

Caching the cover lines recovered only about a fifth of the regression, because the Hall sets genuinely differ. So the cover is stated only above a definition-range width threshold, and every example above is byte-identical to before. A rewrite that is asymptotically better can still be worse everywhere anyone actually is.

## A new lane, because nothing could see this class

The audit lane solves **without** `ProofOptions`, so no justification is ever emitted and no reason materialised — it structurally cannot see per-value work done while writing a proof. The `[.proofscaling]` survey can, but it is run by hand and pins nothing. `TEST_CASE("Large domain proof sizes")` closes that gap: each row is a wide definition range with a narrow domain, solved with proofs, and its proof both counted and checked with VeriPB. Registered unconditionally, since it needs no guard.

It discriminates: **3 failures and 39 s without this change, 0 failures and 0.18 s with it.**

That shape is also why the class stayed hidden. Every other probe in the file gets its wide definition range *by* wanting a wide domain, so a variable whose domain is narrow while its definition range is wide never arose.

## A correction to #939's own premise

I filed #939 saying this was what drives `GlobalCardinality/hall`'s 10× proof growth in the survey. **It is not.** That row never reaches an at-least-one at all — its longest proof line is 190 characters — and its growth is the demand-side per-value pruning already documented as a `KnownTrip`. Applying this fix leaves that row at exactly 43 988 → 439 988. The at-least-one cost is real and much worse, but it needed a probe nobody had written. I have corrected the issue.

## Gates

- release ctest **829/829**, *nothing skipped* (MiniZinc 2.9.7 and the real `cake_pb_cp` verified chain both on `PATH`)
- `-DGCS_TEST_CAP_DEFAULTS=OFF` **829/829**
- Sanitize **829/829**
- clang **833/833**
- `-DGCS_WERROR=ON` clean, clang-format 21.1.8 clean
- audit lane with the guard **ON**: 211 assertions, 3 test cases, no verdict moved
- merges cleanly with current `main` (which has #937 and #940)



---

## Second commit: AllDifferent (added after review feedback)

### Naming only the still-possible values

Each caller now names only the values **its variable can still take**, not its whole value set. They differ whenever that set is a Hall set, a cover, or a union of domains and one variable's domain is a small part of it — which is every caller here. On a Hall violator over eight values the at-least-ones drop from ten terms to four:

```
-  rup 1 i[_1][eq0] 1 i[_1][eq1] ... 1 i[_1][eq8] 1 i[_1][in9_1000] >= 1;
+  rup 1 i[_1][eq0] 1 i[_1][eq1] 1 i[_1][eq2] 1 i[_1][in3_1000] >= 1;
```

Naming a value the variable cannot take was only wasteful, not wrong — its pol term is zero under the reason either way. What the tightening actually buys is the correspondence: the residue is now exactly the complement of the domain, which is exactly what the reason states, so the leftovers discharge by construction rather than by an argument about which runs happen to sit inside which holes.

**Measured honestly, it is 0.5–0.8% of proof size** on a violator whose hall set is 4–64× any one domain. Small, because the at-least-ones are not where the volume is (the pairwise at-most-ones are, and they are cached at Top). **It also does not remove the need for the width threshold**: it makes each line smaller, and the narrow-domain regression is about how *many* lines there are, so `sudoku` only improves from +16.3% to +10.4% with the threshold off. The threshold stays; the examples stay byte-identical.

### The thing that was actually costing AllDifferent

`AllDifferent::prepare` built its compressed value set — the union of the initial domains, which is the right-hand side of GAC's bipartite graph — by walking every value of every domain and **linearly scanning what it had collected so far** for each one. O(values × distinct values): asymptotically worse than the algorithm it feeds.

| initial domain | before | after |
|---|---|---|
| `0..10^4` | 67 ms | **2 ms** |
| `0..10^5` | 6 637 ms | **38 ms** |
| `0..10^6` | did not finish in 200 s | **528 ms** |

Membership now goes through a set, leaving the order — first-seen, and so the value indices the propagator's graph uses — exactly as it was. **340 proof artefacts across the two AllDifferent test binaries are byte-identical at a pinned seed**, which is what "the order is unchanged" has to mean. `AllDifferentExcept` had the same loop and gets the same treatment.

This **does not change the audit lane's verdict, and should not**: GAC still wants a graph vertex per value, so a genuinely wide domain remains the `KnownTrip` the lane records, and what it needs is stage 5's weaker arm rather than a faster setup. `consistency::VC` on the same probe was 0 ms at every width throughout, which is what made the attribution unambiguous.

### Gates re-run for this commit

release **830/830** nothing skipped · caps-off **830/830** · Sanitize **830/830** · clang **834/834** · `-Werror` clean · clang-format clean · guard-on audit lane 211 assertions, no verdict moved · `ortho_latin`, `sudoku`, `crystal_maze`, `colour`, `n_fractions` byte-identical · merges cleanly with current `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AsUZjNThjBFs7VsFkCQfux
